### PR TITLE
[WIP] Add cudnn fused multi-head attention for JAX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "3rdparty/googletest"]
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
-[submodule "3rdparty/cudnn-frontend"]
-	path = 3rdparty/cudnn-frontend
-	url = https://github.com/NVIDIA/cudnn-frontend.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/googletest"]
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
+[submodule "3rdparty/cudnn-frontend"]
+	path = 3rdparty/cudnn-frontend
+	url = https://github.com/NVIDIA/cudnn-frontend.git

--- a/tests/jax/test_fmha.py
+++ b/tests/jax/test_fmha.py
@@ -1,0 +1,536 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-class-docstring
+
+from typing import Optional
+import math
+import pytest
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import nn as jax_nn
+from jax import lax
+from jax import value_and_grad, jit
+
+from transformer_engine.jax.fmha import self_fmha, cross_fmha
+
+# Type annotations
+Array = jnp.ndarray
+
+CASES = [(32, 512, 16, 64), (32, 128, 16, 64)]
+CROSS_FMHA_CASES = [(32, 128, 512, 16, 64)]
+DTYPES = [jnp.bfloat16, jnp.float16]
+
+
+def make_causal_mask(x: Array, extra_batch_dims: int = 0) -> Array:
+    idxs = jnp.broadcast_to(jnp.arange(x.shape[-1], dtype=jnp.int32), x.shape)
+    return make_attention_mask(idxs, idxs, jnp.greater_equal, extra_batch_dims=extra_batch_dims)
+
+
+def make_attention_mask(query_input, key_input, pairwise_fn=jnp.multiply, extra_batch_dims=0):
+    # [batch, len_q, len_kv]
+    mask = pairwise_fn(
+    # [batch, len_q] -> [batch, len_q, 1]
+        jnp.expand_dims(query_input, axis=-1),
+    # [batch, len_q] -> [batch, 1, len_kv]
+        jnp.expand_dims(key_input, axis=-2))
+
+    # [batch, 1, len_q, len_kv]. This creates the head dim.
+    mask = jnp.expand_dims(mask, axis=-3)
+    mask = jnp.expand_dims(mask, axis=tuple(range(extra_batch_dims)))
+    return mask
+
+
+def combine_biases(*masks):
+    masks = [m for m in masks if m is not None]
+    if not masks:
+        return None
+    assert all(map(lambda x: x.ndim == masks[0].ndim,
+                   masks)), (f'masks must have same rank: {tuple(map(lambda x: x.ndim, masks))}')
+    mask, *other_masks = masks
+    for other_mask in other_masks:
+        mask = mask + other_mask
+    return mask
+
+
+def combine_masks(*masks: Optional[Array]):
+    masks = [m for m in masks if m is not None]
+    if not masks:
+        return None
+    assert all(map(lambda x: x.ndim == masks[0].ndim,
+                   masks)), (f'masks must have same rank: {tuple(map(lambda x: x.ndim, masks))}')
+    mask, *other_masks = masks
+    for other_mask in other_masks:
+        mask = jnp.logical_and(mask, other_mask)
+    return mask
+
+
+def make_decoder_mask(decoder_target_tokens: Array,
+                      decoder_causal_attention: Optional[Array] = None,
+                      decoder_segment_ids: Optional[Array] = None) -> Array:
+    masks = []
+    # The same mask is applied to all attention heads. So the head dimension is 1,
+    # i.e., the mask will be broadcast along the heads dim.
+    # [batch, 1, length, length]
+    causal_mask = make_causal_mask(decoder_target_tokens)
+
+    # Positions with value 1 in `decoder_causal_attneition` can attend
+    # bidirectionally.
+    if decoder_causal_attention is not None:
+        # [batch, 1, length, length]
+        inputs_mask = make_attention_mask(decoder_causal_attention, decoder_causal_attention,
+                                          jnp.logical_and)
+        masks.append(jnp.logical_or(causal_mask, inputs_mask))
+    else:
+        masks.append(causal_mask)
+
+    # Padding mask.
+    masks.append(make_attention_mask(decoder_target_tokens > 0, decoder_target_tokens > 0))
+
+    # Packing mask
+    if decoder_segment_ids is not None:
+        masks.append(make_attention_mask(decoder_segment_ids, decoder_segment_ids, jnp.equal))
+
+    return combine_masks(*masks)
+
+
+def core_attention(query,
+                   key,
+                   value,
+                   bias=None,
+                   dropout_rng=None,
+                   dropout_rate=0.,
+                   deterministic=False,
+                   dtype=jnp.float32,
+                   float32_logits=True):
+
+    assert key.ndim == query.ndim == value.ndim, 'q, k, v must have same rank.'
+    batch_dim = 0
+    assert query.shape[batch_dim] == key.shape[batch_dim] == value.shape[batch_dim], (
+        'q, k, v batch dims must match.')
+    assert query.shape[-2] == key.shape[-2] == value.shape[-2], ('q, k, v num_heads must match.')
+    sequence_dim = 1
+    assert key.shape[sequence_dim] == value.shape[sequence_dim], 'k, v lengths must match.'
+    assert query.shape[-1] == key.shape[-1], 'q, k depths must match.'
+
+    # Casting logits and softmax computation for float32 for model stability.
+    if float32_logits:
+        query = query.astype(jnp.float32)
+        key = key.astype(jnp.float32)
+
+    # `attn_weights`: [batch, num_heads, q_length, kv_length]
+    attn_weights = jnp.einsum('bqhd,bkhd->bhqk', query, key)
+
+    # Apply attention bias: masking, dropout, proximity bias, etc.
+    if bias is not None:
+        attn_weights = attn_weights + bias.astype(attn_weights.dtype)
+
+    # Normalize the attention weights across `kv_length` dimension.
+    attn_weights = jax_nn.softmax(attn_weights).astype(dtype)
+
+    # Apply attention dropout.
+    if not deterministic and dropout_rate > 0.:
+        keep_prob = 1.0 - dropout_rate
+        # T5 broadcasts along the "length" dim, but unclear which one that
+        # corresponds to in positional dimensions here, assuming query dim.
+        dropout_shape = list(attn_weights.shape)
+        dropout_shape[-2] = 1
+        keep = jax.random.bernoulli(dropout_rng, keep_prob, dropout_shape)
+        keep = jnp.broadcast_to(keep, attn_weights.shape)
+        multiplier = (keep.astype(attn_weights.dtype) / jnp.asarray(keep_prob, dtype=dtype))
+        attn_weights = attn_weights * multiplier
+
+    return jnp.einsum('bhqk,bkhd->bqhd', attn_weights, value)
+
+
+def jax_self_fmha(qkv, bias, q_token, kv_token, **kwargs):
+    is_causal_masking = kwargs['is_causal_masking']
+    if is_causal_masking:
+        mask = make_decoder_mask(q_token)
+    else:
+        mask = make_attention_mask(q_token > 0, kv_token > 0)
+    attention_bias = lax.select(mask > 0,
+                                jnp.full(mask.shape, 0.).astype(qkv.dtype),
+                                jnp.full(mask.shape, -1e10).astype(qkv.dtype))
+    bias = combine_biases(bias, attention_bias)
+    query, key, value = jnp.split(qkv, [1, 2], axis=-3)
+    query = query.reshape(*query.shape[:2], *query.shape[-2:])
+    key = key.reshape(*value.shape[:2], *key.shape[-2:])
+    value = value.reshape(*value.shape[:2], *value.shape[-2:])
+    query = query * kwargs['scaling_factor']
+    output = core_attention(query,
+                            key,
+                            value,
+                            bias=bias,
+                            dropout_rate=kwargs['dropout_probability'],
+                            dtype=qkv.dtype)
+    return output
+
+
+def jax_cross_fmha(q, kv, q_token, kv_token, **kwargs):
+    is_causal_masking = kwargs['is_causal_masking']
+    if is_causal_masking:
+        raise NotImplementedError
+    mask = make_attention_mask(q_token > 0, kv_token > 0)
+    assert q.dtype == kv.dtype
+    attention_bias = lax.select(mask > 0,
+                                jnp.full(mask.shape, 0.).astype(q.dtype),
+                                jnp.full(mask.shape, -1e10).astype(q.dtype))
+    bias = attention_bias
+    query = q
+    key, value = jnp.split(kv, [1], axis=-3)
+    key = key.reshape(*value.shape[:2], *key.shape[-2:])
+    value = value.reshape(*value.shape[:2], *value.shape[-2:])
+    query = query * kwargs['scaling_factor']
+    output = core_attention(query,
+                            key,
+                            value,
+                            bias=bias,
+                            dropout_rate=kwargs['dropout_probability'],
+                            dtype=q.dtype)
+    return output
+
+
+def customcall_self_fmha(qkv, bias, q_token, kv_token, **kwargs):
+    is_causal_masking = kwargs['is_causal_masking']
+    if is_causal_masking:
+        mask = make_decoder_mask(q_token)
+    else:
+        mask = make_attention_mask(q_token > 0, kv_token > 0)
+
+    q_seqlen = jnp.sum(mask[:, :, :, 0], axis=(-1, -2), dtype=jnp.int32)
+    kv_seqlen = jnp.sum(mask[:, :, :, 0], axis=(-1, -2), dtype=jnp.int32)
+
+    return self_fmha(qkv, bias, q_seqlen, kv_seqlen, **kwargs)
+
+
+def customcall_cross_fmha(q, kv, q_token, kv_token, **kwargs):
+    is_causal_masking = kwargs['is_causal_masking']
+    if is_causal_masking:
+        raise NotImplementedError
+    mask = make_attention_mask(q_token > 0, kv_token > 0)
+
+    q_seqlen = jnp.sum(mask[:, :, :, 0], axis=(-1, -2), dtype=jnp.int32)
+    kv_seqlen = jnp.sum(mask[:, :, 0, :], axis=(-1, -2), dtype=jnp.int32)
+
+    return cross_fmha(q, kv, q_seqlen, kv_seqlen, **kwargs)
+
+
+class TestSelfFMHA():
+
+    def set_input(self, b, s, h, d, dtype, is_causal_masking, pad_len):
+        key = jax.random.PRNGKey(0)
+        subkeys = jax.random.split(key, 2)
+
+        qkv_shape = (b, s, 3, h, d)
+        bias_shape = (1, h, s, s)
+        self.valid_len = s - pad_len
+
+        min_val, max_val = -1, 1
+        self.qkv = jax.random.uniform(subkeys[0], qkv_shape, dtype, min_val, max_val)
+        self.bias = jax.random.uniform(subkeys[1], bias_shape, dtype, min_val, max_val)
+
+        self.q_token = jnp.concatenate((jnp.ones((b, self.valid_len)), jnp.zeros((b, pad_len))),
+                                       axis=-1)
+        self.kv_token = self.q_token
+
+        self.seed = 0
+        self.scaling_factor = 1. / math.sqrt(d)
+        self.dropout_probability = 0.
+        self.is_causal_masking = is_causal_masking
+
+    @pytest.mark.parametrize('b, s, h, d', CASES)
+    @pytest.mark.parametrize('is_causal_masking', [False, True])
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_forward(self, b, s, h, d, is_causal_masking, dtype):
+
+        self.set_input(b, s, h, d, is_causal_masking=is_causal_masking, dtype=dtype, pad_len=117)
+
+        reference_out = jax_self_fmha(
+            self.qkv,
+            self.bias,
+            self.q_token,
+            self.kv_token,
+            seed=self.seed,    # no used currently
+            scaling_factor=self.scaling_factor,
+            dropout_probability=self.dropout_probability,    # no used currently
+            is_causal_masking=self.is_causal_masking)
+
+        primitive_out = customcall_self_fmha(self.qkv,
+                                             self.bias,
+                                             self.q_token,
+                                             self.kv_token,
+                                             seed=self.seed,
+                                             scaling_factor=self.scaling_factor,
+                                             dropout_probability=self.dropout_probability,
+                                             is_causal_masking=self.is_causal_masking)
+
+        ref_valid, _ = jnp.split(reference_out, (self.valid_len,), axis=1)
+        pri_valid, pri_invalid = jnp.split(primitive_out, (self.valid_len,), axis=1)
+
+        np.testing.assert_allclose(jnp.asarray(pri_valid, np.float32),
+                                   jnp.asarray(ref_valid, np.float32),
+                                   rtol=1e-2,
+                                   atol=5e-4)
+
+        np.testing.assert_allclose(jnp.asarray(pri_invalid, jnp.float32),
+                                   jnp.zeros_like(pri_invalid, jnp.float32))
+
+    @pytest.mark.parametrize('b, s, h, d', CASES)
+    @pytest.mark.parametrize('is_causal_masking', [False, True])
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_forward_backward(self, b, s, h, d, is_causal_masking, dtype):
+        self.set_input(b,
+                       s,
+                       h,
+                       d,
+                       is_causal_masking=is_causal_masking,
+                       dtype=dtype,
+                       pad_len=(161 if s > 128 else 19))
+
+        def grad_func(fmha_func, *args, **kwargs):
+            # Gradient is small, use a gradient multiplier to amplify the graident
+            gradient_multiplier = 1000 if dtype == jnp.bfloat16 else 10000
+            if self.is_causal_masking:
+                gradient_multiplier = gradient_multiplier / 10
+            # Keep only valid result for the gradient
+            # fmha output has shape (b, s, h, d)
+            valid_fmha_ret, _ = jnp.split(fmha_func(*args, **kwargs), (self.valid_len,), axis=1)
+            return (jnp.mean(valid_fmha_ret, dtype=jnp.float32) * gradient_multiplier).astype(dtype)
+
+        kwargs = {
+            'seed': self.seed,
+            'scaling_factor': self.scaling_factor,
+            'dropout_probability': self.dropout_probability,
+            'is_causal_masking': self.is_causal_masking
+        }
+
+        # Use FP16/BF16 to sum the FMHA results may cause overflow, use FP32 for the summation
+        jitted_primitive = jit(
+            value_and_grad(
+                lambda qkv, bias, q_token, kv_token: grad_func(
+                    customcall_self_fmha, qkv, bias, q_token, kv_token, **kwargs), (0, 1)))
+
+        jitted_reference = jit(
+            value_and_grad(
+                lambda qkv, bias, q_token, kv_token: grad_func(jax_self_fmha, qkv.astype(
+                    jnp.float32), bias.astype(jnp.float32), q_token, kv_token, **kwargs), (0, 1)))
+
+        primitive_out, (primitive_dqkv,
+                        primitive_dbeta) = jitted_primitive(self.qkv, self.bias, self.q_token,
+                                                            self.kv_token)
+
+        reference_out, (reference_dqkv,
+                        reference_dbeta) = jitted_reference(self.qkv, self.bias, self.q_token,
+                                                            self.kv_token)
+
+        np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
+                                   jnp.asarray(reference_out, np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        valid_primitive_dqkv, invalid_primitive_dqkv = jnp.split(primitive_dqkv, (self.valid_len,),
+                                                                 axis=1)
+        valid_reference_dqkv, invalid_reference_dqkv = jnp.split(reference_dqkv, (self.valid_len,),
+                                                                 axis=1)
+
+        # dQ
+        np.testing.assert_allclose(jnp.asarray(valid_primitive_dqkv[:, :, 0], np.float32),
+                                   jnp.asarray(valid_reference_dqkv[:, :, 0], np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        # dK
+        np.testing.assert_allclose(jnp.asarray(valid_primitive_dqkv[:, :, 1], np.float32),
+                                   jnp.asarray(valid_reference_dqkv[:, :, 1], np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        # dV
+        np.testing.assert_allclose(jnp.asarray(valid_primitive_dqkv[:, :, 2], np.float32),
+                                   jnp.asarray(valid_reference_dqkv[:, :, 2], np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        assert jnp.allclose(invalid_primitive_dqkv, invalid_reference_dqkv)
+
+        # Padded part should be 0s
+        assert jnp.allclose(invalid_primitive_dqkv, jnp.zeros_like(invalid_primitive_dqkv))
+
+        # dbeta valid part
+        np.testing.assert_allclose(
+            jnp.asarray(primitive_dbeta[:, :, :self.valid_len, :self.valid_len], np.float32),
+            jnp.asarray(reference_dbeta[:, :, :self.valid_len, :self.valid_len], np.float32),
+            rtol=1e-4,
+            atol=1e-5)
+
+        # dbeta padded part
+        np.testing.assert_allclose(
+            jnp.asarray(primitive_dbeta[:, :, self.valid_len:, self.valid_len:], np.float32),
+            jnp.asarray(reference_dbeta[:, :, self.valid_len:, self.valid_len:], np.float32))
+
+        assert jnp.allclose(primitive_dbeta[:, :, self.valid_len:, self.valid_len:],
+                            jnp.zeros_like(primitive_dbeta[:, :, self.valid_len:, self.valid_len:]))
+
+
+class TestCrossFMHA():
+
+    def set_input(self, b, s_q, s_kv, h, d, dtype, is_causal_masking, pad_len):
+        key = jax.random.PRNGKey(0)
+        subkeys = jax.random.split(key, 2)
+
+        q_shape = (b, s_q, h, d)
+        kv_shape = (b, s_kv, 2, h, d)
+        assert pad_len < min(s_q, s_kv)
+        self.q_valid_len = s_q - pad_len
+        self.kv_valid_len = s_kv - pad_len
+
+        min_val, max_val = -1, 1
+        self.q = jax.random.uniform(subkeys[0], q_shape, dtype, min_val, max_val)
+        self.kv = jax.random.uniform(subkeys[1], kv_shape, dtype, min_val, max_val)
+
+        self.q_token = jnp.concatenate((jnp.ones((b, self.q_valid_len)), jnp.zeros((b, pad_len))),
+                                       axis=-1)
+        self.kv_token = jnp.concatenate((jnp.ones((b, self.kv_valid_len)), jnp.zeros((b, pad_len))),
+                                        axis=-1)
+        self.seed = 0
+        self.scaling_factor = 1. / math.sqrt(d)
+        self.dropout_probability = 0.
+        self.is_causal_masking = is_causal_masking
+
+    @pytest.mark.parametrize('b, s_q, s_kv, h, d', CROSS_FMHA_CASES)
+    @pytest.mark.parametrize('is_causal_masking', [False])
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_forward(self, b, s_q, s_kv, h, d, is_causal_masking, dtype):
+
+        self.set_input(b,
+                       s_q,
+                       s_kv,
+                       h,
+                       d,
+                       is_causal_masking=is_causal_masking,
+                       dtype=dtype,
+                       pad_len=63)
+
+        reference_out = jax_cross_fmha(
+            self.q,
+            self.kv,
+            self.q_token,
+            self.kv_token,
+            seed=self.seed,    # no used currently
+            scaling_factor=self.scaling_factor,
+            dropout_probability=self.dropout_probability,    # no used currently
+            is_causal_masking=self.is_causal_masking)
+
+        primitive_out = customcall_cross_fmha(self.q,
+                                              self.kv,
+                                              self.q_token,
+                                              self.kv_token,
+                                              seed=self.seed,
+                                              scaling_factor=self.scaling_factor,
+                                              dropout_probability=self.dropout_probability,
+                                              is_causal_masking=self.is_causal_masking)
+
+        ref_valid, _ = jnp.split(reference_out, (self.q_valid_len,), axis=1)
+        pri_valid, pri_invalid = jnp.split(primitive_out, (self.q_valid_len,), axis=1)
+
+        np.testing.assert_allclose(jnp.asarray(pri_valid, np.float32),
+                                   jnp.asarray(ref_valid, np.float32),
+                                   rtol=1e-2,
+                                   atol=5e-4)
+
+        np.testing.assert_allclose(jnp.asarray(pri_invalid, jnp.float32),
+                                   jnp.zeros_like(pri_invalid, jnp.float32))
+
+    @pytest.mark.parametrize('b, s_q, s_kv, h, d', CROSS_FMHA_CASES)
+    @pytest.mark.parametrize('is_causal_masking', [False])
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_forward_backward(self, b, s_q, s_kv, h, d, is_causal_masking, dtype):
+        self.set_input(b,
+                       s_q,
+                       s_kv,
+                       h,
+                       d,
+                       is_causal_masking=is_causal_masking,
+                       dtype=dtype,
+                       pad_len=19)
+
+        def grad_func(fmha_func, *args, **kwargs):
+            # Gradient is small, use a gradient multiplier to amplify the graident
+            gradient_multiplier = 10000
+            if self.is_causal_masking:
+                gradient_multiplier = gradient_multiplier / 10
+            # Keep only valid result for the gradient
+            # fmha output has shape (b, s_q, h, d)
+            valid_fmha_ret, _ = jnp.split(fmha_func(*args, **kwargs), (self.q_valid_len,), axis=1)
+            return (jnp.mean(valid_fmha_ret, dtype=jnp.float32) * gradient_multiplier).astype(dtype)
+
+        kwargs = {
+            'seed': self.seed,
+            'scaling_factor': self.scaling_factor,
+            'dropout_probability': self.dropout_probability,
+            'is_causal_masking': self.is_causal_masking
+        }
+
+        # Use FP16/BF16 to sum the FMHA results may cause overflow, use FP32 for the summation
+        jitted_primitive = jit(
+            value_and_grad(
+                lambda q, kv, q_token, kv_token: grad_func(customcall_cross_fmha, q, kv, q_token,
+                                                           kv_token, **kwargs), (0, 1)))
+
+        jitted_reference = jit(
+            value_and_grad(
+                lambda q, kv, q_token, kv_token: grad_func(jax_cross_fmha, q.astype(
+                    jnp.float32), kv.astype(jnp.float32), q_token, kv_token, **kwargs), (0, 1)))
+
+        primitive_out, (primitive_dq,
+                        primitive_dkv) = jitted_primitive(self.q, self.kv, self.q_token,
+                                                          self.kv_token)
+
+        reference_out, (reference_dq,
+                        reference_dkv) = jitted_reference(self.q, self.kv, self.q_token,
+                                                          self.kv_token)
+
+        np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
+                                   jnp.asarray(reference_out, np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        valid_primitive_dq, invalid_primitive_dq = jnp.split(primitive_dq, (self.q_valid_len,),
+                                                             axis=1)
+        valid_reference_dq, invalid_reference_dq = jnp.split(reference_dq, (self.q_valid_len,),
+                                                             axis=1)
+
+        valid_primitive_dkv, invalid_primitive_dkv = jnp.split(primitive_dkv, (self.kv_valid_len,),
+                                                               axis=1)
+        valid_reference_dkv, invalid_reference_dkv = jnp.split(reference_dkv, (self.kv_valid_len,),
+                                                               axis=1)
+
+        # dQ
+        np.testing.assert_allclose(jnp.asarray(valid_primitive_dq, np.float32),
+                                   jnp.asarray(valid_reference_dq, np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        # dK
+        np.testing.assert_allclose(jnp.asarray(valid_primitive_dkv[:, :, 0], np.float32),
+                                   jnp.asarray(valid_reference_dkv[:, :, 0], np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        # dV
+        np.testing.assert_allclose(jnp.asarray(valid_primitive_dkv[:, :, 1], np.float32),
+                                   jnp.asarray(valid_reference_dkv[:, :, 1], np.float32),
+                                   rtol=1e-4,
+                                   atol=1e-5)
+
+        assert jnp.allclose(invalid_primitive_dq, invalid_reference_dq)
+        assert jnp.allclose(invalid_primitive_dkv, invalid_reference_dkv)
+
+        # Padded part should be 0s
+        assert jnp.allclose(invalid_primitive_dq, jnp.zeros_like(invalid_primitive_dq))
+        assert jnp.allclose(invalid_primitive_dkv, jnp.zeros_like(invalid_primitive_dkv))

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -67,6 +67,7 @@ _KEY_OF_MLP_ACTIVATIONS = "mlp_activations"
 _KEY_OF_FUSE_MLP_WI = "fuse_mlp_wi"
 _KEY_OF_LAYERNORM_TYPE = 'layernorm_type'
 _KEY_OF_TRANSPOSE_BS = 'transpose_batch_sequence'
+_KEY_OF_SCALE_ATTN_LOGITS = "scale_attn_logits"
 
 BASE_ATTRS = {_KEY_OF_TRANSPOSE_BS: True}
 
@@ -97,6 +98,7 @@ ATTRS = [{
     _KEY_OF_FUSE_MLP_WI: True
 }, {
     _KEY_OF_TRANSPOSE_BS: False,
+    _KEY_OF_SCALE_ATTN_LOGITS: True,
     _KEY_OF_LAYERNORM_TYPE: 'rmsnorm',
     _KEY_OF_DROPOUT_RATE: 0.0,
     _KEY_OF_MLP_ACTIVATIONS: (('gelu', 'linear')),

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -17,11 +17,12 @@ add_library(transformer_engine SHARED
                                rmsnorm/rmsnorm_fwd_cuda_kernel.cu
                                util/cast.cu
                                fused_softmax/scaled_masked_softmax.cu
-                               fused_softmax/scaled_upper_triang_masked_softmax.cu)
+                               fused_softmax/scaled_upper_triang_masked_softmax.cu
+                               fused_mha/cudnn_fmha.cu)
 
 target_include_directories(transformer_engine PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-list(APPEND transformer_engine_LINKER_LIBS CUDA::cublas CUDA::cudart CUDA::nvToolsExt)
+list(APPEND transformer_engine_LINKER_LIBS CUDA::cublas CUDA::cudart CUDA::nvToolsExt cudnn)
 target_link_libraries(transformer_engine PUBLIC ${transformer_engine_LINKER_LIBS})
 
 target_include_directories(transformer_engine PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
@@ -30,5 +31,10 @@ set_source_files_properties(fused_softmax/scaled_masked_softmax.cu
                             fused_softmax/scaled_upper_triang_masked_softmax.cu
                             PROPERTIES
                             COMPILE_OPTIONS "--use_fast_math")
+
+set_source_files_properties(fused_mha/cudnn_fmha.cu
+                            PROPERTIES
+                            INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/../3rdparty/cudnn-frontend/include")
+
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -32,9 +32,17 @@ set_source_files_properties(fused_softmax/scaled_masked_softmax.cu
                             PROPERTIES
                             COMPILE_OPTIONS "--use_fast_math")
 
+include(FetchContent)
+FetchContent_Declare(
+    cudnn-frontend
+    GIT_REPOSITORY https://github.com/NVIDIA/cudnn-frontend.git
+    GIT_TAG        8f488bd41229aa0a3d5f7c0168f59e4d69c618ee # release v0.8
+)
+FetchContent_Populate(cudnn-frontend)
+
 set_source_files_properties(fused_mha/cudnn_fmha.cu
                             PROPERTIES
-                            INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/../3rdparty/cudnn-frontend/include")
+                            INCLUDE_DIRECTORIES "${cudnn-frontend_SOURCE_DIR}/include")
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")

--- a/transformer_engine/common/fused_mha/cudnn_fmha.cu
+++ b/transformer_engine/common/fused_mha/cudnn_fmha.cu
@@ -1,0 +1,1698 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include "transformer_engine/fmha.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "cudnn_frontend.h"
+
+#define CUDNN_FRONTEND_UNUSED(X) ((void)X)
+
+#define FatalError(s)                                                 \
+  {                                                                   \
+    std::stringstream _where, _message;                               \
+    _where << __FILE__ << ':' << __LINE__;                            \
+    _message << std::string(s) + "\n" << __FILE__ << ':' << __LINE__; \
+    std::cerr << _message.str() << "\nAborting...\n";                 \
+    cudaDeviceReset();                                                \
+    exit(EXIT_FAILURE);                                               \
+  }
+
+#define checkCudaErr(...)                                              \
+  do {                                                                 \
+    int64_t err =                                                      \
+        checkCudaError(__VA_ARGS__, #__VA_ARGS__, __FILE__, __LINE__); \
+    assert(err == 0);                                                  \
+  } while (0)
+
+#define checkCudnnErr(...)                                              \
+  do {                                                                  \
+    int64_t err =                                                       \
+        checkCudnnError(__VA_ARGS__, #__VA_ARGS__, __FILE__, __LINE__); \
+    assert(err == 0);                                                   \
+  } while (0)
+
+#define checkCudaErrors(status)                                        \
+  {                                                                    \
+    std::stringstream _error;                                          \
+    if (status != 0) {                                                 \
+      _error << "Cuda failure\nError: " << cudaGetErrorString(status); \
+      FatalError(_error.str());                                        \
+    }                                                                  \
+  }
+
+#define checkCublasErrors(status)                        \
+  {                                                      \
+    std::stringstream _error;                            \
+    if (status != 0) {                                   \
+      _error << "Cublas failure\nError code " << status; \
+      FatalError(_error.str());                          \
+    }                                                    \
+  }
+
+namespace transformer_engine {
+namespace fmha {
+int64_t checkCudaError(cudaError_t code, const char *expr, const char *file,
+                       int line) {
+  if (code) {
+    printf("CUDA error at %s:%d, code=%d (%s) in '%s'", file, line, static_cast<int>(code),
+           cudaGetErrorString(code), expr);
+    return 1;
+  }
+  return 0;
+}
+
+int64_t checkCudnnError(cudnnStatus_t code, const char *expr, const char *file,
+                        int line) {
+  if (code) {
+    printf("CUDNN error at %s:%d, code=%d (%s) in '%s'\n", file, line,
+           static_cast<int>(code), cudnnGetErrorString(code), expr);
+    return 1;
+  }
+  return 0;
+}
+
+// Used for MHA
+void generateMHAStrides(int64_t b, int64_t h, int64_t s_q, int64_t s_kv,
+                        int64_t d, int64_t *strideA, MHA_Layout layout,
+                        MHA_Matrix matrix) {
+  CUDNN_FRONTEND_UNUSED(b);
+  constexpr int batch_dim_idx = 0;
+  constexpr int head_dim_idx = 1;
+  constexpr int seqlen_dim_idx = 2;
+  constexpr int hidden_dim_idx = 3;
+
+  constexpr int seqlen_transpose_dim_idx = 3;
+  constexpr int hidden_transpose_dim_idx = 2;
+
+  constexpr int seqlen_q_dim_idx = 2;
+  constexpr int seqlen_kv_dim_idx = 3;
+
+  switch (matrix) {
+    case MHA_Matrix::Q_Matrix:
+      if (layout == MHA_Layout::QKV_INTERLEAVED) {
+        strideA[hidden_dim_idx] = 1;
+        strideA[seqlen_dim_idx] = 3 * h * d;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_q * 3 * h * d;
+      } else {
+        strideA[hidden_dim_idx] = 1;
+        strideA[seqlen_dim_idx] = h * d;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_q * h * d;
+      }
+      break;
+    case MHA_Matrix::K_Matrix:
+      if (layout == MHA_Layout::QKV_INTERLEAVED) {
+        strideA[seqlen_transpose_dim_idx] = 3 * h * d;
+        strideA[hidden_transpose_dim_idx] = 1;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_kv * 3 * h * d;
+      } else if (layout == MHA_Layout::KV_INTERLEAVED) {
+        strideA[seqlen_transpose_dim_idx] = 2 * h * d;
+        strideA[hidden_transpose_dim_idx] = 1;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_kv * 2 * h * d;
+      } else {
+        strideA[seqlen_transpose_dim_idx] = h * d;
+        strideA[hidden_transpose_dim_idx] = 1;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_kv * h * d;
+      }
+      break;
+    case MHA_Matrix::V_Matrix:
+      if (layout == MHA_Layout::QKV_INTERLEAVED) {
+        strideA[hidden_dim_idx] = 1;
+        strideA[seqlen_dim_idx] = 3 * h * d;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_kv * 3 * h * d;
+      } else if (layout == MHA_Layout::KV_INTERLEAVED) {
+        strideA[hidden_dim_idx] = 1;
+        strideA[seqlen_dim_idx] = 2 * h * d;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_kv * 2 * h * d;
+      } else {
+        strideA[hidden_dim_idx] = 1;
+        strideA[seqlen_dim_idx] = h * d;
+        strideA[head_dim_idx] = d;
+        strideA[batch_dim_idx] = s_kv * h * d;
+      }
+      break;
+    case MHA_Matrix::S_Matrix:
+      strideA[seqlen_kv_dim_idx] = 1;
+      strideA[seqlen_q_dim_idx] = s_kv;
+      strideA[head_dim_idx] = s_q * s_kv;
+      strideA[batch_dim_idx] = h * s_q * s_kv;
+      break;
+    case MHA_Matrix::O_Matrix:
+      strideA[seqlen_kv_dim_idx] = 1;
+      strideA[seqlen_q_dim_idx] = h * d;
+      strideA[head_dim_idx] = d;
+      strideA[batch_dim_idx] = s_q * h * d;
+      break;
+  }
+}
+
+#define Q_ID 1
+#define K_ID 2
+#define V_ID 3
+#define O_ID 4
+#define S_ID 5
+#define B_ID 6
+#define D_CONST_ID 7
+#define S_CONST_ID 8
+#define Q_SEQLEN_ID 9
+#define K_SEQLEN_ID 10
+#define dQ_ID 11
+#define dK_ID 12
+#define dV_ID 13
+#define dO_ID 14
+#define MASK_VAL_ID 15
+#define dS_ID 16
+
+#define VIRTUAL_ID 20
+
+static bool allowAllConfig(cudnnBackendDescriptor_t engine_config) {
+  (void)engine_config;
+  return false;
+}
+
+static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id,
+                                            int64_t const *dim,
+                                            int64_t const *stride,
+                                            bool is_virtual, bool is_value) {
+  int nbDims = 4;
+  auto tensor_created =
+      cudnn_frontend::TensorBuilder()
+          .setDim(nbDims, dim)
+          .setStride(nbDims, stride)
+          .setId(id)
+          .setAlignment(
+              16)  // 16B alignment is needed to run a tensor core engine
+          .setDataType(type)
+          .setVirtual(is_virtual)
+          .setByValue(is_value)
+          .build();
+  // std::cout << tensor_created.describe() << std::endl;
+  return tensor_created;
+}
+
+static cudnn_frontend::PointWiseDesc pw_desc_create(cudnnDataType_t type,
+                                                    cudnnPointwiseMode_t mode) {
+  auto pw_desc_created = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(mode)
+                             .setComputeType(type)
+                             .build();
+
+  // std::cout << pw_desc_created.describe() << std::endl;
+  return pw_desc_created;
+}
+
+static cudnn_frontend::Operation unary_pw_op_create(
+    cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &yDesc,
+    cudnn_frontend::PointWiseDesc const &pwDesc) {
+  auto pw_op_created = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(xDesc)
+                           .setyDesc(yDesc)
+                           .setpwDesc(pwDesc)
+                           .build();
+  // std::cout << pw_op_created.describe() << std::endl;
+  return pw_op_created;
+}
+
+static cudnn_frontend::Operation binary_pw_op_create(
+    cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc,
+    cudnn_frontend::Tensor const &yDesc,
+    cudnn_frontend::PointWiseDesc const &pwDesc) {
+  auto pw_op_created = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(xDesc)
+                           .setbDesc(bDesc)
+                           .setyDesc(yDesc)
+                           .setpwDesc(pwDesc)
+                           .build();
+  // std::cout << pw_op_created.describe() << std::endl;
+  return pw_op_created;
+}
+
+static cudnn_frontend::Operation ternary_pw_op_create(
+    cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc,
+    cudnn_frontend::Tensor const &tDesc, cudnn_frontend::Tensor const &yDesc,
+    cudnn_frontend::PointWiseDesc const &pwDesc) {
+  auto pw_op_created = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(xDesc)
+                           .setbDesc(bDesc)
+                           .settDesc(tDesc)
+                           .setyDesc(yDesc)
+                           .setpwDesc(pwDesc)
+                           .build();
+  // std::cout << pw_op_created.describe() << std::endl;
+  return pw_op_created;
+}
+
+#if (CUDNN_VERSION >= 8700)
+void run_b2b_batch_gemm(int64_t *q_dim, int64_t *k_dim, int64_t *s_dim,
+                        int64_t *v_dim, int64_t *o_dim, void *devPtrQ,
+                        void *devPtrK, void *devPtrV, void *devPtrO,
+                        cudnnDataType_t tensorType, int32_t nbDims,
+                        int64_t *q_stride, int64_t *k_stride, int64_t *s_stride,
+                        int64_t *v_stride, int64_t *o_stride) {
+  cudnnHandle_t handle_;
+  CUDNN_FRONTEND_UNUSED(nbDims);
+  try {
+    // Create cudnn handle
+    checkCudnnErr(cudnnCreate(&handle_));
+
+    // Creates the necessary tensor descriptors
+    auto qTensor =
+        tensor_create(tensorType, 'q', q_dim, q_stride, false, false);
+    auto kTensor =
+        tensor_create(tensorType, 'k', k_dim, k_stride, false, false);
+
+    // first GEMM output
+    auto sTensor = tensor_create(tensorType, 's', s_dim, s_stride, true,
+                                 false);  // is virtual
+    auto vTensor =
+        tensor_create(tensorType, 'v', v_dim, v_stride, false, false);
+
+    // second GEMM output
+    auto oTensor =
+        tensor_create(tensorType, 'o', o_dim, o_stride, false, false);
+
+    // Define the matmul 1 desc
+    auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder()
+                             .setComputeType(CUDNN_DATA_FLOAT)
+                             .build();
+    // std::cout << matmul_1_Desc.describe() << std::endl;
+
+    // Create a matmul 1 Node
+    auto matmul_1_op = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                           .setaMatDesc(qTensor)
+                           .setbMatDesc(kTensor)
+                           .setcMatDesc(sTensor)
+                           .setmatmulDesc(matmul_1_Desc)
+                           .build();
+    // std::cout << matmul_1_op.describe() << std::endl;
+
+    // Define the matmul 2 desc
+    auto matmul_2_Desc = cudnn_frontend::MatMulDescBuilder()
+                             .setComputeType(CUDNN_DATA_FLOAT)
+                             .build();
+    // std::cout << matmul_2_Desc.describe() << std::endl;
+
+    // Create a matmul 2 Node
+    auto matmul_2_op = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                           .setaMatDesc(sTensor)
+                           .setbMatDesc(vTensor)
+                           .setcMatDesc(oTensor)
+                           .setmatmulDesc(matmul_2_Desc)
+                           .build();
+    std::cout << matmul_2_op.describe() << std::endl;
+
+    // Create an Operation Graph. In this case it is gemm-gemm
+    std::array<cudnn_frontend::Operation const *, 2> ops = {&matmul_1_op,
+                                                            &matmul_2_op};
+    auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                       .setHandle(handle_)
+                       .setOperationGraph(ops.size(), ops.data())
+                       .build();
+
+    cudnn_frontend::EngineConfigList filtered_configs;
+    auto statuses = cudnn_frontend::get_heuristics_list<1>(
+        {"heuristics_instant"}, opGraph, allowAllConfig, filtered_configs,
+        true);
+
+    if (filtered_configs.size() == 0) {
+      cudnn_frontend::set_error_and_throw_exception(
+          nullptr, CUDNN_STATUS_NOT_SUPPORTED,
+          "run_b2b_batch_gemm: No config returned by the heuristics");
+    }
+
+    auto plan = cudnn_frontend::ExecutionPlanBuilder()
+                    .setHandle(handle_)
+                    .setEngineConfig(filtered_configs[0], opGraph.getTag())
+                    .build();
+
+    // std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+    auto workspace_size = plan.getWorkspaceSize();
+    // std::cout << plan.describe() << " requires workspace " << workspace_size
+    //           << std::endl;
+
+    void *workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+      checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+    }
+    void *data_ptrs[] = {devPtrQ, devPtrK, devPtrV, devPtrO};
+    int64_t uids[] = {'q', 'k', 'v', 'o'};
+    auto variantPack = cudnn_frontend::VariantPackBuilder()
+                           .setWorkspacePointer(workspace_ptr)
+                           .setDataPointers(4, data_ptrs)
+                           .setUids(4, uids)
+                           .build();
+    // std::cout << "variantPack " << variantPack.describe() << std::endl;
+    cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(),
+                                               variantPack.get_raw_desc());
+    if (workspace_size > 0) {
+      checkCudaErr(cudaFree(workspace_ptr));
+    }
+
+    checkCudnnErr(cudnnDestroy(handle_));
+
+    cudnn_frontend::throw_if(
+        [status]() { return (status != CUDNN_STATUS_SUCCESS); },
+        "Plan execute error", status);
+  } catch (cudnn_frontend::cudnnException &e) {
+    struct cudaDeviceProp prop;
+    checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+
+    // this example is only for GA100 cards and GH100 cards
+    if (!((prop.major == 8 && prop.minor == 0) ||
+          (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8800)) &&
+        (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH ||
+         e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+      std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and "
+                   "GH100 (cuDNN >= 8800) GPUs"
+                << std::endl;
+    } else {
+      std::cout << "[ERROR] Exception " << e.what() << std::endl;
+      // CHECK(false);
+    }
+  }
+}
+
+static void createScale(int64_t b, int64_t h, int64_t s_q, int64_t s_kv,
+                        int64_t d, MHA_Layout layout,
+                        cudnnDataType_t tensorType,
+                        // NOLINTNEXTLINE(runtime/references)
+                        std::vector<cudnn_frontend::Operation> &ops) {
+  // scale
+  int64_t scale_dim[4] = {1, 1, 1, 1};
+  int64_t scale_stride[4] = {1, 1, 1, 1};
+
+  int64_t k_dim[4] = {b, h, d, s_kv};
+  int64_t k_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout,
+                     MHA_Matrix::K_Matrix);
+
+  auto scaleTensor = tensor_create(tensorType, S_CONST_ID, scale_dim,
+                                   scale_stride, false, true);  // is by value
+  auto kTensor = tensor_create(tensorType, K_ID, k_dim, k_stride, false, false);
+  auto afterScaleKTensor = tensor_create(tensorType, VIRTUAL_ID, k_dim,
+                                         k_stride, true, false);  // is virtual
+
+  // Define the scale descriptor
+  auto scaleDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+  // Create a Scale Node.
+  auto scale_op =
+      binary_pw_op_create(kTensor, scaleTensor, afterScaleKTensor, scaleDesc);
+
+  ops.push_back(std::move(scale_op));
+}
+
+static cudnn_frontend::Tensor createBMM1(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+    MHA_Layout layout, cudnnDataType_t tensorType,
+    // NOLINTNEXTLINE(runtime/references)
+    std::vector<cudnn_frontend::Operation> &ops) {
+  // Creates the necessary tensor descriptors
+  int64_t q_dim[4] = {b, h, s_q, d};
+  int64_t q_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, q_stride, layout,
+                     MHA_Matrix::Q_Matrix);
+
+  int64_t k_dim[4] = {b, h, d, s_kv};
+  int64_t k_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout,
+                     MHA_Matrix::K_Matrix);
+
+  int64_t p_dim[4] = {b, h, s_q, s_kv};
+  int64_t p_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, p_stride, layout,
+                     MHA_Matrix::S_Matrix);
+
+  int64_t seqlen_dim[4] = {b, 1, 1, 1};
+  int64_t seqlen_stride[4] = {1, 1, 1, 1};
+
+  auto qTensor = tensor_create(tensorType, Q_ID, q_dim, q_stride, false, false);
+  auto afterScaleKTensor = tensor_create(tensorType, VIRTUAL_ID, k_dim,
+                                         k_stride, true, false);  // is virtual
+  // first GEMM output
+  auto pTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 1, p_dim,
+                               p_stride, true, false);  // is virtual
+
+  auto seqlenQTensor = tensor_create(CUDNN_DATA_INT32, Q_SEQLEN_ID, seqlen_dim,
+                                     seqlen_stride, false, false);
+  auto seqlenKTensor = tensor_create(CUDNN_DATA_INT32, K_SEQLEN_ID, seqlen_dim,
+                                     seqlen_stride, false, false);
+
+  // Define the matmul 1 desc
+  auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder()
+                           .setComputeType(CUDNN_DATA_FLOAT)
+                           .build();
+  // std::cout << matmul_1_Desc.describe() << std::endl;
+
+  // Create a matmul 1 Node
+  auto matmul_op1 = cudnn_frontend::OperationBuilder(
+                        CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                        .setaMatDesc(qTensor)
+                        .setbMatDesc(afterScaleKTensor)
+                        .setcMatDesc(pTensor)
+                        .setmOverrideDesc(seqlenQTensor)
+                        .setnOverrideDesc(seqlenKTensor)
+                        .setmatmulDesc(matmul_1_Desc)
+                        .build();
+
+  // std::cout << matmul_op1.describe() << std::endl;
+
+  ops.push_back(std::move(matmul_op1));
+
+  return pTensor;
+}
+
+static cudnn_frontend::Tensor createBias(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+    MHA_Layout layout, cudnnDataType_t tensorType,
+    // NOLINTNEXTLINE(runtime/references)
+    std::vector<cudnn_frontend::Operation> &ops,
+    cudnn_frontend::Tensor const &prevBlockOutputTensor) {
+  cudnn_frontend::throw_if(ops.size() == 0,
+                           "Bias op constructed incorrectly as the first one",
+                           CUDNN_STATUS_BAD_PARAM);
+
+  int64_t b_dim[4] = {1, h, s_q, s_kv};
+  int64_t b_stride[4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+  int64_t afterBias_dim[4] = {b, h, s_q, s_kv};
+  int64_t afterBias_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, afterBias_stride, layout,
+                     MHA_Matrix::S_Matrix);
+
+  // bias
+  auto bTensor = tensor_create(tensorType, B_ID, b_dim, b_stride, false, false);
+  // output
+  auto afterBiasTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 50, afterBias_dim,
+                    afterBias_stride, true, false);  // is virtual
+
+  // Define the bias descriptor
+  auto biasDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_ADD);
+
+  // Create a Bias Node.
+  auto bias_op = binary_pw_op_create(prevBlockOutputTensor, bTensor,
+                                     afterBiasTensor, biasDesc);
+
+  ops.push_back(std::move(bias_op));
+
+  return afterBiasTensor;
+}
+
+static cudnn_frontend::Tensor createMask(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+    MHA_Layout layout, bool is_causal_masking, cudnnDataType_t tensorType,
+    // NOLINTNEXTLINE(runtime/references)
+    std::vector<cudnn_frontend::Operation> &ops,
+    cudnn_frontend::Tensor const &prevBlockOutputTensor,
+    bool is_bprop) {
+  CUDNN_FRONTEND_UNUSED(d);
+  CUDNN_FRONTEND_UNUSED(layout);
+  CUDNN_FRONTEND_UNUSED(tensorType);
+  CUDNN_FRONTEND_UNUSED(is_bprop);
+
+  cudnn_frontend::throw_if(
+      ops.size() == 0, "Padding Mask constructed incorrectly as the first one",
+      CUDNN_STATUS_BAD_PARAM);
+
+  // subtraction output
+  int64_t afterBMM1_dim[4] = {b, h, s_q, s_kv};
+  int64_t afterBMM1_stride[4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+  int64_t seqlen_dim[4] = {b, 1, 1, 1};
+  int64_t seqlen_stride[4] = {1, 1, 1, 1};
+
+  int64_t maskVal_dim[4] = {1, 1, 1, 1};
+  int64_t maskVal_stride[4] = {1, 1, 1, 1};
+
+  // mask value to put in the masked pixels
+  auto maskValTensor =
+      tensor_create(CUDNN_DATA_FLOAT, MASK_VAL_ID, maskVal_dim, maskVal_stride,
+                    false, true);  // is by value
+
+  auto seqlenQTensor = tensor_create(CUDNN_DATA_INT32, Q_SEQLEN_ID, seqlen_dim,
+                                     seqlen_stride, false, false);
+  auto seqlenKTensor = tensor_create(CUDNN_DATA_INT32, K_SEQLEN_ID, seqlen_dim,
+                                     seqlen_stride, false, false);
+  // gen index row output
+  auto rowIndexTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 100, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+  // gen index column output
+  auto columnIndexTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 101, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+  // less than row output
+  auto lessThanRowTensor =
+      tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 102, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+                                                     // less than column output
+  auto lessThanColTensor =
+      tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 103, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+  // padding mask (lessthanRow && lessthanCol)
+  auto paddingMaskTensor =
+      tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 104, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+  // row >= col check for causal mask
+  auto rowGreaterColTensor =
+      tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 105, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+  // create causal mask (padding && row >= col)
+  auto causalMaskTensor =
+      tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 106, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+
+  // output after masking
+  int64_t maskOutputTensor_id = VIRTUAL_ID + 107;
+  int64_t maskOutputTensor_virtual = true;
+  cudnnDataType_t maskOutputTensor_dataType = CUDNN_DATA_FLOAT;
+  auto maskOutputTensor_reorderType =
+    cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_NONE;
+
+  if (is_bprop) {
+    maskOutputTensor_id = dS_ID;
+    maskOutputTensor_virtual = false;
+    maskOutputTensor_dataType = tensorType;
+    maskOutputTensor_reorderType =
+      cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16;
+  }
+
+  auto maskOutputTensor =
+      cudnn_frontend::TensorBuilder()
+          .setDim(4, afterBMM1_dim)
+          .setStride(4, afterBMM1_stride)
+          .setAlignment(
+              16)  // 16B alignment is needed to run a tensor core engine
+          .setByValue(false)
+          .setDataType(maskOutputTensor_dataType)
+          .setVirtual(maskOutputTensor_virtual)
+          .setId(maskOutputTensor_id)
+          .setReorderType(maskOutputTensor_reorderType)
+          .build();
+
+  // Define the gen index for row descriptor
+  auto genIndexRowDesc = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                             .setAxis(2)
+                             .setComputeType(CUDNN_DATA_FLOAT)
+                             .build();
+  // std::cout << genIndexRowDesc.describe() << std::endl;
+
+  // Create a gen index Node.
+  auto genIndexRow_op = unary_pw_op_create(prevBlockOutputTensor,
+                                           rowIndexTensor, genIndexRowDesc);
+  // std::cout << genIndexRow_op.describe() << std::endl;
+
+  // Define the gen index for row descriptor
+  auto genIndexColumnDesc = cudnn_frontend::PointWiseDescBuilder()
+                                .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                                .setAxis(3)
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .build();
+  // std::cout << genIndexColumnDesc.describe() << std::endl;
+
+  // Create a gen index Node.
+  auto genIndexColumn_op = unary_pw_op_create(
+      prevBlockOutputTensor, columnIndexTensor, genIndexColumnDesc);
+
+  // Define the less than comparison for row descriptor
+  auto lessThanRowDesc =
+      pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_CMP_LT);
+
+  // Create a less than comparison for row Node.
+  auto lessThanRow_op = binary_pw_op_create(rowIndexTensor, seqlenQTensor,
+                                            lessThanRowTensor, lessThanRowDesc);
+
+  // Define the less than comparison for column descriptor
+  auto lessThanColDesc =
+      pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_CMP_LT);
+
+  // Create a less than comparison for col Node.
+  auto lessThanCol_op = binary_pw_op_create(columnIndexTensor, seqlenKTensor,
+                                            lessThanColTensor, lessThanColDesc);
+
+  // Define the less than comparison for column descriptor
+  auto paddingMaskAndDesc =
+      pw_desc_create(CUDNN_DATA_BOOLEAN, CUDNN_POINTWISE_LOGICAL_AND);
+
+  // Create a and node for combining lessThanRow and lessThanCol
+  auto paddingMaskAnd_op =
+      binary_pw_op_create(lessThanRowTensor, lessThanColTensor,
+                          paddingMaskTensor, paddingMaskAndDesc);
+
+  // Define the greater than equal to comparison descriptor
+  auto rowGreaterColDesc =
+      pw_desc_create(CUDNN_DATA_BOOLEAN, CUDNN_POINTWISE_CMP_GE);
+
+  // Create a greater than equal to Node.
+  auto rowGreaterCol_op =
+      binary_pw_op_create(rowIndexTensor, columnIndexTensor,
+                          rowGreaterColTensor, rowGreaterColDesc);
+
+  // Define the and to create causal mask descriptor
+  auto causalMaskAndDesc =
+      pw_desc_create(CUDNN_DATA_BOOLEAN, CUDNN_POINTWISE_LOGICAL_AND);
+
+  // Create a causal Mask Node.
+  auto causalMaskAnd_op =
+      binary_pw_op_create(paddingMaskTensor, rowGreaterColTensor,
+                          causalMaskTensor, causalMaskAndDesc);
+
+  /////////////////// Apply the mask //////////////////////////
+
+  auto maskTensor = (is_causal_masking) ? std::move(causalMaskTensor)
+                                        : std::move(paddingMaskTensor);
+
+  // Define the binary select to perform masking descriptor
+  auto maskDesc =
+      pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_BINARY_SELECT);
+
+  // Create a binary select Node.
+  auto mask_op = ternary_pw_op_create(prevBlockOutputTensor, maskValTensor,
+                                      maskTensor, maskOutputTensor, maskDesc);
+
+  ops.push_back(std::move(genIndexRow_op));
+  ops.push_back(std::move(genIndexColumn_op));
+  ops.push_back(std::move(lessThanRow_op));
+  ops.push_back(std::move(lessThanCol_op));
+  ops.push_back(std::move(paddingMaskAnd_op));
+  if (is_causal_masking) ops.push_back(std::move(rowGreaterCol_op));
+  if (is_causal_masking) ops.push_back(std::move(causalMaskAnd_op));
+  ops.push_back(std::move(mask_op));
+
+  return maskOutputTensor;
+}
+
+static cudnn_frontend::Tensor createSoftmaxForward(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+    MHA_Layout layout, bool enable_dropout, bool softmax_output_virtual,
+    cudnnDataType_t tensorType,
+    // NOLINTNEXTLINE(runtime/references)
+    std::vector<cudnn_frontend::Operation> &ops,
+    cudnn_frontend::Tensor const &prevBlockOutputTensor) {
+  CUDNN_FRONTEND_UNUSED(d);
+  CUDNN_FRONTEND_UNUSED(layout);
+
+  int64_t afterBMM1_dim[4] = {b, h, s_q, s_kv};
+  int64_t afterBMM1_stride[4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+  int64_t afterReduction_dim[4] = {b, h, s_q, 1};
+  int64_t afterReduction_stride[4] = {h * s_q, s_q, 1, 1};
+
+  cudnnDataType_t softmaxOutputType = (enable_dropout || softmax_output_virtual)
+                                          ? CUDNN_DATA_FLOAT
+                                          : tensorType;
+  uint64_t softmaxOutputName = softmax_output_virtual ? VIRTUAL_ID + 154 : S_ID;
+
+  // max (x)
+  auto afterMaxReductionTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 150, afterReduction_dim,
+                    afterReduction_stride, true, false);  // is virtual
+  // x - max(x)
+  auto afterSubtractionTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 151, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+  // e^(x - max(x))
+  auto afterExponentTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 152, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual;
+  // sum (e^(x - max(x)))
+  auto afterAddReductionTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 153, afterReduction_dim,
+                    afterReduction_stride, true, false);  // is virtual
+  // divide (e/ sum(e))
+
+  auto reorder_type =
+    cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16;
+
+  auto afterDivisionTensor =
+      cudnn_frontend::TensorBuilder()
+          .setDim(4, afterBMM1_dim)
+          .setStride(4, afterBMM1_stride)
+          .setId(softmaxOutputName)
+          .setAlignment(
+              16)  // 16B alignment is needed to run a tensor core engine
+          .setDataType(softmaxOutputType)
+          .setVirtual(softmax_output_virtual)
+          .setByValue(false)
+          .setReorderType(reorder_type)
+          .build();
+
+  // Define the reduction descriptor
+  auto reductionMaxDesc = cudnn_frontend::ReductionDescBuilder()
+                              .setComputeType(CUDNN_DATA_FLOAT)
+                              .setReductionOp(CUDNN_REDUCE_TENSOR_MAX)
+                              .build();
+  // std::cout << reductionMaxDesc.describe() << std::endl;
+
+  // Create a reduction max Node.
+  auto reductionMax_op = cudnn_frontend::OperationBuilder(
+                             CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                             .setxDesc(prevBlockOutputTensor)
+                             .setyDesc(afterMaxReductionTensor)
+                             .setreductionDesc(reductionMaxDesc)
+                             .build();
+  // std::cout << reductionMax_op.describe() << std::endl;
+
+  // Define the subtract descriptor
+  auto subtractDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+
+  // Create a subtract Node.
+  auto subtract_op =
+      binary_pw_op_create(prevBlockOutputTensor, afterMaxReductionTensor,
+                          afterSubtractionTensor, subtractDesc);
+
+  // Define the exponent descriptor
+  auto exponentDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_EXP);
+
+  // Create a exponent Node.
+  auto exponent_op = unary_pw_op_create(afterSubtractionTensor,
+                                        afterExponentTensor, exponentDesc);
+
+  // Define the reduction descriptor
+  auto reductionAddDesc = cudnn_frontend::ReductionDescBuilder()
+                              .setComputeType(CUDNN_DATA_FLOAT)
+                              .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                              .build();
+  // std::cout << reductionAddDesc.describe() << std::endl;
+
+  // Create a reduction add Node.
+  auto reductionAdd_op = cudnn_frontend::OperationBuilder(
+                             CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                             .setxDesc(afterExponentTensor)
+                             .setyDesc(afterAddReductionTensor)
+                             .setreductionDesc(reductionAddDesc)
+                             .build();
+
+  // std::cout << reductionAdd_op.describe() << std::endl;
+
+  // Define the division descriptor
+  auto divisionDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_DIV);
+
+  // Create a subtract Node.
+  auto division_op =
+      binary_pw_op_create(afterExponentTensor, afterAddReductionTensor,
+                          afterDivisionTensor, divisionDesc);
+
+  ops.push_back(std::move(reductionMax_op));
+  ops.push_back(std::move(subtract_op));
+  ops.push_back(std::move(exponent_op));
+  ops.push_back(std::move(reductionAdd_op));
+  ops.push_back(std::move(division_op));
+
+  return afterDivisionTensor;
+}
+
+static cudnn_frontend::Tensor createDropout(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d, int64_t seed,
+    double probability, cudnnDataType_t tensorType,
+    // NOLINTNEXTLINE(runtime/references)
+    std::vector<cudnn_frontend::Operation> &ops,
+    cudnn_frontend::Tensor const &prevBlockOutputTensor) {
+  CUDNN_FRONTEND_UNUSED(d);
+
+  cudnn_frontend::throw_if(
+      ops.size() == 0, "Dropout DAG constructed incorrectly as the first one",
+      CUDNN_STATUS_BAD_PARAM);
+
+  int64_t afterBMM1_dim[4] = {b, h, s_q, s_kv};
+  int64_t afterBMM1_stride[4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+  int64_t scale_dim[4] = {1, 1, 1, 1};
+  int64_t scale_stride[4] = {1, 1, 1, 1};
+
+  // mask for the dropout
+  auto dropoutMaskTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 200, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+
+  auto reorder_type =
+    cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16;
+
+  // after dropout tensor
+  auto afterDropoutTensor =
+      cudnn_frontend::TensorBuilder()
+          .setDim(4, afterBMM1_dim)
+          .setStride(4, afterBMM1_stride)
+          .setId(S_ID)
+          .setAlignment(
+              16)  // 16B alignment is needed to run a tensor core engine
+          .setDataType(tensorType)
+          .setVirtual(false)
+          .setByValue(false)
+          .setReorderType(reorder_type)
+          .build();
+  // scale after dropout
+  auto scaleDropoutTensor =
+      tensor_create(tensorType, D_CONST_ID, scale_dim, scale_stride, false,
+                    true);  // is by value
+  // after Scale
+  auto afterScaleTensor =
+      tensor_create(tensorType, VIRTUAL_ID + 201, afterBMM1_dim,
+                    afterBMM1_stride, true, false);  // is virtual
+
+  // Define the reduction descriptor
+  auto rngDesc = cudnn_frontend::RngDescBuilder()
+                     .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
+                     .setBernoulliDistProbability(1.0 - probability)
+                     .build();
+  // std::cout << rngDesc.describe() << std::endl;
+
+  // Create a rng Node.
+  auto rng_op =
+      cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
+          .setyDesc(dropoutMaskTensor)
+          .setSeed(seed)
+          .setRngDesc(rngDesc)
+          .build();
+
+  // std::cout << rng_op.describe() << std::endl;
+
+  // Define the multiply mask descriptor
+  auto maskMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+  // Create a multiply mask Node.
+  auto maskMul_op =
+      binary_pw_op_create(prevBlockOutputTensor, dropoutMaskTensor,
+                          afterDropoutTensor, maskMulDesc);
+
+  // Define the multiply scale descriptor
+  auto scaleMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+  // Create a multiply mask Node.
+  auto scaleMul_op = binary_pw_op_create(afterDropoutTensor, scaleDropoutTensor,
+                                         afterScaleTensor, scaleMulDesc);
+
+  ops.push_back(std::move(rng_op));
+  ops.push_back(std::move(maskMul_op));
+  ops.push_back(std::move(scaleMul_op));
+
+  return afterScaleTensor;
+}
+
+static void createBMM2(int64_t b, int64_t h, int64_t s_q, int64_t s_kv,
+                       int64_t d, MHA_Layout layout, cudnnDataType_t tensorType,
+                       // NOLINTNEXTLINE(runtime/references)
+                       std::vector<cudnn_frontend::Operation> &ops,
+                       cudnn_frontend::Tensor const &prevBlockOutputTensor) {
+  cudnn_frontend::throw_if(ops.size() == 0,
+                           "BMM2 op constructed incorrectly as the first one",
+                           CUDNN_STATUS_BAD_PARAM);
+
+  int64_t seqlen_dim[4] = {b, 1, 1, 1};
+  int64_t seqlen_stride[4] = {1, 1, 1, 1};
+
+  int64_t v_dim[4] = {b, h, s_kv, d};
+  int64_t v_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, v_stride, layout,
+                     MHA_Matrix::V_Matrix);
+
+  int64_t o_dim[4] = {b, h, s_q, d};
+  int64_t o_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout,
+                     MHA_Matrix::O_Matrix);
+
+  auto seqlenQTensor = tensor_create(CUDNN_DATA_INT32, Q_SEQLEN_ID, seqlen_dim,
+                                     seqlen_stride, false, false);
+  auto seqlenKTensor = tensor_create(CUDNN_DATA_INT32, K_SEQLEN_ID, seqlen_dim,
+                                     seqlen_stride, false, false);
+  auto vTensor = tensor_create(tensorType, V_ID, v_dim, v_stride, false, false);
+  // second GEMM output
+  auto oTensor = tensor_create(tensorType, O_ID, o_dim, o_stride, false, false);
+
+  // Define the matmul 2 desc
+  auto matmul_2_Desc = cudnn_frontend::MatMulDescBuilder()
+                           .setComputeType(CUDNN_DATA_FLOAT)
+                           .build();
+  // std::cout << matmul_2_Desc.describe() << std::endl;
+
+  // Create a matmul 2 Node
+  auto matmul_op2 = cudnn_frontend::OperationBuilder(
+                        CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                        .setaMatDesc(prevBlockOutputTensor)
+                        .setbMatDesc(vTensor)
+                        .setcMatDesc(oTensor)
+                        .setmOverrideDesc(seqlenQTensor)
+                        .setkOverrideDesc(seqlenKTensor)
+                        .setmatmulDesc(matmul_2_Desc)
+                        .build();
+
+  // std::cout << matmul_op2.describe() << std::endl;
+
+  ops.push_back(std::move(matmul_op2));
+}
+
+static cudnn_frontend::Tensor createSoftmaxBackward(
+    int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+    MHA_Layout layout, cudnnDataType_t tensorType,
+    // NOLINTNEXTLINE(runtime/references)
+    std::vector<cudnn_frontend::Operation> &ops,
+    cudnn_frontend::Tensor const &yTensor,
+    cudnn_frontend::Tensor const &dyTensor) {
+  CUDNN_FRONTEND_UNUSED(tensorType);
+
+  cudnn_frontend::throw_if(
+      ops.size() == 0,
+      "Softmax backward constructed incorrectly as the first one",
+      CUDNN_STATUS_BAD_PARAM);
+
+  int64_t p_dim[4] = {b, h, s_q, s_kv};
+  int64_t p_stride[4];
+  generateMHAStrides(b, h, s_q, s_kv, d, p_stride, layout,
+                     MHA_Matrix::S_Matrix);
+
+  int64_t p_reduction_dim[4] = {b, h, s_q, 1};
+  int64_t p_reduction_stride[4];
+
+  p_reduction_stride[3] = 1;
+  p_reduction_stride[2] = 1;
+  p_reduction_stride[1] = s_q;
+  p_reduction_stride[0] = s_q * h;
+
+  int64_t const_dim[4] = {1, 1, 1, 1};
+  int64_t const_stride[4] = {1, 1, 1, 1};
+
+  // creating all tensors
+  auto softmaxScaleTensor = tensor_create(CUDNN_DATA_FLOAT, S_CONST_ID,
+                                          const_dim, const_stride, false, true);
+  auto dyMulYTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 250, p_dim,
+                                    p_stride, true, false);
+  auto dxAfterReductionTensor =
+      tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 251, p_reduction_dim,
+                    p_reduction_stride, true, false);
+  auto dxAfterSubtractionTensor = tensor_create(
+      CUDNN_DATA_FLOAT, VIRTUAL_ID + 252, p_dim, p_stride, true, false);
+  auto dxUnscaleTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 253,
+                                       p_dim, p_stride, true, false);
+  auto dxTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 254, p_dim,
+                                p_stride, true, false);
+
+  // creating all ops
+  // mul (y * dy)
+  auto mul_1_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+  auto mul_1_op =
+      binary_pw_op_create(yTensor, dyTensor, dyMulYTensor, mul_1_desc);
+
+  // reduction add sum (y * dy)
+  auto reductionAddDesc = cudnn_frontend::ReductionDescBuilder()
+                              .setComputeType(CUDNN_DATA_FLOAT)
+                              .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                              .build();
+  // std::cout << reductionAddDesc.describe() << std::endl;
+
+  auto reductionAdd_op = cudnn_frontend::OperationBuilder(
+                             CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                             .setxDesc(dyMulYTensor)
+                             .setyDesc(dxAfterReductionTensor)
+                             .setreductionDesc(reductionAddDesc)
+                             .build();
+
+  // std::cout << reductionAdd_op.describe() << std::endl;
+
+  // subtraction (dy - sum(y * dy))
+  auto sub_0_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+  auto sub_0_op = binary_pw_op_create(dyTensor, dxAfterReductionTensor,
+                                      dxAfterSubtractionTensor, sub_0_desc);
+
+  // mul (y * (dy - sum(y * dy)))
+  auto mul_2_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+  auto mul_2_op = binary_pw_op_create(yTensor, dxAfterSubtractionTensor,
+                                      dxUnscaleTensor, mul_2_desc);
+
+  // mul (scale * dx)
+  auto mul_3_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+  auto mul_3_op = binary_pw_op_create(dxUnscaleTensor, softmaxScaleTensor,
+                                      dxTensor, mul_3_desc);
+
+  ops.push_back(std::move(mul_1_op));
+  ops.push_back(std::move(reductionAdd_op));
+  ops.push_back(std::move(sub_0_op));
+  ops.push_back(std::move(mul_2_op));
+  ops.push_back(std::move(mul_3_op));
+
+  return dxTensor;
+}
+
+struct FMHADescriptor {
+  std::int64_t b;
+  std::int64_t h;
+  std::int64_t s_q;
+  std::int64_t s_kv;
+  std::int64_t d;
+  std::int64_t seed;
+  float scaling_factor;
+  float dropout_probability;
+  bool is_causal_masking;
+  MHA_Layout layout;
+  MHA_Bias_Type bias_type;
+  cudnnDataType_t tensor_type;
+
+  bool operator<(const FMHADescriptor &rhs) const {
+    return std::tie(b, h, s_q, s_kv, d, seed, scaling_factor,
+                    dropout_probability, is_causal_masking, layout, bias_type,
+                    tensor_type) < std::tie(rhs.b, rhs.h, rhs.s_q, rhs.s_kv,
+                                            rhs.d, rhs.seed, rhs.scaling_factor,
+                                            rhs.dropout_probability,
+                                            rhs.is_causal_masking, rhs.layout,
+                                            rhs.bias_type, rhs.tensor_type);
+  }
+};
+}  // namespace fmha
+}  // namespace transformer_engine
+
+using namespace transformer_engine::fmha;
+
+void nvte_fmha_fwd(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+                   int64_t seed, MHA_Layout layout, float scaling_factor,
+                   double dropout_probability, MHA_Bias_Type bias_type,
+                   bool is_causal_masking, void *devPtrQ, void *devPtrK,
+                   void *devPtrV, void *devPtrS, void *devPtrO,
+                   void *devPtrBias, void *devActualSeqlenQ,
+                   void *devActualSeqlenK, cudnnDataType_t tensorType,
+                   cudaStream_t stream, cudnnHandle_t handle_) {
+  // cudnnHandle_t handle_;
+  try {
+    // Create cudnn handle
+    // checkCudnnErr(cudnnCreate(&handle_));
+    checkCudnnErr(cudnnSetStream(handle_, stream));
+
+    FMHADescriptor descriptor{b,
+                              h,
+                              s_q,
+                              s_kv,
+                              d,
+                              seed,
+                              scaling_factor,
+                              static_cast<float>(dropout_probability),
+                              is_causal_masking,
+                              layout,
+                              bias_type,
+                              tensorType};
+
+    using CacheType = std::map<FMHADescriptor, cudnn_frontend::ExecutionPlan>;
+    static CacheType fmha_fprop_cache;
+
+    bool enable_dropout = (dropout_probability != 0.0f);
+
+    // Get plan from cache if cache is available, otherwise create one
+    auto get_plan = [&](CacheType &cache, const FMHADescriptor &descriptor) {
+      // if hit, return
+      auto it = cache.find(descriptor);
+      if (it != cache.end()) {
+        auto plan = it->second;
+        return plan;
+      }
+
+      // otherwise, build the op_graph and the plan. Then update cache
+      std::vector<cudnn_frontend::Operation const *> all_ops;
+      std::vector<cudnn_frontend::Operation> ops;
+
+      createScale(b, h, s_q, s_kv, d, layout, tensorType, ops);
+
+      auto bmm1_output =
+          createBMM1(b, h, s_q, s_kv, d, layout, tensorType, ops);
+
+      if (bias_type != MHA_Bias_Type::NO_BIAS) {
+        createBias(b, h, s_q, s_kv, d, layout, tensorType, ops, bmm1_output);
+      }
+
+      auto mask_output =
+          createMask(b, h, s_q, s_kv, d, layout, is_causal_masking, tensorType,
+                     ops, bmm1_output, false);
+
+      cudnn_frontend::throw_if(dropout_probability == 1.0f,
+                               "Dropout probability cannot be 1.0",
+                               CUDNN_STATUS_BAD_PARAM);
+
+      bool softmax_output_virtual = enable_dropout || devPtrS == nullptr;
+      auto softmax_output = createSoftmaxForward(
+          b, h, s_q, s_kv, d, layout, enable_dropout, softmax_output_virtual,
+          tensorType, ops, mask_output);
+
+      if (dropout_probability != 0.0f) {
+        auto dropout_output =
+            createDropout(b, h, s_q, s_kv, d, seed, dropout_probability,
+                          tensorType, ops, softmax_output);
+        createBMM2(b, h, s_q, s_kv, d, layout, tensorType, ops, dropout_output);
+      } else {
+        createBMM2(b, h, s_q, s_kv, d, layout, tensorType, ops, softmax_output);
+      }
+
+      for (unsigned int i = 0; i < ops.size(); i++) {
+        all_ops.push_back(&ops[i]);
+      }
+      // std::cout << "Total ops created: " << ops.size() << std::endl;
+
+      // Create an Operation Graph
+      auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                         .setHandle(handle_)
+                         .setOperationGraph(all_ops.size(), all_ops.data())
+                         .build();
+
+      cudnn_frontend::EngineConfigList filtered_configs;
+      auto statuses = cudnn_frontend::get_heuristics_list<1>(
+          {"heuristics_instant"}, opGraph, allowAllConfig, filtered_configs,
+          true);
+
+      if (filtered_configs.size() == 0) {
+        cudnn_frontend::set_error_and_throw_exception(
+            nullptr, CUDNN_STATUS_NOT_SUPPORTED,
+            "run_mha_fprop: No config returned by the heuristics");
+      }
+      auto plan = cudnn_frontend::ExecutionPlanBuilder()
+                      .setHandle(handle_)
+                      .setEngineConfig(filtered_configs[0], opGraph.getTag())
+                      .build();
+      cache.insert({descriptor, plan});
+      return plan;
+    };
+
+    auto plan = get_plan(fmha_fprop_cache, descriptor);
+    // std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+    auto workspace_size = plan.getWorkspaceSize();
+    // std::cout << plan.describe() << " requires workspace " << workspace_size
+    //           << std::endl;
+
+    void *workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+      checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+    }
+
+    std::set<std::pair<uint64_t, void *>> data_ptrs;
+    // change this if you have access to float_min
+    float negInfinity = -1.0E+10;
+    float scale_dropout = 1 / (1 - dropout_probability);
+
+    // add all the data pointers to be used in the variant pack
+    data_ptrs.insert(std::pair<uint64_t, void *>(Q_ID, devPtrQ));
+    data_ptrs.insert(std::pair<uint64_t, void *>(K_ID, devPtrK));
+    data_ptrs.insert(std::pair<uint64_t, void *>(V_ID, devPtrV));
+    data_ptrs.insert(
+        std::pair<uint64_t, void *>(Q_SEQLEN_ID, devActualSeqlenQ));
+    data_ptrs.insert(
+        std::pair<uint64_t, void *>(K_SEQLEN_ID, devActualSeqlenK));
+    data_ptrs.insert(std::pair<uint64_t, void *>(MASK_VAL_ID, &negInfinity));
+
+    if (tensorType == CUDNN_DATA_FLOAT) {
+      data_ptrs.insert(
+          std::pair<uint64_t, void *>(S_CONST_ID, &scaling_factor));
+    } else if (tensorType == CUDNN_DATA_HALF) {
+      __half cast_scaling_factor{scaling_factor};
+      data_ptrs.insert(
+          std::pair<uint64_t, void *>(S_CONST_ID, &cast_scaling_factor));
+    } else if (tensorType == CUDNN_DATA_BFLOAT16) {
+      __nv_bfloat16 cast_scaling_factor{scaling_factor};
+      data_ptrs.insert(
+          std::pair<uint64_t, void *>(S_CONST_ID, &cast_scaling_factor));
+    } else {
+      std::cerr << "Not supported tensorType." << std::endl;
+    }
+
+    data_ptrs.insert(std::pair<uint64_t, void *>(O_ID, devPtrO));
+
+    if (bias_type != MHA_Bias_Type::NO_BIAS) {
+      data_ptrs.insert(std::pair<uint64_t, void *>(B_ID, devPtrBias));
+    }
+
+    if (devPtrS != nullptr) {
+      data_ptrs.insert(std::pair<uint64_t, void *>(S_ID, devPtrS));
+    }
+
+    if (enable_dropout) {
+      data_ptrs.insert(std::pair<uint64_t, void *>(D_CONST_ID, &scale_dropout));
+    }
+
+    auto variantPack = cudnn_frontend::VariantPackBuilder()
+                           .setWorkspacePointer(workspace_ptr)
+                           .setDataPointers(data_ptrs)
+                           .build();
+    // std::cout << "variantPack " << variantPack.describe() << std::endl;
+    cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(),
+                                               variantPack.get_raw_desc());
+    if (workspace_size > 0) {
+      checkCudaErr(cudaFree(workspace_ptr));
+    }
+
+    // checkCudnnErr(cudnnDestroy(handle_));
+
+    cudnn_frontend::throw_if(
+        [status]() { return (status != CUDNN_STATUS_SUCCESS); },
+        "Plan execute error", status);
+  } catch (cudnn_frontend::cudnnException &e) {
+    struct cudaDeviceProp prop;
+    checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+
+    // this example is only for GA100 cards (cudnn Version >= 8700) and GH100
+    // cards (cudnn Version >= 8800)
+    if (!((prop.major == 8 && prop.minor == 0) ||
+          (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8800)) &&
+        (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH ||
+         e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+      std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and "
+                   "GH100 (cuDNN >= 8800) GPUs"
+                << std::endl;
+    } else {
+      std::cout << "[ERROR] Exception " << e.what() << std::endl;
+      // CHECK(false);
+    }
+  }
+}
+
+void nvte_fmha_bwd(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+                   MHA_Layout layout, float scaling_factor,
+                   float dropout_probability, bool is_causal_masking,
+                   void *devPtrQ, void *devPtrK, void *devPtrV, void *devPtrS,
+                   void *devPtrdQ, void *devPtrdK, void *devPtrdV,
+                   void *devPtrdO, void *devPtrdS, void *devActualSeqlenQ,
+                   void *devActualSeqlenK, cudnnDataType_t tensorType,
+                   cudaStream_t stream, cudnnHandle_t handle_) {
+  // cudnnHandle_t handle_;
+  try {
+    // Create cudnn handle
+    // checkCudnnErr(cudnnCreate(&handle_));
+    checkCudnnErr(cudnnSetStream(handle_, stream));
+
+    FMHADescriptor descriptor{b,
+                              h,
+                              s_q,
+                              s_kv,
+                              d,
+                              0,
+                              scaling_factor,
+                              static_cast<float>(dropout_probability),
+                              is_causal_masking,
+                              layout,
+                              MHA_Bias_Type::NO_BIAS,
+                              tensorType};
+
+    using CacheType = std::map<FMHADescriptor, cudnn_frontend::ExecutionPlan>;
+    static CacheType fmha_bprop_cache;
+
+    auto get_plan = [&](CacheType &cache, const FMHADescriptor &descriptor) {
+      auto it = cache.find(descriptor);
+      if (it != cache.end()) {
+        return it->second;
+      }
+
+      std::vector<cudnn_frontend::Operation const *> all_ops;
+      std::vector<cudnn_frontend::Operation> ops;
+
+      // Creates the necessary tensor descriptors
+      int64_t q_dim[4] = {b, h, s_q, d};
+      int64_t q_stride[4];
+      generateMHAStrides(b, h, s_q, s_kv, d, q_stride, layout,
+                         MHA_Matrix::Q_Matrix);
+
+      int64_t k_dim[4] = {b, h, s_kv, d};
+      int64_t k_stride[4];
+      generateMHAStrides(
+          b, h, s_q, s_kv, d, k_stride, layout,
+          MHA_Matrix::V_Matrix);  // type is correct as K is not transposed
+
+      int64_t v_dim[4] = {b, h, d, s_kv};
+      int64_t v_stride[4];
+      generateMHAStrides(
+          b, h, s_q, s_kv, d, v_stride, layout,
+          MHA_Matrix::K_Matrix);  // type is correct as V is transposed
+
+      int64_t p_dim[4] = {b, h, s_q, s_kv};
+      int64_t p_stride[4];
+      generateMHAStrides(b, h, s_q, s_kv, d, p_stride, layout,
+                         MHA_Matrix::S_Matrix);
+
+      int64_t p_transpose_dim[4] = {b, h, s_kv, s_q};
+      int64_t p_transpose_stride[4];
+      p_transpose_stride[0] = p_stride[0];
+      p_transpose_stride[1] = p_stride[1];
+      p_transpose_stride[2] = p_stride[3];
+      p_transpose_stride[3] = p_stride[2];
+
+      int64_t o_dim[4] = {b, h, s_q, d};
+      int64_t o_stride[4];
+      generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout,
+                         MHA_Matrix::O_Matrix);
+
+      int64_t seqlen_dim[4] = {b, 1, 1, 1};
+      int64_t seqlen_stride[4] = {1, 1, 1, 1};
+
+      int64_t scale_dim[4] = {1, 1, 1, 1};
+      int64_t scale_stride[4] = {1, 1, 1, 1};
+
+      // inputs to fprop
+      auto qTensor =
+          tensor_create(tensorType, Q_ID, q_dim, q_stride, false, false);
+      auto kTensor =
+          tensor_create(tensorType, K_ID, k_dim, k_stride, false, false);
+      auto vTensor =
+          tensor_create(tensorType, V_ID, v_dim, v_stride, false, false);
+      auto seqlenQTensor =
+          tensor_create(CUDNN_DATA_INT32, Q_SEQLEN_ID, seqlen_dim,
+                        seqlen_stride, false, false);
+      auto seqlenKTensor =
+          tensor_create(CUDNN_DATA_INT32, K_SEQLEN_ID, seqlen_dim,
+                        seqlen_stride, false, false);
+
+      // gradient of the output
+      auto doTensor =
+          tensor_create(tensorType, dO_ID, o_dim, o_stride, false, false);
+
+      auto reorder_type =
+        cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16;
+
+      // activation from fprop
+      auto pTensor =
+          cudnn_frontend::TensorBuilder()
+              .setDim(4, p_dim)
+              .setStride(4, p_stride)
+              .setId(S_ID)
+              .setAlignment(
+                  16)  // 16B alignment is needed to run a tensor core engine
+              .setDataType(tensorType)
+              .setVirtual(false)
+              .setByValue(false)
+              .setReorderType(reorder_type)
+              .build();
+
+      // outputs from bprop
+      auto dqTensor =
+          tensor_create(tensorType, dQ_ID, q_dim, q_stride, false, false);
+      auto dkTensor =
+          tensor_create(tensorType, dK_ID, k_dim, k_stride, false, false);
+      auto dvTensor =
+          tensor_create(tensorType, dV_ID, k_dim, k_stride, false,
+                        false);  // not transposed therefore k_dim and k_stride
+
+      ////////////////////////////////////////////////////////
+      // start creating the ops and the intermediate tensors
+      auto pReshapeTensor =
+          tensor_create(tensorType, VIRTUAL_ID + 300, p_transpose_dim,
+                        p_transpose_stride, true, false);
+
+      // reshape to perform transpose and make pReshape
+      auto reshape_op = cudnn_frontend::OperationBuilder(
+                            CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                            .setxDesc(pTensor)
+                            .setyDesc(pReshapeTensor)
+                            .build();
+
+      // std::cout << reshape_op.describe() << std::endl;
+      ops.push_back(std::move(reshape_op));
+
+      // scale dropout
+      auto dropoutScaleTensor =
+          tensor_create(CUDNN_DATA_FLOAT, D_CONST_ID, scale_dim, scale_stride,
+                        false, true);  // is by value
+      auto pAfterScaleTensor =
+          tensor_create(tensorType, VIRTUAL_ID + 301, p_transpose_dim,
+                        p_transpose_stride, true, false);
+
+      auto scaleMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+      auto scaleMul_op = binary_pw_op_create(pReshapeTensor, dropoutScaleTensor,
+                                             pAfterScaleTensor, scaleMulDesc);
+      ops.push_back(std::move(scaleMul_op));
+
+      // perform absolute operation to remove the mask bit
+      auto pTransposeAfterAbsTensor =
+          tensor_create(tensorType, VIRTUAL_ID + 302, p_transpose_dim,
+                        p_transpose_stride, true, false);
+
+      auto absDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_ABS);
+      auto abs_op = unary_pw_op_create(pAfterScaleTensor,
+                                       pTransposeAfterAbsTensor, absDesc);
+      ops.push_back(std::move(abs_op));
+
+      // matmul to calculate dvTensor
+      auto matmul_0_Desc = cudnn_frontend::MatMulDescBuilder()
+                               .setComputeType(CUDNN_DATA_FLOAT)
+                               .build();
+      // std::cout << matmul_0_Desc.describe() << std::endl;
+
+      auto matmul_op0 = cudnn_frontend::OperationBuilder(
+                            CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(pTransposeAfterAbsTensor)
+                            .setbMatDesc(doTensor)
+                            .setcMatDesc(dvTensor)
+                            .setmOverrideDesc(seqlenKTensor)
+                            .setkOverrideDesc(seqlenQTensor)
+                            .setmatmulDesc(matmul_0_Desc)
+                            .build();
+
+      // std::cout << matmul_op0.describe() << std::endl;
+
+      ops.push_back(std::move(matmul_op0));
+
+      // matmul to calculate dpTensor
+      auto dpTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 303, p_dim,
+                                    p_stride, true, false);
+
+      auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder()
+                               .setComputeType(CUDNN_DATA_FLOAT)
+                               .build();
+      // std::cout << matmul_1_Desc.describe() << std::endl;
+
+      auto matmul_op1 = cudnn_frontend::OperationBuilder(
+                            CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(doTensor)
+                            .setbMatDesc(vTensor)
+                            .setcMatDesc(dpTensor)
+                            .setmOverrideDesc(seqlenQTensor)
+                            .setnOverrideDesc(seqlenKTensor)
+                            .setmatmulDesc(matmul_1_Desc)
+                            .build();
+
+      // std::cout << matmul_op1.describe() << std::endl;
+
+      ops.push_back(std::move(matmul_op1));
+
+      // mask the values which were dropped in dropout
+      auto pAbsTensor = tensor_create(tensorType, VIRTUAL_ID + 304, p_dim,
+                                      p_stride, true, false);
+
+      auto p_absDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_ABS);
+      auto p_abs_op = unary_pw_op_create(pTensor, pAbsTensor, p_absDesc);
+      ops.push_back(std::move(p_abs_op));
+
+      // create the dropout mask
+      auto zeroTensor =
+          tensor_create(CUDNN_DATA_FLOAT, MASK_VAL_ID, scale_dim, scale_stride,
+                        false, true);  // is by value
+      auto dropoutMaskTensor = tensor_create(
+          CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 305, p_dim, p_stride, true, false);
+
+      auto greater_than_0_desc =
+          pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_CMP_GT);
+      auto greater_than_0_op = binary_pw_op_create(
+          pTensor, zeroTensor, dropoutMaskTensor, greater_than_0_desc);
+      ops.push_back(std::move(greater_than_0_op));
+
+      // scale for the dropout
+      auto dpAfterScaleTensor = tensor_create(
+          CUDNN_DATA_FLOAT, VIRTUAL_ID + 306, p_dim, p_stride, true, false);
+
+      auto mul_0_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+      auto mul_0_op = binary_pw_op_create(dpTensor, dropoutScaleTensor,
+                                          dpAfterScaleTensor, mul_0_desc);
+      ops.push_back(std::move(mul_0_op));
+
+      // drop the values based on the dropout mask
+      auto dpAfterDropoutTensor = tensor_create(
+          CUDNN_DATA_FLOAT, VIRTUAL_ID + 307, p_dim, p_stride, true, false);
+
+      auto selection_0_desc =
+          pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_BINARY_SELECT);
+      auto selection_0_op = ternary_pw_op_create(
+          dpAfterScaleTensor, zeroTensor, dropoutMaskTensor,
+          dpAfterDropoutTensor, selection_0_desc);
+      ops.push_back(std::move(selection_0_op));
+
+      // softmax backward
+      auto dsTensor =
+          createSoftmaxBackward(b, h, s_q, s_kv, d, layout, tensorType, ops,
+                                pAbsTensor, dpAfterDropoutTensor);
+
+      // mask
+      auto dsAfterMaskTensor =
+          createMask(b, h, s_q, s_kv, d, layout, is_causal_masking, tensorType,
+                     ops, dsTensor, true);
+
+      // matmul to calculate dqTensor
+      auto matmul_2_Desc = cudnn_frontend::MatMulDescBuilder()
+                               .setComputeType(CUDNN_DATA_FLOAT)
+                               .build();
+      // std::cout << matmul_2_Desc.describe() << std::endl;
+
+      auto matmul_op2 = cudnn_frontend::OperationBuilder(
+                            CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(dsAfterMaskTensor)
+                            .setbMatDesc(kTensor)
+                            .setcMatDesc(dqTensor)
+                            .setmOverrideDesc(seqlenQTensor)
+                            .setkOverrideDesc(seqlenKTensor)
+                            .setmatmulDesc(matmul_2_Desc)
+                            .build();
+
+      // std::cout << matmul_op2.describe() << std::endl;
+
+      ops.push_back(std::move(matmul_op2));
+
+      // reshape for transpose of ds
+      auto dsAfterMaskReshapeTensor =
+          tensor_create(tensorType, VIRTUAL_ID + 308, p_transpose_dim,
+                        p_transpose_stride, true, false);
+
+      auto reshape_2_op = cudnn_frontend::OperationBuilder(
+                              CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                              .setxDesc(dsAfterMaskTensor)
+                              .setyDesc(dsAfterMaskReshapeTensor)
+                              .build();
+
+      // std::cout << reshape_2_op.describe() << std::endl;
+      ops.push_back(std::move(reshape_2_op));
+
+      // matmul to calculate dkTensor
+      auto matmul_3_Desc = cudnn_frontend::MatMulDescBuilder()
+                               .setComputeType(CUDNN_DATA_FLOAT)
+                               .build();
+      // std::cout << matmul_3_Desc.describe() << std::endl;
+
+      auto matmul_op3 = cudnn_frontend::OperationBuilder(
+                            CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(dsAfterMaskReshapeTensor)
+                            .setbMatDesc(qTensor)
+                            .setcMatDesc(dkTensor)
+                            .setmOverrideDesc(seqlenKTensor)
+                            .setkOverrideDesc(seqlenQTensor)
+                            .setmatmulDesc(matmul_3_Desc)
+                            .build();
+
+      // std::cout << matmul_op3.describe() << std::endl;
+
+      ops.push_back(std::move(matmul_op3));
+
+      /////////////////////////////////////////////////////////////////
+
+      // std::cout << "Total ops created: " << ops.size() << std::endl;
+
+      for (unsigned int i = 0; i < ops.size(); i++) {
+        all_ops.push_back(&ops[i]);
+      }
+
+      // Create an Operation Graph
+      auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                         .setHandle(handle_)
+                         .setOperationGraph(all_ops.size(), all_ops.data())
+                         .build();
+
+      cudnn_frontend::EngineConfigList filtered_configs;
+      auto statuses = cudnn_frontend::get_heuristics_list<1>(
+          {"heuristics_instant"}, opGraph, allowAllConfig, filtered_configs,
+          true);
+
+      if (filtered_configs.size() == 0) {
+        cudnn_frontend::set_error_and_throw_exception(
+            nullptr, CUDNN_STATUS_NOT_SUPPORTED,
+            "run_mha_bprop: No config returned by the heuristics");
+      }
+
+      auto plan = cudnn_frontend::ExecutionPlanBuilder()
+                      .setHandle(handle_)
+                      .setEngineConfig(filtered_configs[0], opGraph.getTag())
+                      .build();
+      cache.insert({descriptor, plan});
+      return plan;
+    };
+
+    auto plan = get_plan(fmha_bprop_cache, descriptor);
+    // std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+    auto workspace_size = plan.getWorkspaceSize();
+    // std::cout << plan.describe() << " requires workspace " << workspace_size
+    //           << std::endl;
+
+    void *workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+      checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+    }
+
+    std::set<std::pair<uint64_t, void *>> data_ptrs;
+    // add all the data pointers to be used in the variant pack
+    data_ptrs.insert(std::pair<uint64_t, void *>(dQ_ID, devPtrdQ));
+    data_ptrs.insert(std::pair<uint64_t, void *>(dK_ID, devPtrdK));
+    data_ptrs.insert(std::pair<uint64_t, void *>(dV_ID, devPtrdV));
+
+    data_ptrs.insert(std::pair<uint64_t, void *>(Q_ID, devPtrQ));
+    data_ptrs.insert(std::pair<uint64_t, void *>(K_ID, devPtrK));
+    data_ptrs.insert(std::pair<uint64_t, void *>(V_ID, devPtrV));
+    data_ptrs.insert(std::pair<uint64_t, void *>(S_ID, devPtrS));
+    data_ptrs.insert(std::pair<uint64_t, void *>(dO_ID, devPtrdO));
+    data_ptrs.insert(std::pair<uint64_t, void *>(dS_ID, devPtrdS));
+    data_ptrs.insert(
+        std::pair<uint64_t, void *>(Q_SEQLEN_ID, devActualSeqlenQ));
+    data_ptrs.insert(
+        std::pair<uint64_t, void *>(K_SEQLEN_ID, devActualSeqlenK));
+
+    float zeroVal = 0.0f;
+    float dropoutScale = 1.0f / (1.0f - dropout_probability);
+
+    data_ptrs.insert(std::pair<uint64_t, void *>(D_CONST_ID, &dropoutScale));
+    data_ptrs.insert(std::pair<uint64_t, void *>(S_CONST_ID, &scaling_factor));
+    data_ptrs.insert(std::pair<uint64_t, void *>(MASK_VAL_ID, &zeroVal));
+
+    auto variantPack = cudnn_frontend::VariantPackBuilder()
+                           .setWorkspacePointer(workspace_ptr)
+                           .setDataPointers(data_ptrs)
+                           .build();
+    // std::cout << "variantPack " << variantPack.describe() << std::endl;
+    cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(),
+                                               variantPack.get_raw_desc());
+    if (workspace_size > 0) {
+      checkCudaErr(cudaFree(workspace_ptr));
+    }
+
+    // checkCudnnErr(cudnnDestroy(handle_));
+
+    cudnn_frontend::throw_if(
+        [status]() { return (status != CUDNN_STATUS_SUCCESS); },
+        "Plan execute error", status);
+  } catch (cudnn_frontend::cudnnException &e) {
+    struct cudaDeviceProp prop;
+    checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+
+    // this example is only for GA100 cards and GH100 cards
+    if (!((prop.major == 8 && prop.minor == 0) ||
+          (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8800)) &&
+        (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH ||
+         e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+      std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and "
+                   "GH100 (cuDNN >= 8800) GPUs"
+                << std::endl;
+    } else {
+      std::cout << "[ERROR] Exception " << e.what() << std::endl;
+      // CHECK(false);
+    }
+  }
+}
+#endif

--- a/transformer_engine/common/include/transformer_engine/fmha.h
+++ b/transformer_engine/common/include/transformer_engine/fmha.h
@@ -1,6 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights
- *reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE for license information.
  ************************************************************************/

--- a/transformer_engine/common/include/transformer_engine/fmha.h
+++ b/transformer_engine/common/include/transformer_engine/fmha.h
@@ -1,0 +1,64 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+/*! \file fmha.h
+ *  \brief Functions for fused multi-head attention
+ */
+
+#ifndef TRANSFORMER_ENGINE_FMHA_H_
+#define TRANSFORMER_ENGINE_FMHA_H_
+
+// #include <cudnn_frontend.h>
+#include <cudnn.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum class MHA_Layout {
+  NOT_INTERLEAVED = 0,
+  QKV_INTERLEAVED = 1,
+  KV_INTERLEAVED = 2
+};
+
+enum class MHA_Matrix {
+  Q_Matrix = 0,  // queries
+  K_Matrix = 1,  // keys
+  V_Matrix = 2,  // values
+  S_Matrix = 3,  // output of GEMM1
+  O_Matrix = 4   // final output
+};
+
+enum class MHA_Bias_Type {
+  NO_BIAS = 0,
+  PRE_SCALE_BIAS = 1,
+  POST_SCALE_BIAS = 2
+};
+
+void nvte_fmha_fwd(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+                   int64_t seed, MHA_Layout layout, float scaling_factor,
+                   double dropout_probability, MHA_Bias_Type bias_type,
+                   bool is_causal_masking, void *devPtrQ, void *devPtrK,
+                   void *devPtrV, void *devPtrS, void *devPtrO,
+                   void *devPtrBias, void *devActualSeqlenQ,
+                   void *devActualSeqlenK, cudnnDataType_t tensorType,
+                   cudaStream_t stream, cudnnHandle_t handle_);
+
+void nvte_fmha_bwd(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+                   MHA_Layout layout, float scaling_factor,
+                   float dropout_probability, bool is_causal_masking,
+                   void *devPtrQ, void *devPtrK, void *devPtrV, void *devPtrS,
+                   void *devPtrdQ, void *devPtrdK, void *devPtrdV,
+                   void *devPtrdO, void *devPtrdS, void *devActualSeqlenQ,
+                   void *devActualSeqlenK, cudnnDataType_t tensorType,
+                   cudaStream_t stream, cudnnHandle_t handle_);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // TRANSFORMER_ENGINE_FMHA_H_

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -1970,3 +1970,443 @@ def scaled_upper_triang_masked_softmax_bwd(grad_outputs: jnp.ndarray, softmax_ou
     return _scaled_upper_triang_masked_softmax_bwd_p.bind(grad_outputs,
                                                           softmax_outputs,
                                                           scale_factor=scale_factor)
+
+
+class SelfMultiHeadAttentionFwdPrimitive(BasePrimitive):
+    """
+    Self Multi-head Attention Forward Primitive
+    """
+    name = "te_self_fmha_forward"
+    multiple_results = True
+
+    @staticmethod
+    def abstract(
+            qkv,
+            bias,
+            q_seqlen,
+            kv_seqlen,
+            *,
+            seed,    # pylint: disable=unused-argument
+            scaling_factor,    # pylint: disable=unused-argument
+            dropout_probability,    # pylint: disable=unused-argument
+            is_causal_masking    # pylint: disable=unused-argument
+    ):
+        """
+        Self multi-head attention fwd abstract
+        """
+        qkv_dtype = dtypes.canonicalize_dtype(qkv.dtype)
+        batch, max_seqlen, nqkv, num_head, head_dim = qkv.shape
+        assert nqkv == 3
+        assert qkv.dtype == bias.dtype
+        assert q_seqlen.dtype == kv_seqlen.dtype
+
+        output_shape = (batch, max_seqlen, num_head, head_dim)
+        output_dtype = qkv_dtype
+
+        softmax_aux_shape = (batch, num_head, max_seqlen, max_seqlen)
+        softmax_dtype = qkv_dtype
+
+        return (
+            ShapedArray(output_shape, output_dtype, named_shape=qkv.named_shape),    # fmha_output
+            ShapedArray(softmax_aux_shape, softmax_dtype,
+                        named_shape=qkv.named_shape),    # softmax_aux
+        )
+
+    @staticmethod
+    def lowering(ctx, qkv, bias, q_seqlen, kv_seqlen, *, seed, scaling_factor, dropout_probability,
+                 is_causal_masking):
+        """
+        Self multi-head attention fwd lowering rules
+        """
+        qkv_aval, _, _, _ = ctx.avals_in
+
+        ir_qkv_type = ir.RankedTensorType(qkv.type)
+        ir_qkv_shape = ir_qkv_type.shape
+
+        ir_bias_type = ir.RankedTensorType(bias.type)
+        ir_bias_shape = ir_bias_type.shape
+
+        ir_q_seqlen_type = ir.RankedTensorType(q_seqlen.type)
+        ir_q_seqlen_shape = ir_q_seqlen_type.shape
+
+        ir_kv_seqlen_type = ir.RankedTensorType(kv_seqlen.type)
+        ir_kv_seqlen_shape = ir_kv_seqlen_type.shape
+
+        batch, max_seqlen, nqkv, num_head, head_dim = ir_qkv_shape
+        assert nqkv == 3
+
+        output_shape = (batch, max_seqlen, num_head, head_dim)
+        softmax_aux_shape = (batch, num_head, max_seqlen, max_seqlen)
+
+        out_types = [
+            ir.RankedTensorType.get(output_shape, ir_qkv_type.element_type),
+            ir.RankedTensorType.get(softmax_aux_shape, ir_qkv_type.element_type)
+        ]
+        operands = [qkv, bias, q_seqlen, kv_seqlen]
+        operand_shapes = [ir_qkv_shape, ir_bias_shape, ir_q_seqlen_shape, ir_kv_seqlen_shape]
+
+        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
+        opaque = transformer_engine_jax.pack_fmha_descriptor(batch, num_head, max_seqlen,
+                                                             max_seqlen, head_dim, seed,
+                                                             scaling_factor, dropout_probability,
+                                                             is_causal_masking,
+                                                             jax_dtype_to_te_dtype(qkv_aval.dtype))
+
+        out = custom_caller(SelfMultiHeadAttentionFwdPrimitive.name,
+                            args,
+                            opaque,
+                            has_side_effect=False)
+
+        return out
+
+
+_self_fmha_fwd_p = register_primitive(SelfMultiHeadAttentionFwdPrimitive)
+
+
+def self_fmha_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, q_seqlen: jnp.ndarray,
+                  kv_seqlen: jnp.ndarray, seed: int, scaling_factor: float,
+                  dropout_probability: float, is_causal_masking: bool):
+    """
+    Wrapper for TE self multi-head attention fwd
+    """
+    return _self_fmha_fwd_p.bind(qkv,
+                                 bias,
+                                 q_seqlen,
+                                 kv_seqlen,
+                                 seed=seed,
+                                 scaling_factor=scaling_factor,
+                                 dropout_probability=dropout_probability,
+                                 is_causal_masking=is_causal_masking)
+
+
+class SelfMultiHeadAttentionBwdPrimitive(BasePrimitive):
+    """
+    Self Multi-head Attention Backward Primitive
+    """
+    name = "te_self_fmha_backward"
+    multiple_results = True
+
+    @staticmethod
+    def abstract(
+            qkv,
+            softmax_aux,
+            doutput,
+            q_seqlen,
+            kv_seqlen,
+            *,
+            scaling_factor,    # pylint: disable=unused-argument
+            dropout_probability,    # pylint: disable=unused-argument
+            is_causal_masking    # pylint: disable=unused-argument
+    ):
+        """
+        Self multi-head attention bwd abstract
+        """
+        qkv_dtype = dtypes.canonicalize_dtype(qkv.dtype)
+        softmax_aux_dtype = dtypes.canonicalize_dtype(softmax_aux.dtype)
+        assert qkv.dtype == softmax_aux.dtype == doutput.dtype
+        assert q_seqlen.dtype == kv_seqlen.dtype
+
+        return (
+            ShapedArray(qkv.shape, qkv_dtype, named_shape=qkv.named_shape),    # dqkv
+            ShapedArray(softmax_aux.shape, softmax_aux_dtype,
+                        named_shape=softmax_aux.named_shape),    # dsoftmax
+        )
+
+    @staticmethod
+    def lowering(ctx, qkv, softmax_aux, doutput, q_seqlen, kv_seqlen, *, scaling_factor,
+                 dropout_probability, is_causal_masking):
+        """
+        Self multi-head attention bwd lowering rules
+        """
+        qkv_aval, _, _, _, _ = ctx.avals_in
+
+        ir_qkv_type = ir.RankedTensorType(qkv.type)
+        ir_qkv_shape = ir_qkv_type.shape
+
+        ir_softmax_aux_type = ir.RankedTensorType(softmax_aux.type)
+        ir_softmax_aux_shape = ir_softmax_aux_type.shape
+
+        ir_doutput_type = ir.RankedTensorType(doutput.type)
+        ir_doutput_shape = ir_doutput_type.shape
+
+        ir_q_seqlen_type = ir.RankedTensorType(q_seqlen.type)
+        ir_q_seqlen_shape = ir_q_seqlen_type.shape
+
+        ir_kv_seqlen_type = ir.RankedTensorType(kv_seqlen.type)
+        ir_kv_seqlen_shape = ir_kv_seqlen_type.shape
+
+        batch, max_seqlen, num_head, head_dim = ir_doutput_shape
+
+        out_types = [
+            ir.RankedTensorType.get(ir_qkv_shape, ir_qkv_type.element_type),
+            ir.RankedTensorType.get(ir_softmax_aux_shape, ir_softmax_aux_type.element_type)
+        ]
+        operands = [qkv, softmax_aux, doutput, q_seqlen, kv_seqlen]
+        operand_shapes = [
+            ir_qkv_shape, ir_softmax_aux_shape, ir_doutput_shape, ir_q_seqlen_shape,
+            ir_kv_seqlen_shape
+        ]
+
+        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
+        opaque = transformer_engine_jax.pack_fmha_descriptor(
+            batch,
+            num_head,
+            max_seqlen,
+            max_seqlen,
+            head_dim,
+            0,    # unused in bwd
+            scaling_factor,
+            dropout_probability,
+            is_causal_masking,
+            jax_dtype_to_te_dtype(qkv_aval.dtype))
+
+        out = custom_caller(SelfMultiHeadAttentionBwdPrimitive.name,
+                            args,
+                            opaque,
+                            has_side_effect=False,
+                            operand_output_aliases={1: 1})
+
+        return out
+
+
+_self_fmha_bwd_p = register_primitive(SelfMultiHeadAttentionBwdPrimitive)
+
+
+def self_fmha_bwd(qkv: jnp.ndarray, softmax_aux: jnp.ndarray, doutput: jnp.ndarray,
+                  q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray, scaling_factor: float,
+                  dropout_probability: float, is_causal_masking: bool):
+    """
+    Wrapper for TE self multi-head attention bwd
+    """
+    return _self_fmha_bwd_p.bind(qkv,
+                                 softmax_aux,
+                                 doutput,
+                                 q_seqlen,
+                                 kv_seqlen,
+                                 scaling_factor=scaling_factor,
+                                 dropout_probability=dropout_probability,
+                                 is_causal_masking=is_causal_masking)
+
+
+class CrossMultiHeadAttentionFwdPrimitive(BasePrimitive):
+    """
+    Cross Multi-head Attention Forward Primitive
+    """
+    name = "te_cross_fmha_forward"
+    multiple_results = True
+
+    @staticmethod
+    def abstract(
+            q,
+            kv,
+            q_seqlen,
+            kv_seqlen,
+            *,
+            seed,    # pylint: disable=unused-argument
+            scaling_factor,    # pylint: disable=unused-argument
+            dropout_probability,    # pylint: disable=unused-argument
+            is_causal_masking    # pylint: disable=unused-argument
+    ):
+        """
+        Cross multi-head attention fwd abstract
+        """
+        q_dtype = dtypes.canonicalize_dtype(q.dtype)
+        batch_q, max_q_seqlen, num_head_q, head_dim_q = q.shape
+        kv_dtype = dtypes.canonicalize_dtype(kv.dtype)
+        batch_kv, max_kv_seqlen, nkv, num_head_kv, head_dim_kv = kv.shape
+
+        assert q_dtype == kv_dtype
+        assert batch_q == batch_kv
+        assert num_head_q == num_head_kv
+        assert head_dim_q == head_dim_kv
+        assert nkv == 2
+        assert q_seqlen.dtype == kv_seqlen.dtype
+
+        output_shape = q.shape
+        output_dtype = q_dtype
+        softmax_aux_shape = (batch_q, num_head_q, max_q_seqlen, max_kv_seqlen)
+        softmax_aux_dtype = q_dtype
+
+        return (
+            ShapedArray(output_shape, output_dtype, named_shape=q.named_shape),    # fmha_output
+            ShapedArray(softmax_aux_shape, softmax_aux_dtype,
+                        named_shape=q.named_shape),    # softmax_aux
+        )
+
+    @staticmethod
+    def lowering(ctx, q, kv, q_seqlen, kv_seqlen, *, seed, scaling_factor, dropout_probability,
+                 is_causal_masking):
+        """
+        Cross multi-head attention fwd lowering rules
+        """
+        q_aval, kv_aval, _, _ = ctx.avals_in
+        assert q_aval.dtype == kv_aval.dtype
+
+        ir_q_type = ir.RankedTensorType(q.type)
+        ir_q_shape = ir_q_type.shape
+
+        ir_kv_type = ir.RankedTensorType(kv.type)
+        ir_kv_shape = ir_kv_type.shape
+
+        ir_q_seqlen_shape = ir.RankedTensorType(q_seqlen.type).shape
+        ir_kv_seqlen_shape = ir.RankedTensorType(kv_seqlen.type).shape
+
+        batch, max_q_seqlen, num_head, head_dim = ir_q_shape
+        max_kv_seqlen = ir_kv_shape[1]
+
+        output_shape = (batch, max_q_seqlen, num_head, head_dim)
+        softmax_aux_shape = (batch, num_head, max_q_seqlen, max_kv_seqlen)
+
+        out_types = [
+            ir.RankedTensorType.get(output_shape, ir_q_type.element_type),
+            ir.RankedTensorType.get(softmax_aux_shape, ir_q_type.element_type)
+        ]
+        operands = [q, kv, q_seqlen, kv_seqlen]
+        operand_shapes = [ir_q_shape, ir_kv_shape, ir_q_seqlen_shape, ir_kv_seqlen_shape]
+
+        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
+        opaque = transformer_engine_jax.pack_fmha_descriptor(batch, num_head, max_q_seqlen,
+                                                             max_kv_seqlen, head_dim, seed,
+                                                             scaling_factor, dropout_probability,
+                                                             is_causal_masking,
+                                                             jax_dtype_to_te_dtype(q_aval.dtype))
+
+        out = custom_caller(CrossMultiHeadAttentionFwdPrimitive.name,
+                            args,
+                            opaque,
+                            has_side_effect=False)
+
+        return out
+
+
+_cross_fmha_fwd_p = register_primitive(CrossMultiHeadAttentionFwdPrimitive)
+
+
+def cross_fmha_fwd(q: jnp.ndarray, kv: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
+                   seed: int, scaling_factor: float, dropout_probability: float,
+                   is_causal_masking: bool):
+    """
+    Wrapper for TE cross multi-head attention fwd
+    """
+    return _cross_fmha_fwd_p.bind(q,
+                                  kv,
+                                  q_seqlen,
+                                  kv_seqlen,
+                                  seed=seed,
+                                  scaling_factor=scaling_factor,
+                                  dropout_probability=dropout_probability,
+                                  is_causal_masking=is_causal_masking)
+
+
+class CrossMultiHeadAttentionBwdPrimitive(BasePrimitive):
+    """
+    Cross Multi-head Attention Backward Primitive
+    """
+    name = "te_cross_fmha_backward"
+    multiple_results = True
+
+    @staticmethod
+    def abstract(
+            q,
+            kv,
+            softmax_aux,
+            doutput,
+            q_seqlen,
+            kv_seqlen,
+            *,
+            scaling_factor,    # pylint: disable=unused-argument
+            dropout_probability,    # pylint: disable=unused-argument
+            is_causal_masking    # pylint: disable=unused-argument
+    ):
+        """
+        Cross multi-head attention bwd abstract
+        """
+        q_dtype = dtypes.canonicalize_dtype(q.dtype)
+        kv_dtype = dtypes.canonicalize_dtype(kv.dtype)
+        softmax_aux_dtype = dtypes.canonicalize_dtype(softmax_aux.dtype)
+        doutput_dtype = dtypes.canonicalize_dtype(doutput.dtype)
+        assert q_dtype == kv_dtype == softmax_aux_dtype == doutput_dtype
+        assert q_seqlen.dtype == kv_seqlen.dtype
+
+        return (
+            ShapedArray(q.shape, q_dtype, named_shape=q.named_shape),    # dq
+            ShapedArray(kv.shape, kv_dtype, named_shape=kv.named_shape),    # dkv
+            ShapedArray(softmax_aux.shape, softmax_aux_dtype,
+                        named_shape=softmax_aux.named_shape),    # dsoftmax
+        )
+
+    @staticmethod
+    def lowering(ctx, q, kv, softmax_aux, doutput, q_seqlen, kv_seqlen, *, scaling_factor,
+                 dropout_probability, is_causal_masking):
+        """
+        Cross multi-head attention bwd lowering rules
+        """
+        q_aval, _, _, _, _, _ = ctx.avals_in
+
+        ir_q_type = ir.RankedTensorType(q.type)
+        ir_q_shape = ir_q_type.shape
+
+        ir_kv_type = ir.RankedTensorType(kv.type)
+        ir_kv_shape = ir_kv_type.shape
+
+        ir_softmax_aux_type = ir.RankedTensorType(softmax_aux.type)
+        ir_softmax_aux_shape = ir_softmax_aux_type.shape
+
+        ir_doutput_shape = ir.RankedTensorType(doutput.type).shape
+        ir_q_seqlen_shape = ir.RankedTensorType(q_seqlen.type).shape
+        ir_kv_seqlen_shape = ir.RankedTensorType(kv_seqlen.type).shape
+
+        batch, max_q_seqlen, num_head, head_dim = ir_doutput_shape
+        max_kv_seqlen = ir_kv_shape[1]
+
+        out_types = [
+            ir.RankedTensorType.get(ir_q_shape, ir_q_type.element_type),
+            ir.RankedTensorType.get(ir_kv_shape, ir_kv_type.element_type),
+            ir.RankedTensorType.get(ir_softmax_aux_shape, ir_softmax_aux_type.element_type)
+        ]
+        operands = [q, kv, softmax_aux, doutput, q_seqlen, kv_seqlen]
+        operand_shapes = [
+            ir_q_shape, ir_kv_shape, ir_softmax_aux_shape, ir_doutput_shape, ir_q_seqlen_shape,
+            ir_kv_seqlen_shape
+        ]
+
+        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
+        opaque = transformer_engine_jax.pack_fmha_descriptor(
+            batch,
+            num_head,
+            max_q_seqlen,
+            max_kv_seqlen,
+            head_dim,
+            0,    # unused in bwd
+            scaling_factor,
+            dropout_probability,
+            is_causal_masking,
+            jax_dtype_to_te_dtype(q_aval.dtype))
+
+        out = custom_caller(CrossMultiHeadAttentionBwdPrimitive.name,
+                            args,
+                            opaque,
+                            has_side_effect=False,
+                            operand_output_aliases={2: 2})
+
+        return out
+
+
+_cross_fmha_bwd_p = register_primitive(CrossMultiHeadAttentionBwdPrimitive)
+
+
+def cross_fmha_bwd(q: jnp.ndarray, kv: jnp.ndarray, softmax_aux: jnp.ndarray, doutput: jnp.ndarray,
+                   q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray, scaling_factor: float,
+                   dropout_probability: float, is_causal_masking: bool):
+    """
+    Wrapper for TE cross multi-head attention bwd
+    """
+    return _cross_fmha_bwd_p.bind(q,
+                                  kv,
+                                  softmax_aux,
+                                  doutput,
+                                  q_seqlen,
+                                  kv_seqlen,
+                                  scaling_factor=scaling_factor,
+                                  dropout_probability=dropout_probability,
+                                  is_causal_masking=is_causal_masking)

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -43,6 +43,10 @@ pybind11::dict Registrations() {
         EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxForward);
     dict["te_scaled_upper_triang_masked_softmax_backward"] =
         EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxBackward);
