### PR TITLE
Add fused attention API interface and cudnn frontend utils

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -17,7 +17,9 @@ add_library(transformer_engine SHARED
                                rmsnorm/rmsnorm_fwd_cuda_kernel.cu
                                util/cast.cu
                                fused_softmax/scaled_masked_softmax.cu
-                               fused_softmax/scaled_upper_triang_masked_softmax.cu)
+                               fused_softmax/scaled_upper_triang_masked_softmax.cu
+                               fused_attention/cudnn_frontend_utils.cu
+                               fused_attention/fused_attention.cu)
 
 target_include_directories(transformer_engine PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
@@ -30,5 +32,18 @@ set_source_files_properties(fused_softmax/scaled_masked_softmax.cu
                             fused_softmax/scaled_upper_triang_masked_softmax.cu
                             PROPERTIES
                             COMPILE_OPTIONS "--use_fast_math")
+
+include(FetchContent)
+FetchContent_Declare(
+    cudnn-frontend
+    GIT_REPOSITORY https://github.com/NVIDIA/cudnn-frontend.git
+    GIT_TAG        8f488bd41229aa0a3d5f7c0168f59e4d69c618ee # release v0.8
+)
+FetchContent_Populate(cudnn-frontend)
+
+set_source_files_properties(fused_attention/cudnn_frontend_utils.cu
+                            PROPERTIES
+                            INCLUDE_DIRECTORIES "${cudnn-frontend_SOURCE_DIR}/include")
+
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")

--- a/transformer_engine/common/fused_attention/cudnn_frontend_utils.cu
+++ b/transformer_engine/common/fused_attention/cudnn_frontend_utils.cu
@@ -1,0 +1,261 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include "cudnn_frontend_utils.h"
+
+cudnnDataType_t get_cudnn_dtype(const transformer_engine::DType t) {
+    using namespace transformer_engine;
+    if (debug) printf("cudnn get type %d\n", static_cast<int>(t));
+    switch (t) {
+        case DType::kFloat16:
+            return CUDNN_DATA_HALF;
+        case DType::kFloat32:
+            return CUDNN_DATA_FLOAT;
+        case DType::kBFloat16:
+            return CUDNN_DATA_BFLOAT16;
+        case DType::kFloat8E4M3:
+            if (debug) printf(" type DType::kFloat8E4M3 \n");
+            return CUDNN_DATA_FP8_E4M3;
+        case DType::kFloat8E5M2:
+            if (debug) printf(" type DType::kFloat8E5M2 \n");
+            return CUDNN_DATA_FP8_E5M2;
+        default:
+            NVTE_ERROR("Invalid type");
+    }
+}
+
+MHA_Layout get_mha_layout(const int layout) {
+    switch (layout) {
+        case 0:
+            return MHA_Layout::NOT_INTERLEAVED;
+        case 1:
+            return MHA_Layout::QKV_INTERLEAVED;
+        case 2:
+            return MHA_Layout::KV_INTERLEAVED;
+        default:
+            NVTE_ERROR("Invalid layout");
+    }
+}
+
+namespace transformer_engine {
+namespace fused_attention {
+
+using namespace transformer_engine;
+
+void generateMHAStrides(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+                        int64_t *strideA, MHA_Layout layout, MHA_Matrix matrix) {
+    CUDNN_FRONTEND_UNUSED(b);
+    constexpr int batch_dim_idx = 0;
+    constexpr int head_dim_idx = 1;
+    constexpr int seqlen_dim_idx = 2;
+    constexpr int hidden_dim_idx = 3;
+
+    constexpr int seqlen_transpose_dim_idx = 3;
+    constexpr int hidden_transpose_dim_idx = 2;
+
+    constexpr int seqlen_q_dim_idx = 2;
+    constexpr int seqlen_kv_dim_idx = 3;
+
+    switch (matrix) {
+        case MHA_Matrix::Q_Matrix:
+            if (layout == MHA_Layout::QKV_INTERLEAVED) {
+                strideA[hidden_dim_idx] = 1;
+                strideA[seqlen_dim_idx] = 3 * h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_q * 3 * h * d;
+            } else {
+                strideA[hidden_dim_idx] = 1;
+                strideA[seqlen_dim_idx] = h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_q * h * d;
+            }
+            break;
+        case MHA_Matrix::K_Matrix:
+            if (layout == MHA_Layout::QKV_INTERLEAVED) {
+                strideA[seqlen_dim_idx] = 3 * h * d;
+                strideA[hidden_dim_idx] = 1;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 3 * h * d;
+            } else if (layout == MHA_Layout::KV_INTERLEAVED) {
+                strideA[seqlen_transpose_dim_idx] = 2 * h * d;
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 2 * h * d;
+            } else {
+                strideA[seqlen_transpose_dim_idx] = h * d;
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * h * d;
+            }
+            break;
+        case MHA_Matrix::K_Matrix_Transpose:
+            if (layout == MHA_Layout::QKV_INTERLEAVED) {
+                strideA[seqlen_transpose_dim_idx] = 3 * h * d;
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 3 * h * d;
+            } else if (layout == MHA_Layout::KV_INTERLEAVED) {
+                strideA[seqlen_transpose_dim_idx] = 2 * h * d;
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 2 * h * d;
+            } else {
+                strideA[seqlen_transpose_dim_idx] = h * d;
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * h * d;
+            }
+            break;
+        case MHA_Matrix::V_Matrix:
+            if (layout == MHA_Layout::QKV_INTERLEAVED) {
+                strideA[hidden_dim_idx] = 1;
+                strideA[seqlen_dim_idx] = 3 * h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 3 * h * d;
+            } else if (layout == MHA_Layout::KV_INTERLEAVED) {
+                strideA[hidden_dim_idx] = 1;
+                strideA[seqlen_dim_idx] = 2 * h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 2 * h * d;
+            } else {
+                strideA[hidden_dim_idx] = 1;
+                strideA[seqlen_dim_idx] = h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * h * d;
+            }
+            break;
+        case MHA_Matrix::V_Matrix_Transpose:
+            if (layout == MHA_Layout::QKV_INTERLEAVED) {
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[seqlen_transpose_dim_idx] = 3 * h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 3 * h * d;
+            } else if (layout == MHA_Layout::KV_INTERLEAVED) {
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[seqlen_transpose_dim_idx] = 2 * h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * 2 * h * d;
+            } else {
+                strideA[hidden_transpose_dim_idx] = 1;
+                strideA[seqlen_transpose_dim_idx] = h * d;
+                strideA[head_dim_idx] = d;
+                strideA[batch_dim_idx] = s_kv * h * d;
+            }
+            break;
+        case MHA_Matrix::S_Matrix:
+            strideA[seqlen_kv_dim_idx] = 1;
+            strideA[seqlen_q_dim_idx] = s_kv;
+            strideA[head_dim_idx] = s_q * s_kv;
+            strideA[batch_dim_idx] = h * s_q * s_kv;
+            break;
+        case MHA_Matrix::O_Matrix:
+            strideA[seqlen_kv_dim_idx] = 1;
+            strideA[seqlen_q_dim_idx] = h * d;
+            strideA[head_dim_idx] = d;
+            strideA[batch_dim_idx] = s_q * h * d;
+            break;
+    }
+}
+
+bool allowAllConfig(cudnnBackendDescriptor_t engine_config) {
+    (void)engine_config;
+    return false;
+}
+
+static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id, int64_t const *dim,
+                                            int64_t const *stride, bool is_virtual, bool is_value) {
+    int nbDims = 4;
+    auto tensor_created =
+        cudnn_frontend::TensorBuilder()
+            .setDim(nbDims, dim)
+            .setStride(nbDims, stride)
+            .setId(id)
+            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+            .setDataType(type)
+            .setVirtual(is_virtual)
+            .setByValue(is_value)
+            .build();
+    if (debug) std::cout << tensor_created.describe() << std::endl;
+    return tensor_created;
+}
+
+#if (CUDNN_VERSION >= 8900)
+static cudnn_frontend::Tensor tensor_create_with_offset(
+    cudnnDataType_t type, int64_t id, int64_t const *dim, int64_t const *stride, bool is_virtual,
+    bool is_value, std::shared_ptr<cudnn_frontend::Tensor> const &raggedOffset) {
+    int nbDims = 4;
+    auto tensor_created =
+        cudnn_frontend::TensorBuilder()
+            .setDim(nbDims, dim)
+            .setStride(nbDims, stride)
+            .setId(id)
+            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+            .setDataType(type)
+            .setVirtual(is_virtual)
+            .setByValue(is_value)
+            .setRaggedOffset(raggedOffset)
+            .build();
+    if (debug) std::cout << tensor_created.describe() << std::endl;
+    return tensor_created;
+}
+#endif
+
+static cudnn_frontend::PointWiseDesc pw_desc_create(cudnnDataType_t type,
+                                                    cudnnPointwiseMode_t mode) {
+    auto pw_desc_created =
+        cudnn_frontend::PointWiseDescBuilder().setMode(mode).setComputeType(type).build();
+
+    if (debug) std::cout << pw_desc_created.describe() << std::endl;
+    return pw_desc_created;
+}
+
+static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const &xDesc,
+                                                    cudnn_frontend::Tensor const &yDesc,
+                                                    cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created =
+        cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+            .setxDesc(xDesc)
+            .setyDesc(yDesc)
+            .setpwDesc(pwDesc)
+            .build();
+    if (debug) std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor const &xDesc,
+                                                     cudnn_frontend::Tensor const &bDesc,
+                                                     cudnn_frontend::Tensor const &yDesc,
+                                                     cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created =
+        cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+            .setxDesc(xDesc)
+            .setbDesc(bDesc)
+            .setyDesc(yDesc)
+            .setpwDesc(pwDesc)
+            .build();
+    if (debug) std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Operation ternary_pw_op_create(cudnn_frontend::Tensor const &xDesc,
+                                                      cudnn_frontend::Tensor const &bDesc,
+                                                      cudnn_frontend::Tensor const &tDesc,
+                                                      cudnn_frontend::Tensor const &yDesc,
+                                                      cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created =
+        cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+            .setxDesc(xDesc)
+            .setbDesc(bDesc)
+            .settDesc(tDesc)
+            .setyDesc(yDesc)
+            .setpwDesc(pwDesc)
+            .build();
+    if (debug) std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+}  // namespace fused_attention
+}  // namespace transformer_engine

--- a/transformer_engine/common/fused_attention/cudnn_frontend_utils.h
+++ b/transformer_engine/common/fused_attention/cudnn_frontend_utils.h
@@ -1,0 +1,61 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#ifndef TRANSFORMER_ENGINE_COMMON_FUSED_ATTENTION_CUDNN_FRONTEND_UTILS_H_
+#define TRANSFORMER_ENGINE_COMMON_FUSED_ATTENTION_CUDNN_FRONTEND_UTILS_H_
+
+#include "../common.h"
+#include "transformer_engine/fused_attention.h"
+
+#include "cudnn_frontend.h"
+
+constexpr static bool debug = false;
+
+cudnnDataType_t get_cudnn_dtype(const transformer_engine::DType t);
+
+MHA_Layout get_mha_layout(const int layout);
+
+namespace transformer_engine {
+namespace fused_attention {
+
+using namespace transformer_engine;
+
+void generateMHAStrides(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, int64_t d,
+                        int64_t *strideA, MHA_Layout layout, MHA_Matrix matrix);
+
+bool allowAllConfig(cudnnBackendDescriptor_t engine_config);
+
+static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id, int64_t const *dim,
+                                            int64_t const *stride, bool is_virtual, bool is_value);
+
+#if (CUDNN_VERSION >= 8900)
+static cudnn_frontend::Tensor tensor_create_with_offset(
+    cudnnDataType_t type, int64_t id, int64_t const *dim, int64_t const *stride, bool is_virtual,
+    bool is_value, std::shared_ptr<cudnn_frontend::Tensor> const &raggedOffset);
+#endif
+
+static cudnn_frontend::PointWiseDesc pw_desc_create(cudnnDataType_t type,
+                                                    cudnnPointwiseMode_t mode);
+
+static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const &xDesc,
+                                                    cudnn_frontend::Tensor const &yDesc,
+                                                    cudnn_frontend::PointWiseDesc const &pwDesc);
+
+static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor const &xDesc,
+                                                     cudnn_frontend::Tensor const &bDesc,
+                                                     cudnn_frontend::Tensor const &yDesc,
+                                                     cudnn_frontend::PointWiseDesc const &pwDesc);
+
+static cudnn_frontend::Operation ternary_pw_op_create(cudnn_frontend::Tensor const &xDesc,
+                                                      cudnn_frontend::Tensor const &bDesc,
+                                                      cudnn_frontend::Tensor const &tDesc,
+                                                      cudnn_frontend::Tensor const &yDesc,
+                                                      cudnn_frontend::PointWiseDesc const &pwDesc);
+
+}  // namespace fused_attention
+}  // namespace transformer_engine
+
+#endif

