### PR TITLE
Pin FA version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
 
     # Framework-specific requirements
     if "pytorch" in frameworks():
-        add_unique(install_reqs, ["torch", "flash-attn>=1.0.2"])
+        add_unique(install_reqs, ["torch", "flash-attn==1.0.6"])
         add_unique(test_reqs, ["numpy", "onnxruntime", "torchvision"])
     if "jax" in frameworks():
         if not found_pybind11():


### PR DESCRIPTION
This allows TE to be tested against specific FA releases and upgrade when necessary, to avoid situations such as https://github.com/HazyResearch/flash-attention/pull/241, when changes to FA introduces bugs in TE