### PR TITLE
Correct cuDNN version requirement

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ Prerequisites
 1. Linux x86_64
 2. `CUDA 11.8 <https://developer.nvidia.com/cuda-downloads>`__
 3. |driver link|_ supporting CUDA 11.8 or later.
-4. `cuDNN 8 <https://developer.nvidia.com/cudnn>`__ or later.
+4. `cuDNN 8.1 <https://developer.nvidia.com/cudnn>`__ or later.
 5. For FP8 fused attention, `CUDA 12.1 <https://developer.nvidia.com/cuda-downloads>`__ or later, |driver link|_ supporting CUDA 12.1 or later, and `cuDNN 8.9 <https://developer.nvidia.com/cudnn>`__ or later.
 
 


### PR DESCRIPTION
I confirmed with cuDNN team that the exact version that allows compilation of TE with cuDNN frontend is 8.1 instead of 8.0, so making this correction here. 