### PR TITLE
Fix segfault during onnx export

### DIFF
--- a/transformer_engine/pytorch/te_onnx_extensions.py
+++ b/transformer_engine/pytorch/te_onnx_extensions.py
@@ -82,7 +82,11 @@ def compute_in_fp32(g, inp, subgraph, cast_outp):
     If `inp` data type is not FP32, add a cast of `inp` to FP32 and feed that into `subgraph`.
     Then, if `cast_output` is true, cast subgraphs's output back to `inp` data type.
     """
-    inp_dtype = _type_utils.JitScalarType.from_value(inp)
+    inp_dtype = {
+        "Float": _C_onnx.TensorProtoDataType.FLOAT,
+        "Half": _C_onnx.TensorProtoDataType.FLOAT16,
+        "BFloat16": _C_onnx.TensorProtoDataType.BFLOAT16,
+    }[inp.type().scalarType()]
     is_fp32 = inp_dtype == _type_utils.JitScalarType.FLOAT
     if not is_fp32:
         inp = g.op("Cast", inp, to_i=_C_onnx.TensorProtoDataType.FLOAT)


### PR DESCRIPTION
The function `_type_utils.JitScalarType.from_value` causes segfaults during the ONNX exports for torch version <1.14.