### PR TITLE
Add pip install jax[jax_test]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -428,6 +428,9 @@ setup(
     extras_require={
         'test': ['pytest',
                  'tensorflow_datasets'],
+        'jax_test': ['pytest',
+                     'tensorflow_datasets',
+                     'flax', 'praxis'],
         'test_pytest': ['onnxruntime',],
     },
     license_files=("LICENSE",),


### PR DESCRIPTION
This allows us to update the jax tests dependency without impacting users.