### PR TITLE
Fix TE discovery in python virtual environments

### DIFF
--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -7,15 +7,16 @@ import ctypes
 import os
 import platform
 import subprocess
+import sys
 
 
 def get_te_path():
     """Find Transformer Engine install path using pip"""
 
-    command = ["pip", "show", "transformer_engine"]
+    command = [sys.executable, "-m", "pip", "show", "transformer_engine"]
     result = subprocess.run(command, capture_output=True, check=True, text=True)
     result = result.stdout.replace("\n", ":").split(":")
-    return result[result.index("Location")+1].strip()
+    return result[result.index("Location") + 1].strip()
 
 
 def _load_library():


### PR DESCRIPTION
Allows TE discovery mechanisms to pick up the `python` interpreter (and associated `pip`, as opposed to the global `python`) running in the virtual-environment that code is being run in.