### PR TITLE
Fix illegal memory access in general layer norm backward kernel

### DIFF
--- a/transformer_engine/common/layer_norm/ln_bwd_kernels.cuh
+++ b/transformer_engine/common/layer_norm/ln_bwd_kernels.cuh
@@ -389,8 +389,12 @@ void ln_bwd_general_kernel(layer_norm::BwdParams params) {
           cta_row < params.rows;
           cta_row += gdimm ) {
         const int row = cta_row + warp_m;
-        const compute_t mu = static_cast<const compute_t *>(params.mu)[row];
-        const compute_t rs = static_cast<const compute_t *>(params.rs)[row];
+        compute_t mu = 0.f;
+        compute_t rs = 0.f;
+        if ( row < params.rows ) {
+            mu = static_cast<const compute_t *>(params.mu)[row];
+            rs = static_cast<const compute_t *>(params.rs)[row];
+        }
 
         Cvec dy[LDGS];
         Cvec y[LDGS];


### PR DESCRIPTION
I forgot to check some bounds.

Running on an A2, I see no unit test failures with the general layer norm kernels using `compute-sanitizer`. I do see one failure with the optimized kernel since `dgamma` is ever so slightly outside the numerical tolerances, but that shouldn't have been affected by this change.