### PR TITLE
Clearer error messages for dtype and shape assertions

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -27,7 +27,7 @@ from ..utils import (
     divide,
     get_default_init_method,
     cast_if_needed,
-    check_dim_for_fp8_forward_exec,
+    assert_dim_for_fp8_forward_exec,
 )
 from ..distributed import (
     set_tensor_model_parallel_attributes,
@@ -94,9 +94,9 @@ class _LayerNormLinear(torch.autograd.Function):
         in_features = ln_weight.numel()
         assert inp.shape[-1] == in_features, "GEMM not possible"
         inputmat = inp.view((-1, in_features))
-        assert (
-            not fp8 or check_dim_for_fp8_forward_exec(inputmat, weight)
-        ), "Input and weight dimensions are not compatible for FP8 execution."
+        if fp8:
+            assert_dim_for_fp8_forward_exec(inputmat)
+            assert_dim_for_fp8_forward_exec(weight)
 
         update_fp8_weights = is_first_microbatch is None or is_first_microbatch
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -24,7 +24,7 @@ from ..utils import (
     divide,
     get_default_init_method,
     cast_if_needed,
-    check_dim_for_fp8_forward_exec,
+    assert_dim_for_fp8_forward_exec,
 )
 from ..distributed import (
     set_tensor_model_parallel_attributes,
@@ -80,9 +80,9 @@ class _Linear(torch.autograd.Function):
         in_features = weight.shape[-1]
         assert inp.shape[-1] == in_features, "GEMM not possible"
         inputmat = inp.view((-1, in_features))
-        assert (
-            not fp8 or check_dim_for_fp8_forward_exec(inputmat, weight)
-        ), "Input and weight dimensions are not compatible for FP8 execution."
+        if fp8:
+            assert_dim_for_fp8_forward_exec(inputmat)
+            assert_dim_for_fp8_forward_exec(weight)
 
         update_fp8_weights = is_first_microbatch is None or is_first_microbatch
 

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -179,8 +179,16 @@ def cast_if_needed(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
         return tensor if tensor is None or tensor.dtype == dtype else tensor.to(dtype)
 
 
-def check_dim_for_fp8_forward_exec(*tensors: Tuple[torch.Tensor, ...]) -> bool:
+def check_dim_for_fp8_forward_exec(*tensors: torch.Tensor) -> bool:
     """For fp8 fprop (TN layout), inputs and weights must be such
        that dim0 is divisible by 8 and dim1 is divisible by 16.
     """
     return all(not t.shape[0] % 8 and not t.shape[1] % 16 for t in tensors)
+
+
+def assert_dim_for_fp8_forward_exec(tensor: torch.Tensor) -> None:
+    # single tensor check so it's clear which tensor is triggering the assertion
+    assert check_dim_for_fp8_forward_exec(tensor), (
+        "Tensor dimensions are not compatible for FP8 execution: "
+        f"({tensor.shape[0]} % 8 != 0, {tensor.shape[1]} % 16 != 0)"
+    )

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -179,11 +179,11 @@ def cast_if_needed(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
         return tensor if tensor is None or tensor.dtype == dtype else tensor.to(dtype)
 
 
-def check_dim_for_fp8_forward_exec(*tensors: torch.Tensor) -> bool:
+def check_dim_for_fp8_forward_exec(tensor: torch.Tensor) -> bool:
     """For fp8 fprop (TN layout), inputs and weights must be such
        that dim0 is divisible by 8 and dim1 is divisible by 16.
     """
-    return all(not t.shape[0] % 8 and not t.shape[1] % 16 for t in tensors)
+    return not tensor.shape[0] % 8 and not tensor.shape[1] % 16
 
 
 def assert_dim_for_fp8_forward_exec(tensor: torch.Tensor) -> None:

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -187,6 +187,9 @@ def check_dim_for_fp8_forward_exec(*tensors: torch.Tensor) -> bool:
 
 
 def assert_dim_for_fp8_forward_exec(tensor: torch.Tensor) -> None:
+    """For fp8 fprop (TN layout), inputs and weights must be such
+       that dim0 is divisible by 8 and dim1 is divisible by 16.
+    """
     # single tensor check so it's clear which tensor is triggering the assertion
     assert check_dim_for_fp8_forward_exec(tensor), (
         "Tensor dimensions are not compatible for FP8 execution: "


### PR DESCRIPTION
Addressing issues found when debugging https://github.com/Lightning-AI/lit-llama/issues/249