### PR TITLE
Softmax docstrings and type fixes

### DIFF
--- a/docs/api/c/index.rst
+++ b/docs/api/c/index.rst
@@ -18,5 +18,6 @@ directly from C/C++, without Python.
    cast.h <cast>
    gemm.h <gemm>
    layer_norm.h <layer_norm>
+   softmax.h <softmax>
    transformer_engine.h <transformer_engine>
    transpose.h <transpose>

--- a/docs/api/c/softmax.rst
+++ b/docs/api/c/softmax.rst
@@ -1,0 +1,9 @@
+..
+    Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+    See LICENSE for license information.
+
+softmax.h
+======
+
+.. doxygenfile:: softmax.h

--- a/transformer_engine/common/fused_softmax/scaled_masked_softmax.cu
+++ b/transformer_engine/common/fused_softmax/scaled_masked_softmax.cu
@@ -350,7 +350,7 @@ template <typename input_t, typename output_t, typename acc_t, int log2_elements
 __global__ void scaled_masked_softmax_warp_backward(
     output_t *gradInput,
     input_t *grad,
-    const input_t *output,
+    input_t *output,
     acc_t scale,
     int micro_batch_size,
     int element_count) {
@@ -774,7 +774,7 @@ template<typename input_t, typename output_t, typename acc_t>
 void dispatch_scaled_masked_softmax_backward(
     output_t *grad_input,
     input_t *grad,
-    const input_t *output,
+    input_t *output,
     const acc_t scale,
     int query_seq_len,
     int key_seq_len,
@@ -969,7 +969,7 @@ void scaled_softmax_forward(
 
 void scaled_softmax_backward(
     const Tensor output_grads,
-    const Tensor softmax_results,
+    Tensor softmax_results,
     float scale_factor,
     cudaStream_t stream) {
 
@@ -984,7 +984,7 @@ void scaled_softmax_backward(
         dispatch_scaled_masked_softmax_backward<softmax_type, softmax_type, float>(
             reinterpret_cast<softmax_type*>(output_grads.dptr),
             reinterpret_cast<softmax_type*>(output_grads.dptr),
-            reinterpret_cast<softmax_type const*>(softmax_results.dptr),
+            reinterpret_cast<softmax_type*>(softmax_results.dptr),
             scale_factor,
             query_seq_len,
             key_seq_len,
@@ -1024,7 +1024,7 @@ void scaled_masked_softmax_forward(
 
 void scaled_masked_softmax_backward(
     const Tensor output_grads,
-    const Tensor softmax_results,
+    Tensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 )  {
@@ -1039,7 +1039,7 @@ void scaled_masked_softmax_backward(
         dispatch_scaled_masked_softmax_backward<softmax_type, softmax_type, float>(
             reinterpret_cast<softmax_type*>(output_grads.dptr),
             reinterpret_cast<softmax_type*>(output_grads.dptr),
-            reinterpret_cast<softmax_type const*>(softmax_results.dptr),
+            reinterpret_cast<softmax_type*>(softmax_results.dptr),
             scale_factor,
             query_seq_len,
             key_seq_len,
@@ -1069,14 +1069,14 @@ void nvte_scaled_softmax_forward(
 
 void nvte_scaled_softmax_backward(
     const NVTETensor output_grads,
-    const NVTETensor softmax_results,
+    NVTETensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 ) {
     using namespace transformer_engine;
     scaled_softmax_backward(
         *reinterpret_cast<const Tensor*>(output_grads),
-        *reinterpret_cast<const Tensor*>(softmax_results),
+        *reinterpret_cast<Tensor*>(softmax_results),
         scale_factor,
         stream);
 }
@@ -1100,14 +1100,14 @@ void nvte_scaled_masked_softmax_forward(
 
 
 void nvte_scaled_masked_softmax_backward(
-    const NVTETensor input,
+    const NVTETensor output_grads,
     NVTETensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 ) {
     using namespace transformer_engine;
     scaled_masked_softmax_backward(
-        *reinterpret_cast<const Tensor*>(input),
+        *reinterpret_cast<const Tensor*>(output_grads),
         *reinterpret_cast<Tensor*>(softmax_results),
         scale_factor,
         stream);

--- a/transformer_engine/common/fused_softmax/scaled_upper_triang_masked_softmax.cu
+++ b/transformer_engine/common/fused_softmax/scaled_upper_triang_masked_softmax.cu
@@ -248,8 +248,8 @@ __global__ void scaled_upper_triang_masked_softmax_warp_forward(
 template <typename input_t, typename output_t, typename acc_t, int log2_elements>
 __global__ void scaled_upper_triang_masked_softmax_warp_backward(
     output_t *gradInput,
-    input_t *grad,
-    input_t *output,
+    const input_t *grad,
+    const input_t *output,
     acc_t scale,
     int micro_batch_size,
     int stride,
@@ -509,8 +509,8 @@ void dispatch_scaled_upper_triang_masked_softmax_forward(
 template<typename input_t, typename output_t, typename acc_t>
 void dispatch_scaled_upper_triang_masked_softmax_backward(
     output_t *grad_input,
-    input_t *grad,
-    input_t *output,
+    const input_t *grad,
+    const input_t *output,
     const acc_t scale,
     int softmax_elements,
     int softmax_elements_stride,
@@ -683,8 +683,9 @@ void scaled_upper_triang_masked_softmax_forward(
 
 
 void scaled_upper_triang_masked_softmax_backward(
-    const Tensor output_grads,
-    Tensor softmax_results,
+    Tensor output_grads,
+    const Tensor incoming_grads,
+    const Tensor softmax_results,
     float scale_factor,
     cudaStream_t stream)  {
 
@@ -695,8 +696,8 @@ void scaled_upper_triang_masked_softmax_backward(
     TRANSFORMER_ENGINE_TYPE_SWITCH_16BIT(output_grads.dtype, softmax_type,
         dispatch_scaled_upper_triang_masked_softmax_backward<softmax_type, softmax_type, float>(
             reinterpret_cast<softmax_type*>(output_grads.dptr),
-            reinterpret_cast<softmax_type*>(output_grads.dptr),
-            reinterpret_cast<softmax_type*>(softmax_results.dptr),
+            reinterpret_cast<softmax_type const*>(incoming_grads.dptr),
+            reinterpret_cast<softmax_type const*>(softmax_results.dptr),
             scale_factor,
             seq_len,
             seq_len,
@@ -723,15 +724,17 @@ void nvte_scaled_upper_triang_masked_softmax_forward(
 
 
 void nvte_scaled_upper_triang_masked_softmax_backward(
-    const NVTETensor output_grads,
-    NVTETensor softmax_results,
+    const NVTETensor incoming_grads,
+    const NVTETensor softmax_results,
+    NVTETensor output_grads,
     float scale_factor,
     cudaStream_t stream
 ) {
     using namespace transformer_engine;
     scaled_upper_triang_masked_softmax_backward(
-        *reinterpret_cast<const Tensor*>(output_grads),
-        *reinterpret_cast<Tensor*>(softmax_results),
+        *reinterpret_cast<Tensor*>(output_grads),
+        *reinterpret_cast<const Tensor*>(incoming_grads),
+        *reinterpret_cast<const Tensor*>(softmax_results),
         scale_factor,
         stream);
 }

--- a/transformer_engine/common/fused_softmax/scaled_upper_triang_masked_softmax.cu
+++ b/transformer_engine/common/fused_softmax/scaled_upper_triang_masked_softmax.cu
@@ -249,7 +249,7 @@ template <typename input_t, typename output_t, typename acc_t, int log2_elements
 __global__ void scaled_upper_triang_masked_softmax_warp_backward(
     output_t *gradInput,
     input_t *grad,
-    const input_t *output,
+    input_t *output,
     acc_t scale,
     int micro_batch_size,
     int stride,
@@ -510,7 +510,7 @@ template<typename input_t, typename output_t, typename acc_t>
 void dispatch_scaled_upper_triang_masked_softmax_backward(
     output_t *grad_input,
     input_t *grad,
-    const input_t *output,
+    input_t *output,
     const acc_t scale,
     int softmax_elements,
     int softmax_elements_stride,
@@ -684,7 +684,7 @@ void scaled_upper_triang_masked_softmax_forward(
 
 void scaled_upper_triang_masked_softmax_backward(
     const Tensor output_grads,
-    const Tensor softmax_results,
+    Tensor softmax_results,
     float scale_factor,
     cudaStream_t stream)  {
 
@@ -696,7 +696,7 @@ void scaled_upper_triang_masked_softmax_backward(
         dispatch_scaled_upper_triang_masked_softmax_backward<softmax_type, softmax_type, float>(
             reinterpret_cast<softmax_type*>(output_grads.dptr),
             reinterpret_cast<softmax_type*>(output_grads.dptr),
-            reinterpret_cast<softmax_type const*>(softmax_results.dptr),
+            reinterpret_cast<softmax_type*>(softmax_results.dptr),
             scale_factor,
             seq_len,
             seq_len,
@@ -724,14 +724,14 @@ void nvte_scaled_upper_triang_masked_softmax_forward(
 
 void nvte_scaled_upper_triang_masked_softmax_backward(
     const NVTETensor output_grads,
-    const NVTETensor softmax_results,
+    NVTETensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 ) {
     using namespace transformer_engine;
     scaled_upper_triang_masked_softmax_backward(
         *reinterpret_cast<const Tensor*>(output_grads),
-        *reinterpret_cast<const Tensor*>(softmax_results),
+        *reinterpret_cast<Tensor*>(softmax_results),
         scale_factor,
         stream);
 }

--- a/transformer_engine/common/include/transformer_engine/softmax.h
+++ b/transformer_engine/common/include/transformer_engine/softmax.h
@@ -15,7 +15,13 @@
 extern "C" {
 #endif
 
-
+/*! \brief Compute scaled softmax activation on the input.
+ *
+ *  \param[in]     input           Input tensor for softmax.
+ *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     scale_factor    Scalar for the input tensor.
+ *  \param[in]     stream          CUDA stream used for the operation.
+ */
 void nvte_scaled_softmax_forward(
     const NVTETensor input,
     NVTETensor softmax_results,
@@ -23,15 +29,31 @@ void nvte_scaled_softmax_forward(
     cudaStream_t stream
 );
 
-
+/*! \brief Compute the backward of the scaled softmax activation.
+ *
+ *  - `output_grads` is the input tensor containing the gradients received from the following layer.
+ *  - `softmax_results` is the output tensor containing the computed gradients.
+ * 
+ *  \param[in]     output_grads    Input tensor for softmax.
+ *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     scale_factor    Scalar for the output tensor.
+ *  \param[in]     stream          CUDA stream used for the operation.
+ */
 void nvte_scaled_softmax_backward(
     const NVTETensor output_grads,
-    const NVTETensor softmax_results,
+    NVTETensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 );
 
-
+/*! \brief Compute scaled masked softmax activation on the input.
+ *
+ *  \param[in]     input           Input tensor for softmax.
+ *  \param[in]     mask            Mask for the input tensor.
+ *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     scale_factor    Scalar for the input tensor.
+ *  \param[in]     stream          CUDA stream used for the operation.
+ */
 void nvte_scaled_masked_softmax_forward(
     const NVTETensor input,
     const NVTETensor mask,
@@ -40,15 +62,30 @@ void nvte_scaled_masked_softmax_forward(
     cudaStream_t stream
 );
 
-
+/*! \brief Compute the backward of the scaled masked softmax activation.
+ *
+ *  - `output_grads` is the input tensor containing the gradients received from the following layer.
+ *  - `softmax_results` is the output tensor containing the computed gradients.
+ * 
+ *  \param[in]     output_grads    Input tensor for softmax.
+ *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     scale_factor    Scalar for the output tensor.
+ *  \param[in]     stream          CUDA stream used for the operation.
+ */
 void nvte_scaled_masked_softmax_backward(
-    const NVTETensor input,
+    const NVTETensor output_grads,
     NVTETensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 );
 
-
+/*! \brief Compute scaled softmax activation using a 2D upper triangular mask on the input.
+ *
+ *  \param[in]     input           Input tensor for softmax.
+ *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     scale_factor    Scalar for the input tensor.
+ *  \param[in]     stream          CUDA stream used for the operation.
+ */
 void nvte_scaled_upper_triang_masked_softmax_forward(
     const NVTETensor input,
     NVTETensor softmax_results,
@@ -56,10 +93,19 @@ void nvte_scaled_upper_triang_masked_softmax_forward(
     cudaStream_t stream
 );
 
-
+/*! \brief Compute the backward of the scaled softmax activation using a 2D upper triangular mask.
+ *
+ *  - `output_grads` is the input tensor containing the gradients received from the following layer.
+ *  - `softmax_results` is the output tensor containing the computed gradients.
+ * 
+ *  \param[in]     output_grads    Input tensor for softmax.
+ *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     scale_factor    Scalar for the output tensor.
+ *  \param[in]     stream          CUDA stream used for the operation.
+ */
 void nvte_scaled_upper_triang_masked_softmax_backward(
     const NVTETensor output_grads,
-    const NVTETensor softmax_results,
+    NVTETensor softmax_results,
     float scale_factor,
     cudaStream_t stream
 );

--- a/transformer_engine/common/include/transformer_engine/softmax.h
+++ b/transformer_engine/common/include/transformer_engine/softmax.h
@@ -33,7 +33,7 @@ void nvte_scaled_softmax_forward(
  *
  *  - `output_grads` is the input tensor containing the gradients received from the following layer.
  *  - `softmax_results` is the output tensor containing the computed gradients.
- * 
+ *
  *  \param[in]     output_grads    Input tensor for softmax.
  *  \param[out]    softmax_results Output tensor.
  *  \param[in]     scale_factor    Scalar for the output tensor.
@@ -66,7 +66,7 @@ void nvte_scaled_masked_softmax_forward(
  *
  *  - `output_grads` is the input tensor containing the gradients received from the following layer.
  *  - `softmax_results` is the output tensor containing the computed gradients.
- * 
+ *
  *  \param[in]     output_grads    Input tensor for softmax.
  *  \param[out]    softmax_results Output tensor.
  *  \param[in]     scale_factor    Scalar for the output tensor.
@@ -97,7 +97,7 @@ void nvte_scaled_upper_triang_masked_softmax_forward(
  *
  *  - `output_grads` is the input tensor containing the gradients received from the following layer.
  *  - `softmax_results` is the output tensor containing the computed gradients.
- * 
+ *
  *  \param[in]     output_grads    Input tensor for softmax.
  *  \param[out]    softmax_results Output tensor.
  *  \param[in]     scale_factor    Scalar for the output tensor.

--- a/transformer_engine/common/include/transformer_engine/softmax.h
+++ b/transformer_engine/common/include/transformer_engine/softmax.h
@@ -29,22 +29,27 @@ void nvte_scaled_softmax_forward(
     cudaStream_t stream
 );
 
+
 /*! \brief Compute the backward of the scaled softmax activation.
  *
- *  - `output_grads` is the input tensor containing the gradients received from the following layer.
- *  - `softmax_results` is the output tensor containing the computed gradients.
+ *  - `incoming_grads` is the input tensor containing the gradients received from the following layer.
+ *  - `softmax_results` is the output tensor of the corresponding forward softmax operation.
+ *  - `output_grads` is the output tensor containing the computed gradients.
  *
- *  \param[in]     output_grads    Input tensor for softmax.
- *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     incoming_grads  Input gradient tensor for backward.
+ *  \param[in]     softmax_results Output tensor of softmax forward.
+ *  \param[out]    output_grads    Output tensor.
  *  \param[in]     scale_factor    Scalar for the output tensor.
  *  \param[in]     stream          CUDA stream used for the operation.
  */
 void nvte_scaled_softmax_backward(
-    const NVTETensor output_grads,
-    NVTETensor softmax_results,
+    const NVTETensor incoming_grads,
+    const NVTETensor softmax_results,
+    NVTETensor output_grads,
     float scale_factor,
     cudaStream_t stream
 );
+
 
 /*! \brief Compute scaled masked softmax activation on the input.
  *
@@ -62,22 +67,27 @@ void nvte_scaled_masked_softmax_forward(
     cudaStream_t stream
 );
 
+
 /*! \brief Compute the backward of the scaled masked softmax activation.
  *
- *  - `output_grads` is the input tensor containing the gradients received from the following layer.
- *  - `softmax_results` is the output tensor containing the computed gradients.
+ *  - `incoming_grads` is the input tensor containing the gradients received from the following layer.
+ *  - `softmax_results` is the output tensor of the corresponding forward softmax operation.
+ *  - `output_grads` is the output tensor containing the computed gradients.
  *
- *  \param[in]     output_grads    Input tensor for softmax.
- *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     incoming_grads  Input gradient tensor for backward.
+ *  \param[in]     softmax_results Output tensor of softmax forward.
+ *  \param[out]    output_grads    Output tensor.
  *  \param[in]     scale_factor    Scalar for the output tensor.
  *  \param[in]     stream          CUDA stream used for the operation.
  */
 void nvte_scaled_masked_softmax_backward(
-    const NVTETensor output_grads,
-    NVTETensor softmax_results,
+    const NVTETensor incoming_grads,
+    const NVTETensor softmax_results,
+    NVTETensor output_grads,
     float scale_factor,
     cudaStream_t stream
 );
+
 
 /*! \brief Compute scaled softmax activation using a 2D upper triangular mask on the input.
  *
@@ -93,19 +103,23 @@ void nvte_scaled_upper_triang_masked_softmax_forward(
     cudaStream_t stream
 );
 
+
 /*! \brief Compute the backward of the scaled softmax activation using a 2D upper triangular mask.
  *
- *  - `output_grads` is the input tensor containing the gradients received from the following layer.
- *  - `softmax_results` is the output tensor containing the computed gradients.
+ *  - `incoming_grads` is the input tensor containing the gradients received from the following layer.
+ *  - `softmax_results` is the output tensor of the corresponding forward softmax operation.
+ *  - `output_grads` is the output tensor containing the computed gradients.
  *
- *  \param[in]     output_grads    Input tensor for softmax.
- *  \param[out]    softmax_results Output tensor.
+ *  \param[in]     incoming_grads  Input gradient tensor for backward.
+ *  \param[in]     softmax_results Output tensor of softmax forward.
+ *  \param[out]    output_grads    Output tensor.
  *  \param[in]     scale_factor    Scalar for the output tensor.
  *  \param[in]     stream          CUDA stream used for the operation.
  */
 void nvte_scaled_upper_triang_masked_softmax_backward(
-    const NVTETensor output_grads,
-    NVTETensor softmax_results,
+    const NVTETensor incoming_grads,
+    const NVTETensor softmax_results,
+    NVTETensor output_grads,
     float scale_factor,
     cudaStream_t stream
 );

--- a/transformer_engine/pytorch/csrc/extensions.cu
+++ b/transformer_engine/pytorch/csrc/extensions.cu
@@ -537,8 +537,9 @@ at::Tensor scaled_softmax_backward(at::Tensor output_grad_,
     auto output_grads_cu = makeTransformerEngineTensor(output_grads);
     auto softmax_results_cu = makeTransformerEngineTensor(softmax_results);
 
+    // Produce gradients in place.
     nvte_scaled_softmax_backward(
-          output_grads_cu.data(), softmax_results_cu.data(),
+          output_grads_cu.data(), softmax_results_cu.data(), output_grads_cu.data(),
           scale_factor, at::cuda::getCurrentCUDAStream());
 
     return output_grads;
@@ -608,8 +609,9 @@ at::Tensor scaled_masked_softmax_backward(at::Tensor output_grad_,
     auto output_grads_cu = makeTransformerEngineTensor(output_grads);
     auto softmax_results_cu = makeTransformerEngineTensor(softmax_results);
 
+    // Produce gradients in place.
     nvte_scaled_softmax_backward(
-          output_grads_cu.data(), softmax_results_cu.data(),
+          output_grads_cu.data(), softmax_results_cu.data(), output_grads_cu.data(),
           scale_factor, at::cuda::getCurrentCUDAStream());
 
     return output_grads;
@@ -671,8 +673,10 @@ at::Tensor scaled_upper_triang_masked_softmax_backward(at::Tensor output_grads_,
     auto output_grads_cu = makeTransformerEngineTensor(output_grads);
     auto softmax_results_cu = makeTransformerEngineTensor(softmax_results);
 
+    // Produce gradients in place.
     nvte_scaled_upper_triang_masked_softmax_backward(output_grads_cu.data(),
                                                      softmax_results_cu.data(),
+                                                     output_grads_cu.data(),
                                                      scale_factor,
                                                      at::cuda::getCurrentCUDAStream());
 


### PR DESCRIPTION
Add docstrings to `softmax.h` for C API and remove const modifiers from output Tensors.