### PR TITLE
Zero-centered gamma (Layernorm1p) support for JAX

### DIFF
--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -66,6 +66,7 @@ _KEY_OF_DROPOUT_RATE = "dropout_rate"
 _KEY_OF_MLP_ACTIVATIONS = "mlp_activations"
 _KEY_OF_FUSE_MLP_WI = "fuse_mlp_wi"
 _KEY_OF_LAYERNORM_TYPE = 'layernorm_type'
+_KEY_OF_ZERO_CENTERED_GAMMA = 'zero_centered_gamma'
 _KEY_OF_TRANSPOSE_BS = 'transpose_batch_sequence'
 
 BASE_ATTRS = {_KEY_OF_TRANSPOSE_BS: True}
@@ -74,6 +75,9 @@ ATTRS = [{
     _KEY_OF_LAYERNORM_TYPE: 'rmsnorm',
 }, {
     _KEY_OF_LAYERNORM_TYPE: 'layernorm',
+}, {
+    _KEY_OF_LAYERNORM_TYPE: 'layernorm',
+    _KEY_OF_ZERO_CENTERED_GAMMA: True
 }, {
     _KEY_OF_LAYERNORM_TYPE: 'rmsnorm',
     _KEY_OF_RESIDUAL_POST_LAYERNORM: True

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -1108,7 +1108,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
-            0,    # RMSNorm doesn't support zero_centered_gamma
+            False,    # RMSNorm doesn't support zero_centered_gamma
             epsilon,
         )
 
@@ -1209,7 +1209,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
-            0,    # RMSNorm doesn't support zero_centered_gamma
+            False,    # RMSNorm doesn't support zero_centered_gamma
             epsilon,
         )
 
@@ -1300,7 +1300,7 @@ class RmsNormBwdPrimitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
-            0,    # RMSNorm doesn't support zero_centered_gamma
+            False,    # RMSNorm doesn't support zero_centered_gamma
             epsilon,
         )
 

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -745,13 +745,7 @@ class LayerNormFwdPrimitive(BasePrimitive):
     multiple_results = True
 
     @staticmethod
-    def abstract(
-            x,
-            gamma,
-            beta,
-            *,
-            epsilon    # pylint: disable=unused-argument
-    ):
+    def abstract(x, gamma, beta, **kwargs):    # pylint: disable=unused-argument
         """
         LayerNorm fwd abstract
         """
@@ -774,7 +768,7 @@ class LayerNormFwdPrimitive(BasePrimitive):
         )
 
     @staticmethod
-    def lowering(ctx, x, gamma, beta, *, epsilon):
+    def lowering(ctx, x, gamma, beta, *, zero_centered_gamma, epsilon):
         """
         LayerNorm fwd lowering rules
         """
@@ -815,6 +809,7 @@ class LayerNormFwdPrimitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
+            zero_centered_gamma,
             epsilon,
         )
 
@@ -826,11 +821,16 @@ class LayerNormFwdPrimitive(BasePrimitive):
 _layernorm_fwd_p = register_primitive(LayerNormFwdPrimitive)
 
 
-def layernorm_fwd(x: jnp.ndarray, gamma: jnp.ndarray, beta: jnp.ndarray, epsilon: float):
+def layernorm_fwd(x: jnp.ndarray, gamma: jnp.ndarray, beta: jnp.ndarray, zero_centered_gamma: bool,
+                  epsilon: float):
     """
     Wrapper for TE layernorm fwd
     """
-    return _layernorm_fwd_p.bind(x, gamma, beta, epsilon=epsilon)
+    return _layernorm_fwd_p.bind(x,
+                                 gamma,
+                                 beta,
+                                 zero_centered_gamma=zero_centered_gamma,
+                                 epsilon=epsilon)
 
 
 class LayerNormFwdFp8Primitive(BasePrimitive):
@@ -848,8 +848,7 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
             amax,
             scale,
             scale_inv,
-            *,
-            epsilon    # pylint: disable=unused-argument
+            **kwargs    # pylint: disable=unused-argument
     ):
         """
         LayerNorm fwd (fp8 out) abstract
@@ -879,7 +878,7 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
         )
 
     @staticmethod
-    def lowering(ctx, x, gamma, beta, amax, scale, scale_inv, *, epsilon):
+    def lowering(ctx, x, gamma, beta, amax, scale, scale_inv, *, zero_centered_gamma, epsilon):
         """
         LayerNorm fwd (fp8 out) lowering rules
         """
@@ -928,6 +927,7 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
+            zero_centered_gamma,
             epsilon,
         )
 
@@ -944,11 +944,19 @@ _layernorm_fwd_fp8_p = register_primitive(LayerNormFwdFp8Primitive)
 
 
 def layernorm_fwd_fp8(x: jnp.ndarray, gamma: jnp.ndarray, beta: jnp.ndarray, amax: jnp.ndarray,
-                      scale: jnp.ndarray, scale_inv: jnp.ndarray, epsilon: float):
+                      scale: jnp.ndarray, scale_inv: jnp.ndarray, zero_centered_gamma: bool,
+                      epsilon: float):
     """
     Wrapper for TE layernorm fwd (fp8 out)
     """
-    return _layernorm_fwd_fp8_p.bind(x, gamma, beta, amax, scale, scale_inv, epsilon=epsilon)
+    return _layernorm_fwd_fp8_p.bind(x,
+                                     gamma,
+                                     beta,
+                                     amax,
+                                     scale,
+                                     scale_inv,
+                                     zero_centered_gamma=zero_centered_gamma,
+                                     epsilon=epsilon)
 
 
 class LayerNormBwdPrimitive(BasePrimitive):
@@ -959,15 +967,7 @@ class LayerNormBwdPrimitive(BasePrimitive):
     multiple_results = True
 
     @staticmethod
-    def abstract(
-            grad_output,
-            mu,
-            rsigma,
-            x,
-            gamma,
-            *,
-            epsilon    # pylint: disable=unused-argument
-    ):
+    def abstract(grad_output, mu, rsigma, x, gamma, **kwargs):    # pylint: disable=unused-argument
         """
         Layernorm bwd abstract
         """
@@ -993,7 +993,7 @@ class LayerNormBwdPrimitive(BasePrimitive):
         )
 
     @staticmethod
-    def lowering(ctx, grad_output, mu, rsigma, x, gamma, *, epsilon):
+    def lowering(ctx, grad_output, mu, rsigma, x, gamma, *, zero_centered_gamma, epsilon):
         """
         Layernorm bwd lowering rules
         """
@@ -1029,6 +1029,7 @@ class LayerNormBwdPrimitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
+            zero_centered_gamma,
             epsilon,
         )
 
@@ -1041,11 +1042,17 @@ _layernorm_bwd_p = register_primitive(LayerNormBwdPrimitive)
 
 
 def layernorm_bwd(g: jnp.ndarray, mu: jnp.ndarray, rsigma: jnp.ndarray, x: jnp.ndarray,
-                  gamma: jnp.ndarray, epsilon: float):
+                  gamma: jnp.ndarray, zero_centered_gamma: bool, epsilon: float):
     """
     Wrapper for TE layernorm bwd
     """
-    return _layernorm_bwd_p.bind(g, mu, rsigma, x, gamma, epsilon=epsilon)
+    return _layernorm_bwd_p.bind(g,
+                                 mu,
+                                 rsigma,
+                                 x,
+                                 gamma,
+                                 zero_centered_gamma=zero_centered_gamma,
+                                 epsilon=epsilon)
 
 
 class RmsNormFwdPrimitive(BasePrimitive):
@@ -1056,12 +1063,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
     multiple_results = True
 
     @staticmethod
-    def abstract(
-            x,
-            gamma,
-            *,
-            epsilon    # pylint: disable=unused-argument
-    ):
+    def abstract(x, gamma, **kwargs):    # pylint: disable=unused-argument
         """
         RMSNorm fwd abstract
         """
@@ -1106,6 +1108,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
+            0,    # RMSNorm doesn't support zero_centered_gamma
             epsilon,
         )
 
@@ -1138,8 +1141,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
             amax,
             scale,
             scale_inv,
-            *,
-            epsilon    # pylint: disable=unused-argument
+            **kwargs    # pylint: disable=unused-argument
     ):
         """
         RMSNorm fwd (fp8 out) abstract
