### PR TITLE
Stop creating pip wheels in GitHub build tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: 'PyTorch'
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/pytorch:23.06-py3
+      image: nvcr.io/nvidia/pytorch:23.03-py3
       options: --user root
     steps:
       - name: 'Checkout'
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       #image: nvcr.io/nvidia/jax:XX.XX-py3  # Not yet available
-      image: nvcr.io/nvidia/tensorflow:23.06-tf2-py3
+      image: nvcr.io/nvidia/tensorflow:23.03-tf2-py3
       options: --user root
     steps:
       - name: 'Checkout'
@@ -50,7 +50,7 @@ jobs:
     name: 'TensorFlow'
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/tensorflow:23.06-tf2-py3
+      image: nvcr.io/nvidia/tensorflow:23.03-tf2-py3
       options: --user root
     steps:
       - name: 'Checkout'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: 'PyTorch'
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/pytorch:23.03-py3
+      image: nvcr.io/nvidia/pytorch:23.06-py3
       options: --user root
     steps:
       - name: 'Checkout'
@@ -20,17 +20,10 @@ jobs:
         with:
           submodules: recursive
       - name: 'Build'
-        run: |
-          mkdir -p wheelhouse && \
-          NVTE_FRAMEWORK=pytorch MAX_JOBS=1 pip wheel -w wheelhouse . -v
-      - name: 'Upload wheel'
-        uses: actions/upload-artifact@v3
-        with:
-          name: te_wheel_pyt
-          path: wheelhouse/transformer_engine*.whl
-          retention-days: 7
-      - name: 'Install'
-        run: pip install --no-cache-dir wheelhouse/transformer_engine*.whl
+        run: pip install . -v
+        env:
+          NVTE_FRAMEWORK: pytorch
+          MAX_JOBS: 1
       - name: 'Sanity check'
         run: python tests/pytorch/test_sanity_import.py
   jax:
@@ -38,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       #image: nvcr.io/nvidia/jax:XX.XX-py3  # Not yet available
-      image: nvcr.io/nvidia/tensorflow:23.03-tf2-py3
+      image: nvcr.io/nvidia/tensorflow:23.06-tf2-py3
       options: --user root
     steps:
       - name: 'Checkout'
@@ -48,23 +41,16 @@ jobs:
       - name: 'Build'
         run: |
           pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html && \
-          mkdir -p wheelhouse && \
-          NVTE_FRAMEWORK=jax pip wheel -w wheelhouse . -v
-      - name: 'Upload wheel'
-        uses: actions/upload-artifact@v3
-        with:
-          name: te_wheel_jax
-          path: wheelhouse/transformer_engine*.whl
-          retention-days: 7
-      - name: 'Install'
-        run: pip install --no-cache-dir wheelhouse/transformer_engine*.whl
+          pip install . -v
+        env:
+          NVTE_FRAMEWORK: jax
       - name: 'Sanity check'
         run: python tests/jax/test_sanity_import.py
   tensorflow:
     name: 'TensorFlow'
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/tensorflow:23.03-tf2-py3
+      image: nvcr.io/nvidia/tensorflow:23.06-tf2-py3
       options: --user root
     steps:
       - name: 'Checkout'
@@ -72,16 +58,8 @@ jobs:
         with:
           submodules: recursive
       - name: 'Build'
-        run: |
-          mkdir -p wheelhouse && \
-          NVTE_FRAMEWORK=tensorflow pip wheel -w wheelhouse . -v
-      - name: 'Upload wheel'
-        uses: actions/upload-artifact@v3
-        with:
-          name: te_wheel_tf
-          path: wheelhouse/transformer_engine*.whl
-          retention-days: 7
-      - name: 'Install'
-        run: pip install --no-cache-dir wheelhouse/transformer_engine*.whl
+        run: pip install . -v
+        env:
+          NVTE_FRAMEWORK: tensorflow
       - name: 'Sanity check'
         run: python tests/tensorflow/test_sanity_import.py


### PR DESCRIPTION
Since July 7 we've experienced test failures in our GitHub-hosted PyTorch build tests ([example](https://github.com/NVIDIA/TransformerEngine/actions/runs/5487892849/jobs/10005440313)). These are out-of-memory errors that show up while building Flash Attention. [GitHub runners have 14 GB of available disk memory](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), [NGC PyTorch containers are about ~9 GB](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags), and the pip wheels of TE dependencies take about 2.5 GB (with possibly multiple copies during the build stage), so it seems we've been sitting close to the memory limit for a while. I'm not sure what pushed us over last Friday though: neither https://github.com/NVIDIA/TransformerEngine/commit/a7a1a07024cca5535edab97ca93531de4a93149f or https://github.com/NVIDIA/TransformerEngine/commit/a7bc7cf755b1347065640f10ec1ead521a0c4942 are particularly suspicious and as far as I can tell there haven't been any changes in the dependencies.

Given the memory limit, I think the best fix is to stop generating and exporting pip wheels. I haven't found them particularly useful for debugging, especially compared to the containers built in our internal CI. This PR changes the tests to just build Transformer Engine and check that the import works. I've also taken the liberty of updating our NGC container versions.

We should keep this problem in mind when we want to release official pip wheels. It doesn't seem that GitHub-hosted runners will be up to the task if we need need all frameworks available instead of just PyTorch.