### PR TITLE
Fix numerics for activation recompute

### DIFF
--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -220,7 +220,7 @@ def warmup_jit_bias_gelu(
 
     bias = torch.rand(ffn_hidden_size_per_partition, dtype=dtype, device="cuda")
     inp = torch.rand(
-        (seq_length, micro_batch_size, ffn_hidden_size_per_partition),
+        (seq_length * micro_batch_size, ffn_hidden_size_per_partition),
         dtype=dtype,
         device="cuda",
     )
@@ -229,8 +229,9 @@ def warmup_jit_bias_gelu(
     for bias_grad, input_grad in zip([True, True], [False, True]):
         bias.requires_grad, inp.requires_grad = bias_grad, input_grad
         for _ in range(5):
-            output = bias_gelu_fused(inp, bias)
-    del bias, inp, output
+            _ = bias_gelu_fused_(inp, bias)
+            _ = gelu_fused_(inp)
+    del bias, inp
 
     torch.cuda.empty_cache()
     torch.cuda.set_rng_state(rng_state)


### PR DESCRIPTION
This PR is a numerical fix to ensure that the results are bitwise identical when running TE (w/o FP8) with and without activation recompute.

- Add missing warmup for kernel with no bias.
- Fix incorrect input shape during jit warmup. 