### PR TITLE
Get packaging module from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import io
 import re
 import copy
 import tempfile
-from packaging.version import Version
+from pkg_resources import packaging
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 from shutil import copyfile
@@ -172,7 +172,7 @@ class PyTorchBuilder(FrameworkBuilderBase):
 
     @staticmethod
     def install_requires():
-        return ["flash-attn>=1.0.2", "packaging"]
+        return ["flash-attn>=1.0.2"]
 
 
 class TensorFlowBuilder(FrameworkBuilderBase):
@@ -244,13 +244,13 @@ def get_cmake_bin():
     try:
         out = subprocess.check_output([cmake_bin, "--version"])
     except OSError:
-        cmake_installed_version = Version("0.0")
+        cmake_installed_version = packaging.version.Version("0.0")
     else:
-        cmake_installed_version = Version(
+        cmake_installed_version = packaging.version.Version(
             re.search(r"version\s*([\d.]+)", out.decode()).group(1)
         )
 
-    if cmake_installed_version < Version("3.18.0"):
+    if cmake_installed_version < packaging.version.Version("3.18.0"):
         print(
             "Could not find a recent CMake to build Transformer Engine. "
             "Attempting to install CMake 3.18 to a temporary location via pip.",

--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -9,7 +9,7 @@ import warnings
 from importlib.metadata import version
 from contextlib import nullcontext
 from typing import Any, Callable, Optional, Tuple, Union
-from packaging.version import Version
+from pkg_resources import packaging
 
 import torch
 
@@ -45,8 +45,8 @@ from transformer_engine.pytorch.distributed import (
 )
 from transformer_engine.pytorch.export import is_in_onnx_export_mode
 
-_flash_attn_version = Version(version("flash-attn"))
-_flash_attn_version_required = Version("1.0.2")
+_flash_attn_version = packaging.version.Version(version("flash-attn"))
+_flash_attn_version_required = packaging.version.Version("1.0.2")
 warnings.filterwarnings("module", category=DeprecationWarning, module="transformer")
 
 


### PR DESCRIPTION
Fixes #189. 

`packaging` is apparently not a built-in and results in build failures if it's not installed in the user's environment. `pkg_resources` is also not built-in but it's [vendored into setuptools](https://github.com/pypa/setuptools/tree/a94ccbf404a79d56f9b171024dee361de9a948da/pkg_resources) so it's safe to use during build as well as RT.