### PR TITLE
Fix gradients when using AMP

### DIFF
--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -169,4 +169,5 @@ def safely_set_viewless_tensor_data(
 
 def cast_if_needed(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     """Cast tensor to dtype"""
-    return tensor if tensor is None or tensor.dtype == dtype else tensor.to(dtype)
+    with torch.enable_grad():
+        return tensor if tensor is None or tensor.dtype == dtype else tensor.to(dtype)


### PR DESCRIPTION
In PyTorch, custom autograd functions run with gradients disabled. This means each time a new tensor is cast or created, the `requires_grad` field is set to False.  When we cast the `weight` because of AMP, this is what happens and the wgrad is not computed and null grad is returned (silent fail). **Note:** If a gradient is returned from backward, PyTorch will cast it to input type before populating the `.grad` field.

Signed-off-by: Kirthi Shankar Sivamani <ksivamani@nvidia.com>