### PR TITLE
Link performance optimization tutorial to docs

### DIFF
--- a/docs/examples/advanced_optimizations.ipynb
+++ b/docs/examples/advanced_optimizations.ipynb
@@ -5,7 +5,7 @@
    "id": "24184f3f",
    "metadata": {},
    "source": [
-    "# Advanced Performance Optimizations"
+    "# Performance Optimizations"
    ]
   },
   {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Transformer Engine documentation
    :caption: Examples and Tutorials
 
    examples/fp8_primer.ipynb
+   examples/advanced_optimizations.ipynb
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Tutorial was not linked to the main page and so was not rendered.