### PR TITLE
Add checks for tensor parallel use case to ensure all-reduce is called only when necessary

### DIFF
--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -271,10 +271,7 @@ class MultiHeadAttention(torch.nn.Module):
         self.tp_size = tp_size
         self.sequence_parallel = (tp_size > 1) and sequence_parallel
 
-        projection_size = kv_channels * num_attention_heads
-        self.hidden_size_per_attention_head = divide(
-            projection_size, num_attention_heads
-        )
+        self.hidden_size_per_attention_head = kv_channels
         self.num_attention_heads_per_partition = divide(num_attention_heads, tp_size)
 
         common_gemm_kwargs = {


### PR DESCRIPTION
Signed-off-by: Kirthi Shankar Sivamani <ksivamani@nvidia.com>