### PR TITLE
ONNX export test - BF16 support

### DIFF
--- a/tests/pytorch/test_onnx_export.py
+++ b/tests/pytorch/test_onnx_export.py
@@ -133,7 +133,7 @@ def do_export(
 
 
 def to_numpy(tensor):
-    if isinstance(tensor, torch.Tensor)::
+    if isinstance(tensor, torch.Tensor):
         if tensor.dtype == torch.bfloat16:
             tensor = tensor.type(torch.float32)
         tensor = tensor.detach().cpu().numpy()

--- a/tests/pytorch/test_onnx_export.py
+++ b/tests/pytorch/test_onnx_export.py
@@ -29,7 +29,7 @@ import numpy as np
 import onnxruntime as ort
 import torch
 from torch import nn as nn
-from typing import Union, Tuple, List
+from typing import Optional, Union, Tuple, List
 import transformer_engine.pytorch as te
 from transformer_engine.common import recipe
 import transformer_engine_extensions as tex
@@ -133,7 +133,7 @@ def do_export(
 
 
 def to_numpy(tensor):
-    if type(tensor) != np.ndarray:
+    if isinstance(tensor, torch.Tensor)::
         if tensor.dtype == torch.bfloat16:
             tensor = tensor.type(torch.float32)
         tensor = tensor.detach().cpu().numpy()
@@ -152,10 +152,7 @@ def set_layer_scale(module: torch.nn.Module, scale: float, num_gemms: int):
 
 
 def te_infer(model: torch.nn.Module, inps: Union[Tuple[torch.tensor], torch.tensor], is_fp8: bool):
-    """Transformer Engine forward prpoagtation.
-
-    Return results after copying to the CPU and converting to numpy.
-    """
+    """Transformer Engine forward propagation."""
     fp8_recipe = create_fp8_recipe()
     with torch.inference_mode(), te.fp8_autocast(enabled=is_fp8, fp8_recipe=fp8_recipe), warnings.catch_warnings():
         te_outputs = model(*inps if isinstance(inps, tuple) else (inps,))
@@ -195,8 +192,8 @@ def serialize_inputs_outputs(
     fname: str,
     inputs: Union[Tuple[torch.Tensor], torch.Tensor],
     te_outputs: List[torch.Tensor],
-    input_names: List[str]=None,
-    output_names: List[str]=None,
+    input_names: Optional[List[str]] = None,
+    output_names: Optional[List[str]] = None,
 ):
     if not SAVE_TEST_IO:
         return

--- a/tests/pytorch/test_onnx_export.py
+++ b/tests/pytorch/test_onnx_export.py
@@ -1469,7 +1469,7 @@ def test_export_gpt_generation(
     te_outputs = te_infer(model, inp, is_fp8=use_fp8)
     serialize_inputs_outputs(fname, inp, te_outputs, input_names=input_names, output_names=output_names)
     if precision not in (torch.bfloat16, ):
-        validate_result(fname, inp, model, atol=5e-3, is_fp8=use_fp8, input_names=input_names,
+        validate_result(fname, inp, model, atol=6e-3, is_fp8=use_fp8, input_names=input_names,
             te_outputs=te_outputs)
 
     # "Generative phase": use a single input (sequence len=1). For FP8 we need to pad the sequence to mult of 8.
@@ -1479,7 +1479,7 @@ def test_export_gpt_generation(
     te_outputs = te_infer(model, inp, is_fp8=use_fp8)
     serialize_inputs_outputs(fname, inp, te_outputs, input_names=input_names)
     if precision not in (torch.bfloat16, ):
-        validate_result(fname, inp, model, atol=5e-3, is_fp8=use_fp8, input_names=input_names,
+        validate_result(fname, inp, model, atol=6e-3, is_fp8=use_fp8, input_names=input_names,
             te_outputs=te_outputs)
 
 

--- a/transformer_engine/pytorch/te_onnx_extensions.py
+++ b/transformer_engine/pytorch/te_onnx_extensions.py
@@ -178,9 +178,13 @@ def onnx_te_gemm(
     is_fp16 = is_dtype_fp16(inputs)
     if input_type == int(tex.DType.kFloat8E4M3):
         inputs = dequantize(g, inputs, input_scale_inverse, input_fp8_tensor, out_type)
+        if out_type == int(tex.DType.kBFloat16):
+            inputs = g.op("Cast", inputs, to_i=_C_onnx.TensorProtoDataType.FLOAT)
 
     if weight_type == int(tex.DType.kFloat8E4M3):
         weight = dequantize(g, weight, weight_scale_inverse, weight_fp8_tensor, out_type)
+        if out_type == int(tex.DType.kBFloat16):
+            weight = g.op("Cast", weight, to_i=_C_onnx.TensorProtoDataType.FLOAT)
 
     empty_tensor_size = [0]
     bias_empty = torch.onnx.symbolic_helper._get_tensor_sizes(bias) == empty_tensor_size

--- a/transformer_engine/pytorch/te_onnx_extensions.py
+++ b/transformer_engine/pytorch/te_onnx_extensions.py
@@ -178,13 +178,9 @@ def onnx_te_gemm(
     is_fp16 = is_dtype_fp16(inputs)
     if input_type == int(tex.DType.kFloat8E4M3):
         inputs = dequantize(g, inputs, input_scale_inverse, input_fp8_tensor, out_type)
-        if out_type == int(tex.DType.kBFloat16):
-            inputs = g.op("Cast", inputs, to_i=_C_onnx.TensorProtoDataType.FLOAT)
 
     if weight_type == int(tex.DType.kFloat8E4M3):
         weight = dequantize(g, weight, weight_scale_inverse, weight_fp8_tensor, out_type)
-        if out_type == int(tex.DType.kBFloat16):
-            weight = g.op("Cast", weight, to_i=_C_onnx.TensorProtoDataType.FLOAT)
 
     empty_tensor_size = [0]
     bias_empty = torch.onnx.symbolic_helper._get_tensor_sizes(bias) == empty_tensor_size


### PR DESCRIPTION
Adding support for BF16 in ONNX export
* "fake bf16" are bf16 subgraphs with fp32 I/O for testing TE vs ORT
* standard bf16 - for exporting the inputs and outputs and comparing against TRT
* added cast to bf16 before GEMM in BF16, in case input is output of DQ