### PR TITLE
Make userbuffers support strictly opt-in

### DIFF
--- a/qa/L0_cppunittest/test.sh
+++ b/qa/L0_cppunittest/test.sh
@@ -9,11 +9,7 @@ set -e
 TE_LIB_PATH=`pip show transformer-engine | grep Location | cut -d ' ' -f 2`
 export LD_LIBRARY_PATH=$TE_LIB_PATH:$LD_LIBRARY_PATH
 
-# Find MPI
-MPI_HOME=${MPI_HOME:-/usr/local/mpi}
-NVTE_MPI_INCLUDE="$MPI_HOME/lib"
-
 cd $TE_PATH/tests/cpp
-cmake -GNinja -Bbuild -DNVTE_MPI_INCLUDE=$NVTE_MPI_INCLUDE .
+cmake -GNinja -Bbuild .
 cmake --build build
 ctest --test-dir build -j4

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ add_subdirectory(../../3rdparty/googletest ${PROJECT_BINARY_DIR}/googletest)
 
 enable_testing()
 
-include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR}) 
+include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
 if(NOT DEFINED TE_LIB_PATH)
     execute_process(COMMAND bash -c "pip show transformer-engine | grep Location | cut -d ' ' -f 2 | tr -d '\n'"
@@ -27,11 +27,6 @@ if(NOT DEFINED TE_LIB_PATH)
 endif()
 
 find_library(TE_LIB NAMES transformer_engine PATHS ${TE_LIB_PATH} ENV TE_LIB_PATH REQUIRED)
-
-if(EXISTS ${NVTE_MPI_INCLUDE})
-    find_library(MPI_LIB NAMES mpi PATHS ${NVTE_MPI_INCLUDE} REQUIRED)
-    message(STATUS "Found MPI library: ${MPI_LIB}")
-endif()
 
 message(STATUS "Found transformer_engine library: ${TE_LIB}")
 include_directories(../../transformer_engine/common/include)

--- a/tests/cpp/operator/CMakeLists.txt
+++ b/tests/cpp/operator/CMakeLists.txt
@@ -19,10 +19,6 @@ add_executable(test_operator
 
 list(APPEND test_operator_LINKER_LIBS CUDA::cudart GTest::gtest_main ${TE_LIB})
 
-if(EXISTS ${NVTE_MPI_INCLUDE})
-    list(APPEND test_operator_LINKER_LIBS ${MPI_LIB})
-endif()
-
 target_link_libraries(test_operator PUBLIC ${test_operator_LINKER_LIBS})
 target_compile_options(test_operator PRIVATE -O2)
 

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -2,54 +2,73 @@
 #
 # See LICENSE for license information.
 
+# Find userbuffer dependencies
+option(NVTE_WITH_USERBUFFERS
+       "Support for communication with userbuffers (highly experimental)"
+       OFF)
+if(NVTE_WITH_USERBUFFERS)
+    find_package(MPI REQUIRED)
+    find_library(GDRCOPY_LIBRARY gdrapi)
+    if(NOT GDRCOPY_LIBRARY)
+        message(FATAL_ERROR
+                "Attempted to build with support for userbuffers, but could not find GDRCopy")
+    endif()
+    message(STATUS "GDRCopy: ${GDRCOPY_LIBRARY}")
+endif()
+message(STATUS "NVTE_WITH_USERBUFFERS: ${NVTE_WITH_USERBUFFERS}")
+
+# Configure Transformer Engine library
 set(transformer_engine_SOURCES)
-list(APPEND transformer_engine_SOURCES transformer_engine.cpp
-                                       transpose/cast_transpose.cu
-                                       transpose/transpose.cu
-                                       transpose/cast_transpose_fusion.cu
-                                       transpose/transpose_fusion.cu
-                                       transpose/multi_cast_transpose.cu
-                                       activation/gelu.cu
-                                       gemm/cublaslt_gemm.cu
-                                       layer_norm/ln_api.cpp
-                                       layer_norm/ln_bwd_semi_cuda_kernel.cu
-                                       layer_norm/ln_fwd_cuda_kernel.cu
-                                       rmsnorm/rmsnorm_api.cpp
-                                       rmsnorm/rmsnorm_bwd_semi_cuda_kernel.cu
-                                       rmsnorm/rmsnorm_fwd_cuda_kernel.cu
-                                       util/cast.cu
-                                       fused_softmax/scaled_masked_softmax.cu
-                                       fused_softmax/scaled_upper_triang_masked_softmax.cu)
-
-if(NVTE_MPI_FOUND)
-    list(APPEND transformer_engine_SOURCES comm_gemm_overlap/userbuffers.cu
-                                           comm_gemm_overlap/userbuffers-host.cpp)
+list(APPEND transformer_engine_SOURCES
+     transformer_engine.cpp
+     transpose/cast_transpose.cu
+     transpose/transpose.cu
+     transpose/cast_transpose_fusion.cu
+     transpose/transpose_fusion.cu
+     transpose/multi_cast_transpose.cu
+     activation/gelu.cu
+     gemm/cublaslt_gemm.cu
+     layer_norm/ln_api.cpp
+     layer_norm/ln_bwd_semi_cuda_kernel.cu
+     layer_norm/ln_fwd_cuda_kernel.cu
+     rmsnorm/rmsnorm_api.cpp
+     rmsnorm/rmsnorm_bwd_semi_cuda_kernel.cu
+     rmsnorm/rmsnorm_fwd_cuda_kernel.cu
+     util/cast.cu
+     fused_softmax/scaled_masked_softmax.cu
+     fused_softmax/scaled_upper_triang_masked_softmax.cu)
+if(NVTE_WITH_USERBUFFERS)
+    list(APPEND transformer_engine_SOURCES
+         comm_gemm_overlap/userbuffers.cu
+         comm_gemm_overlap/userbuffers-host.cpp)
 endif()
-
 add_library(transformer_engine SHARED ${transformer_engine_SOURCES})
+target_include_directories(transformer_engine PUBLIC
+                           "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-target_include_directories(transformer_engine PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-
-list(APPEND transformer_engine_LINKER_LIBS CUDA::cublas CUDA::cudart CUDA::nvToolsExt)
-if(NVTE_MPI_FOUND)
-    list(APPEND transformer_engine_LINKER_LIBS gdrapi)
+# Configure dependencies
+target_link_libraries(transformer_engine PUBLIC
+                      CUDA::cublas
+                      CUDA::cudart
+                      CUDA::nvToolsExt)
+target_include_directories(transformer_engine PRIVATE
+                           ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+if(NVTE_WITH_USERBUFFERS)
+    target_link_libraries(transformer_engine PUBLIC
+                          MPI::MPI_CXX
+                          ${GDRCOPY_LIBRARY})
 endif()
 
-target_link_libraries(transformer_engine PUBLIC ${transformer_engine_LINKER_LIBS})
-target_include_directories(transformer_engine PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-
+# Compiler options
 set_source_files_properties(fused_softmax/scaled_masked_softmax.cu
                             fused_softmax/scaled_upper_triang_masked_softmax.cu
                             PROPERTIES
                             COMPILE_OPTIONS "--use_fast_math")
-
-if(NVTE_MPI_FOUND)
+if(NVTE_WITH_USERBUFFERS)
     set_source_files_properties(comm_gemm_overlap/userbuffers.cu
                                 comm_gemm_overlap/userbuffers-host.cpp
                                 PROPERTIES
-                                INCLUDE_DIRECTORIES ${NVTE_MPI_INCLUDE}
                                 COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:-maxrregcount=64>")
 endif()
-
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -37,27 +37,4 @@ def _load_library():
     return ctypes.CDLL(dll_path, mode=ctypes.RTLD_GLOBAL)
 
 
-def _load_mpi():
-    """Load MPI shared library"""
-
-    system = platform.system()
-    if system == "Linux":
-        extension = "so"
-    elif system == "Darwin":
-        extension = "dylib"
-    elif system == "Windows":
-        extension = "dll"
-    else:
-        raise RuntimeError(f"Unsupported operating system ({system})")
-    lib_name = "libmpi." + extension
-    MPI_HOME = os.environ.get("MPI_HOME", "/usr/local/mpi")
-    NVTE_MPI_FOUND = os.path.exists(MPI_HOME)
-    dll_path = os.path.join(MPI_HOME, "lib", lib_name)
-
-    if NVTE_MPI_FOUND:
-        return ctypes.CDLL(dll_path, mode=ctypes.RTLD_GLOBAL)
-    return None
-
-
-_TE_LIB_CTYPES = _load_mpi()
 _TE_LIB_CTYPES = _load_library()

--- a/transformer_engine/pytorch/csrc/extensions.cu
+++ b/transformer_engine/pytorch/csrc/extensions.cu
@@ -5,9 +5,9 @@
  ************************************************************************/
 
 #include "extensions.h"
-#ifdef NVTE_MPI_FOUND
+#ifdef NVTE_WITH_USERBUFFERS
 #include "comm_gemm_overlap.h"
-#endif  // NVTE_MPI_FOUND
+#endif  // NVTE_WITH_USERBUFFERS
 
 void te_gemm(at::Tensor A,
              at::Tensor A_scale_inverse,
@@ -1022,7 +1022,7 @@ size_t get_cublasLt_version() {
 
 
 bool userbuf_comm_available() {  // TODO(ksivamani) check on python side
-#ifdef NVTE_MPI_FOUND
+#ifdef NVTE_WITH_USERBUFFERS
     return true;
 #else
     return false;
@@ -1080,7 +1080,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     .def_readwrite("scale_inv", &transformer_engine::FP8TensorMeta::scale_inv)
     .def_readwrite("amax_history", &transformer_engine::FP8TensorMeta::amax_history);
 
-#ifdef NVTE_MPI_FOUND
+#ifdef NVTE_WITH_USERBUFFERS
   py::enum_<ubuf::UBOverlapAlgo>(m, "UbufOverlapAlgo")
     .value("BULK_OVERLAP_AG", ubuf::UBOverlapAlgo::BULK_OVERLAP_AG)
     .value("BULK_OVERLAP_RS", ubuf::UBOverlapAlgo::BULK_OVERLAP_RS)
@@ -1099,11 +1099,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     .def("split_overlap_ag", &ubuf::UbufP2PCommOverlap::split_overlap_ag)
     .def("copy_input_to_ubuf", &ubuf::UbufP2PCommOverlap::copy_input_to_ubuf)
     .def("get_ubuf_output", &ubuf::UbufP2PCommOverlap::get_ubuf_output);
-#else  // NVTE_MPI_FOUND
+#else  // NVTE_WITH_USERBUFFERS
   m.def("UbufOverlapAlgo", &placeholder, "Dummy function for python side annotations");
   m.def("UbufCommOverlap", &placeholder, "Dummy function for python side annotations");
   m.def("UbufP2PCommOverlap", &placeholder, "Dummy function for python side annotations");
-#endif  // NVTE_MPI_FOUND
+#endif  // NVTE_WITH_USERBUFFERS
 
   py::enum_<transformer_engine::DType>(m, "DType", py::module_local())
     .value("kByte", transformer_engine::DType::kByte)


### PR DESCRIPTION
#147 builds with support for userbuffers whenever `MPI_HOME` is set in the environment. This isn't great since users may run on non-DGX systems with MPI support (alas), not to mention userbuffers is very hacky. This PR only builds with userbuffers support when explicitly enabled:
```bash
export NVTE_WITH_USERBUFFERS=1
export MPI_HOME=/usr/local/mpi
cd TransformerEngine
pip install .
```
It also refactors the build system to handle MPI in a more standard way.