### PR TITLE
[JAX] Adjust Module Structure.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,9 @@ pyTorch
 JAX
 ^^^
 
+Flax
+~~~~
+
 .. code-block:: python
 
   import jax
@@ -90,7 +93,7 @@ JAX
 
   # Enable autocasting for the forward pass
   with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
-      model = te.DenseGeneral(features=HIDDEN)
+      model = te.flax.DenseGeneral(features=HIDDEN)
 
       def loss_fn(params, other_vars, inp):
         out = model.apply({'params':params, **other_vars}, inp)

--- a/docs/api/jax.rst
+++ b/docs/api/jax.rst
@@ -9,9 +9,12 @@ Jax
 .. autoapiclass:: transformer_engine.jax.MajorShardingType
 .. autoapiclass:: transformer_engine.jax.ShardingType
 .. autoapiclass:: transformer_engine.jax.TransformerLayerType
-
-
 .. autoapiclass:: transformer_engine.jax.ShardingResource(dp_resource=None, tp_resource=None)
+
+
+.. autoapifunction:: transformer_engine.jax.fp8_autocast
+.. autoapifunction:: transformer_engine.jax.update_collections
+.. autoapifunction:: transformer_engine.jax.update_fp8_metas
 
 
 .. autoapiclass:: transformer_engine.jax.flax.LayerNorm(epsilon=1e-6, layernorm_type='layernorm', **kwargs)
@@ -35,8 +38,4 @@ Jax
 .. autoapiclass:: transformer_engine.jax.flax.TransformerLayer(hidden_size=512, mlp_hidden_size=2048, num_attention_heads=8, **kwargs)
   :members: __call__
 
-
-.. autoapifunction:: transformer_engine.jax.extend_logical_axis_rules
-.. autoapifunction:: transformer_engine.jax.fp8_autocast
-.. autoapifunction:: transformer_engine.jax.update_collections
-.. autoapifunction:: transformer_engine.jax.update_fp8_metas
+.. autoapifunction:: transformer_engine.jax.flax.extend_logical_axis_rules

--- a/docs/api/jax.rst
+++ b/docs/api/jax.rst
@@ -14,25 +14,25 @@ Jax
 .. autoapiclass:: transformer_engine.jax.ShardingResource(dp_resource=None, tp_resource=None)
 
 
