### PR TITLE
Bugfix in Sequence Parallelism

### DIFF
--- a/transformer_engine/pytorch/module.py
+++ b/transformer_engine/pytorch/module.py
@@ -1761,7 +1761,7 @@ class _Linear(torch.autograd.Function):
                 fp8_meta["scaling_fwd"].scale_inv,
                 tex.FP8FwdTensors.GEMM1_WEIGHT,
                 fp8_dtype_forward,
-                inputmat,
+                inputmat_total,
                 fp8_meta["scaling_fwd"].scale_inv,
                 tex.FP8FwdTensors.GEMM1_INPUT,
                 fp8_dtype_forward,


### PR DESCRIPTION
This error shows up in certain configurations of BERT/T5 when the `Linear` API is used to run in column parallel mode.