### PR TITLE
Relax checks for attn_mask_type in FlashAttention

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -504,8 +504,10 @@ class DotProductAttention(torch.nn.Module):
             or key_layer.dtype not in [torch.bfloat16, torch.float16]
             or value_layer.dtype not in [torch.bfloat16, torch.float16]
             or (self.device_compute_capability == 8.6 and key_layer.shape[-1] > 64)
-            or (self.attn_mask_type == "padding" and attention_mask is not None)
         ):
+            use_flash_attention = False
+
+        if self.attn_mask_type == "padding" and attention_mask is not None:
             use_flash_attention = False
 
         if is_in_onnx_export_mode():

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -507,6 +507,7 @@ class DotProductAttention(torch.nn.Module):
             or key_layer.dtype not in [torch.bfloat16, torch.float16]
             or value_layer.dtype not in [torch.bfloat16, torch.float16]
             or (self.device_compute_capability == 8.6 and key_layer.shape[-1] > 64)
+            or attention_mask is not None
         ):
             use_flash_attention = False
 

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -281,9 +281,6 @@ class FlashAttention(torch.nn.Module):
         assert (
             _flash_attn_version >= _flash_attn_version_required
         ), f"FlashAttention minimum version {_flash_attn_version_required} is required."
-        assert (
-            attn_mask_type == "causal"
-        ), 'FlashAttention currently only supports causal attention mask.'
 
         self.attn_causal_mask = attn_mask_type == "causal"
         self.norm_factor = norm_factor
@@ -428,7 +425,6 @@ class DotProductAttention(torch.nn.Module):
         self.device_compute_capability = get_device_compute_capability()
         self.use_flash_attention = (
             int(os.getenv("NVTE_FLASH_ATTN", "1"))
-            and attn_mask_type == "causal"
             and self.device_compute_capability >= 8.0
         )
 


### PR DESCRIPTION
HazyResearch FlashAttention supports 'causal' mask type but also support 'no mask' type. This PR relaxes the restriction on `attn_mask_type` being 'causal' in the PyTorch FlashAttention module. 