--- a/transformer_engine/common/fused_attention/fused_attention.cu
+++ b/transformer_engine/common/fused_attention/fused_attention.cu
@@ -1,0 +1,126 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include "transformer_engine/fused_attention.h"
+
+namespace transformer_engine {
+namespace fused_attention {
+
+void cudnn_fused_attention_fwd(int64_t batch, int64_t max_q_seqlen, int64_t max_kv_seqlen,
+                               int64_t total_seqs, int64_t num_head, int64_t head_size,
+                               float scale_qk, float p_dropout, bool is_causal_masking,
+                               bool is_training, MHA_Layout qkv_layout, MHA_Bias_Type bias_type,
+                               Tensor *qkv, Tensor *m, Tensor *z_inv, Tensor *softmax_aux,
+                               Tensor *output, Tensor *bias, Tensor *q_ragged_offset,
+                               Tensor *kv_ragged_offset, Tensor *actual_q_seqlen,
+                               Tensor *actual_kv_seqlen, Tensor *philox_unpack, Tensor *workspace,
+                               cudaStream_t stream) {
+    // TODO: add more checking
+    const DType qkv_type = qkv->data.dtype;
+
+    if (is_fp8_dtype(qkv_type) && max_q_seqlen <= 512 && max_kv_seqlen <= 512) {
+        // TODD(cyanguwa): flash attention w/ fp8
+    } else if (!is_fp8_dtype(qkv_type) && max_q_seqlen <= 512 && max_kv_seqlen <= 512) {
+        // TODO(rewang): fused multi-head attention w/ bf16/fp16
+    } else if (max_q_seqlen > 512 || max_kv_seqlen > 512) {
+        NVTE_ERROR("cudnn frontend doesn't support seqlen > 512 for now. \n");
+    } else {
+        NVTE_ERROR("Invalid combination of data type and sequence length! \n");
+    }
+}
+
+void cudnn_fused_attention_bwd(int64_t batch, int64_t max_q_seqlen, int64_t max_kv_seqlen,
+                               int64_t total_seqs, int64_t num_head, int64_t head_size,
+                               float scale_qk, float p_dropout, bool is_causal_masking,
+                               MHA_Layout qkv_layout, Tensor *qkv, Tensor *m, Tensor *z_inv,
+                               Tensor *softmax_aux, Tensor *output, Tensor *doutput, Tensor *dqkv,
+                               Tensor *dsoftmax, Tensor *q_ragged_offset, Tensor *kv_ragged_offset,
+                               Tensor *actual_q_seqlen, Tensor *actual_kv_seqlen,
+                               Tensor *philox_unpack, Tensor *workspace, cudaStream_t stream) {
+    // TODO: add more checking
+    const DType qkv_type = qkv->data.dtype;
+
+    if (is_fp8_dtype(qkv_type) && max_q_seqlen <= 512 && max_kv_seqlen <= 512) {
+        // TODD(cyanguwa): flash attention w/ fp8
+    } else if (!is_fp8_dtype(qkv_type) && max_q_seqlen <= 512 && max_kv_seqlen <= 512) {
+        // TODO(rewang): fused multi-head attention w/ bf16/fp16
+    } else if (max_q_seqlen > 512 || max_kv_seqlen > 512) {
+        NVTE_ERROR("cudnn frontend doesn't support seqlen > 512 for now. \n");
+    } else {
+        NVTE_ERROR("Invalid combination of data type and sequence length! \n");
+    }
+}
+
+}  // namespace fused_attention
+}  // namespace transformer_engine
+
+void nvte_cudnn_fused_attention_fwd(
+    int64_t batch, int64_t max_q_seqlen, int64_t max_kv_seqlen, int64_t total_seqs,
+    int64_t num_head, int64_t head_size, float scale_qk, float p_dropout, bool is_causal_masking,
+    bool is_training, MHA_Layout qkv_layout, MHA_Bias_Type bias_type, const NVTETensor qkv,
+    const NVTETensor m, const NVTETensor z_inv, const NVTETensor softmax_aux,
+    const NVTETensor output, const NVTETensor bias, const NVTETensor q_ragged_offset,
+    const NVTETensor kv_ragged_offset, const NVTETensor actual_q_seqlen,
+    const NVTETensor actual_kv_seqlen, const NVTETensor philox_unpack, NVTETensor workspace,
+    cudaStream_t stream) {
+    NVTE_API_CALL(nvte_cudnn_fused_attention_fwd);
+    using namespace transformer_engine;
+
+    Tensor *qkv_tensor = reinterpret_cast<Tensor *>(qkv);
+    Tensor *m_tensor = reinterpret_cast<Tensor *>(m);
+    Tensor *z_inv_tensor = reinterpret_cast<Tensor *>(z_inv);
+    Tensor *softmax_aux_tensor = reinterpret_cast<Tensor *>(softmax_aux);
+    Tensor *output_tensor = reinterpret_cast<Tensor *>(output);
+    Tensor *bias_tensor = reinterpret_cast<Tensor *>(bias);
+    Tensor *q_ragged_offset_tensor = reinterpret_cast<Tensor *>(q_ragged_offset);
+    Tensor *kv_ragged_offset_tensor = reinterpret_cast<Tensor *>(kv_ragged_offset);
+    Tensor *actual_q_seqlen_tensor = reinterpret_cast<Tensor *>(actual_q_seqlen);
+    Tensor *actual_kv_seqlen_tensor = reinterpret_cast<Tensor *>(actual_kv_seqlen);
+    Tensor *philox_unpack_tensor = reinterpret_cast<Tensor *>(philox_unpack);
+    Tensor *workspace_tensor = reinterpret_cast<Tensor *>(workspace);
+
+    fused_attention::cudnn_fused_attention_fwd(
+        batch, max_q_seqlen, max_kv_seqlen, total_seqs, num_head, head_size, scale_qk, p_dropout,
+        is_causal_masking, is_training, qkv_layout, bias_type, qkv_tensor, m_tensor, z_inv_tensor,
+        softmax_aux_tensor, output_tensor, bias_tensor, q_ragged_offset_tensor,
+        kv_ragged_offset_tensor, actual_q_seqlen_tensor, actual_kv_seqlen_tensor,
+        philox_unpack_tensor, workspace_tensor, stream);
+}
+
+void nvte_cudnn_fused_attention_bwd(
+    int64_t batch, int64_t max_q_seqlen, int64_t max_kv_seqlen, int64_t total_seqs,
+    int64_t num_head, int64_t head_size, float scale_qk, float p_dropout, bool is_causal_masking,
+    MHA_Layout qkv_layout, const NVTETensor qkv, const NVTETensor m, const NVTETensor z_inv,
+    const NVTETensor softmax_aux, const NVTETensor output, const NVTETensor doutput,
+    const NVTETensor dqkv, const NVTETensor dsoftmax, const NVTETensor q_ragged_offset,
+    const NVTETensor kv_ragged_offset, const NVTETensor actual_q_seqlen,
+    const NVTETensor actual_kv_seqlen, const NVTETensor philox_unpack, NVTETensor workspace,
+    cudaStream_t stream) {
+    NVTE_API_CALL(nvte_cudnn_fused_attention_bwd);
+    using namespace transformer_engine;
+
+    Tensor *qkv_tensor = reinterpret_cast<Tensor *>(qkv);
+    Tensor *m_tensor = reinterpret_cast<Tensor *>(m);
+    Tensor *z_inv_tensor = reinterpret_cast<Tensor *>(z_inv);
+    Tensor *softmax_aux_tensor = reinterpret_cast<Tensor *>(softmax_aux);
+    Tensor *output_tensor = reinterpret_cast<Tensor *>(output);
+    Tensor *doutput_tensor = reinterpret_cast<Tensor *>(doutput);
+    Tensor *dqkv_tensor = reinterpret_cast<Tensor *>(dqkv);
+    Tensor *dsoftmax_tensor = reinterpret_cast<Tensor *>(dsoftmax);
+    Tensor *q_ragged_offset_tensor = reinterpret_cast<Tensor *>(q_ragged_offset);
+    Tensor *kv_ragged_offset_tensor = reinterpret_cast<Tensor *>(kv_ragged_offset);
+    Tensor *actual_q_seqlen_tensor = reinterpret_cast<Tensor *>(actual_q_seqlen);
+    Tensor *actual_kv_seqlen_tensor = reinterpret_cast<Tensor *>(actual_kv_seqlen);
+    Tensor *philox_unpack_tensor = reinterpret_cast<Tensor *>(philox_unpack);
+    Tensor *workspace_tensor = reinterpret_cast<Tensor *>(workspace);
+
+    fused_attention::cudnn_fused_attention_bwd(
+        batch, max_q_seqlen, max_kv_seqlen, total_seqs, num_head, head_size, scale_qk, p_dropout,
+        is_causal_masking, qkv_layout, qkv_tensor, m_tensor, z_inv_tensor, softmax_aux_tensor,
+        output_tensor, doutput_tensor, dqkv_tensor, dsoftmax_tensor, q_ragged_offset_tensor,
+        kv_ragged_offset_tensor, actual_q_seqlen_tensor, actual_kv_seqlen_tensor,
+        philox_unpack_tensor, workspace_tensor, stream);
+}

