### PR TITLE
[PyTorch] Minor bug fix

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -61,7 +61,7 @@ def _act_func(activation: str):
             'swiglu': (tex.swiglu, tex.dswiglu),
     }
     if activation not in funcs:
-        raise "Activation type " + activation + " is not supported!"
+        raise NotImplementedError("Activation type " + activation + " is not supported!")
     return funcs[activation]
 
 


### PR DESCRIPTION
Incorrect usage of `raise`:

`TypeError: exceptions must derive from BaseException`