### PR TITLE
Exporting MajorShardingType, ShardingType and LayerNorm for TE/JAX.

### DIFF
--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -3,7 +3,9 @@
 # See LICENSE for license information.
 """Transformer Engine bindings for JAX"""
 from .fp8 import fp8_autocast, update_collections, update_fp8_metas
-from .module import DenseGeneral, LayerNormDenseGeneral, LayerNormMLP, TransformerEngineBase
+from .module import LayerNorm, DenseGeneral
+from .module import LayerNormDenseGeneral, LayerNormMLP, TransformerEngineBase
 from .transformer import extend_logical_axis_rules
-from .transformer import RelativePositionBiases, TransformerLayer, TransformerLayerType
-from .sharding import ShardingResource
+from .transformer import RelativePositionBiases, MultiHeadAttention
+from .transformer import TransformerLayer, TransformerLayerType
+from .sharding import ShardingResource, MajorShardingType, ShardingType


### PR DESCRIPTION
- Exporting a new module, LayerNorm.
- Exporting two Enums, MajorShardingType, ShardingType
> MajorShardingType and ShardingType are used to indicate sharding patterns in TE/JAX's module, such as DenseGeneral, LayerNormDenseGeneral and LayerNormMLP. In case that users construct their own models via those modules, instead of TransformerLayer, they would need these two enum classes to enable multi-devices training. Refer [here](https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/jax/module.py#L357) for details.
