### PR TITLE
Switch to upstream flash-attn

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Lint'
         run: |
+          pip install flash-attn==1.0.2
           export PYTHON_ONLY=1
           export TE_PATH=.
           bash ./qa/L0_lint/test.sh

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ class PyTorchBuilder(FrameworkBuilderBase):
 
     @staticmethod
     def install_requires():
-        return ["flash-attn @ git+https://github.com/ksivaman/flash-attention.git@hopper",]
+        return ["flash-attn>=1.0.2",]
 
 class TensorFlowBuilder(FrameworkBuilderBase):
     def cmake_flags(self):


### PR DESCRIPTION
H100 support has been added to upstream flash attention including other features such as [deterministic execution](https://github.com/HazyResearch/flash-attention/pull/147) and [cuda graph capture](https://github.com/HazyResearch/flash-attention/pull/166). These are available in v1.0.2.