+    dict["te_self_fmha_forward"] = EncapsulateFunction(SelfMultiheadAttentionForward);
+    dict["te_self_fmha_backward"] = EncapsulateFunction(SelfMultiheadAttentionBackward);
+    dict["te_cross_fmha_forward"] = EncapsulateFunction(CrossMultiheadAttentionForward);
+    dict["te_cross_fmha_backward"] = EncapsulateFunction(CrossMultiheadAttentionBackward);
     return dict;
 }
 
@@ -52,6 +56,7 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
     m.def("pack_gemm_descriptor", &PackCustomCallGemmDescriptor);
     m.def("pack_norm_descriptor", &PackCustomCallNormDescriptor);
     m.def("pack_softmax_descriptor", &PackCustomCallSoftmaxDescriptor);
+    m.def("pack_fmha_descriptor", &PackCustomCallFMHADescriptor);
 
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())
         .value("kByte", DType::kByte)

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -77,6 +77,15 @@ pybind11::bytes PackCustomCallSoftmaxDescriptor(size_t batch, size_t pad_batch, 
         SoftmaxDescriptor{batch, pad_batch, heads, q_seqlen, k_seqlen, dtype, scale_factor});
 }
 
+pybind11::bytes PackCustomCallFMHADescriptor(size_t batch, size_t num_head, size_t max_q_seqlen,
+                                             size_t max_kv_seqlen, size_t head_dim, size_t seed,
+                                             float scaling_factor, float dropout_probability,
+                                             bool is_causal_masking, DType dtype) {
+    return PackOpaque(CustomCallFMHADescriptor{batch, num_head, max_q_seqlen, max_kv_seqlen,
+                                               head_dim, seed, scaling_factor, dropout_probability,
+                                               is_causal_masking, dtype});
+}
+
 void TransposeImpl(void *input, size_t rows, size_t cols, DType dtype, cudaStream_t stream,
                    void *output) {
     auto input_shape = std::vector<size_t>{rows, cols};
@@ -700,5 +709,179 @@ void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers,
         grad_output_tensor.data(), softmax_output_tensor.data(), dgrad_tensor.data(),
         desc.scale_factor, stream);
 }
