### PR TITLE
Fix BF16 ONNX export for successful ONNX Runtime Verification

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -173,7 +173,7 @@ class UnfusedDotProductAttention(torch.nn.Module):
             output_size[0] * output_size[1],
             output_size[2],
             output_size[3],
-            dtype=torch.float32,
+            dtype=torch.float32 if is_in_onnx_export_mode() else query_layer.dtype,
             device=torch.cuda.current_device(),
         )
 

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -173,7 +173,7 @@ class UnfusedDotProductAttention(torch.nn.Module):
             output_size[0] * output_size[1],
             output_size[2],
             output_size[3],
-            dtype=query_layer.dtype,
+            dtype=torch.float32,
             device=torch.cuda.current_device(),
         )
 

--- a/transformer_engine/pytorch/te_onnx_extensions.py
+++ b/transformer_engine/pytorch/te_onnx_extensions.py
@@ -176,6 +176,7 @@ def onnx_te_gemm(
     """ONNX graph for te_gemm"""
     # pylint: disable=unused-argument
     is_fp16 = is_dtype_fp16(inputs)
+    is_bf16 = is_dtype_bf16(inputs)
     if input_type == int(tex.DType.kFloat8E4M3):
         inputs = dequantize(g, inputs, input_scale_inverse, input_fp8_tensor, out_type)
 
@@ -200,6 +201,8 @@ def onnx_te_gemm(
     else:
         if is_fp16:
             output = g.op("Cast", output, to_i=_C_onnx.TensorProtoDataType.FLOAT16)
+        elif is_bf16:
+            output = g.op("Cast", output, to_i=_C_onnx.TensorProtoDataType.BFLOAT16)
     return output
 
 


### PR DESCRIPTION
Models with BF16 precision export to ONNX successfully but fail to run through ONNX Runtime. Issues observed:
1. Output of GEMM is FP32 - The output of gemm is not type-compliant as an input to a subsequent node that expects a BF16 input. 
2. The `torch.empty` call in the forward definition of  `UnfusedDotProductAttention` sets the type of the `value` attribute of the `ConstantOfShape` node to BF16. This is not supported by ONNX Runtime.

The changes in the MR address the issues above