### PR TITLE
Disable TorchDynamo optimizations in PyTorch modules

### DIFF
--- a/qa/L0_unittest/test.sh
+++ b/qa/L0_unittest/test.sh
@@ -10,3 +10,4 @@ pip install pytest==6.2.5 onnxruntime==1.13.1
 pytest -v -s $TE_PATH/tests/pytorch/test_sanity.py
 PYTORCH_JIT=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 pytest -v -s $TE_PATH/tests/pytorch/test_numerics.py
 NVTE_TORCH_COMPILE=0 pytest -v -s $TE_PATH/tests/pytorch/test_onnx_export.py
+pytest -v -s $TE_PATH/tests/pytorch/test_jit.py

--- a/tests/pytorch/test_jit.py
+++ b/tests/pytorch/test_jit.py
@@ -12,6 +12,8 @@ import transformer_engine.pytorch as te
 # Model names for test_torch_dynamo
 _model_names = ["Linear", "LayerNorm", "LayerNormLinear", "LayerNormMLP"]
 
+
+@pytest.mark.skipif(torch.__version__ < "2", reason="torch.compile not available")
 @pytest.mark.parametrize("model_name", _model_names)
 def test_torch_dynamo(model_name: str):
     """Test compatibility with Torch Dynamo

--- a/tests/pytorch/test_jit.py
+++ b/tests/pytorch/test_jit.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+from typing import Tuple
+
+import pytest
+import torch
+
+import transformer_engine.pytorch as te
+
+# Model names for test_torch_dynamo
+_model_names = ["Linear", "LayerNorm", "LayerNormLinear", "LayerNormMLP"]
+
+@pytest.mark.parametrize("model_name", _model_names)
+def test_torch_dynamo(model_name: str):
+    """Test compatibility with Torch Dynamo
+
+    Construct model, optimize with Torch Dynamo, and perform a single
+    forward and backward pass.
+
+    """
+
+    # Helper function to construct tensor with default options
+    def make_tensor(
+            dims: Tuple[int],
+            dtype: torch.dtype = torch.float32,
+            device: torch.device = "cuda",
+            requires_grad: bool = True,
+            **kwargs,
+    ):
+        return torch.zeros(
+            dims,
+            dtype=dtype,
+            device=device,
+            requires_grad=requires_grad,
+            **kwargs,
+        )
+
+    # Construct model and input tensors
+    model = None
+    inputs = []
+    if model_name == "Linear":
+        model = te.Linear(16, 16)
+        inputs = [make_tensor([16,16])]
+    elif model_name == "LayerNorm":
+        model = te.LayerNorm(16)
+        inputs = [make_tensor([16,16])]
+    elif model_name == "LayerNormLinear":
+        model = te.LayerNormLinear(16,16)
+        inputs = [make_tensor([16,16])]
+    elif model_name == "LayerNormMLP":
+        model = te.LayerNormMLP(16,16)
+        inputs = [make_tensor([16,16])]
+    assert model is not None, f"could not construct {model_name}"
+
+    # Optimize model with TorchDynamo
+    torch.compile(model)
+
+    # Forward and backward pass
+    out = model(*inputs)
+    out.backward(torch.zeros_like(out))

--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -12,6 +12,13 @@ jit_fuser = torch.jit.script
 if torch.__version__ >= "2" and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
     jit_fuser = torch.compile
 
+# Decorator to disable Torch Dynamo
+# See: https://github.com/NVIDIA/TransformerEngine/issues/308
+no_torch_dynamo = lambda func: func
+if torch.__version__ >= "2":
+    import torch._dynamo
+    no_torch_dynamo = torch._dynamo.disable
+
 
 def set_jit_fusion_options() -> None:
     """Set PyTorch JIT layer fusion options."""

--- a/transformer_engine/pytorch/module/layernorm.py
+++ b/transformer_engine/pytorch/module/layernorm.py
@@ -12,6 +12,8 @@ from torch.nn import init
 
 import transformer_engine_extensions as tex
 
+from ..jit import no_torch_dynamo
+
 
 __all__ = ["LayerNorm"]
 
@@ -154,6 +156,7 @@ class LayerNorm(torch.nn.Module):
         init.zeros_(self.bias)
 
 
+    @no_torch_dynamo
     def forward(self, inp: torch.Tensor) -> torch.Tensor:
         """LayerNorm FWD"""
         # Maintain backward compatibility.

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -48,6 +48,7 @@ from ..cpp_extensions import (
     cast_from_fp8,
 )
 from ..constants import GemmParallelModes, dist_group_type, TE_DType
+from ..jit import no_torch_dynamo
 
 
 __all__ = ["LayerNormLinear"]
@@ -820,6 +821,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
 
         return fp8_weight_tensors
 
+    @no_torch_dynamo
     def forward(
         self,
         inp: torch.Tensor,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -44,6 +44,7 @@ from ..distributed import (
 from .. import cpp_extensions as tex
 
 from ..constants import dist_group_type, TE_DType
+from ..jit import no_torch_dynamo
 
 
 __all__ = ["LayerNormMLP"]
@@ -1144,6 +1145,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
 
         return fp8_weight_tensors
 
+    @no_torch_dynamo
     def forward(
         self, inp: torch.Tensor, is_first_microbatch: Optional[bool] = None
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, ...]]:

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -42,6 +42,7 @@ from ..cpp_extensions import (
     cast_to_fp8,
 )
 from ..constants import GemmParallelModes, dist_group_type
+from ..jit import no_torch_dynamo
 
 
 __all__ = ["Linear"]
@@ -667,6 +668,7 @@ class Linear(TransformerEngineBaseModule):
 
         return fp8_weight_tensors
 
+    @no_torch_dynamo
     def forward(
         self,
         inp: torch.Tensor,


### PR DESCRIPTION
As discussed in https://github.com/NVIDIA/TransformerEngine/issues/308, calling `torch.compile` on a Transformer Engine module fails. A full solution would probably require significant changes in both Transformer Engine and PyTorch, so until we have a demonstrated need it will be easier to just disable TorchDynamo. `torch.compile` wouldn't do anything for the Transformer Engine modules in a model, but it could still benefit other model components.

Closes #308.