+
+cudnnDataType_t TEDTypeToCudnnDataType(DType dtype) {
+    switch (dtype) {
+        case DType::kFloat32:
+            return CUDNN_DATA_FLOAT;
+        case DType::kFloat16:
+            return CUDNN_DATA_HALF;
+        case DType::kBFloat16:
+            return CUDNN_DATA_BFLOAT16;
+    }
+    throw std::invalid_argument("Only FP32/FP16/BF16 is supported.");
+    return CUDNN_DATA_FLOAT;
+}
+
+void SelfMultiheadAttentionForward(cudaStream_t stream, void **buffers, const char *opaque,
+                                   size_t opaque_len) {
+    const CustomCallFMHADescriptor &descriptor =
+        *UnpackOpaque<CustomCallFMHADescriptor>(opaque, opaque_len);
+
+    // input
+    void *qkv = buffers[0];
+    void *bias = buffers[1];
+    void *q_seqlen = buffers[2];
+    void *kv_seqlen = buffers[3];
+
+    // output
+    void *output = buffers[4];
+    void *softmax_aux = buffers[5];
+
+    auto batch = descriptor.batch;
+    auto num_head = descriptor.num_head;
+    auto max_q_seqlen = descriptor.max_q_seqlen;
+    auto max_kv_seqlen = descriptor.max_kv_seqlen;
+    auto head_dim = descriptor.head_dim;
+
+    assert(max_q_seqlen == max_kv_seqlen);
+
+    auto dtype_size = typeToSize(descriptor.dtype);
+    assert(dtype_size == 2 && "FMHA only supports BF16/FP16 currently");
+    auto qkv_stride = num_head * head_dim * dtype_size;
+
+    cudaMemsetAsync(output, 0, batch * num_head * max_q_seqlen * head_dim * dtype_size, stream);
+    cudaMemsetAsync(softmax_aux, 0, batch * num_head * max_q_seqlen * max_kv_seqlen * dtype_size,
+                    stream);
+
+    auto handle = cudnnExecutionPlanManager::Instance().GetCudnnHandle();
+
+    nvte_fmha_fwd(batch, num_head, max_q_seqlen, max_kv_seqlen, head_dim, descriptor.seed,
+                  MHA_Layout::QKV_INTERLEAVED, descriptor.scaling_factor,
+                  descriptor.dropout_probability, MHA_Bias_Type::POST_SCALE_BIAS,
+                  descriptor.is_causal_masking, qkv, static_cast<char *>(qkv) + qkv_stride,
+                  static_cast<char *>(qkv) + 2 * qkv_stride, softmax_aux, output, bias, q_seqlen,
+                  kv_seqlen, TEDTypeToCudnnDataType(descriptor.dtype), stream, handle);
+}
+
+void SelfMultiheadAttentionBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                                    size_t opaque_len) {
+    const CustomCallFMHADescriptor &descriptor =
+        *UnpackOpaque<CustomCallFMHADescriptor>(opaque, opaque_len);
+
+    // input
+    void *qkv = buffers[0];
+    void *softmax_aux = buffers[1];
+    void *doutput = buffers[2];
+    void *q_seqlen = buffers[3];
+    void *kv_seqlen = buffers[4];
+
+    // output
+    void *dqkv = buffers[5];
+    void *dp = buffers[6];
+
+    auto batch = descriptor.batch;
+    auto num_head = descriptor.num_head;
+    auto max_q_seqlen = descriptor.max_q_seqlen;
+    auto max_kv_seqlen = descriptor.max_kv_seqlen;
+    auto head_dim = descriptor.head_dim;
+
+    assert(max_q_seqlen == max_kv_seqlen);
+
+    auto dtype_size = typeToSize(descriptor.dtype);
+    assert(dtype_size == 2 && "FMHA only supports BF16/FP16 currently");
+    auto qkv_stride = num_head * head_dim * dtype_size;
+
+    cudaMemsetAsync(dqkv, 0, batch * max_q_seqlen * num_head * head_dim * 3 * dtype_size, stream);
+
+    auto handle = cudnnExecutionPlanManager::Instance().GetCudnnHandle();
+
+    nvte_fmha_bwd(batch, num_head, max_q_seqlen, max_kv_seqlen, head_dim,
+                  MHA_Layout::QKV_INTERLEAVED, descriptor.scaling_factor,
+                  descriptor.dropout_probability, descriptor.is_causal_masking, qkv,
+                  static_cast<char *>(qkv) + qkv_stride, static_cast<char *>(qkv) + 2 * qkv_stride,
+                  softmax_aux, dqkv, static_cast<char *>(dqkv) + qkv_stride,
+                  static_cast<char *>(dqkv) + 2 * qkv_stride, doutput, dp, q_seqlen, kv_seqlen,
+                  TEDTypeToCudnnDataType(descriptor.dtype), stream, handle);
+}
+
+void CrossMultiheadAttentionForward(cudaStream_t stream, void **buffers, const char *opaque,
+                                    size_t opaque_len) {
+    const CustomCallFMHADescriptor &descriptor =
+        *UnpackOpaque<CustomCallFMHADescriptor>(opaque, opaque_len);
+
+    // input
+    void *q = buffers[0];
+    void *kv = buffers[1];
+    void *q_seqlen = buffers[2];
+    void *kv_seqlen = buffers[3];
+
+    // output
+    void *output = buffers[4];
+    void *softmax_aux = buffers[5];
+
+    auto batch = descriptor.batch;
+    auto num_head = descriptor.num_head;
+    auto max_q_seqlen = descriptor.max_q_seqlen;
+    auto max_kv_seqlen = descriptor.max_kv_seqlen;
+    auto head_dim = descriptor.head_dim;
+
+    auto dtype_size = typeToSize(descriptor.dtype);
+    assert(dtype_size == 2 && "FMHA only supports BF16/FP16 currently");
+    auto kv_stride = num_head * head_dim * dtype_size;
+
+    cudaMemsetAsync(output, 0, batch * num_head * max_q_seqlen * head_dim * dtype_size, stream);
+
+    auto handle = cudnnExecutionPlanManager::Instance().GetCudnnHandle();
+
+    nvte_fmha_fwd(batch, num_head, max_q_seqlen, max_kv_seqlen, head_dim, descriptor.seed,
+                  MHA_Layout::KV_INTERLEAVED, descriptor.scaling_factor,
+                  descriptor.dropout_probability, MHA_Bias_Type::NO_BIAS,
+                  descriptor.is_causal_masking, q, static_cast<char *>(kv),
+                  static_cast<char *>(kv) + kv_stride, softmax_aux, output, nullptr, q_seqlen,
+                  kv_seqlen, TEDTypeToCudnnDataType(descriptor.dtype), stream, handle);
+}
+
+void CrossMultiheadAttentionBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                                     size_t opaque_len) {
+    const CustomCallFMHADescriptor &descriptor =
+        *UnpackOpaque<CustomCallFMHADescriptor>(opaque, opaque_len);
+
+    // input
+    void *q = buffers[0];
+    void *kv = buffers[1];
+    void *softmax_aux = buffers[2];
+    void *doutput = buffers[3];
+    void *q_seqlen = buffers[4];
+    void *kv_seqlen = buffers[5];
+
+    // output
+    void *dq = buffers[6];
+    void *dkv = buffers[7];
+    void *dp = buffers[8];
+
+    auto batch = descriptor.batch;
+    auto num_head = descriptor.num_head;
+    auto max_q_seqlen = descriptor.max_q_seqlen;
+    auto max_kv_seqlen = descriptor.max_kv_seqlen;
+    auto head_dim = descriptor.head_dim;
+
+    auto dtype_size = typeToSize(descriptor.dtype);
+    assert(dtype_size == 2 && "FMHA only supports BF16/FP16 currently");
+    auto qkv_stride = num_head * head_dim * dtype_size;
+
+    cudaMemsetAsync(dq, 0, batch * max_q_seqlen * num_head * head_dim * dtype_size, stream);
+    cudaMemsetAsync(dkv, 0, batch * max_kv_seqlen * num_head * head_dim * 2 * dtype_size, stream);
+
+    auto handle = cudnnExecutionPlanManager::Instance().GetCudnnHandle();
+
+    nvte_fmha_bwd(batch, num_head, max_q_seqlen, max_kv_seqlen, head_dim,
+                  MHA_Layout::KV_INTERLEAVED, descriptor.scaling_factor,
+                  descriptor.dropout_probability, descriptor.is_causal_masking, q,
+                  static_cast<char *>(kv), static_cast<char *>(kv) + qkv_stride, softmax_aux, dq,
+                  static_cast<char *>(dkv), static_cast<char *>(dkv) + qkv_stride, doutput, dp,
+                  q_seqlen, kv_seqlen, TEDTypeToCudnnDataType(descriptor.dtype), stream, handle);
+}
+
 }  // namespace jax
 }  // namespace transformer_engine

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -17,6 +17,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "transformer_engine/fmha.h"
 #include "transformer_engine/logging.h"
 #include "transformer_engine/transformer_engine.h"
 
