### PR TITLE
Relax checks for flash-attn

### DIFF
--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -371,9 +371,7 @@ class DotProductAttention(torch.nn.Module):
 
         self.use_flash_attention = (
             int(os.getenv("NVTE_FLASH_ATTN", "1"))
-            and attention_softmax_in_fp32
             and attn_mask_type == "causal"
-            and not apply_query_key_layer_scaling
         )
 
         attn_kwargs = {
@@ -448,8 +446,7 @@ class DotProductAttention(torch.nn.Module):
         """
 
         use_flash_attention = self.use_flash_attention
-        if (attention_mask is not None
-            or query_layer.dtype not in [torch.bfloat16, torch.float16]
+        if (query_layer.dtype not in [torch.bfloat16, torch.float16]
             or key_layer.dtype not in [torch.bfloat16, torch.float16]
             or value_layer.dtype not in [torch.bfloat16, torch.float16]
         ):


### PR DESCRIPTION
I had a few problems running NeMo+TE with flash-attn on. Specifically, `NVTE_FLASH_ATTN=1 python nemo/examples/nlp/language_modeling/megatron_gpt_pretraining.py` did not run through the flash-attn path. I had to make a few changes as listed in the PR to make it work. 
- attention_softmax_in_fp32:  [NeMo](https://github.com/NVIDIA/NeMo/blob/7ac46438db13440a5b1286550ae0392d6cac56af/nemo/collections/nlp/modules/common/megatron/transformer.py#L773) sets it to False by default, but this could be a NeMo usage problem. Or we can relax our check here in TE. We can think about this.  
- apply_query_key_layer_scaling: do we expect users to always remember to add `model.apply_query_key_layer_scaling=False` to NeMo run command when they want to turn flash-attn on? Seems a bit too much work for an average user.  
- the flash-attn path gets turned off if attention_mask is passed in. Could we make it still work, but just provide a warning instead? Otherwise, it's just too easy for the code to not go through the flash-attn path.

Thanks!