--- a/transformer_engine/common/include/transformer_engine/fused_attention.h
+++ b/transformer_engine/common/include/transformer_engine/fused_attention.h
@@ -1,0 +1,59 @@
+/*************************************************************************
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#ifndef TRANSFORMER_ENGINE_FUSED_ATTENTION_H_
+#define TRANSFORMER_ENGINE_FUSED_ATTENTION_H_
+
+#include "../common.h"
+#include "transformer_engine.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CUDNN_FRONTEND_UNUSED(X) ((void)X)
+
+enum class MHA_Layout { NOT_INTERLEAVED = 0, QKV_INTERLEAVED = 1, KV_INTERLEAVED = 2 };
+
+enum class MHA_Matrix {
+    Q_Matrix = 0,            // queries
+    K_Matrix = 1,            // keys
+    K_Matrix_Transpose = 2,  // keys transposed
+    V_Matrix = 3,            // values
+    V_Matrix_Transpose = 4,  // value matrix transposed
+    S_Matrix = 5,            // output of GEMM1
+    O_Matrix = 6,            // final output
+};
+
+enum class MHA_Bias_Type { NO_BIAS = 0, PRE_SCALE_BIAS = 1, POST_SCALE_BIAS = 2 };
+
+void nvte_cudnn_fused_attention_fwd(int64_t batch, int64_t max_q_seqlen, int64_t max_kv_seqlen,
+                                    int64_t total_seqs, int64_t num_head, int64_t head_size,
+                                    float scale_qk, float p_dropout, bool is_causal_masking,
+                                    bool is_training, MHA_Layout qkv_layout,
+                                    MHA_Bias_Type bias_type, NVTETensor qkv, NVTETensor m,
+                                    NVTETensor z_inv, NVTETensor softmax_aux, NVTETensor output,
+                                    NVTETensor bias, NVTETensor q_ragged_offset,
+                                    NVTETensor kv_ragged_offset, NVTETensor actual_q_seqlen,
+                                    NVTETensor actual_kv_seqlen, NVTETensor philox_unpack,
+                                    NVTETensor workspace, cudaStream_t stream);
+
+void nvte_cudnn_fused_attention_bwd(int64_t batch, int64_t max_q_seqlen, int64_t max_kv_seqlen,
+                                    int64_t total_seqs, int64_t num_head, int64_t head_size,
+                                    float scale_qk, float p_dropout, bool is_causal_masking,
+                                    MHA_Layout qkv_layout, NVTETensor qkv, NVTETensor m,
+                                    NVTETensor z_inv, NVTETensor softmax_aux, NVTETensor output,
+                                    NVTETensor doutput, NVTETensor dqkv, NVTETensor dsoftmax,
+                                    NVTETensor q_ragged_offset, NVTETensor kv_ragged_offset,
+                                    NVTETensor actual_q_seqlen, NVTETensor actual_kv_seqlen,
+                                    NVTETensor philox_unpack, NVTETensor workspace,
+                                    cudaStream_t stream);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif


### PR DESCRIPTION
This PR is to create an unified interface for the fused attention/flash attention and also to add the common utility functions to `common/fused_attention/cudnn_frontend_utils.h/cu`.

After this PR, we can have independent works (PR) for fused attention and fp8 flash attention in `cudnn_fused_attention_fwd`, `cudnn_fused_attention_bwd`.