### PR TITLE
Fix model load exception when state resides on GPU

### DIFF
--- a/tests/pytorch/test_onnx_export.py
+++ b/tests/pytorch/test_onnx_export.py
@@ -103,8 +103,9 @@ def do_export(
                 opset_version=opset,
                 input_names=input_names,
                 output_names=output_names,
-                # Do Not constant-fold because torch.onnx incorrectly folds LN(data, scale=gamma+1) which
-                # happens when we use LN with zero-centered gamma.
+                # Do not constant-fold because torch.onnx incorrectly folds
+                # layer_norm(data, scale=add(gamma,1)) to layer_norm(data, scale=gamma)
+                # when we use LN with zero-centered gamma.
                 do_constant_folding=False,
                 operator_export_type=torch.onnx.OperatorExportTypes.ONNX_FALLTHROUGH)
 

--- a/transformer_engine/pytorch/module.py
+++ b/transformer_engine/pytorch/module.py
@@ -318,7 +318,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             return
 
         if isinstance(state, torch.Tensor):
-            state = pickle.loads(state.detach().numpy().tobytes())
+            state = pickle.loads(state.detach().cpu().numpy().tobytes())
             if state is None:
                 return
 


### PR DESCRIPTION
In this commit:

- Whenever converting a torch.tensor to numpy, we need to first migrate the tensor storage to the host CPU.

- Add a warning not to do contant-folding when exporting to ONNX. This is due to a torch.onnx export bug.

- Refactor compare_outputs