@@ -93,6 +94,24 @@ pybind11::bytes PackCustomCallSoftmaxDescriptor(size_t batch, size_t pad_batch, 
                                                 size_t q_seqlen, size_t k_seqlen, DType dtype,
                                                 float scale_factor);
 
+struct CustomCallFMHADescriptor {
+    size_t batch;
+    size_t num_head;
+    size_t max_q_seqlen;
+    size_t max_kv_seqlen;
+    size_t head_dim;
+    size_t seed;
+    float scaling_factor;
+    float dropout_probability;
+    bool is_causal_masking;
+    DType dtype;
+};
+
+pybind11::bytes PackCustomCallFMHADescriptor(size_t batch, size_t num_head, size_t max_q_seqlen,
+                                             size_t max_kv_seqlen, size_t head_dim, size_t seed,
+                                             float scaling_factor, float dropout_probability,
+                                             bool is_causal_masking, DType dtype);
+
 void Transpose(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 
 void CastTranspose(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
@@ -142,6 +161,18 @@ void ScaledUpperTriangMaskedSoftmaxForward(cudaStream_t stream, void **buffers, 
 
 void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers, const char *opaque,
                                             std::size_t opaque_len);
+
+void SelfMultiheadAttentionForward(cudaStream_t stream, void **buffers, const char *opaque,
+                                   size_t opaque_len);
+
+void SelfMultiheadAttentionBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                                    size_t opaque_len);
+
+void CrossMultiheadAttentionForward(cudaStream_t stream, void **buffers, const char *opaque,
+                                    size_t opaque_len);
+
+void CrossMultiheadAttentionBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                                     size_t opaque_len);
 
 }  // namespace jax
 }  // namespace transformer_engine