-.. autoapiclass:: transformer_engine.jax.LayerNorm(epsilon=1e-6, layernorm_type='layernorm', **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.LayerNorm(epsilon=1e-6, layernorm_type='layernorm', **kwargs)
   :members: __call__
 
-.. autoapiclass:: transformer_engine.jax.DenseGeneral(features, layernorm_type='layernorm', use_bias=False, **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.DenseGeneral(features, layernorm_type='layernorm', use_bias=False, **kwargs)
   :members: __call__
 
-.. autoapiclass:: transformer_engine.jax.LayerNormDenseGeneral(features, layernorm_type='layernorm', epsilon=1e-6, use_bias=False, **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.LayerNormDenseGeneral(features, layernorm_type='layernorm', epsilon=1e-6, use_bias=False, **kwargs)
   :members: __call__
 
-.. autoapiclass:: transformer_engine.jax.LayerNormMLP(intermediate_dim=2048, layernorm_type='layernorm', epsilon=1e-6, use_bias=False, **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.LayerNormMLP(intermediate_dim=2048, layernorm_type='layernorm', epsilon=1e-6, use_bias=False, **kwargs)
   :members: __call__
 
-.. autoapiclass:: transformer_engine.jax.RelativePositionBiases(num_buckets, max_distance, num_heads, **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.RelativePositionBiases(num_buckets, max_distance, num_heads, **kwargs)
   :members: __call__
 
-.. autoapiclass:: transformer_engine.jax.MultiHeadAttention(head_dim, num_heads, **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.MultiHeadAttention(head_dim, num_heads, **kwargs)
   :members: __call__
 
-.. autoapiclass:: transformer_engine.jax.TransformerLayer(hidden_size=512, mlp_hidden_size=2048, num_attention_heads=8, **kwargs)
+.. autoapiclass:: transformer_engine.jax.flax.TransformerLayer(hidden_size=512, mlp_hidden_size=2048, num_attention_heads=8, **kwargs)
   :members: __call__
 
 

--- a/examples/jax/encoder/test_model_parallel_encoder.py
+++ b/examples/jax/encoder/test_model_parallel_encoder.py
@@ -59,7 +59,7 @@ class Net(nn.Module):
     def __call__(self, x, mask, disable_dropout=False):
         x = nn.Embed(num_embeddings=self.num_embed, features=256, dtype=jnp.bfloat16)(x)
 
-        te_Encoder = partial(te.TransformerLayer,
+        te_Encoder = partial(te.flax.TransformerLayer,
                              hidden_size=256,
                              mlp_hidden_size=1024,
                              num_attention_heads=8,
@@ -73,17 +73,17 @@ class Net(nn.Module):
 
         x = x.reshape(x.shape[0], -1)
 
-        x = te.DenseGeneral(features=256,
-                            kernel_axes=(NAMED_BROADCAST_AXIS, NAMED_TP_AXIS),
-                            bias_axes=(NAMED_TP_AXIS,),
-                            sharding_type=te.ShardingType.DP_TP_COL,
-                            dtype=jnp.bfloat16)(x)
+        x = te.flax.DenseGeneral(features=256,
+                                 kernel_axes=(NAMED_BROADCAST_AXIS, NAMED_TP_AXIS),
+                                 bias_axes=(NAMED_TP_AXIS,),
+                                 sharding_type=te.ShardingType.DP_TP_COL,
+                                 dtype=jnp.bfloat16)(x)
 
-        x = te.DenseGeneral(features=256,
-                            kernel_axes=(NAMED_TP_AXIS, NAMED_BROADCAST_AXIS),
-                            bias_axes=(NAMED_BROADCAST_AXIS,),
-                            sharding_type=te.ShardingType.DP_TP_ROW,
-                            dtype=jnp.bfloat16)(x)
+        x = te.flax.DenseGeneral(features=256,
+                                 kernel_axes=(NAMED_TP_AXIS, NAMED_BROADCAST_AXIS),
+                                 bias_axes=(NAMED_BROADCAST_AXIS,),
+                                 sharding_type=te.ShardingType.DP_TP_ROW,
+                                 dtype=jnp.bfloat16)(x)
 
         x = nn.Dense(features=2, dtype=jnp.bfloat16)(x)
         return x

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -56,7 +56,7 @@ class Net(nn.Module):
     def __call__(self, x, mask, disable_dropout=False):
         x = nn.Embed(num_embeddings=self.num_embed, features=256, dtype=jnp.bfloat16)(x)
 
-        te_Encoder = partial(te.TransformerLayer,
+        te_Encoder = partial(te.flax.TransformerLayer,
                              hidden_size=256,
                              mlp_hidden_size=1024,
                              num_attention_heads=8,
@@ -70,9 +70,11 @@ class Net(nn.Module):
 
         x = x.reshape(x.shape[0], -1)
 
-        x = te.DenseGeneral(features=256, sharding_type=te.ShardingType.DP, dtype=jnp.bfloat16)(x)
+        x = te.flax.DenseGeneral(features=256, sharding_type=te.ShardingType.DP,
+                                 dtype=jnp.bfloat16)(x)
 
-        x = te.DenseGeneral(features=256, sharding_type=te.ShardingType.DP, dtype=jnp.bfloat16)(x)
+        x = te.flax.DenseGeneral(features=256, sharding_type=te.ShardingType.DP,
+                                 dtype=jnp.bfloat16)(x)
 
         x = nn.Dense(features=2, dtype=jnp.bfloat16)(x)
         return x

--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -46,7 +46,7 @@ class Net(nn.Module):
     def __call__(self, x, mask, disable_dropout=False):
         x = nn.Embed(num_embeddings=self.num_embed, features=256, dtype=jnp.bfloat16)(x)
 
-        te_Encoder = partial(te.TransformerLayer,
+        te_Encoder = partial(te.flax.TransformerLayer,
                              hidden_size=256,
                              mlp_hidden_size=1024,
                              num_attention_heads=8,
@@ -60,9 +60,9 @@ class Net(nn.Module):
 
         x = x.reshape(x.shape[0], -1)
 
-        x = te.DenseGeneral(features=256, dtype=jnp.bfloat16)(x)
+        x = te.flax.DenseGeneral(features=256, dtype=jnp.bfloat16)(x)
 
-        x = te.DenseGeneral(features=256, dtype=jnp.bfloat16)(x)
+        x = te.flax.DenseGeneral(features=256, dtype=jnp.bfloat16)(x)
 
         x = nn.Dense(features=2, dtype=jnp.bfloat16)(x)
         return x

--- a/examples/jax/mnist/test_single_gpu_mnist.py
+++ b/examples/jax/mnist/test_single_gpu_mnist.py
@@ -47,7 +47,7 @@ class Net(nn.Module):
     @nn.compact
     def __call__(self, x, disable_dropout=False):
         if self.use_te:
-            nn_Dense = te.DenseGeneral
+            nn_Dense = te.flax.DenseGeneral
         else:
             nn_Dense = nn.Dense
 

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import pytest
 
 from transformer_engine.common.recipe import Format
-from transformer_engine.jax import TransformerLayer, TransformerLayerType
+from transformer_engine.jax.flax import TransformerLayer, TransformerLayerType
 from transformer_engine.jax.fp8 import FP8Helper
 from utils import assert_allclose, is_fp8_supported
 from utils import DecoderLayer as RefDecoderLayer

--- a/tests/jax/test_sharding.py
+++ b/tests/jax/test_sharding.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from jax.experimental import maps
 
-from transformer_engine.jax import extend_logical_axis_rules
+from transformer_engine.jax.flax import extend_logical_axis_rules
 from transformer_engine.jax.sharding import get_dot_sharding_meta
 from transformer_engine.jax.sharding import get_elementwise_sharding_meta
 from transformer_engine.jax.sharding import get_fp8_meta_sharding_meta

--- a/transformer_engine/common/utils.py
+++ b/transformer_engine/common/utils.py
@@ -1,38 +1,50 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""The utilities for Transformer Engine"""
 import inspect
 import warnings
 from enum import Enum
 
 warnings.simplefilter('default')
 
-def deprecate_wrapper(obj, msg):
 
+class DeprecatedEnum:    # pylint: disable=too-few-public-methods
+    """DeprecatedEnum"""
+
+    def __init__(self, enum_cls, msg):
+        self.enum_cls = enum_cls
+        self.msg = msg
+
+    def __getattr__(self, name):
+        if name in self.enum_cls.__members__:
+            warnings.warn(self.msg, DeprecationWarning)
+            return self.enum_cls.__members__[name]
+        raise AttributeError(f"{self.enum_cls} does not contain {name}")
+
+
+def deprecate_wrapper(obj, msg):
+    """Deprecate wrapper"""
     if inspect.isclass(obj):
         if issubclass(obj, Enum):
-            class Deprecated:
-                def __init__(self, enum_cls):
-                    self.enum_cls = enum_cls
+            return DeprecatedEnum(obj, msg)
 
-                def __getattr__(self, name):
-                    if name in self.enum_cls.__members__:
-                        warnings.warn(msg, DeprecationWarning)
-                        return self.enum_cls.__members__[name]
-                    raise AttributeError(f"{self.enum_cls} does not contain {name}")
+        class DeprecatedCls(obj):    # pylint: disable=too-few-public-methods
+            """DeprecatedCls"""
 
-            return Deprecated(obj)
-        else:
-            class Deprecated(obj):
-                def __init__(self, *args, **kwargs):
-                    warnings.warn(msg, DeprecationWarning)
-                    super().__init__(*args, **kwargs)
+            def __init__(self, *args, **kwargs):
+                warnings.warn(msg, DeprecationWarning)
+                super().__init__(*args, **kwargs)
 
-            return Deprecated
-    elif inspect.isfunction(obj):
+        return DeprecatedCls
+
+    if inspect.isfunction(obj):
 
         def deprecated(*args, **kwargs):
             warnings.warn(msg, DeprecationWarning)
             return obj(*args, **kwargs)
 
         return deprecated
-    else:
-        raise NotImplementedError(
+
+    raise NotImplementedError(
         f"deprecate_cls_wrapper only support Class and Function, but got {type(obj)}.")

--- a/transformer_engine/common/utils.py
+++ b/transformer_engine/common/utils.py
@@ -1,0 +1,38 @@
+import inspect
+import warnings
+from enum import Enum
+
+warnings.simplefilter('default')
+
+def deprecate_wrapper(obj, msg):
+
+    if inspect.isclass(obj):
+        if issubclass(obj, Enum):
+            class Deprecated:
+                def __init__(self, enum_cls):
+                    self.enum_cls = enum_cls
+
+                def __getattr__(self, name):
+                    if name in self.enum_cls.__members__:
+                        warnings.warn(msg, DeprecationWarning)
+                        return self.enum_cls.__members__[name]
+                    raise AttributeError(f"{self.enum_cls} does not contain {name}")
+
+            return Deprecated(obj)
+        else:
+            class Deprecated(obj):
+                def __init__(self, *args, **kwargs):
+                    warnings.warn(msg, DeprecationWarning)
+                    super().__init__(*args, **kwargs)
+
+            return Deprecated
+    elif inspect.isfunction(obj):
+
+        def deprecated(*args, **kwargs):
+            warnings.warn(msg, DeprecationWarning)
+            return obj(*args, **kwargs)
+
+        return deprecated
+    else:
+        raise NotImplementedError(
+        f"deprecate_cls_wrapper only support Class and Function, but got {type(obj)}.")

--- a/transformer_engine/common/utils.py
+++ b/transformer_engine/common/utils.py
@@ -16,6 +16,9 @@ class DeprecatedEnum:    # pylint: disable=too-few-public-methods
         self.enum_cls = enum_cls
         self.msg = msg
 
+    def __iter__(self):
+        return iter(list(self.enum_cls.__members__.values()))
+
     def __getattr__(self, name):
         if name in self.enum_cls.__members__:
             warnings.warn(self.msg, DeprecationWarning)

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -2,10 +2,41 @@
 #
 # See LICENSE for license information.
 """Transformer Engine bindings for JAX"""
-from .flax import DenseGeneral, LayerNorm
-from .flax import LayerNormDenseGeneral, LayerNormMLP, TransformerEngineBase
-from .flax import extend_logical_axis_rules
-from .flax import MultiHeadAttention, RelativePositionBiases
-from .flax import TransformerLayer, TransformerLayerType
+
+from . import flax
 from .fp8 import fp8_autocast, update_collections, update_fp8_metas, get_delayed_scaling
 from .sharding import MajorShardingType, ShardingResource, ShardingType
+from ..common.utils import deprecate_wrapper
+
+extend_logical_axis_rules = deprecate_wrapper(
+    flax.extend_logical_axis_rules,
+    "extend_logical_axis_rules is moving to transformer_engine.jax.flax module")
+DenseGeneral = deprecate_wrapper(flax.DenseGeneral,
+                                 "DenseGeneral is moving to transformer_engine.jax.flax module")
+LayerNorm = deprecate_wrapper(flax.LayerNorm,
+                              "LayerNorm is moving to transformer_engine.jax.flax module")
+LayerNormDenseGeneral = deprecate_wrapper(
+    flax.LayerNormDenseGeneral,
+    "LayerNormDenseGeneral is moving to transformer_engine.jax.flax module")
+LayerNormMLP = deprecate_wrapper(flax.LayerNormMLP,
+                                 "LayerNormMLP is moving to transformer_engine.jax.flax module")
+TransformerEngineBase = deprecate_wrapper(
+    flax.TransformerEngineBase,
+    "TransformerEngineBase is moving to transformer_engine.jax.flax module")
+MultiHeadAttention = deprecate_wrapper(
+    flax.MultiHeadAttention, "MultiHeadAttention is moving to transformer_engine.jax.flax module")
+RelativePositionBiases = deprecate_wrapper(
+    flax.RelativePositionBiases,
+    "RelativePositionBiases is moving to transformer_engine.jax.flax module")
+TransformerLayer = deprecate_wrapper(
+    flax.TransformerLayer, "TransformerLayer is moving to transformer_engine.jax.flax module")
+TransformerLayerType = deprecate_wrapper(
+    flax.TransformerLayerType,
+    "TransformerLayerType is moving to transformer_engine.jax.flax module")
+
+__all__ = [
+    'fp8_autocast', 'update_collections', 'update_fp8_metas', 'get_delayed_scaling',
+    'MajorShardingType', 'ShardingResource', 'ShardingType', 'flax', 'DenseGeneral', 'LayerNorm',
+    'LayerNormDenseGeneral', 'LayerNormMLP', 'TransformerEngineBase', 'MultiHeadAttention',
+    'RelativePositionBiases', 'TransformerLayer', 'TransformerLayerType'
+]

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -2,5 +2,10 @@
 #
 # See LICENSE for license information.
 """Transformer Engine bindings for JAX"""
+from .flax import DenseGeneral, LayerNorm
+from .flax import LayerNormDenseGeneral, LayerNormMLP, TransformerEngineBase
+from .flax import extend_logical_axis_rules
+from .flax import MultiHeadAttention, RelativePositionBiases
+from .flax import TransformerLayer, TransformerLayerType
 from .fp8 import fp8_autocast, update_collections, update_fp8_metas, get_delayed_scaling
 from .sharding import MajorShardingType, ShardingResource, ShardingType

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -3,9 +3,4 @@
 # See LICENSE for license information.
 """Transformer Engine bindings for JAX"""
 from .fp8 import fp8_autocast, update_collections, update_fp8_metas, get_delayed_scaling
-from .module import DenseGeneral, LayerNorm
-from .module import LayerNormDenseGeneral, LayerNormMLP, TransformerEngineBase
-from .transformer import extend_logical_axis_rules
-from .transformer import MultiHeadAttention, RelativePositionBiases
-from .transformer import TransformerLayer, TransformerLayerType
 from .sharding import MajorShardingType, ShardingResource, ShardingType

--- a/transformer_engine/jax/flax/__init__.py
+++ b/transformer_engine/jax/flax/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""Transformer Engine bindings for JAX"""
+from .module import DenseGeneral, LayerNorm
+from .module import LayerNormDenseGeneral, LayerNormMLP, TransformerEngineBase
+from .transformer import extend_logical_axis_rules
+from .transformer import MultiHeadAttention, RelativePositionBiases
+from .transformer import TransformerLayer, TransformerLayerType

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -178,6 +178,11 @@ class Softmax(nn.Module):
 
 class LayerNorm(nn.Module):
     r"""
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     Applies layer normalization over a mini-batch of inputs.
     There are two types of normalization supported by this module,
     regular and root mean square layer Normalization.
@@ -344,6 +349,11 @@ class TransformerEngineBase(nn.Module):
 
 class DenseGeneral(TransformerEngineBase):
     """
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     Applies a linear transformation to the incoming data :math:`y = xA^T + b`
 
     Parameters
@@ -458,6 +468,11 @@ class DenseGeneral(TransformerEngineBase):
 
 class LayerNormDenseGeneral(TransformerEngineBase):
     r"""
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     Applies layer normalization followed by linear transformation to the incoming data.
 
     Parameters
@@ -671,6 +686,11 @@ class LayerNormDenseGeneral(TransformerEngineBase):
 
 class LayerNormMLP(TransformerEngineBase):
     r"""
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     Applies layer normalization on the input followed by the MLP module,
     consisting of 2 successive linear transformations, separated by given activations.
 

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -16,15 +16,15 @@ from jax import lax
 from jax import nn as jax_nn
 from jax import random as jax_random
 
-from .dot import fp8_dot
-from .fp8 import FP8GemmPackage, FP8Helper
-from .layernorm import canonicalize_layernorm_type
-from .layernorm import layernorm, layernorm_fp8_dot
-from .mlp import fp8_ln_mlp, geglu
-from .sharding import infer_sharding_type
-from .softmax import is_softmax_kernel_available
-from .sharding import MajorShardingType, ShardingType
-from .softmax import softmax, SoftmaxType
+from ..dot import fp8_dot
+from ..fp8 import FP8GemmPackage, FP8Helper
+from ..layernorm import canonicalize_layernorm_type
+from ..layernorm import layernorm, layernorm_fp8_dot
+from ..mlp import fp8_ln_mlp, geglu
+from ..sharding import infer_sharding_type
+from ..softmax import is_softmax_kernel_available
+from ..sharding import MajorShardingType, ShardingType
+from ..softmax import softmax, SoftmaxType
 
 PRNGKey = Any
 Shape = Tuple[int, ...]
@@ -44,6 +44,13 @@ def _canonicalize_tuple(x):
     if isinstance(x, Iterable):
         return tuple(x)
     return (x,)
+
+
+def _obtain_default_layernorm_scale_init_if_need(original_init, zero_centered_gamma):
+    if original_init is None:
+        if not zero_centered_gamma:
+            return nn.initializers.ones
+    return nn.initializers.zeros
 
 
 def _create_layernorm_parameters(layernorm_type, shape, scale_init, scale_axes, bias_init,
@@ -250,11 +257,8 @@ class LayerNorm(nn.Module):
     sharding_type: ShardingType = ShardingType.SINGLE
 
     def __post_init__(self):
-        if self.scale_init is None:
-            if not self.zero_centered_gamma:
-                self.scale_init = nn.initializers.ones
-            else:
-                self.scale_init = nn.initializers.zeros
+        self.scale_init = _obtain_default_layernorm_scale_init_if_need(
+            self.scale_init, self.zero_centered_gamma)
         super().__post_init__()
 
     @nn.compact
@@ -551,11 +555,8 @@ class LayerNormDenseGeneral(TransformerEngineBase):
     def __post_init__(self):
         if self.kernel_init is None:
             self.kernel_init = nn.initializers.variance_scaling(1.0, 'fan_in', 'truncated_normal')
-        if self.scale_init is None:
-            if not self.zero_centered_gamma:
-                self.scale_init = nn.initializers.ones
-            else:
-                self.scale_init = nn.initializers.zeros
+        self.scale_init = _obtain_default_layernorm_scale_init_if_need(
+            self.scale_init, self.zero_centered_gamma)
         super().__post_init__()
 
     @nn.compact
@@ -785,11 +786,8 @@ class LayerNormMLP(TransformerEngineBase):
     def __post_init__(self):
         if self.kernel_init is None:
             self.kernel_init = nn.initializers.variance_scaling(1.0, 'fan_in', 'truncated_normal')
-        if self.scale_init is None:
-            if not self.zero_centered_gamma:
-                self.scale_init = nn.initializers.ones
-            else:
-                self.scale_init = nn.initializers.zeros
+        self.scale_init = _obtain_default_layernorm_scale_init_if_need(
+            self.scale_init, self.zero_centered_gamma)
         super().__post_init__()
 
     @nn.compact

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -178,11 +178,6 @@ class Softmax(nn.Module):
 
 class LayerNorm(nn.Module):
     r"""
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     Applies layer normalization over a mini-batch of inputs.
     There are two types of normalization supported by this module,
     regular and root mean square layer Normalization.
@@ -349,11 +344,6 @@ class TransformerEngineBase(nn.Module):
 
 class DenseGeneral(TransformerEngineBase):
     """
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     Applies a linear transformation to the incoming data :math:`y = xA^T + b`
 
     Parameters
@@ -468,11 +458,6 @@ class DenseGeneral(TransformerEngineBase):
 
 class LayerNormDenseGeneral(TransformerEngineBase):
     r"""
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     Applies layer normalization followed by linear transformation to the incoming data.
 
     Parameters
@@ -686,11 +671,6 @@ class LayerNormDenseGeneral(TransformerEngineBase):
 
 class LayerNormMLP(TransformerEngineBase):
     r"""
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     Applies layer normalization on the input followed by the MLP module,
     consisting of 2 successive linear transformations, separated by given activations.
 

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -18,9 +18,9 @@ from jax import lax, vmap
 
 from .module import DenseGeneral, LayerNormDenseGeneral, LayerNormMLP
 from .module import LayerNorm, Softmax
-from .softmax import SoftmaxType
-from .sharding import infer_major_sharding_type, infer_sharding_type
-from .sharding import global_shard_resource, ShardingType
+from ..softmax import SoftmaxType
+from ..sharding import infer_major_sharding_type, infer_sharding_type
+from ..sharding import global_shard_resource, ShardingType
 
 PRNGKey = Any
 Shape = Tuple[int, ...]

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -41,11 +41,6 @@ def _generate_drop_path_shape(shape: Sequence[int], batch_dim: int) -> Sequence[
 
 def extend_logical_axis_rules(rules: LogicalRules) -> LogicalRules:
     """
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     Extend the given Flax logical axis rules with the predefined TransformerLayer's
     logical axis rules.
 
@@ -192,11 +187,6 @@ class AttentionType(Enum):
 
 class MultiHeadAttention(nn.Module):
     r"""
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     Multi-head Attention (MHA), including Query,
     Key, Value and Output projection.
 
@@ -560,11 +550,6 @@ class MultiHeadAttention(nn.Module):
 
 class RelativePositionBiases(nn.Module):
     """
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     T5-style relative positional embeddings to the attention logits.
 
     Parameters
@@ -657,11 +642,6 @@ class RelativePositionBiases(nn.Module):
 
 class TransformerLayerType(Enum):
     r"""
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     TransformerLayerType is an Enum class to specify a type of TransformerLayer
 
     Values
@@ -677,11 +657,6 @@ class TransformerLayerType(Enum):
 
 class TransformerLayer(nn.Module):
     r"""
-    .. warning::
-        This function is moved into submodule `flax`. Please import this from
-        `transformer_engine.jax.flax` and current importing path will be deprecated
-        in near feature.
-
     TransformerLayer is made up of a relative embedding,
     an attention block and a feedforward network (MLP).
     This standard layer is based on the paper “Attention Is All You Need”.

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -41,6 +41,11 @@ def _generate_drop_path_shape(shape: Sequence[int], batch_dim: int) -> Sequence[
 
 def extend_logical_axis_rules(rules: LogicalRules) -> LogicalRules:
     """
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     Extend the given Flax logical axis rules with the predefined TransformerLayer's
     logical axis rules.
 
@@ -187,6 +192,11 @@ class AttentionType(Enum):
 
 class MultiHeadAttention(nn.Module):
     r"""
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     Multi-head Attention (MHA), including Query,
     Key, Value and Output projection.
 
@@ -550,6 +560,11 @@ class MultiHeadAttention(nn.Module):
 
 class RelativePositionBiases(nn.Module):
     """
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     T5-style relative positional embeddings to the attention logits.
 
     Parameters
@@ -642,6 +657,11 @@ class RelativePositionBiases(nn.Module):
 
 class TransformerLayerType(Enum):
     r"""
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     TransformerLayerType is an Enum class to specify a type of TransformerLayer
 
     Values
@@ -657,6 +677,11 @@ class TransformerLayerType(Enum):
 
 class TransformerLayer(nn.Module):
     r"""
+    .. warning::
+        This function is moved into submodule `flax`. Please import this from
+        `transformer_engine.jax.flax` and current importing path will be deprecated
+        in near feature.
+
     TransformerLayer is made up of a relative embedding,
     an attention block and a feedforward network (MLP).
     This standard layer is based on the paper “Attention Is All You Need”.


### PR DESCRIPTION
1. Collect Flax related modules to a sub-folder, flax.
2. Add a function to unify scale_init for zero-centered-gamma LN.

Note: This PR is for the further Praxis (another NN library on top of JAX) support.