@@ -1207,6 +1209,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
+            0,    # RMSNorm doesn't support zero_centered_gamma
             epsilon,
         )
 
@@ -1243,8 +1246,7 @@ class RmsNormBwdPrimitive(BasePrimitive):
             rsigma,
             x,
             gamma,
-            *,
-            epsilon    # pylint: disable=unused-argument
+            **kwargs    # pylint: disable=unused-argument
     ):
         """
         RMSNorm bwd abstract
@@ -1298,6 +1300,7 @@ class RmsNormBwdPrimitive(BasePrimitive):
             hidden_size,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
+            0,    # RMSNorm doesn't support zero_centered_gamma
             epsilon,
         )
 

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -294,7 +294,7 @@ void LayerNormForwardImpl(size_t n, size_t hidden, bool zero_centered_gamma, flo
 
     auto layernorm_fwd_func = zero_centered_gamma ? nvte_layernorm1p_fwd : nvte_layernorm_fwd;
     if (!is_layer_norm) {
-        assert(!zero_centered_gamma && "rmsnorm doesn't support zero_centered_gamma.");
+        NVTE_CHECK(!zero_centered_gamma, "rmsnorm doesn't support zero_centered_gamma.");
     }
 
     // The first call is to query the required workspace
@@ -369,7 +369,7 @@ void LayerNormBackwardImpl(size_t n, size_t hidden, bool zero_centered_gamma, fl
 
     auto layernorm_bwd_func = zero_centered_gamma ? nvte_layernorm1p_bwd : nvte_layernorm_bwd;
     if (!is_layer_norm) {
-        assert(!zero_centered_gamma && "rmsnorm doesn't support zero_centered_gamma.");
+        NVTE_CHECK(!zero_centered_gamma, "rmsnorm doesn't support zero_centered_gamma.");
     }
 
     // The first call is to query the workspace

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -73,11 +73,12 @@ struct CustomCallNormDescriptor {
     size_t hidden;
     DType x_dtype;
     DType w_dtype;
+    bool zero_centered_gamma;
     float eps;
 };
 
 pybind11::bytes PackCustomCallNormDescriptor(size_t n, size_t hidden, DType x_dtype, DType w_dtype,
-                                             float eps);
+                                             bool zero_centered_gamma, float eps);
 
 struct SoftmaxDescriptor {
     size_t batch;

--- a/transformer_engine/jax/layernorm.py
+++ b/transformer_engine/jax/layernorm.py
@@ -51,7 +51,8 @@ def layernorm(inputs: jnp.ndarray,
     if layernorm_type == 'rmsnorm':
         assert beta is None, "beta should be None if layernorm_type is 'rmsnorm'"
         if zero_centered_gamma:
-            raise NotImplementedError
+            assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+            "if layernorm_type is 'rmsnorm'"
 
     if sharding_type is ShardingType.SINGLE:
         output = _layernorm(inputs,
@@ -113,7 +114,8 @@ def _layernorm_fwd(
     if layernorm_type == 'layernorm':
         output, mu, rsigma = layernorm_fwd(x, gamma, beta, zero_centered_gamma, epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        "if layernorm_type is 'rmsnorm'"
         output, rsigma = rmsnorm_fwd(x, gamma, epsilon)
         mu = None
     return output, (mu, rsigma, x, gamma)
@@ -132,7 +134,8 @@ def _layernorm_bwd(layernorm_type, zero_centered_gamma, epsilon, sharding_type, 
                                                           zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        "if layernorm_type is 'rmsnorm'"
         grad_input, grad_gamma = rmsnorm_bwd(g, rsigma, x, gamma, epsilon=epsilon)
         grad_beta = None
 
@@ -167,7 +170,8 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
     if layernorm_type == 'rmsnorm':
         assert beta is None, "beta should be None if layernorm_type is 'rmsnorm'"
         if zero_centered_gamma:
-            raise NotImplementedError
+            assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+            "if layernorm_type is 'rmsnorm'"
 
     assert fp8_gemm_pkg.num_of_gemm == 1
     inputs = fp8_gemm_pkg.inputs
@@ -313,7 +317,8 @@ def _layernorm_fp8_dot_fwd(
                                                            zero_centered_gamma=zero_centered_gamma,
                                                            epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        "if layernorm_type is 'rmsnorm'"
         ln_out, rsigma, input_amax = rmsnorm_fwd_fp8(inputs,
                                                      gamma,
                                                      input_amax,
@@ -403,6 +408,8 @@ def _layernorm_fp8_dot_bwd(
                                                           zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        "if layernorm_type is 'rmsnorm'"
         grad_input, grad_gamma = rmsnorm_bwd(dgrad, rsigma, inputs, gamma, epsilon=epsilon)
         grad_beta = None
 

--- a/transformer_engine/jax/layernorm.py
+++ b/transformer_engine/jax/layernorm.py
@@ -37,6 +37,7 @@ def layernorm(inputs: jnp.ndarray,
               gamma: jnp.ndarray,
               beta: jnp.ndarray,
               layernorm_type: str,
+              zero_centered_gamma: bool = False,
               epsilon: float = 1e-6,
               sharding_type: ShardingType = ShardingType.SINGLE,
               dp_dim_index: int = 0):
@@ -49,15 +50,18 @@ def layernorm(inputs: jnp.ndarray,
     layernorm_type = canonicalize_layernorm_type(layernorm_type)
     if layernorm_type == 'rmsnorm':
         assert beta is None, "beta should be None if layernorm_type is 'rmsnorm'"
+        if zero_centered_gamma:
+            raise NotImplementedError
 
     if sharding_type is ShardingType.SINGLE:
         output = _layernorm(inputs,
                             gamma,
                             beta,
                             layernorm_type=layernorm_type,
+                            zero_centered_gamma=zero_centered_gamma,
+                            epsilon=epsilon,
                             sharding_type=sharding_type,
-                            dp_axis_name="",
-                            epsilon=epsilon)
+                            dp_axis_name="")
     else:
         dp_axis_name = "batch"
         tp_axis_name = "model"
@@ -75,9 +79,10 @@ def layernorm(inputs: jnp.ndarray,
 
         partial_ln = partial(_layernorm,
                              layernorm_type=layernorm_type,
+                             zero_centered_gamma=zero_centered_gamma,
+                             epsilon=epsilon,
                              sharding_type=sharding_type,
-                             dp_axis_name=dp_axis_name,
-                             epsilon=epsilon)
+                             dp_axis_name=dp_axis_name)
 
         output = xmap_runner(partial_ln, in_axes, sharding_meta.out_axes,
                              sharding_meta.axis_resources, (inputs_, gamma_, beta_))
@@ -87,9 +92,11 @@ def layernorm(inputs: jnp.ndarray,
     return output
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(3, 4, 5, 6))
-def _layernorm(x, gamma, beta, layernorm_type, sharding_type, dp_axis_name, epsilon=1e-6):
-    output, _ = _layernorm_fwd(x, gamma, beta, layernorm_type, sharding_type, dp_axis_name, epsilon)
+@partial(jax.custom_vjp, nondiff_argnums=(3, 4, 5, 6, 7))
+def _layernorm(x, gamma, beta, layernorm_type, zero_centered_gamma, epsilon, sharding_type,
+               dp_axis_name):
+    output, _ = _layernorm_fwd(x, gamma, beta, layernorm_type, zero_centered_gamma, epsilon,
+                               sharding_type, dp_axis_name)
     return output
 
 
@@ -98,23 +105,34 @@ def _layernorm_fwd(
         gamma,
         beta,
         layernorm_type,
+        zero_centered_gamma,
+        epsilon,
         sharding_type,    # pylint: disable=unused-argument
-        dp_axis_name,    # pylint: disable=unused-argument
-        epsilon):
+        dp_axis_name    # pylint: disable=unused-argument
+):
     if layernorm_type == 'layernorm':
-        output, mu, rsigma = layernorm_fwd(x, gamma, beta, epsilon)
+        output, mu, rsigma = layernorm_fwd(x, gamma, beta, zero_centered_gamma, epsilon)
     else:
+        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
         output, rsigma = rmsnorm_fwd(x, gamma, epsilon)
         mu = None
     return output, (mu, rsigma, x, gamma)
 
 
-def _layernorm_bwd(layernorm_type, sharding_type, dp_axis_name, epsilon, ctx, g):
+def _layernorm_bwd(layernorm_type, zero_centered_gamma, epsilon, sharding_type, dp_axis_name, ctx,
+                   g):
     mu, rsigma, x, gamma = ctx
 
     if layernorm_type == 'layernorm':
-        grad_input, grad_gamma, grad_beta = layernorm_bwd(g, mu, rsigma, x, gamma, epsilon=epsilon)
+        grad_input, grad_gamma, grad_beta = layernorm_bwd(g,
+                                                          mu,
+                                                          rsigma,
+                                                          x,
+                                                          gamma,
+                                                          zero_centered_gamma=zero_centered_gamma,
+                                                          epsilon=epsilon)
     else:
+        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
         grad_input, grad_gamma = rmsnorm_bwd(g, rsigma, x, gamma, epsilon=epsilon)
         grad_beta = None
 
@@ -135,9 +153,10 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
                       fwd_dtype: TEDType,
                       bwd_dtype: TEDType,
                       contracting_dims: Tuple[Sequence[int], Sequence[int]] = ((-1,), (0,)),
+                      zero_centered_gamma: bool = False,
+                      epsilon: float = 1e-6,
                       sharding_type: ShardingType = ShardingType.SINGLE,
-                      dp_dim_index: int = 0,
-                      epsilon: float = 1e-6) -> jnp.ndarray:
+                      dp_dim_index: int = 0) -> jnp.ndarray:
     """
     LN + fp8 dot fusion wrapper
     """
@@ -147,6 +166,8 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
     layernorm_type = canonicalize_layernorm_type(layernorm_type)
     if layernorm_type == 'rmsnorm':
         assert beta is None, "beta should be None if layernorm_type is 'rmsnorm'"
+        if zero_centered_gamma:
+            raise NotImplementedError
 
     assert fp8_gemm_pkg.num_of_gemm == 1
     inputs = fp8_gemm_pkg.inputs
@@ -169,10 +190,11 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
                                     fwd_dtype,
                                     bwd_dtype,
                                     contracting_dims,
+                                    zero_centered_gamma=zero_centered_gamma,
+                                    epsilon=epsilon,
                                     sharding_type=sharding_type,
                                     dp_axis_name="",
-                                    tp_axis_name="",
-                                    epsilon=epsilon)
+                                    tp_axis_name="")
     else:
         dp_axis_name = "batch"
         tp_axis_name = "model"
@@ -214,10 +236,11 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
                                      fwd_dtype=fwd_dtype,
                                      bwd_dtype=bwd_dtype,
                                      contracting_dims=contracting_dims,
+                                     zero_centered_gamma=zero_centered_gamma,
+                                     epsilon=epsilon,
                                      sharding_type=sharding_type,
                                      dp_axis_name=dp_axis_name,
-                                     tp_axis_name=tp_axis_name,
-                                     epsilon=epsilon)
+                                     tp_axis_name=tp_axis_name)
 
         # input, kernel, gamma, beta, fp8_metas
         in_axes = (ln_sharding_meta.in_axes[0], dot_sharding_meta.in_axes[1],
@@ -230,27 +253,18 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
     return output
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(8, 9, 10, 11, 12, 13, 14, 15))
-def _layernorm_fp8_dot(inputs: jnp.ndarray,
-                       kernel: jnp.ndarray,
-                       gamma: jnp.ndarray,
-                       beta: jnp.ndarray,
-                       fp8_maxs: jnp.ndarray,
-                       amax: jnp.ndarray,
-                       scale: jnp.ndarray,
-                       scale_inv: jnp.ndarray,
-                       layernorm_type: str,
-                       fwd_dtype: TEDType,
-                       bwd_dtype: TEDType,
+@partial(jax.custom_vjp, nondiff_argnums=(8, 9, 10, 11, 12, 13, 14, 15, 16))
+def _layernorm_fp8_dot(inputs: jnp.ndarray, kernel: jnp.ndarray, gamma: jnp.ndarray,
+                       beta: jnp.ndarray, fp8_maxs: jnp.ndarray, amax: jnp.ndarray,
+                       scale: jnp.ndarray, scale_inv: jnp.ndarray, layernorm_type: str,
+                       fwd_dtype: TEDType, bwd_dtype: TEDType,
                        contracting_dims: Tuple[Sequence[int], Sequence[int]],
-                       sharding_type: ShardingType,
-                       dp_axis_name: str,
-                       tp_axis_name: str,
-                       epsilon: float = 1e-6) -> jnp.ndarray:
+                       zero_centered_gamma: bool, epsilon: float, sharding_type: ShardingType,
+                       dp_axis_name: str, tp_axis_name: str) -> jnp.ndarray:
     output, _ = _layernorm_fp8_dot_fwd(inputs, kernel, gamma, beta, fp8_maxs, amax, scale,
                                        scale_inv, layernorm_type, fwd_dtype, bwd_dtype,
-                                       contracting_dims, sharding_type, dp_axis_name, tp_axis_name,
-                                       epsilon)
+                                       contracting_dims, zero_centered_gamma, epsilon,
+                                       sharding_type, dp_axis_name, tp_axis_name)
     return output
 
 
@@ -267,10 +281,11 @@ def _layernorm_fp8_dot_fwd(
         fwd_dtype,
         bwd_dtype,    # pylint: disable=unused-argument
         contracting_dims,
+        zero_centered_gamma,
+        epsilon,
         sharding_type,
         dp_axis_name,    # pylint: disable=unused-argument
-        tp_axis_name,
-        epsilon):
+        tp_axis_name):
 
     lhs_contracting_dims, rhs_contracting_dims = contracting_dims
     input_shape_pre = inputs.shape[:min(lhs_contracting_dims)]
@@ -295,8 +310,10 @@ def _layernorm_fp8_dot_fwd(
                                                            input_amax,
                                                            input_scale,
                                                            input_scale_inv,
+                                                           zero_centered_gamma=zero_centered_gamma,
                                                            epsilon=epsilon)
     else:
+        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
         ln_out, rsigma, input_amax = rmsnorm_fwd_fp8(inputs,
                                                      gamma,
                                                      input_amax,
@@ -337,10 +354,11 @@ def _layernorm_fp8_dot_bwd(
         fwd_dtype,
         bwd_dtype,
         contracting_dims,    # pylint: disable=unused-argument
+        zero_centered_gamma,
+        epsilon,
         sharding_type,
         dp_axis_name,
         tp_axis_name,
-        epsilon,
         ctx,
         g):
     ln_out_, kernel_cast, \
@@ -377,7 +395,13 @@ def _layernorm_fp8_dot_bwd(
         dgrad = jax.lax.psum(dgrad, tp_axis_name)
 
     if layernorm_type == 'layernorm':
-        grad_input, grad_gamma, grad_beta = layernorm_bwd(dgrad, mu, rsigma, inputs, gamma, epsilon)
+        grad_input, grad_gamma, grad_beta = layernorm_bwd(dgrad,
+                                                          mu,
+                                                          rsigma,
+                                                          inputs,
+                                                          gamma,
+                                                          zero_centered_gamma=zero_centered_gamma,
+                                                          epsilon=epsilon)
     else:
         grad_input, grad_gamma = rmsnorm_bwd(dgrad, rsigma, inputs, gamma, epsilon=epsilon)
         grad_beta = None

--- a/transformer_engine/jax/layernorm.py
+++ b/transformer_engine/jax/layernorm.py
@@ -50,8 +50,7 @@ def layernorm(inputs: jnp.ndarray,
     layernorm_type = canonicalize_layernorm_type(layernorm_type)
     if layernorm_type == 'rmsnorm':
         assert beta is None, "beta should be None if layernorm_type is 'rmsnorm'"
-        if zero_centered_gamma:
-            assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
             "if layernorm_type is 'rmsnorm'"
 
     if sharding_type is ShardingType.SINGLE:
@@ -114,8 +113,8 @@ def _layernorm_fwd(
     if layernorm_type == 'layernorm':
         output, mu, rsigma = layernorm_fwd(x, gamma, beta, zero_centered_gamma, epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
-        "if layernorm_type is 'rmsnorm'"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
+            "if layernorm_type is 'rmsnorm'"
         output, rsigma = rmsnorm_fwd(x, gamma, epsilon)
         mu = None
     return output, (mu, rsigma, x, gamma)
@@ -134,8 +133,8 @@ def _layernorm_bwd(layernorm_type, zero_centered_gamma, epsilon, sharding_type, 
                                                           zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
-        "if layernorm_type is 'rmsnorm'"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
+            "if layernorm_type is 'rmsnorm'"
         grad_input, grad_gamma = rmsnorm_bwd(g, rsigma, x, gamma, epsilon=epsilon)
         grad_beta = None
 
@@ -169,8 +168,7 @@ def layernorm_fp8_dot(fp8_gemm_pkg: FP8GemmPackage,
     layernorm_type = canonicalize_layernorm_type(layernorm_type)
     if layernorm_type == 'rmsnorm':
         assert beta is None, "beta should be None if layernorm_type is 'rmsnorm'"
-        if zero_centered_gamma:
-            assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
             "if layernorm_type is 'rmsnorm'"
 
     assert fp8_gemm_pkg.num_of_gemm == 1
@@ -317,8 +315,8 @@ def _layernorm_fp8_dot_fwd(
                                                            zero_centered_gamma=zero_centered_gamma,
                                                            epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
-        "if layernorm_type is 'rmsnorm'"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
+            "if layernorm_type is 'rmsnorm'"
         ln_out, rsigma, input_amax = rmsnorm_fwd_fp8(inputs,
                                                      gamma,
                                                      input_amax,
@@ -408,8 +406,8 @@ def _layernorm_fp8_dot_bwd(
                                                           zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
-        "if layernorm_type is 'rmsnorm'"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
+            "if layernorm_type is 'rmsnorm'"
         grad_input, grad_gamma = rmsnorm_bwd(dgrad, rsigma, inputs, gamma, epsilon=epsilon)
         grad_beta = None
 

--- a/transformer_engine/jax/mlp.py
+++ b/transformer_engine/jax/mlp.py
@@ -127,7 +127,8 @@ def fp8_ln_mlp(
     if layernorm_type == 'rmsnorm':
         assert ln_bias is None, "ln_bias should be None if layernorm_type is 'rmsnorm'"
         if zero_centered_gamma:
-            raise NotImplementedError
+            assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+            "if layernorm_type is 'rmsnorm'"
 
     assert activations == ('gelu', 'linear')
     if major_sharding_type is MajorShardingType.SINGLE:
@@ -286,7 +287,8 @@ def _fp8_mlp_fwd(
                                                             zero_centered_gamma=zero_centered_gamma,
                                                             epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        "if layernorm_type is 'rmsnorm'"
         ln_out, rsigma, ln_out_amax = rmsnorm_fwd_fp8(inputs_,
                                                       gamma,
                                                       input_amax,
@@ -410,7 +412,8 @@ def _fp8_mlp_bwd(
                                                           zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        "if layernorm_type is 'rmsnorm'"
         grad_input, grad_gamma = rmsnorm_bwd(dgrad_1, rsigma, inputs_, gamma, epsilon=epsilon)
         grad_beta = None
 

--- a/transformer_engine/jax/mlp.py
+++ b/transformer_engine/jax/mlp.py
@@ -103,6 +103,7 @@ def fp8_ln_mlp(
     layernorm_type: str,
     fwd_dtype: TEDType,
     bwd_dtype: TEDType,
+    zero_centered_gamma: bool = False,
     epsilon: float = 1e-6,
     contracting_dims: Tuple[Sequence[int], Sequence[int]] = ((-1,), (0,)),
     major_sharding_type: MajorShardingType = MajorShardingType.SINGLE,
@@ -125,12 +126,14 @@ def fp8_ln_mlp(
     layernorm_type = canonicalize_layernorm_type(layernorm_type)
     if layernorm_type == 'rmsnorm':
         assert ln_bias is None, "ln_bias should be None if layernorm_type is 'rmsnorm'"
+        if zero_centered_gamma:
+            raise NotImplementedError
 
     assert activations == ('gelu', 'linear')
     if major_sharding_type is MajorShardingType.SINGLE:
         res = _fp8_mlp(inputs, ln_scale, ln_bias, kernel_1, kernel_2, fp8_max, amax, scale,
-                       scale_inv, layernorm_type, activations, epsilon, fwd_dtype, bwd_dtype,
-                       contracting_dims, major_sharding_type, "", "")
+                       scale_inv, layernorm_type, activations, zero_centered_gamma, epsilon,
+                       fwd_dtype, bwd_dtype, contracting_dims, major_sharding_type, "", "")
     else:
         dp_axis_name = "batch"
         tp_axis_name = "model"
@@ -177,6 +180,7 @@ def fp8_ln_mlp(
         partial_fp8_mlp = partial(_fp8_mlp,
                                   layernorm_type=layernorm_type,
                                   activations=activations,
+                                  zero_centered_gamma=zero_centered_gamma,
                                   epsilon=epsilon,
                                   fwd_dtype=fwd_dtype,
                                   bwd_dtype=bwd_dtype,
@@ -196,12 +200,13 @@ def fp8_ln_mlp(
     return res
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(9, 10, 11, 12, 13, 14, 15, 16, 17))
+@partial(jax.custom_vjp, nondiff_argnums=(9, 10, 11, 12, 13, 14, 15, 16, 17, 18))
 def _fp8_mlp(inputs: jnp.ndarray, ln_scale: jnp.ndarray, ln_bias: jnp.ndarray,
              kernel_1: jnp.ndarray, kernel_2: jnp.ndarray, fp8_maxs: jnp.ndarray, amax: jnp.ndarray,
              scale: jnp.ndarray, scale_inv: jnp.ndarray, layernorm_type: str,
-             activations: Sequence[Union[str, Callable]], epsilon: float, fwd_dtype: TEDType,
-             bwd_dtype: TEDType, contracting_dims: Tuple[Sequence[int], Sequence[int]],
+             activations: Sequence[Union[str, Callable]], zero_centered_gamma: bool, epsilon: float,
+             fwd_dtype: TEDType, bwd_dtype: TEDType, contracting_dims: Tuple[Sequence[int],
+                                                                             Sequence[int]],
              major_sharding_type: MajorShardingType, dp_axis_name: str, tp_axis_name: str):
     res, _ = _fp8_mlp_fwd(inputs,
                           ln_scale,
@@ -214,6 +219,7 @@ def _fp8_mlp(inputs: jnp.ndarray, ln_scale: jnp.ndarray, ln_bias: jnp.ndarray,
                           scale_inv,
                           layernorm_type,
                           activations,
+                          zero_centered_gamma,
                           epsilon,
                           fwd_dtype,
                           bwd_dtype,
@@ -236,6 +242,7 @@ def _fp8_mlp_fwd(
         scale_inv,
         layernorm_type,
         activations,
+        zero_centered_gamma,
         epsilon,
         fwd_dtype,
         bwd_dtype,    # pylint: disable=unused-argument
@@ -276,8 +283,10 @@ def _fp8_mlp_fwd(
                                                             input_amax,
                                                             input_scale,
                                                             input_scale_inv,
+                                                            zero_centered_gamma=zero_centered_gamma,
                                                             epsilon=epsilon)
     else:
+        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
         ln_out, rsigma, ln_out_amax = rmsnorm_fwd_fp8(inputs_,
                                                       gamma,
                                                       input_amax,
@@ -334,6 +343,7 @@ def _fp8_mlp_fwd(
 def _fp8_mlp_bwd(
         layernorm_type,
         activations,    # pylint: disable=unused-argument
+        zero_centered_gamma,
         epsilon,
         fwd_dtype,
         bwd_dtype,
@@ -397,8 +407,10 @@ def _fp8_mlp_bwd(
                                                           rsigma,
                                                           inputs_,
                                                           gamma,
+                                                          zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
+        assert not zero_centered_gamma, "zero_centered_gamma is only supported by layernorm"
         grad_input, grad_gamma = rmsnorm_bwd(dgrad_1, rsigma, inputs_, gamma, epsilon=epsilon)
         grad_beta = None
 

--- a/transformer_engine/jax/mlp.py
+++ b/transformer_engine/jax/mlp.py
@@ -126,8 +126,7 @@ def fp8_ln_mlp(
     layernorm_type = canonicalize_layernorm_type(layernorm_type)
     if layernorm_type == 'rmsnorm':
         assert ln_bias is None, "ln_bias should be None if layernorm_type is 'rmsnorm'"
-        if zero_centered_gamma:
-            assert not zero_centered_gamma, "zero_centered_gamma is not supported "
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
             "if layernorm_type is 'rmsnorm'"
 
     assert activations == ('gelu', 'linear')
@@ -287,8 +286,8 @@ def _fp8_mlp_fwd(
                                                             zero_centered_gamma=zero_centered_gamma,
                                                             epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
-        "if layernorm_type is 'rmsnorm'"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
+            "if layernorm_type is 'rmsnorm'"
         ln_out, rsigma, ln_out_amax = rmsnorm_fwd_fp8(inputs_,
                                                       gamma,
                                                       input_amax,
@@ -412,8 +411,8 @@ def _fp8_mlp_bwd(
                                                           zero_centered_gamma=zero_centered_gamma,
                                                           epsilon=epsilon)
     else:
-        assert not zero_centered_gamma, "zero_centered_gamma is not supported "
-        "if layernorm_type is 'rmsnorm'"
+        assert not zero_centered_gamma, "zero_centered_gamma is not supported " \
+            "if layernorm_type is 'rmsnorm'"
         grad_input, grad_gamma = rmsnorm_bwd(dgrad_1, rsigma, inputs_, gamma, epsilon=epsilon)
         grad_beta = None
 

--- a/transformer_engine/jax/module.py
+++ b/transformer_engine/jax/module.py
@@ -202,20 +202,20 @@ class LayerNorm(nn.Module):
         A value added to the denominator of layer normalization for numerical stability.
     layernorm_type : {'layernorm', 'rmsnorm'}, default = 'layernorm'
         Indicate the type of layer normalization.
-    zero_centered_gamma: bool, default = False
+    zero_centered_gamma : bool, default = False
         If set to `True`, the LayerNorm formula changes to
 
         .. math::
             y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
             (1 + \gamma) + \beta
 
-        The default of `scale_init` will also be changed. See `scale_init`
+        This parameter is only applicable for 'layernorm'.
+        The default of `scale_init` will also be changed. See `scale_init`.
     scale_init : Initializer, default = None
         Used for initializing scale factors :math:`\gamma`.
-        If `None` is provided, the following rules will be applied to `scale_init`
-        `scale_init` is `flax.linen.initializers.ones` when `zero_centered_gamma == False`.
-        Otherwise, `scale_init` is
-        `flax.linen.initializers.zeros` when `zero_centered_gamma == True`
+        If `None` is provided, the following rules will be applied to `scale_init`:
+            If `zero_centered_gamma == False`: `scale_init` = `flax.linen.initializers.ones`.
+            If `zero_centered_gamma == True`: `scale_init` = `flax.linen.initializers.zeros`.
         It should be a callable object with three arguments (jax.random.PRNGKey, shape, dtype).
     scale_axes : Tuple[str, ...], default = ('embed', )
         The name of axes used to shard the scale factors :math:`\gamma` with a corresponding mesh.
@@ -464,20 +464,20 @@ class LayerNormDenseGeneral(TransformerEngineBase):
         Indicate the type of layer normalization.
     epsilon : float, default = 1e-6
         A value added to the denominator of layer normalization for numerical stability.
-    zero_centered_gamma: bool, default = False
+    zero_centered_gamma : bool, default = False
         If set to `True`, the LayerNorm formula changes to
 
         .. math::
             y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
             (1 + \gamma) + \beta
 
+        This parameter is only applicable for 'layernorm'.
         The default of `scale_init` will also be changed. See `scale_init`
     scale_init : Initializer, default = None
         Used for initializing scale factors :math:`\gamma`.
-        If `None` is provided, the following rules will be applied to `scale_init`
-        `scale_init` is `flax.linen.initializers.ones` when `zero_centered_gamma == False`.
-        Otherwise, `scale_init` is
-        `flax.linen.initializers.zeros` when `zero_centered_gamma == True`
+        If `None` is provided, the following rules will be applied to `scale_init`:
+            If `zero_centered_gamma == False`: `scale_init` = `flax.linen.initializers.ones`.
+            If `zero_centered_gamma == True`: `scale_init` = `flax.linen.initializers.zeros`.
         It should be a callable object with three arguments (jax.random.PRNGKey, shape, dtype).
     scale_axes : Tuple[str, ...], default = ('embed', )
         The name of axes used to shard the scale factors :math:`\gamma` with a corresponding mesh,
@@ -679,20 +679,20 @@ class LayerNormMLP(TransformerEngineBase):
         Indicate the type of layer normalization.
     epsilon : float, default = 1e-6
         A value added to the denominator of layer normalization for numerical stability.
-    zero_centered_gamma: bool, default = False
+    zero_centered_gamma : bool, default = False
         If set to `True`, the LayerNorm formula changes to
 
         .. math::
             y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
             (1 + \gamma) + \beta
 
-        The default of `scale_init` will also be changed. See `scale_init`
+        This parameter is only applicable for 'layernorm'.
+        The default of `scale_init` will also be changed. See `scale_init`.
     scale_init : Initializer, default = None
         Used for initializing scale factors :math:`\gamma`.
-        If `None` is provided, the following rules will be applied to `scale_init`
-        `scale_init` is `flax.linen.initializers.ones` when `zero_centered_gamma == False`.
-        Otherwise, `scale_init` is
-        `flax.linen.initializers.zeros` when `zero_centered_gamma == True`
+        If `None` is provided, the following rules will be applied to `scale_init`:
+            If `zero_centered_gamma == False`: `scale_init` = `flax.linen.initializers.ones`.
+            If `zero_centered_gamma == True`: `scale_init` = `flax.linen.initializers.zeros`.
         It should be a callable object with three arguments (jax.random.PRNGKey, shape, dtype).
     scale_axes : Tuple[str, ...], default = ('embed', )
         The name of axes used to shard the scale factors :math:`\gamma` with a corresponding mesh,

--- a/transformer_engine/jax/module.py
+++ b/transformer_engine/jax/module.py
@@ -213,9 +213,9 @@ class LayerNorm(nn.Module):
         The default of `scale_init` will also be changed. See `scale_init`.
     scale_init : Initializer, default = None
         Used for initializing scale factors :math:`\gamma`.
-        If `None` is provided, the following rules will be applied to `scale_init`:
-            If `zero_centered_gamma == False`: `scale_init` = `flax.linen.initializers.ones`.
-            If `zero_centered_gamma == True`: `scale_init` = `flax.linen.initializers.zeros`.
+        If `None` is provided, scale_init is set according to the value of zero_centered_gamma.
+        If zero_centered_gamma is set to `True`, then scale_init is `flax.linen.initializers.zeros`.
+        Otherwise, scale_init is `flax.linen.initializers.ones`.
         It should be a callable object with three arguments (jax.random.PRNGKey, shape, dtype).
     scale_axes : Tuple[str, ...], default = ('embed', )
         The name of axes used to shard the scale factors :math:`\gamma` with a corresponding mesh.
@@ -475,9 +475,9 @@ class LayerNormDenseGeneral(TransformerEngineBase):
         The default of `scale_init` will also be changed. See `scale_init`
     scale_init : Initializer, default = None
         Used for initializing scale factors :math:`\gamma`.
-        If `None` is provided, the following rules will be applied to `scale_init`:
-            If `zero_centered_gamma == False`: `scale_init` = `flax.linen.initializers.ones`.
-            If `zero_centered_gamma == True`: `scale_init` = `flax.linen.initializers.zeros`.
+        If `None` is provided, scale_init is set according to the value of zero_centered_gamma.
+        If zero_centered_gamma is set to `True`, then scale_init is `flax.linen.initializers.zeros`.
+        Otherwise, scale_init is `flax.linen.initializers.ones`.
         It should be a callable object with three arguments (jax.random.PRNGKey, shape, dtype).
     scale_axes : Tuple[str, ...], default = ('embed', )
         The name of axes used to shard the scale factors :math:`\gamma` with a corresponding mesh,
@@ -690,9 +690,9 @@ class LayerNormMLP(TransformerEngineBase):
         The default of `scale_init` will also be changed. See `scale_init`.
     scale_init : Initializer, default = None
         Used for initializing scale factors :math:`\gamma`.
-        If `None` is provided, the following rules will be applied to `scale_init`:
-            If `zero_centered_gamma == False`: `scale_init` = `flax.linen.initializers.ones`.
-            If `zero_centered_gamma == True`: `scale_init` = `flax.linen.initializers.zeros`.
+        If `None` is provided, scale_init is set according to the value of zero_centered_gamma.
+        If zero_centered_gamma is set to `True`, then scale_init is `flax.linen.initializers.zeros`.
+        Otherwise, scale_init is `flax.linen.initializers.ones`.
         It should be a callable object with three arguments (jax.random.PRNGKey, shape, dtype).
     scale_axes : Tuple[str, ...], default = ('embed', )
         The name of axes used to shard the scale factors :math:`\gamma` with a corresponding mesh,

--- a/transformer_engine/jax/transformer.py
+++ b/transformer_engine/jax/transformer.py
@@ -205,6 +205,12 @@ class MultiHeadAttention(nn.Module):
         Indicate the type of layer normalization.
     layernorm_epsilon: float, default = 1e-6
         A value added to the denominator of layer normalization for numerical stability.
+    zero_centered_gamma: bool, default = False
+        If set to `True`, the LayerNorm formula changes to
+
+        .. math::
+            y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
+            (1 + \gamma) + \beta
     kernel_init: Initializer, default =
         flax.linen.initializers.variance_scaling(1.0, 'fan_in', 'normal')
         Used for initializing the QKV and Output projection weights.
@@ -250,6 +256,7 @@ class MultiHeadAttention(nn.Module):
     dropout_rng_name: str = 'dropout'
     layernorm_type: str = "layernorm"
     layernorm_epsilon: float = 1e-6
+    zero_centered_gamma: bool = False
     kernel_init: Initializer = None
     use_bias: bool = False
     bias_init: Initializer = nn.initializers.zeros
@@ -346,6 +353,7 @@ class MultiHeadAttention(nn.Module):
                 qkv_proj, ln_out = LayerNormDenseGeneral(
                     enable_layernorm=not self.output_layernorm,
                     layernorm_type=self.layernorm_type,
+                    zero_centered_gamma=self.zero_centered_gamma,
                     epsilon=self.layernorm_epsilon,
                     axis=-1,
                     features=(3, self.num_heads * self.head_dim),
@@ -369,6 +377,7 @@ class MultiHeadAttention(nn.Module):
                 query, ln_out = LayerNormDenseGeneral(
                     enable_layernorm=not self.output_layernorm,
                     layernorm_type=self.layernorm_type,
+                    zero_centered_gamma=self.zero_centered_gamma,
                     epsilon=self.layernorm_epsilon,
                     axis=-1,
                     features=self.num_heads * self.head_dim,
@@ -412,6 +421,7 @@ class MultiHeadAttention(nn.Module):
             query, ln_out = LayerNormDenseGeneral(
                 enable_layernorm=not self.output_layernorm,
                 layernorm_type=self.layernorm_type,
+                zero_centered_gamma=self.zero_centered_gamma,
                 epsilon=self.layernorm_epsilon,
                 axis=-1,
                 features=self.num_heads * self.head_dim,
@@ -661,6 +671,12 @@ class TransformerLayer(nn.Module):
         Indicate the type of layer normalization.
     layernorm_epsilon: float, default = 1e-6
         A value added to the denominator of layer normalization for numerical stability.
+    zero_centered_gamma: bool, default = False
+        If set to `True`, the LayerNorm formula changes to
+
+        .. math::
+            y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
+            (1 + \gamma) + \beta
     hidden_dropout: float, default = 0.1
         Dropout probability for the dropout op after FC2 layer.
     hidden_dropout_dims: Sequence[int], default = ()
@@ -740,6 +756,7 @@ class TransformerLayer(nn.Module):
     num_attention_heads: int = 8
     layernorm_type: str = 'layernorm'
     layernorm_epsilon: float = 1e-6
+    zero_centered_gamma: bool = False
     hidden_dropout: float = 0.1
     hidden_dropout_dims: Sequence[int] = ()
     attention_dropout: float = 0.1
@@ -874,6 +891,7 @@ class TransformerLayer(nn.Module):
             scaled_query_init=self.scaled_query_init,
             layernorm_type=self.layernorm_type,
             layernorm_epsilon=self.layernorm_epsilon,
+            zero_centered_gamma=self.zero_centered_gamma,
             apply_residual_connection_post_layernorm=self.apply_residual_connection_post_layernorm,
             output_layernorm=self.output_layernorm,
             attn_type=self_attn_type,
@@ -919,6 +937,7 @@ class TransformerLayer(nn.Module):
                 dropout_rng_name=self.dropout_rng_name,
                 layernorm_type=self.layernorm_type,
                 layernorm_epsilon=self.layernorm_epsilon,
+                zero_centered_gamma=self.zero_centered_gamma,
                 apply_residual_connection_post_layernorm=self.
                 apply_residual_connection_post_layernorm,
                 output_layernorm=False,    # Must do LayerNorm before MHA.
@@ -941,6 +960,7 @@ class TransformerLayer(nn.Module):
         residual = mlp_input
         z, ln_out = LayerNormMLP(
             layernorm_type=self.layernorm_type,
+            zero_centered_gamma=self.zero_centered_gamma,
             epsilon=self.layernorm_epsilon,
             major_sharding_type=infer_major_sharding_type(),
             transpose_batch_sequence=self.transpose_batch_sequence,
@@ -973,11 +993,12 @@ class TransformerLayer(nn.Module):
         if self.output_layernorm:
             ln_sharding_type, _ = infer_sharding_type()
             z = LayerNorm(layernorm_type=self.layernorm_type,
+                          zero_centered_gamma=self.zero_centered_gamma,
+                          epsilon=self.layernorm_epsilon,
                           scale_axes=('embed',),
                           bias_axes=('embed',),
                           transpose_batch_sequence=self.transpose_batch_sequence,
                           dtype=self.dtype,
-                          epsilon=self.layernorm_epsilon,
                           sharding_type=ln_sharding_type,
                           name="output_layer_norm")(z)
 

--- a/transformer_engine/jax/transformer.py
+++ b/transformer_engine/jax/transformer.py
@@ -205,12 +205,14 @@ class MultiHeadAttention(nn.Module):
         Indicate the type of layer normalization.
     layernorm_epsilon: float, default = 1e-6
         A value added to the denominator of layer normalization for numerical stability.
-    zero_centered_gamma: bool, default = False
+    zero_centered_gamma : bool, default = False
         If set to `True`, the LayerNorm formula changes to
 
         .. math::
             y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
             (1 + \gamma) + \beta
+
+        This parameter is only applicable for 'layernorm'.
     kernel_init: Initializer, default =
         flax.linen.initializers.variance_scaling(1.0, 'fan_in', 'normal')
         Used for initializing the QKV and Output projection weights.
@@ -671,12 +673,14 @@ class TransformerLayer(nn.Module):
         Indicate the type of layer normalization.
     layernorm_epsilon: float, default = 1e-6
         A value added to the denominator of layer normalization for numerical stability.
-    zero_centered_gamma: bool, default = False
+    zero_centered_gamma : bool, default = False
         If set to `True`, the LayerNorm formula changes to
 
         .. math::
             y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} *
             (1 + \gamma) + \beta
+
+        This parameter is only applicable for 'layernorm'.
     hidden_dropout: float, default = 0.1
         Dropout probability for the dropout op after FC2 layer.
     hidden_dropout_dims: Sequence[int], default = ()


### PR DESCRIPTION
This PR adds `zero_centered_gamma` support for JAX layernorm in different modules.

For `TransformerLayer`, `MultiHeadAttention` module, the gamma initializer becomes 0s initializer and use (1+gamma) instead of gamma when `zero_centered_gamma` is used.

It is similar for `LayerNorm`, `LayerNormDenseGeneral`, and `LayerNormMLP`. The default initializer for them is `nn.initializers.ones` when `zero_centered_gamma` is `False`, and it becomes `nn.initializers.zeros` when `zero_centered_gamma` is `True` through `__post_init__`. Besides, users can still provides their own initializer through `scale_init` for these three modules.