### PR TITLE
ONNX export test - fix file name in transformer layer tests

### DIFF
--- a/tests/pytorch/test_onnx_export.py
+++ b/tests/pytorch/test_onnx_export.py
@@ -1258,7 +1258,7 @@ def test_export_transformer_layer(
     fuse_qkv_params_str = "_fused-qkv" if fuse_qkv_params else ""
     high_prec_str = dtype2str(precision)
     attn_mask_str = get_attn_mask_str(use_mask, attn_mask_type)
-    fname = f"te.transformer_layer{fp8_str}{attn_mask_str}{fuse_qkv_params_str}{high_prec_str}.onnx"
+    fname = f"te.transformer_layer{fp8_str}{attn_mask_str}{fuse_qkv_params_str}{high_prec_str}_{activation}.onnx"
 
     model = te.TransformerLayer(
         hidden_size,


### PR DESCRIPTION
Same filename is used for all activations, file is getting overridden to last activation type executed