### PR TITLE
Add dependencies for JAX examples

### DIFF
--- a/examples/jax/encoder/requirements.txt
+++ b/examples/jax/encoder/requirements.txt
@@ -1,4 +1,7 @@
+cuda-python
 flax
+jax
 nltk
+numpy
 optax
 tensorflow-datasets

--- a/examples/jax/mnist/requirements.txt
+++ b/examples/jax/mnist/requirements.txt
@@ -1,3 +1,6 @@
+cuda-python
 flax
+jax
+numpy
 optax
 tensorflow-datasets


### PR DESCRIPTION
It seems that our internal JAX container has removed `cuda-python`, so recent CI tests have been failing. This PR makes the `requirement.txt` s "include what you use".

Pinging @ksivaman and @jeng1220.