--- a/transformer_engine/jax/csrc/utils.h
+++ b/transformer_engine/jax/csrc/utils.h
@@ -10,6 +10,7 @@
 #include <pybind11/pybind11.h>
 
 #include <cstdint>
+#include <mutex>  // NOLINT [build/c++11]
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -78,6 +79,23 @@ class cudaDevicePropertiesManager {
  private:
     bool prop_queried_ = false;
     cudaDeviceProp prop_;
+};
+
+class cudnnExecutionPlanManager {
+ public:
+    static cudnnExecutionPlanManager &Instance() {
+        static thread_local cudnnExecutionPlanManager instance;
+        return instance;
+    }
+
+    cudnnHandle_t GetCudnnHandle() {
+        static std::once_flag flag;
+        std::call_once(flag, [&] { cudnnCreate(&handle_); });
+        return handle_;
+    }
+
+ private:
+    cudnnHandle_t handle_;
 };
 
 }  // namespace jax

--- a/transformer_engine/jax/fmha.py
+++ b/transformer_engine/jax/fmha.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""JAX multi-head attention modules"""
+
+from functools import partial
+import jax
+import jax.numpy as jnp
+
+from .cpp_extensions import self_fmha_fwd, self_fmha_bwd
+from .cpp_extensions import cross_fmha_fwd, cross_fmha_bwd
+from .sharding import ShardingType
+# from .sharding import get_elementwise_sharding_meta
+# from .sharding import get_dot_sharding_meta, get_fp8_meta_sharding_meta
+# from .sharding import is_dp_enabled, is_tp_enabled, merge_axis_resources
+from .sharding import is_dp_enabled
+# from .sharding import xmap_runner
+
+jax.config.update('experimental_xmap_spmd_lowering', True)
+jax.config.update('experimental_xmap_spmd_lowering_manual', True)
+
+
+def self_fmha(qkv: jnp.ndarray,
+              bias: jnp.ndarray,
+              q_seqlen: jnp.ndarray,
+              kv_seqlen: jnp.ndarray,
+              seed: int,
+              scaling_factor: float,
+              dropout_probability: float,
+              is_causal_masking: bool,
+              sharding_type: ShardingType = ShardingType.SINGLE,
+              dp_dim_index: int = 0):
+    """
+    Self multi-head attention wrapper
+    """
+    assert sharding_type not in (ShardingType.TP_ROW, ShardingType.DP_TP_ROW), \
+        "FMHA does not support row-split tensor parallelism currently."
+
+    assert dp_dim_index is not None    # TODO(rewang): remove this
+
+    if sharding_type is ShardingType.SINGLE:
+        output = _self_fmha(qkv,
+                            bias,
+                            q_seqlen,
+                            kv_seqlen,
+                            seed=seed,
+                            scaling_factor=scaling_factor,
+                            dropout_probability=dropout_probability,
+                            is_causal_masking=is_causal_masking,
+                            sharding_type=sharding_type,
+                            dp_axis_name="")
+    else:
+        raise NotImplementedError
+
+    return output
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(4, 5, 6, 7, 8, 9))
+def _self_fmha(qkv: jnp.ndarray, bias: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
+               seed: int, scaling_factor: float, dropout_probability: float,
+               is_causal_masking: bool, sharding_type: ShardingType, dp_axis_name: str):
+    output, _ = _self_fmha_fwd(qkv, bias, q_seqlen, kv_seqlen, seed, scaling_factor,
+                               dropout_probability, is_causal_masking, sharding_type, dp_axis_name)
+    return output
+
+
+def _self_fmha_fwd(
+        qkv,
+        bias,
+        q_seqlen,
+        kv_seqlen,
+        seed,
+        scaling_factor,
+        dropout_probability,
+        is_causal_masking,
+        sharding_type,    # pylint: disable=unused-argument
+        dp_axis_name    # pylint: disable=unused-argument
+):
+    output, softmax_aux = self_fmha_fwd(qkv, bias, q_seqlen, kv_seqlen, seed, scaling_factor,
+                                        dropout_probability, is_causal_masking)
+    return output, (softmax_aux, qkv, q_seqlen, kv_seqlen)
+
+
+def _self_fmha_bwd(
+        seed,    # pylint: disable=unused-argument
+        scaling_factor,
+        dropout_probability,
+        is_causal_masking,
+        sharding_type,
+        dp_axis_name,
+        ctx,
+        grad):
+    softmax_aux, qkv, q_seqlen, kv_seqlen = ctx
+
+    doutput = grad
+
+    grad_qkv, grad_softmax = self_fmha_bwd(qkv,
+                                           softmax_aux,
+                                           doutput,
+                                           q_seqlen,
+                                           kv_seqlen,
+                                           scaling_factor=scaling_factor,
+                                           dropout_probability=dropout_probability,
+                                           is_causal_masking=is_causal_masking)
+
+    _, max_seqlen, nqkv, num_head, _ = qkv.shape
+    assert nqkv == 3
+
+    grad_beta = jnp.sum(grad_softmax.astype(jnp.float32) / scaling_factor,
+                        axis=0,
+                        keepdims=True,
+                        dtype=jnp.float32).astype(grad.dtype)
+    grad_beta = _reshape_softmax(grad_beta, 1, max_seqlen, num_head)
+
+    # TODO(rewang): is it needed?
+    if is_dp_enabled(sharding_type.value[0]):
+        grad_qkv = jax.lax.psum(grad_qkv, dp_axis_name)
+        grad_beta = jax.lax.psum(grad_beta, dp_axis_name)
+
+    return grad_qkv, grad_beta, None, None
+
+
+_self_fmha.defvjp(_self_fmha_fwd, _self_fmha_bwd)
+
+
+def cross_fmha(q: jnp.ndarray,
+               kv: jnp.ndarray,
+               q_seqlen: jnp.ndarray,
+               kv_seqlen: jnp.ndarray,
+               seed: int,
+               scaling_factor: float,
+               dropout_probability: float,
+               is_causal_masking: bool,
+               sharding_type: ShardingType = ShardingType.SINGLE,
+               dp_dim_index: int = 0):
+    """
+    Cross multi-head attention wrapper
+    """
+    assert sharding_type not in (ShardingType.TP_ROW, ShardingType.DP_TP_ROW), \
+        "FMHA does not support row-split tensor parallelism currently."
+
+    assert dp_dim_index is not None    # TODO(rewang): remove this
+
+    if sharding_type is ShardingType.SINGLE:
+        output = _cross_fmha(q,
+                             kv,
+                             q_seqlen,
+                             kv_seqlen,
+                             seed=seed,
+                             scaling_factor=scaling_factor,
+                             dropout_probability=dropout_probability,
+                             is_causal_masking=is_causal_masking,
+                             sharding_type=sharding_type,
+                             dp_axis_name="")
+    else:
+        raise NotImplementedError
+
+    return output
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(4, 5, 6, 7, 8, 9))
+def _cross_fmha(q: jnp.ndarray, kv: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
+                seed: int, scaling_factor: float, dropout_probability: float,
+                is_causal_masking: bool, sharding_type: ShardingType, dp_axis_name: str):
+    output, _ = _cross_fmha_fwd(q, kv, q_seqlen, kv_seqlen, seed, scaling_factor,
+                                dropout_probability, is_causal_masking, sharding_type, dp_axis_name)
+    return output
+
+
+def _cross_fmha_fwd(
+        q,
+        kv,
+        q_seqlen,
+        kv_seqlen,
+        seed,
+        scaling_factor,
+        dropout_probability,
+        is_causal_masking,
+        sharding_type,    # pylint: disable=unused-argument
+        dp_axis_name    # pylint: disable=unused-argument
+):
+    output, softmax_aux = cross_fmha_fwd(q, kv, q_seqlen, kv_seqlen, seed, scaling_factor,
+                                         dropout_probability, is_causal_masking)
+    return output, (softmax_aux, q, kv, q_seqlen, kv_seqlen)
+
+
+def _cross_fmha_bwd(
+        seed,    # pylint: disable=unused-argument
+        scaling_factor,
+        dropout_probability,
+        is_causal_masking,
+        sharding_type,
+        dp_axis_name,
+        ctx,
+        grad):
+    softmax_aux, q, kv, q_seqlen, kv_seqlen = ctx
+
+    doutput = grad
+
+    # TODO(rewang): remove dsoftmax for cross_fmha
+    grad_q, grad_kv, _ = cross_fmha_bwd(q,
+                                        kv,
+                                        softmax_aux,
+                                        doutput,
+                                        q_seqlen,
+                                        kv_seqlen,
+                                        scaling_factor=scaling_factor,
+                                        dropout_probability=dropout_probability,
+                                        is_causal_masking=is_causal_masking)
+
+    # TODO(rewang): is it needed?
+    if is_dp_enabled(sharding_type.value[0]):
+        grad_q = jax.lax.psum(grad_q, dp_axis_name)
+        grad_kv = jax.lax.psum(grad_kv, dp_axis_name)
+        grad_beta = jax.lax.psum(grad_beta, dp_axis_name)
+
+    return grad_q, grad_kv, None, None
+
+
+_cross_fmha.defvjp(_cross_fmha_fwd, _cross_fmha_bwd)
+
+
+# TODO(rewang): refactor
+def _reshape_softmax(S, b, s, h, warps_m=1, warps_n=4):
+    # This should not expose to public
+    m = s if s == 128 else 16
+    n = s
+    m_per_cta = warps_m * 16
+    n_per_cta = warps_n * 16
+    mmas_m = m // m_per_cta
+    mmas_n = n // n_per_cta
+    loops = s // (mmas_m * m_per_cta)
+    assert (loops == 1 and s == 128) or (loops == 16 and s == 256) or (
+        loops == 32 and s == 512) or (loops == 24 and s == 384), "no.."
+    quads = 8
+    lohi = 2
+    lr = 2
+    vals = 2
+
+    magic_shape = (b, h, loops, mmas_m, mmas_n, warps_n, warps_m, quads, 4, lohi, lr, vals)
+
+    magic_s = jnp.reshape(S, magic_shape)
+    transposed_s = jnp.transpose(magic_s, [0, 1, 2, 3, 6, 9, 7, 4, 5, 10, 8, 11])
+    ret_s = jnp.reshape(transposed_s, (b, h, s, s))
+    return ret_s

--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -8,6 +8,7 @@ Sharding Meta for xmap with CustomCall
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
+from itertools import repeat
 from typing import Union, Tuple, Dict, Callable, Sequence
 from jax.interpreters import pxla
 import jax
@@ -820,6 +821,121 @@ class SoftmaxShardingMetaGenerator(ShardingMetaGenerator):
         }, input_new_shapes, [input_shape])
 
 
+class FMHAShardingMetaGenerator(ShardingMetaGenerator):
+    """
+    FMHAShardingMetaGenerator
+    """
+
+    def get_dp_sharding_meta(
+            self,
+            input_shapes: Tuple[Tuple[int, ...]],
+            output_shapes: Tuple[Tuple[int, ...]],
+            dp_dims: Tuple[Tuple[int, ...]],
+            tp_dims: Tuple[Tuple[int, ...]],    # pylint: disable=unused-argument
+            dp_axis_name: str = 'data',
+            tp_axis_name: str = 'model'    # pylint: disable=unused-argument
+    ) -> ShardingMeta:
+        """get_dp_sharding_meta"""
+        dummy_tp_dims = [repeat(None), repeat(None)]
+        return FMHAShardingMetaGenerator._get_dptp_sharding_meta(input_shapes, output_shapes,
+                                                                 dp_dims, dummy_tp_dims,
+                                                                 dp_axis_name, None)
+
+    def get_tp_col_sharding_meta(self, *argv, **kwargs) -> ShardingMeta:
+        """get_tp_col_sharding_meta"""
+        return FMHAShardingMetaGenerator._get_tp_sharding_meta(*argv, **kwargs)
+
+    def get_tp_row_sharding_meta(self, *argv, **kwargs) -> ShardingMeta:
+        """get_tp_row_sharding_meta"""
+        return FMHAShardingMetaGenerator._get_tp_sharding_meta(*argv, **kwargs)
+
+    def get_dp_tp_col_sharding_meta(self, *argv, **kwargs) -> ShardingMeta:
+        """get_dp_tp_col_sharding_meta"""
+        return FMHAShardingMetaGenerator._get_dptp_sharding_meta(*argv, **kwargs)
+
+    def get_dp_tp_row_sharding_meta(self, *argv, **kwargs) -> ShardingMeta:
+        """get_dp_tp_row_sharding_meta"""
+        return FMHAShardingMetaGenerator._get_dptp_sharding_meta(*argv, **kwargs)
+
+    @staticmethod
+    def _get_tp_sharding_meta(
+            input_shapes: Tuple[Tuple[int, ...]],
+            output_shapes: Tuple[Tuple[int, ...]],
+            dp_dims: Tuple[Tuple[int, ...]],    # pylint: disable=unused-argument
+            tp_dims: Tuple[Tuple[int, ...]],
+            dp_axis_name: str = 'data',    # pylint: disable=unused-argument
+            tp_axis_name: str = 'model') -> ShardingMeta:
+        """get_tp_sharding_meta"""
+        dummy_dp_dims = [repeat(None), repeat(None)]
+        return FMHAShardingMetaGenerator._get_dptp_sharding_meta(input_shapes, output_shapes,
+                                                                 dummy_dp_dims, tp_dims, None,
+                                                                 tp_axis_name)
+
+    @staticmethod
+    def _get_dptp_sharding_meta(input_shapes: Tuple[Tuple[int, ...]],
+                                output_shapes: Tuple[Tuple[int, ...]],
+                                dp_dims: Tuple[Tuple[int, ...]],
+                                tp_dims: Tuple[Tuple[int, ...]],
+                                dp_axis_name: str = 'data',
+                                tp_axis_name: str = 'model') -> ShardingMeta:
+        """get_dp_tp_sharding_meta"""
+
+        dp_size, dp_mesh_axis = _get_mesh_info(global_shard_resource().dp_resource)
+        tp_size, tp_mesh_axis = _get_mesh_info(global_shard_resource().tp_resource)
+
+        input_dp_dims, output_dp_dims = dp_dims
+        input_tp_dims, output_tp_dims = tp_dims
+
+        input_new_shapes = []
+        in_axes = []
+
+        for input_shape, dp_dim, tp_dim in zip(input_shapes, input_dp_dims, input_tp_dims):
+            in_axis = {}
+            if dp_dim is not None:
+                in_axis[dp_dim] = dp_axis_name
+                assert input_shape[dp_dim] % dp_size == 0, \
+                    f"The dimension of batch in input_shape should be a multiple of " \
+                    f"data parallelism size, but got {input_shape[dp_dim]=} and {dp_size=}."
+                input_shape = (*input_shape[:dp_dim], dp_size, input_shape[dp_dim] // dp_size,
+                               *input_shape[dp_dim + 1:])
+
+                # the input shape has been expanded for dp_dim, tp_dim should +1 if tp_dim >= dp_dim
+                if tp_dim is not None and tp_dim >= dp_dim:
+                    tp_dim = tp_dim + 1
+
+            if tp_dim is not None:
+                in_axis[tp_dim] = tp_axis_name
+                assert input_shape[tp_dim] % tp_size == 0, \
+                    f"The dimension of tensor parallel in input_shape should be a multiple of " \
+                    f"tensor parallelism size, but got {input_shape[tp_dim]=} and {tp_size=}."
+                input_shape = (*input_shape[:tp_dim], tp_size, input_shape[tp_dim] // tp_size,
+                               *input_shape[tp_dim + 1:])
+
+            in_axes.append(in_axis)
+            input_new_shapes.append(input_shape)
+
+        output_new_shapes = output_shapes
+        out_axes = []
+        for dp_dim, tp_dim in zip(output_dp_dims, output_tp_dims):
+            out_axis = {}
+            if dp_dim is not None:
+                out_axis[dp_dim] = dp_axis_name
+                if tp_dim is not None and tp_dim >= dp_dim:
+                    tp_dim = tp_dim + 1
+            if tp_dim is not None:
+                out_axis[tp_dim] = tp_axis_name
+            out_axes.append(out_axis)
+
+        axis_resources = {}
+        if dp_axis_name is not None:
+            axis_resources[dp_axis_name] = dp_mesh_axis
+        if tp_axis_name is not None:
+            axis_resources[tp_axis_name] = tp_mesh_axis
+
+        return ShardingMeta(tuple(in_axes), out_axes, axis_resources, input_new_shapes,
+                            output_new_shapes)
+
+
 def get_fp8_meta_sharding_meta(stype: ShardingType,
                                num_of_meta: int,
                                dp_axis_name: str = 'data',
@@ -882,6 +998,21 @@ def get_softmax_sharding_meta(stype: ShardingType,
     """
     return SoftmaxShardingMetaGenerator().get_sharding_meta(stype, input_shape, dp_dim, tp_dim,
                                                             dp_axis_name, tp_axis_name)
