### PR TITLE
Jax bug fixes for the dot product attention

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -238,11 +238,11 @@ class TestSelfFusedAttnMax512():
                 (0, 1)))
 
         primitive_out, (primitive_dqkv,
-                        primitive_dbeta) = jitted_primitive(self.qkv, self.bias, self.q_token,
+                        primitive_dbias) = jitted_primitive(self.qkv, self.bias, self.q_token,
                                                             self.kv_token, self.dropout_rng)
 
         reference_out, (reference_dqkv,
-                        reference_dbeta) = jitted_reference(self.qkv, self.bias, self.q_token,
+                        reference_dbias) = jitted_reference(self.qkv, self.bias, self.q_token,
                                                             self.kv_token, self.dropout_rng)
 
         np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
@@ -279,21 +279,21 @@ class TestSelfFusedAttnMax512():
         assert jnp.allclose(invalid_primitive_dqkv, jnp.zeros_like(invalid_primitive_dqkv))
 
         if self.attn_bias_type != AttnBiasType.NO_BIAS:
-            # dbeta valid part
+            # dbias valid part
             np.testing.assert_allclose(
-                jnp.asarray(primitive_dbeta[:, :, :self.valid_len, :self.valid_len], np.float32),
-                jnp.asarray(reference_dbeta[:, :, :self.valid_len, :self.valid_len], np.float32),
+                jnp.asarray(primitive_dbias[:, :, :self.valid_len, :self.valid_len], np.float32),
+                jnp.asarray(reference_dbias[:, :, :self.valid_len, :self.valid_len], np.float32),
                 rtol=1e-4,
                 atol=3e-5)
 
