### PR TITLE
[JAX] Stop unnecessarily wrapping primitive output in list

### DIFF
--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -39,6 +39,8 @@ def te_dtype_to_jax_dtype(te_dtype):
         return jnp.bfloat16
     if te_dtype == TEDType.kInt32:
         return jnp.int32
+    if te_dtype == TEDType.kInt64:
+        return jnp.int64
     return jnp.int8
 
 
@@ -214,7 +216,7 @@ class TransposePrimitive(BasePrimitive):
 
         out = custom_caller(TransposePrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _transpose_p = register_primitive(TransposePrimitive)
@@ -362,7 +364,7 @@ class GatedGeluPrimitive(BasePrimitive):
 
         out = custom_caller(GatedGeluPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _gated_gelu_p = register_primitive(GatedGeluPrimitive)
@@ -520,7 +522,7 @@ class DgatedGeluPrimitive(BasePrimitive):
 
         out = custom_caller(DgatedGeluPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _dgated_gelu_p = register_primitive(DgatedGeluPrimitive)
@@ -708,7 +710,7 @@ class GemmPrimitive(BasePrimitive):
 
         out = custom_caller(GemmPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _gemm_p = register_primitive(GemmPrimitive)
@@ -1464,7 +1466,7 @@ class DequantizePrimitive(BasePrimitive):
 
         out = custom_caller(DequantizePrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _dequantize_p = register_primitive(DequantizePrimitive)
@@ -1558,7 +1560,7 @@ class SoftmaxPrimitive(BasePrimitive):
 
         out = custom_caller(name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 class ScaledSoftmaxFwdPrimitive(SoftmaxPrimitive):
@@ -1632,7 +1634,7 @@ class ScaledSoftmaxFwdPrimitive(SoftmaxPrimitive):
 
         out = custom_caller(ScaledSoftmaxFwdPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _scaled_softmax_fwd_p = register_primitive(ScaledSoftmaxFwdPrimitive)
@@ -1673,11 +1675,9 @@ class ScaledSoftmaxBwdPrimitive(SoftmaxPrimitive):
         """
         te_scaled_softmax_backward lowering rules
         """
-        out = SoftmaxPrimitive.softmax_backward_lowering(ScaledSoftmaxBwdPrimitive.name, ctx,
-                                                         grad_outputs, softmax_outputs,
-                                                         scale_factor)
-
-        return [out]
+        return SoftmaxPrimitive.softmax_backward_lowering(ScaledSoftmaxBwdPrimitive.name, ctx,
+                                                          grad_outputs, softmax_outputs,
+                                                          scale_factor)
 
 
 _scaled_softmax_bwd_p = register_primitive(ScaledSoftmaxBwdPrimitive)
@@ -1780,7 +1780,7 @@ class ScaledMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
 
         out = custom_caller(ScaledMaskedSoftmaxFwdPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 
 _scaled_masked_softmax_fwd_p = register_primitive(ScaledMaskedSoftmaxFwdPrimitive)
@@ -1822,11 +1822,9 @@ class ScaledMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
         """
         te_scaled_masked_softmax_backward lowering rules
         """
-        out = SoftmaxPrimitive.softmax_backward_lowering(ScaledMaskedSoftmaxBwdPrimitive.name, ctx,
-                                                         grad_outputs, softmax_outputs,
-                                                         scale_factor)
-
-        return [out]
+        return SoftmaxPrimitive.softmax_backward_lowering(ScaledMaskedSoftmaxBwdPrimitive.name, ctx,
+                                                          grad_outputs, softmax_outputs,
+                                                          scale_factor)
 
 
 _scaled_masked_softmax_bwd_p = register_primitive(ScaledMaskedSoftmaxBwdPrimitive)
@@ -1915,7 +1913,7 @@ class ScaledUpperTriangMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
 
         out = custom_caller(ScaledUpperTriangMaskedSoftmaxFwdPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
 _scaled_upper_triang_masked_softmax_fwd_p = \
     register_primitive(ScaledUpperTriangMaskedSoftmaxFwdPrimitive)
@@ -1956,11 +1954,9 @@ class ScaledUpperTriangMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
         """
         te_scaled_upper_triang_masked_softmax_backward lowering rules
         """
-        out = SoftmaxPrimitive.softmax_backward_lowering(
+        return SoftmaxPrimitive.softmax_backward_lowering(
             ScaledUpperTriangMaskedSoftmaxBwdPrimitive.name, ctx, grad_outputs, softmax_outputs,
             scale_factor)
-
-        return [out]
 
 _scaled_upper_triang_masked_softmax_bwd_p = \
     register_primitive(ScaledUpperTriangMaskedSoftmaxBwdPrimitive)

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -69,7 +69,7 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())
         .value("kByte", DType::kByte)
         .value("kInt32", DType::kInt32)
-        .value("KInt64", DType::kInt64)
+        .value("kInt64", DType::kInt64)
         .value("kFloat32", DType::kFloat32)
         .value("kFloat16", DType::kFloat16)
         .value("kBFloat16", DType::kBFloat16)


### PR DESCRIPTION
We've suddenly started experiencing some esoteric JAX errors:
```
jax._src.traceback_util.UnfilteredStackTrace: AssertionError: ([[<jaxlib.mlir._mlir_libs._mlir.ir.OpResultList object at 0x7fb46a22ca30>]], a:bf16[64,8,32,32] = te_scaled_masked_softmax_backward[scale_factor=1.0] b c)
```
@nouiz found that this change fixed the error. I don't fully understand, what's going on here, but [this JAX documentation](https://github.com/google/jax/blob/6e8181495a99aa31bf27e1bf7b23981876c8f9db/docs/notebooks/Writing_custom_interpreters_in_Jax.md#2-evaluating-a-jaxpr) suggests that if a primitive outputs a single tensor, the tensor is wrapped in a list when the primitive is evaluated. We wrap the tensor in a list as well, so these nested lists might be messing things up. It's strange that this error only seems to affect softmax and not other primitives with a single output (e.g. GEMMs). Also, the relevant code hasn't been changed since JAX support was first added in https://github.com/NVIDIA/TransformerEngine/pull/53. There are two suspicious events that happened right when the error first started showing up:
- https://github.com/NVIDIA/TransformerEngine/pull/175
- [JAX 0.4.9](https://github.com/google/jax/tree/jaxlib-v0.4.9) is released

Pinging @mingxu1067 @nouiz @zlsh80826 @jeng1220