+
+
+def get_fmha_sharding_meta(stype: ShardingType,
+                           input_shapes: Tuple[Tuple[int, ...]],
+                           output_shapes: Tuple[Tuple[int, ...]],
+                           dp_dims: Tuple[Tuple[int, ...]],
+                           tp_dims: Tuple[Tuple[int, ...]],
+                           dp_axis_name: str = 'data',
+                           tp_axis_name: str = 'model') -> ShardingMeta:
+    """
+    get_self_fmha_sharding_meta
+    """
+    return FMHAShardingMetaGenerator().get_sharding_meta(stype, input_shapes, output_shapes,
+                                                         dp_dims, tp_dims, dp_axis_name,
+                                                         tp_axis_name)
 
 
 def xmap_runner(func: Callable, in_axes: Tuple[Dict, ...],

--- a/transformer_engine/jax/transformer.py
+++ b/transformer_engine/jax/transformer.py
@@ -6,6 +6,7 @@ Wrapper module for Transformer related layers with FP8 support.
 """
 import functools
 from enum import Enum
+from math import sqrt
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import jax.numpy as jnp
@@ -121,6 +122,7 @@ def combine_biases(*masks: Optional[Array]):
 def core_attention(query: Array,
                    key: Array,
                    value: Array,
+                   scale_factor: float,
                    transpose_batch_sequence: bool,
                    softmax_type: SoftmaxType = SoftmaxType.SCALED,
                    softmax_sharding_type: ShardingType = ShardingType.SINGLE,
@@ -151,6 +153,7 @@ def core_attention(query: Array,
         attn_weights = jnp.einsum('bqhd,bkhd->bhqk', query, key)
 
     attn_weights = Softmax(softmax_type=softmax_type,
+                           scale_factor=scale_factor,
                            sharding_type=softmax_sharding_type)(attn_weights, mask, bias)
 
     if not deterministic and dropout_rate > 0.:
@@ -295,9 +298,8 @@ class MultiHeadAttention(nn.Module):
             Output tensors.
         """
 
-        depth_scaling = jnp.sqrt(self.head_dim).astype(self.dtype)
-
         def query_init(*args):
+            depth_scaling = jnp.sqrt(self.head_dim).astype(self.dtype)
             return self.kernel_init(*args) / (depth_scaling if self.scaled_query_init else 1.0)
 
         def qkv_init(key, shape, dtype):
@@ -355,8 +357,6 @@ class MultiHeadAttention(nn.Module):
                 query = jnp.reshape(query, (*query.shape[:-2], -1))
                 key = jnp.reshape(key, (*key.shape[:-2], -1))
                 value = jnp.reshape(value, (*value.shape[:-2], -1))
-                if self.scale_attn_logits:
-                    query = query / depth_scaling
             else:
                 query, ln_out = LayerNormDenseGeneral(
                     enable_layernorm=not self.output_layernorm,
@@ -367,7 +367,6 @@ class MultiHeadAttention(nn.Module):
                     sharding_type=first_sharding_type,
                     transpose_batch_sequence=self.transpose_batch_sequence,
                     return_layernorm_output=self.apply_residual_connection_post_layernorm,
-                    depth_scaling=depth_scaling if self.scale_attn_logits else None,
                     scale_axes=('embed',),
                     kernel_axes=('embed', 'joined_kv'),
                     use_bias=self.use_bias,
@@ -410,7 +409,6 @@ class MultiHeadAttention(nn.Module):
                 sharding_type=first_sharding_type,
                 transpose_batch_sequence=self.transpose_batch_sequence,
                 return_layernorm_output=True,
-                depth_scaling=depth_scaling if self.scale_attn_logits else None,
                 scale_axes=('embed',),
                 kernel_axes=('embed', 'joined_kv'),
                 use_bias=self.use_bias,
@@ -499,6 +497,8 @@ class MultiHeadAttention(nn.Module):
         x = core_attention(query,
                            key,
                            value,
+                           scale_factor=1.0 /
+                           sqrt(self.head_dim) if self.scale_attn_logits else 1.0,
                            transpose_batch_sequence=self.transpose_batch_sequence,
                            softmax_type=softmax_type,
                            softmax_sharding_type=first_sharding_type,


### PR DESCRIPTION
1. Move `scale_factor` to core attention to align fused multi-head attention implementation [transformer.py, module.py]
2. Add cudnn-frontend submodule into `3rdparty/cudnn-frontend`
3. Add cudnn-frontend fused multi-head attention with both self attention and cross attention
4. Fused multi-head attention will be auto enabled if the network satisify the following rules
    - not decode
    - not transpose_batch_sequence
    - fuse_qkv
    - dropout_rate = 0 (dropout can be fused into FMHA, but we lack model convergence test. Will add it in the future)
    - dtype = bfloat16 or float16
    - q_seqlen and kv_seqlen = 128 or 256 or 384 or 512
5. MHA supports DP and TP sharding