### PR TITLE
Reduce unit tests time

### DIFF
--- a/qa/L0_cppunittest/test.sh
+++ b/qa/L0_cppunittest/test.sh
@@ -11,4 +11,4 @@ export LD_LIBRARY_PATH=$TE_LIB_PATH:$LD_LIBRARY_PATH
 cd $TE_PATH/tests/cpp
 cmake -GNinja -Bbuild .
 cmake --build build
-cd build && ctest
+ctest --test-dir build -j4

--- a/tests/cpp/operator/CMakeLists.txt
+++ b/tests/cpp/operator/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(test_operator
                ../test_common.cu)
 
 target_link_libraries(test_operator PUBLIC CUDA::cudart GTest::gtest_main ${TE_LIB})
+target_compile_options(test_operator PRIVATE -O2)
 
 include(GoogleTest)
 gtest_discover_tests(test_operator)


### PR DESCRIPTION
The unit test time will be increased as more kernels are added. This PR is to reduce the unit test time for a shorter development cycle.
1. Calculating the reference answer is the hotspot of unit test time on the CPU. Enabling `-O2` can bring 6~7x speedup. (`TestLN/float32Xfloat32X2048X12288` from 12645ms to 1874ms)
2. Set ctest parallel level to 4, which can run multiple tests on different processes. Current unit tests are small, I think OOM or extreme resource contention should not happen.