### PR TITLE
Move from Sphinx Autodoc to sphinx-autoapi

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -19,6 +19,8 @@ jobs:
           pip install breathe sphinx-autoapi
           sudo apt-get install -y pandoc graphviz doxygen
           export GIT_SHA=$(git show-ref --hash HEAD)
+      - name: 'Build docs'
+        run: |
           doxygen docs/Doxyfile
           cd docs
           make html
@@ -26,5 +28,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: te_docs
-          path: _build/html
+          path: docs/_build/html
           retention-days: 7

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+# A workflow to trigger the build of TE documentation on GitHub
+name: 'Build documentation'
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: 'Install dependencies'
+        run: |
+          pip install sphinx sphinx_rtd_theme nbsphinx IPython ipython_genutils ipywidgets
+          pip install breathe sphinx-autoapi
+          sudo apt-get install -y pandoc graphviz doxygen
+          export GIT_SHA=$(git show-ref --hash HEAD)
+          doxygen docs/Doxyfile
+          cd docs
+          make html
+      - name: 'Upload docs'
+        uses: actions/upload-artifact@v3
+        with:
+          name: te_docs
+          path: _build/html
+          retention-days: 7

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -15,8 +15,8 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Install dependencies'
         run: |
-          pip install sphinx sphinx_rtd_theme nbsphinx IPython ipython_genutils ipywidgets
-          pip install breathe sphinx-autoapi
+          pip install sphinx==5.1.1 sphinx_rtd_theme==1.0.0 nbsphinx==0.8.10 IPython ipython_genutils==0.2.0 ipywidgets==8.0.2
+          pip install breathe==4.34.0 sphinx-autoapi==2.0.1
           sudo apt-get install -y pandoc graphviz doxygen
           export GIT_SHA=$(git show-ref --hash HEAD)
       - name: 'Build docs'

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -9,7 +9,7 @@ Common API
 Classes
 -------
 
-.. autoclass:: transformer_engine.common.recipe.Format
+.. autoapiclass:: transformer_engine.common.recipe.Format
 
-.. autoclass:: transformer_engine.common.recipe.DelayedScaling(margin=0, interval=1, fp8_format=Format.E4M3, amax_history_len=1, amax_compute_algo="most_recent", scaling_factor_compute_algo=None, override_linear_precision=(False, False, False))
+.. autoapiclass:: transformer_engine.common.recipe.DelayedScaling(margin=0, interval=1, fp8_format=Format.E4M3, amax_history_len=1, amax_compute_algo="most_recent", scaling_factor_compute_algo=None, override_linear_precision=(False, False, False))
 

--- a/docs/api/common.rst
+++ b/docs/api/common.rst
@@ -6,9 +6,6 @@
 Common API
 ==========
 
-Classes
--------
-
 .. autoapiclass:: transformer_engine.common.recipe.Format
 
 .. autoapiclass:: transformer_engine.common.recipe.DelayedScaling(margin=0, interval=1, fp8_format=Format.E4M3, amax_history_len=1, amax_compute_algo="most_recent", scaling_factor_compute_algo=None, override_linear_precision=(False, False, False))

--- a/docs/api/pytorch.rst
+++ b/docs/api/pytorch.rst
@@ -9,26 +9,26 @@ pyTorch
 Modules
 -------
 
-.. autoclass:: transformer_engine.pytorch.Linear(in_features, out_features, bias=True, **kwargs)
+.. autoapiclass:: transformer_engine.pytorch.Linear(in_features, out_features, bias=True, **kwargs)
   :members: forward
 
-.. autoclass:: transformer_engine.pytorch.LayerNorm(hidden_size, eps=1e-5, **kwargs)
+.. autoapiclass:: transformer_engine.pytorch.LayerNorm(hidden_size, eps=1e-5, **kwargs)
 
-.. autoclass:: transformer_engine.pytorch.LayerNormLinear(in_features, out_features, eps=1e-5, bias=True, **kwargs)
+.. autoapiclass:: transformer_engine.pytorch.LayerNormLinear(in_features, out_features, eps=1e-5, bias=True, **kwargs)
   :members: forward
 
-.. autoclass:: transformer_engine.pytorch.LayerNormMLP(hidden_size, ffn_hidden_size, eps=1e-5, bias=True, **kwargs)
+.. autoapiclass:: transformer_engine.pytorch.LayerNormMLP(hidden_size, ffn_hidden_size, eps=1e-5, bias=True, **kwargs)
   :members: forward
 
-.. autoclass:: transformer_engine.pytorch.DotProductAttention(num_attention_heads, kv_channels, **kwargs)
+.. autoapiclass:: transformer_engine.pytorch.DotProductAttention(num_attention_heads, kv_channels, **kwargs)
   :members: forward
 
-.. autoclass:: transformer_engine.pytorch.TransformerLayer(hidden_size, ffn_hidden_size, num_attention_heads, **kwargs)
+.. autoapiclass:: transformer_engine.pytorch.TransformerLayer(hidden_size, ffn_hidden_size, num_attention_heads, **kwargs)
   :members: forward
 
 Functions
 ---------
 
-.. autofunction:: transformer_engine.pytorch.fp8_autocast
+.. autoapifunction:: transformer_engine.pytorch.fp8_autocast
 
-.. autofunction:: transformer_engine.pytorch.checkpoint
+.. autoapifunction:: transformer_engine.pytorch.checkpoint

--- a/docs/api/pytorch.rst
+++ b/docs/api/pytorch.rst
@@ -6,9 +6,6 @@
 pyTorch
 =======
 
-Modules
--------
-
 .. autoapiclass:: transformer_engine.pytorch.Linear(in_features, out_features, bias=True, **kwargs)
   :members: forward
 
@@ -25,9 +22,6 @@ Modules
 
 .. autoapiclass:: transformer_engine.pytorch.TransformerLayer(hidden_size, ffn_hidden_size, num_attention_heads, **kwargs)
   :members: forward
-
-Functions
----------
 
 .. autoapifunction:: transformer_engine.pytorch.fp8_autocast
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,3 +100,4 @@ breathe_projects = {"TransformerEngine": os.path.abspath("doxygen/xml/")}
 breathe_default_project = "TransformerEngine"
 
 autoapi_generate_api_docs = False
+autoapi_dirs = ["../transformer_engine"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,8 @@ extensions = [
         'sphinx.ext.mathjax',
         'sphinx.ext.napoleon',
         'nbsphinx',
-        'breathe']
+        'breathe',
+        'autoapi.extension']
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
@@ -97,3 +98,5 @@ napoleon_custom_sections = [('Parallelism parameters', 'params_style'),
 
 breathe_projects = {"TransformerEngine": os.path.abspath("doxygen/xml/")}
 breathe_default_project = "TransformerEngine"
+
+autoapi_generate_api_docs = False

--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -13,7 +13,7 @@ import torch
 
 from flash_attn.flash_attn_interface import flash_attn_unpadded_func
 
-from transformer_engine.pytorch import LayerNormLinear, Linear, LayerNormMLP, LayerNorm
+from transformer_engine.pytorch.module import LayerNormLinear, Linear, LayerNormMLP, LayerNorm
 from transformer_engine.pytorch.jit import (
     set_jit_fusion_options,
     warmup_jit_bias_dropout_add_all_dtypes,


### PR DESCRIPTION
As we move forward with the support for multiple frameworks, the behavior of autodoc to import everything becomes an issue - we would need to have a container with all frameworks installed, which is going to be an issue with handling all of the dependencies. AutoAPI does not need to import the module to generate documentation, which is much better in this case.

Also add GitHub action to build the documentation.