-            # dbeta padded part
+            # dbias padded part
             np.testing.assert_allclose(
-                jnp.asarray(primitive_dbeta[:, :, self.valid_len:, self.valid_len:], np.float32),
-                jnp.asarray(reference_dbeta[:, :, self.valid_len:, self.valid_len:], np.float32))
+                jnp.asarray(primitive_dbias[:, :, self.valid_len:, self.valid_len:], np.float32),
+                jnp.asarray(reference_dbias[:, :, self.valid_len:, self.valid_len:], np.float32))
 
             assert jnp.allclose(
-                primitive_dbeta[:, :, self.valid_len:, self.valid_len:],
-                jnp.zeros_like(primitive_dbeta[:, :, self.valid_len:, self.valid_len:]))
+                primitive_dbias[:, :, self.valid_len:, self.valid_len:],
+                jnp.zeros_like(primitive_dbias[:, :, self.valid_len:, self.valid_len:]))
 
 
 @pytest.mark.skipif(not is_fused_attn_kernel_available(),

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -103,6 +103,12 @@ ATTRS = [{
     _KEY_OF_MLP_ACTIVATIONS: (('gelu', 'linear')),
     _KEY_OF_FUSE_MLP_WI: True
 }, {
+    _KEY_OF_SCALE_ATTN_LOGITS: True,
+    _KEY_OF_LAYERNORM_TYPE: 'rmsnorm',
+    _KEY_OF_DROPOUT_RATE: 0.8,
+    _KEY_OF_MLP_ACTIVATIONS: (('gelu', 'linear')),
+    _KEY_OF_FUSE_MLP_WI: True
+}, {
     _KEY_OF_TRANSPOSE_BS: False,
     _KEY_OF_SCALE_ATTN_LOGITS: True,
     _KEY_OF_LAYERNORM_TYPE: 'rmsnorm',

--- a/transformer_engine/common/fused_attn/fused_attn_fp16_bf16_max_seqlen_512.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_fp16_bf16_max_seqlen_512.cu
@@ -327,7 +327,6 @@ static cudnn_frontend::Tensor createSoftmaxForward(
     // NOLINTNEXTLINE(runtime/references)
     std::vector<cudnn_frontend::Operation> &ops,
     cudnn_frontend::Tensor const &prevBlockOutputTensor) {
-
     int64_t afterBMM1_dim[4] = {b, h, s_q, s_kv};
     int64_t afterBMM1_stride[4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
 
@@ -645,7 +644,7 @@ void fused_attn_max_512_fwd_impl(int64_t b, int64_t h, int64_t s_q, int64_t s_kv
                                 mask_type,   tensorType};
 
         using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
-        static CacheType fmha_fprop_cache;
+        static thread_local CacheType fmha_fprop_cache;
 
         bool enable_dropout = (dropout_probability != 0.0f);
 
@@ -815,7 +814,7 @@ void fused_attn_max_512_bwd_impl(int64_t b, int64_t h, int64_t s_q, int64_t s_kv
             layout, bias_type, mask_type, tensorType};
 
         using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
-        static CacheType fmha_bprop_cache;
+        static thread_local CacheType fmha_bprop_cache;
 
         auto get_plan = [&](CacheType &cache, const FADescriptor &descriptor) {
             auto it = cache.find(descriptor);

--- a/transformer_engine/common/fused_attn/fused_attn_fp16_bf16_max_seqlen_512.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_fp16_bf16_max_seqlen_512.cu
@@ -668,7 +668,8 @@ void fused_attn_max_512_fwd_impl(int64_t b, int64_t h, int64_t s_q, int64_t s_kv
             createScale(b, h, s_q, s_kv, d, layout, tensorType, ops);
 
             // if bias, we need to memset the S buffer to correctly computate dbias
-            auto zero_s = (bias_type != NVTE_Bias_Type::NVTE_NO_BIAS);
+            auto zero_s = (bias_type != NVTE_Bias_Type::NVTE_NO_BIAS) ||
+                          (mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK);
             auto bmm1_output = createBMM1(b, h, s_q, s_kv, d, layout, tensorType, zero_s, ops);
 
             NVTE_CHECK(bias_type != NVTE_Bias_Type::NVTE_PRE_SCALE_BIAS,

--- a/transformer_engine/common/fused_attn/fused_attn_fp8.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_fp8.cu
@@ -1016,7 +1016,7 @@ void fa_fwd_fp8(int64_t b, int64_t s_q, int64_t s_kv, int64_t h, int64_t d,
               NVTE_Bias_Type::NVTE_NO_BIAS, NVTE_Mask_Type::NVTE_PADDING_MASK, tensorType};
 
       using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
-      static CacheType fa_fprop_cache;
+      static thread_local CacheType fa_fprop_cache;
 
       // Get plan from cache if cache is available, otherwise create one
       auto get_plan = [&](CacheType &cache, const FADescriptor &descriptor) {
@@ -1332,7 +1332,7 @@ void fa_bwd_fp8(int64_t b, int64_t s_q, int64_t s_kv, int64_t h, int64_t d,
               NVTE_Bias_Type::NVTE_NO_BIAS, NVTE_Mask_Type::NVTE_PADDING_MASK, tensorType};
 
       using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
-      static CacheType fa_bprop_cache;
+      static thread_local CacheType fa_bprop_cache;
 
       // Get plan from cache if cache is available, otherwise create one
       auto get_plan = [&](CacheType &cache, const FADescriptor &descriptor) {

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -370,7 +370,7 @@ class MultiHeadAttention(nn.Module):
         q_seqlen = inputs_q.shape[0] if self.transpose_batch_sequence else inputs_q.shape[1]
         kv_seqlen = inputs_kv.shape[0] if self.transpose_batch_sequence else inputs_kv.shape[1]
         fused_attn_supported_seqlen = [128, 256, 384, 512]
-        enable_fused_attn = int(os.getenv("NVTE_USE_FUSED_ATTN", "0"))
+        enable_fused_attn = int(os.getenv("NVTE_FUSED_ATTN", "0"))
         use_fused_attn = not decode and not self.transpose_batch_sequence and self.fuse_qkv and \
             self.dropout_rate == 0 and canonicalize_dtype in [jnp.bfloat16, jnp.float16] and \
             q_seqlen in fused_attn_supported_seqlen and kv_seqlen in fused_attn_supported_seqlen \

--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -386,7 +386,7 @@ class FusedAttnShardingMetaGenerator(ShardingMetaGenerator):
 
         for input_shape, dp_dim, tp_dim in zip(input_shapes, input_dp_dims, input_tp_dims):
             in_axis = {}
-            if dp_dim is not None:
+            if dp_dim is not None and input_shape is not None:
                 in_axis[dp_dim] = dp_axis_name
                 assert input_shape[dp_dim] % dp_size == 0, \
                     f"The dimension of batch in input_shape should be a multiple of " \
@@ -398,7 +398,7 @@ class FusedAttnShardingMetaGenerator(ShardingMetaGenerator):
                 if tp_dim is not None and tp_dim >= dp_dim:
                     tp_dim = tp_dim + 1
 
-            if tp_dim is not None:
+            if tp_dim is not None and input_shape is not None:
                 in_axis[tp_dim] = tp_axis_name
                 assert input_shape[tp_dim] % tp_size == 0, \
                     f"The dimension of tensor parallel in input_shape should be a multiple of " \


### PR DESCRIPTION
This PR includes several bug fixes related to the fused and the unfused attention, and also not enabling the fused attention by default.

1. Fixed an issue where fusing the scale and softmax operations with a bias resulted in incorrect computation flow. The fix ensures that the computation flow becomes Softmax(scale * attn_weights + bias). e594bb625b40deb9a5206e3ac4431832fe187967
2. There is a bug that not clearing `S` tensor leads to incorrect answer on cuDNN kernel. WAR by clearing `S` tensor when `causal_masking` + `no_bias` and add the  relevant unit tests. ac67e914b6e3bbd6a6cdbbbdf073026a1e86e9f2
3. Enhance the handling of `None` sharding tensor. 49e73d51f2dae2aeee056c709f8efbdc39f51d73
4. Based on internal discussions, it has been decided to disable fused attention by default for JAX in the upcoming release (0.9). This PR introduces a new flag, `NVTE_USE_FUSED_ATTN`, which enables fused attention for internal convergence tests (t5x/PAXML). The flag will be removed once the convergence tests are successfully completed. ac67e914b6e3bbd6a6cdbbbdf073026a1e86e9f2
5. Add `thread_local` to protect the global static plan cache for thread safety.  8a0d11a8dc0057ee3cf8a392ad27f2a7a4cea6ae