### PR TITLE
revert change causing test failures

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -173,7 +173,7 @@ class UnfusedDotProductAttention(torch.nn.Module):
             output_size[0] * output_size[1],
             output_size[2],
             output_size[3],
-            dtype=torch.float32 if is_in_onnx_export_mode() else query_layer.dtype,
+            dtype=query_layer.dtype,
             device=torch.cuda.current_device(),
         )
 


### PR DESCRIPTION
Reverting the change that caused pipeline failures. A new MR will be filed to address the required changes for the ONNX export while ensuring all tests pass