### PR TITLE
Set DCMAKE_PREFIX_PATH for TensorFlow build to build with pip pybind11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Build'
         run: |
-          apt-get -y update && \
-          apt -y install ninja-build pybind11-dev && \
+          pip install ninja pybind11 && \
           pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html && \
           mkdir -p wheelhouse && \
           NVTE_FRAMEWORK=jax pip wheel -w wheelhouse . -v
@@ -69,8 +68,7 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Build'
         run: |
-          apt-get -y update && \
-          apt -y install ninja-build pybind11-dev && \
+          pip install ninja pybind11 && \
           mkdir -p wheelhouse && \
           NVTE_FRAMEWORK=tensorflow pip wheel -w wheelhouse . -v
       - name: 'Upload wheel'

--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ For JAX and Tensorflow, pybind11 must be installed:
 
 .. code-block:: bash
 
-  pip install pybind11[global]
+  pip install pybind11
 
 Then, you can install this optional dependency:
 

--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ For JAX and Tensorflow, pybind11 must be installed:
 
 .. code-block:: bash
 
-  pip install pybind11
+  pip install pybind11[global]
 
 Then, you can install this optional dependency:
 

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,8 @@ class PyTorchBuilder(FrameworkBuilderBase):
 
 class TensorFlowBuilder(FrameworkBuilderBase):
     def cmake_flags(self):
-        return ["-DENABLE_TENSORFLOW=ON"]
+        p = [d for d in sys.path if 'dist-packages' in d][0]
+        return ["-DENABLE_TENSORFLOW=ON", "-DCMAKE_PREFIX_PATH="+p]
 
     def run(self, extensions):
         print("Building TensorFlow extensions!")


### PR DESCRIPTION
Fixes #142 

~Pybind11 must be installed with `[global]`, otherwise cmake won't find it during the TF build.~

~See pybind11 docs here about this option: https://pybind11.readthedocs.io/en/stable/installing.html#include-with-pypi~

Jax build sets `DCMAKE_PREFIX_PATH` to allow cmake to find the pybind11 cmake config even in the python user package directory. We will do the same for TF.