### PR TITLE
[JAX] flash attention integration

### DIFF
--- a/tests/jax/test_custom_call_shape.py
+++ b/tests/jax/test_custom_call_shape.py
@@ -4,7 +4,7 @@
 
 import pytest
 import jax.numpy as jnp
-from jax.abstract_arrays import ShapedArray
+from jax.core import ShapedArray
 
 from transformer_engine_jax import DType
 from transformer_engine.jax.cpp_extensions import te_dtype_to_jax_dtype

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
+"""Tests for fused attention"""
 
-from typing import Optional
-import math
+import os
+from enum import Enum
+from math import sqrt
 
 import jax
 import jax.numpy as jnp
@@ -14,8 +16,6 @@ from flax.linen import combine_masks
 from flax.linen import dot_product_attention
 from flax.linen import make_attention_mask
 from flax.linen import make_causal_mask
-from jax import lax
-from jax import nn as jax_nn
 from jax import value_and_grad, jit
 
 from transformer_engine.jax.fused_attn import AttnBiasType, AttnMaskType
@@ -25,19 +25,45 @@ from transformer_engine.jax.fused_attn import self_fused_attn, cross_fused_attn
 # Type annotations
 Array = jnp.ndarray
 
-SELF_CASES = [(32, 512, 16, 64), (32, 128, 16, 64)]
+
+class Backend(Enum):
+    """
+    Fused attn backend.
+    Unit tests only, transformer will auto dispatch to the best backend
+    """
+    Max512 = "0"
+    Arbitrary = "1"
+
+
+@pytest.fixture(name="backend", params=[Backend.Max512, Backend.Arbitrary])
+def fixture_backend(request):
+    """
+    Fixture of setting up/tearing down backend
+    """
+    backend = request.param
+    os.environ["NVTE_FUSED_ATTN_BACKEND"] = backend.value
+    yield backend
+    os.environ["NVTE_FUSED_ATTN_BACKEND"] = ""
+
+
+SELF_CASES = [(32, 512, 16, 64), (32, 128, 16, 64), (4, 2048, 12, 64)]
 CROSS_CASES = [(32, 128, 512, 16, 64)]
 DTYPES = [jnp.bfloat16, jnp.float16]
-PAD_RATIO = [0.3]
 
 
 def make_decoder_mask(tokens: Array) -> Array:
+    """
+    Create padded causal mask
+    """
     causal_mask = make_causal_mask(tokens)
     padding_mask = make_attention_mask(tokens > 0, tokens > 0)
     return combine_masks(causal_mask, padding_mask)
 
 
-def jax_self_fused_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwargs):
+def jax_self_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwargs):
+    """
+    Self attention with JAX native implementation
+    """
     attn_mask_type = kwargs['attn_mask_type']
     if attn_mask_type == AttnMaskType.CAUSAL_MASK:
         mask = make_decoder_mask(q_token)
@@ -61,7 +87,10 @@ def jax_self_fused_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwargs):
     return output
 
 
-def jax_cross_fused_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs):
+def jax_cross_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs):
+    """
+    Cross attention with JAX native implementation
+    """
     assert q.dtype == kv.dtype
 
     attn_mask_type = kwargs['attn_mask_type']
@@ -87,6 +116,9 @@ def jax_cross_fused_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs):
 
 
 def customcall_self_fused_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwargs):
+    """
+    Self fused attention
+    """
     if kwargs['attn_mask_type'] == AttnMaskType.CAUSAL_MASK:
         mask = make_decoder_mask(q_token)
     else:
@@ -99,6 +131,9 @@ def customcall_self_fused_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwar
 
 
 def customcall_cross_fused_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs):
+    """
+    Cross fused attention
+    """
     assert q.dtype == kv.dtype
 
     if kwargs['attn_mask_type'] == AttnMaskType.CAUSAL_MASK:
@@ -113,10 +148,33 @@ def customcall_cross_fused_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs)
 
 @pytest.mark.skipif(not is_fused_attn_kernel_available(),
                     reason="Fused attention kernel is not supported.")
-class TestSelfFusedAttnMax512():
+@pytest.mark.parametrize('b, s, h, d', SELF_CASES)
+@pytest.mark.parametrize('attn_bias_type', [AttnBiasType.NO_BIAS, AttnBiasType.POST_SCALE_BIAS])
+@pytest.mark.parametrize('attn_mask_type', [AttnMaskType.PADDING_MASK, AttnMaskType.CAUSAL_MASK])
+@pytest.mark.parametrize('dropout_probability', [0., 0.1])
+@pytest.mark.parametrize('dtype', DTYPES)
+@pytest.mark.parametrize('is_training', [True, False])
+@pytest.mark.parametrize('pad_ratio', [0, 0.3])
+class TestSelfFusedAttn():
+    """Tests for transformer_engine.jax.fused_attn.self_fused_attn"""
 
-    def set_input(self, b, s, h, d, *, attn_bias_type, attn_mask_type, dropout_probability, dtype,
-                  is_training, pad_ratio):
+    @staticmethod
+    def _check_inputs(s, *, attn_bias_type, attn_mask_type, backend, pad_ratio):
+        # Arbitrary seqlen backend has a limited spec for now
+        # No bias, only causal mask, and no variable seqlen
+        if (s > 512 or backend == Backend.Arbitrary) and (attn_bias_type != AttnBiasType.NO_BIAS or
+                                                          attn_mask_type != AttnMaskType.CAUSAL_MASK
+                                                          or pad_ratio != 0):
+            pytest.skip("Unsupported inputs combination.")
+
+    def _set_inputs(self, b, s, h, d, *, attn_bias_type, attn_mask_type, backend,
+                    dropout_probability, dtype, is_training, pad_ratio):
+        """Setup the test inputs"""
+        self.__class__._check_inputs(s,
+                                     attn_bias_type=attn_bias_type,
+                                     attn_mask_type=attn_mask_type,
+                                     backend=backend,
+                                     pad_ratio=pad_ratio)
         key = jax.random.PRNGKey(0)
         subkeys = jax.random.split(key, 2)
 
@@ -137,82 +195,27 @@ class TestSelfFusedAttnMax512():
                                        axis=-1)
         self.kv_token = self.q_token
 
-        self.scaling_factor = 1. / math.sqrt(d)
+        self.scaling_factor = 1. / sqrt(d)
         self.dropout_probability = dropout_probability
         self.dropout_rng = jax.random.PRNGKey(0) if self.dropout_probability > 0 else None
         self.attn_bias_type = attn_bias_type
+        self.attn_mask_type = attn_mask_type
         self.is_training = is_training
 
-    @pytest.mark.parametrize('b, s, h, d', SELF_CASES)
-    @pytest.mark.parametrize('attn_bias_type', [AttnBiasType.NO_BIAS, AttnBiasType.POST_SCALE_BIAS])
-    @pytest.mark.parametrize('attn_mask_type',
-                             [AttnMaskType.PADDING_MASK, AttnMaskType.CAUSAL_MASK])
-    @pytest.mark.parametrize('dropout_probability', [0., 0.1])
-    @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('is_training', [True, False])
-    @pytest.mark.parametrize('pad_ratio', PAD_RATIO)
-    def test_sanity(self, b, s, h, d, attn_bias_type, attn_mask_type, dropout_probability, dtype,
-                    is_training, pad_ratio):
-
-        def grad_func(func, *args, **kwargs):
-            # Keep only valid result for the gradient
-            # fused_attn_max_512 output has shape (b, s, h, d)
-            valid_ret, _ = jnp.split(func(*args, **kwargs), (self.valid_len,), axis=1)
-            return jnp.mean(valid_ret, dtype=jnp.float32).astype(dtype)
-
-        self.set_input(b,
-                       s,
-                       h,
-                       d,
-                       attn_bias_type=attn_bias_type,
-                       attn_mask_type=attn_mask_type,
-                       dropout_probability=dropout_probability,
-                       dtype=dtype,
-                       is_training=is_training,
-                       pad_ratio=pad_ratio)
-
-        kwargs = {
-            'attn_bias_type': self.attn_bias_type,
-            'attn_mask_type': attn_mask_type,
-            'scaling_factor': self.scaling_factor,
-            'dropout_probability': self.dropout_probability,
-            'is_training': self.is_training
-        }
-
-        jitted_primitive = jit(
-            value_and_grad(
-                lambda qkv, bias, q_token, kv_token, dropout_rng: grad_func(
-                    customcall_self_fused_attn, qkv, bias, q_token, kv_token, dropout_rng, **kwargs
-                ), (0, 1)))
-
-        primitive_out, (primitive_dqkv,
-                        primitive_dbias) = jitted_primitive(self.qkv, self.bias, self.q_token,
-                                                            self.kv_token, self.dropout_rng)
-
-    @pytest.mark.parametrize('b, s, h, d', SELF_CASES)
-    @pytest.mark.parametrize('attn_bias_type', [AttnBiasType.NO_BIAS, AttnBiasType.POST_SCALE_BIAS])
-    @pytest.mark.parametrize('attn_mask_type',
-                             [AttnMaskType.PADDING_MASK, AttnMaskType.CAUSAL_MASK])
-    @pytest.mark.parametrize('dropout_probability', [0., 0.1])
-    @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('is_training', [True, False])
-    @pytest.mark.parametrize('pad_ratio', PAD_RATIO)
-    def test_forward(self, b, s, h, d, attn_bias_type, attn_mask_type, dropout_probability, dtype,
-                     is_training, pad_ratio):
-        # dropout can't get the bitmatch result
-        if is_training and dropout_probability > 0.:
-            return
-
-        self.set_input(b,
-                       s,
-                       h,
-                       d,
-                       attn_bias_type=attn_bias_type,
-                       attn_mask_type=attn_mask_type,
-                       dropout_probability=dropout_probability,
-                       dtype=dtype,
-                       is_training=is_training,
-                       pad_ratio=pad_ratio)
+    def test_forward(self, b, s, h, d, attn_bias_type, attn_mask_type, backend, dropout_probability,
+                     dtype, is_training, pad_ratio):
+        """Test only forward"""
+        self._set_inputs(b,
+                         s,
+                         h,
+                         d,
+                         attn_bias_type=attn_bias_type,
+                         attn_mask_type=attn_mask_type,
+                         backend=backend,
+                         dropout_probability=dropout_probability,
+                         dtype=dtype,
+                         is_training=is_training,
+                         pad_ratio=pad_ratio)
 
         primitive_out = customcall_self_fused_attn(self.qkv,
                                                    self.bias,
@@ -225,18 +228,22 @@ class TestSelfFusedAttnMax512():
                                                    dropout_probability=self.dropout_probability,
                                                    is_training=self.is_training)
 
-        reference_out = jax_self_fused_attn(self.qkv,
-                                            self.bias,
-                                            self.q_token,
-                                            self.kv_token,
-                                            self.dropout_rng,
-                                            attn_mask_type=attn_mask_type,
-                                            scaling_factor=self.scaling_factor,
-                                            dropout_probability=self.dropout_probability,
-                                            is_training=self.is_training)
+        reference_out = jax_self_attn(self.qkv,
+                                      self.bias,
+                                      self.q_token,
+                                      self.kv_token,
+                                      self.dropout_rng,
+                                      attn_mask_type=attn_mask_type,
+                                      scaling_factor=self.scaling_factor,
+                                      dropout_probability=self.dropout_probability,
+                                      is_training=self.is_training)
 
         ref_valid, _ = jnp.split(reference_out, (self.valid_len,), axis=1)
         pri_valid, pri_invalid = jnp.split(primitive_out, (self.valid_len,), axis=1)
+
+        # Dropout can't get the bitmatch result, skip the elementwise comparison
+        if is_training and dropout_probability > 0.:
+            return
 
         np.testing.assert_allclose(jnp.asarray(pri_valid, np.float32),
                                    jnp.asarray(ref_valid, np.float32),
@@ -246,38 +253,34 @@ class TestSelfFusedAttnMax512():
         np.testing.assert_allclose(jnp.asarray(pri_invalid, jnp.float32),
                                    jnp.zeros_like(pri_invalid, jnp.float32))
 
-    @pytest.mark.parametrize('b, s, h, d', SELF_CASES)
-    @pytest.mark.parametrize('attn_bias_type', [AttnBiasType.NO_BIAS, AttnBiasType.POST_SCALE_BIAS])
-    @pytest.mark.parametrize('attn_mask_type',
-                             [AttnMaskType.PADDING_MASK, AttnMaskType.CAUSAL_MASK])
-    @pytest.mark.parametrize('dropout_probability', [0.])    # dropout can't get the bitmatch result
-    @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('is_training', [True])    # backward is only used when is_training
-    @pytest.mark.parametrize('pad_ratio', PAD_RATIO)
-    def test_forward_backward(self, b, s, h, d, attn_bias_type, attn_mask_type, dropout_probability,
-                              dtype, is_training, pad_ratio):
-        self.set_input(b,
-                       s,
-                       h,
-                       d,
-                       attn_bias_type=attn_bias_type,
-                       attn_mask_type=attn_mask_type,
-                       dropout_probability=dropout_probability,
-                       dtype=dtype,
-                       is_training=is_training,
-                       pad_ratio=pad_ratio)
+    def test_forward_backward(self, b, s, h, d, attn_bias_type, attn_mask_type, backend,
+                              dropout_probability, dtype, is_training, pad_ratio):
+        """Test both forward and backward"""
+        if not is_training:
+            pytest.skip(f"Backward doesn't support {is_training=}")
 
-        def grad_func(fused_attn_max_512_func, *args, **kwargs):
+        self._set_inputs(b,
+                         s,
+                         h,
+                         d,
+                         attn_bias_type=attn_bias_type,
+                         attn_mask_type=attn_mask_type,
+                         backend=backend,
+                         dropout_probability=dropout_probability,
+                         dtype=dtype,
+                         is_training=is_training,
+                         pad_ratio=pad_ratio)
+
+        def grad_func(fused_attn_func, *args, **kwargs):
             # Gradient is small, use a gradient multiplier to amplify the graident
             gradient_multiplier = 1000 if dtype == jnp.bfloat16 else 10000
             if attn_mask_type == AttnMaskType.CAUSAL_MASK:
                 gradient_multiplier = gradient_multiplier / 10
             # Keep only valid result for the gradient
-            # fused_attn_max_512 output has shape (b, s, h, d)
-            valid_fused_attn_max_512_ret, _ = jnp.split(fused_attn_max_512_func(*args, **kwargs),
-                                                        (self.valid_len,),
-                                                        axis=1)
-            return (jnp.mean(valid_fused_attn_max_512_ret, dtype=jnp.float32) *
+            # fused_attn output has shape (b, s, h, d)
+            valid_fused_attn_ret, _ = jnp.split(fused_attn_func(*args, **kwargs), (self.valid_len,),
+                                                axis=1)
+            return (jnp.mean(valid_fused_attn_ret, dtype=jnp.float32) *
                     gradient_multiplier).astype(dtype)
 
         kwargs = {
@@ -298,8 +301,7 @@ class TestSelfFusedAttnMax512():
         jitted_reference = jit(
             value_and_grad(
                 lambda qkv, bias, q_token, kv_token, dropout_rng: grad_func(
-                    jax_self_fused_attn, qkv, bias, q_token, kv_token, dropout_rng, **kwargs),
-                (0, 1)))
+                    jax_self_attn, qkv, bias, q_token, kv_token, dropout_rng, **kwargs), (0, 1)))
 
         primitive_out, (primitive_dqkv,
                         primitive_dbias) = jitted_primitive(self.qkv, self.bias, self.q_token,
@@ -308,6 +310,10 @@ class TestSelfFusedAttnMax512():
         reference_out, (reference_dqkv,
                         reference_dbias) = jitted_reference(self.qkv, self.bias, self.q_token,
                                                             self.kv_token, self.dropout_rng)
+
+        # Dropout can't get the bitmatch result, skip the elementwise comparison
+        if dropout_probability > 0.:
+            return
 
         np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
                                    jnp.asarray(reference_out, np.float32),
@@ -319,23 +325,14 @@ class TestSelfFusedAttnMax512():
         valid_reference_dqkv, invalid_reference_dqkv = jnp.split(reference_dqkv, (self.valid_len,),
                                                                  axis=1)
 
-        # dQ
-        np.testing.assert_allclose(jnp.asarray(valid_primitive_dqkv[:, :, 0], np.float32),
-                                   jnp.asarray(valid_reference_dqkv[:, :, 0], np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
+        valid_primitive_dq, valid_primitive_dk, valid_primitive_dv = jnp.split(
+            valid_primitive_dqkv.astype(jnp.float32), 3, axis=2)
+        valid_reference_dq, valid_reference_dk, valid_reference_dv = jnp.split(
+            valid_reference_dqkv.astype(jnp.float32), 3, axis=2)
 
-        # dK
-        np.testing.assert_allclose(jnp.asarray(valid_primitive_dqkv[:, :, 1], np.float32),
-                                   jnp.asarray(valid_reference_dqkv[:, :, 1], np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
-
-        # dV
-        np.testing.assert_allclose(jnp.asarray(valid_primitive_dqkv[:, :, 2], np.float32),
-                                   jnp.asarray(valid_reference_dqkv[:, :, 2], np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
+        np.testing.assert_allclose(valid_primitive_dq, valid_reference_dq, rtol=1e-4, atol=1e-5)
+        np.testing.assert_allclose(valid_primitive_dk, valid_reference_dk, rtol=1e-4, atol=1e-5)
+        np.testing.assert_allclose(valid_primitive_dv, valid_reference_dv, rtol=1e-4, atol=1e-5)
 
         assert jnp.allclose(invalid_primitive_dqkv, invalid_reference_dqkv)
 
@@ -362,10 +359,17 @@ class TestSelfFusedAttnMax512():
 
 @pytest.mark.skipif(not is_fused_attn_kernel_available(),
                     reason="Fused attention kernel is not supported.")
-class TestCrossFusedAttnMax512():
+@pytest.mark.parametrize('b, s_q, s_kv, h, d', CROSS_CASES)
+@pytest.mark.parametrize('attn_mask_type', [AttnMaskType.PADDING_MASK])
+@pytest.mark.parametrize('dropout_probability', [0., 0.1])
+@pytest.mark.parametrize('dtype', DTYPES)
+@pytest.mark.parametrize('is_training', [True, False])
+@pytest.mark.parametrize('pad_ratio', [0.3])
+class TestCrossFusedAttn():
+    """Tests for transformer_engine.jax.fused_attn.cross_fused_attn"""
 
-    def set_input(self, b, s_q, s_kv, h, d, *, attn_mask_type, dropout_probability, dtype,
-                  is_training, pad_ratio):
+    def _set_inputs(self, b, s_q, s_kv, h, d, *, attn_mask_type, dropout_probability, dtype,
+                    is_training, pad_ratio):
         key = jax.random.PRNGKey(0)
         subkeys = jax.random.split(key, 2)
 
@@ -385,34 +389,26 @@ class TestCrossFusedAttnMax512():
         self.kv_token = jnp.concatenate((jnp.ones((b, self.kv_valid_len)), jnp.zeros(
             (b, kv_pad_len))),
                                         axis=-1)
-        self.scaling_factor = 1. / math.sqrt(d)
+        self.scaling_factor = 1. / sqrt(d)
         self.dropout_probability = dropout_probability
         self.dropout_rng = jax.random.PRNGKey(0) if self.dropout_probability > 0 else None
         self.attn_bias_type = AttnBiasType.NO_BIAS
+        self.attn_mask_type = attn_mask_type
         self.is_training = is_training
 
-    @pytest.mark.parametrize('b, s_q, s_kv, h, d', CROSS_CASES)
-    @pytest.mark.parametrize('attn_mask_type', [AttnMaskType.PADDING_MASK])
-    @pytest.mark.parametrize('dropout_probability', [0., 0.1])
-    @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('is_training', [True, False])
-    @pytest.mark.parametrize('pad_ratio', PAD_RATIO)
     def test_forward(self, b, s_q, s_kv, h, d, attn_mask_type, dropout_probability, dtype,
                      is_training, pad_ratio):
-        # dropout can't get the bitmatch result
-        if is_training and dropout_probability > 0.:
-            return
-
-        self.set_input(b,
-                       s_q,
-                       s_kv,
-                       h,
-                       d,
-                       attn_mask_type=attn_mask_type,
-                       dropout_probability=dropout_probability,
-                       dtype=dtype,
-                       is_training=is_training,
-                       pad_ratio=pad_ratio)
+        """Test only forward"""
+        self._set_inputs(b,
+                         s_q,
+                         s_kv,
+                         h,
+                         d,
+                         attn_mask_type=attn_mask_type,
+                         dropout_probability=dropout_probability,
+                         dtype=dtype,
+                         is_training=is_training,
+                         pad_ratio=pad_ratio)
 
         primitive_out = customcall_cross_fused_attn(self.q,
                                                     self.kv,
@@ -425,15 +421,19 @@ class TestCrossFusedAttnMax512():
                                                     dropout_probability=self.dropout_probability,
                                                     is_training=self.is_training)
 
-        reference_out = jax_cross_fused_attn(self.q,
-                                             self.kv,
-                                             self.q_token,
-                                             self.kv_token,
-                                             self.dropout_rng,
-                                             attn_mask_type=attn_mask_type,
-                                             scaling_factor=self.scaling_factor,
-                                             dropout_probability=self.dropout_probability,
-                                             is_training=self.is_training)
+        reference_out = jax_cross_attn(self.q,
+                                       self.kv,
+                                       self.q_token,
+                                       self.kv_token,
+                                       self.dropout_rng,
+                                       attn_mask_type=attn_mask_type,
+                                       scaling_factor=self.scaling_factor,
+                                       dropout_probability=self.dropout_probability,
+                                       is_training=self.is_training)
+
+        # Dropout can't get the bitmatch result, skip the elementwise comparison
+        if is_training and dropout_probability > 0.:
+            return
 
         ref_valid, _ = jnp.split(reference_out, (self.q_valid_len,), axis=1)
         pri_valid, pri_invalid = jnp.split(primitive_out, (self.q_valid_len,), axis=1)
@@ -446,36 +446,34 @@ class TestCrossFusedAttnMax512():
         np.testing.assert_allclose(jnp.asarray(pri_invalid, jnp.float32),
                                    jnp.zeros_like(pri_invalid, jnp.float32))
 
-    @pytest.mark.parametrize('b, s_q, s_kv, h, d', CROSS_CASES)
-    @pytest.mark.parametrize('attn_mask_type', [AttnMaskType.PADDING_MASK])
-    @pytest.mark.parametrize('dropout_probability', [0.])    # dropout can't get the bitmatch result
-    @pytest.mark.parametrize('dtype', DTYPES)
-    @pytest.mark.parametrize('is_training', [True])    # backward is only used when is_training
-    @pytest.mark.parametrize('pad_ratio', PAD_RATIO)
     def test_forward_backward(self, b, s_q, s_kv, h, d, attn_mask_type, dropout_probability, dtype,
                               is_training, pad_ratio):
-        self.set_input(b,
-                       s_q,
-                       s_kv,
-                       h,
-                       d,
-                       attn_mask_type=attn_mask_type,
-                       dropout_probability=dropout_probability,
-                       dtype=dtype,
-                       is_training=is_training,
-                       pad_ratio=pad_ratio)
+        """Test both forward and backward"""
+        if not is_training:
+            pytest.skip(f"Backward doesn't support {is_training=}")
 
-        def grad_func(fused_attn_max_512_func, *args, **kwargs):
+        self._set_inputs(b,
+                         s_q,
+                         s_kv,
+                         h,
+                         d,
+                         attn_mask_type=attn_mask_type,
+                         dropout_probability=dropout_probability,
+                         dtype=dtype,
+                         is_training=is_training,
+                         pad_ratio=pad_ratio)
+
+        def grad_func(fused_attn_func, *args, **kwargs):
             # Gradient is small, use a gradient multiplier to amplify the graident
             gradient_multiplier = 10000
             if attn_mask_type == AttnMaskType.CAUSAL_MASK:
                 gradient_multiplier = gradient_multiplier / 10
             # Keep only valid result for the gradient
-            # fused_attn_max_512 output has shape (b, s_q, h, d)
-            valid_fused_attn_max_512_ret, _ = jnp.split(fused_attn_max_512_func(*args, **kwargs),
-                                                        (self.q_valid_len,),
-                                                        axis=1)
-            return (jnp.mean(valid_fused_attn_max_512_ret, dtype=jnp.float32) *
+            # fused_attn output has shape (b, s_q, h, d)
+            valid_fused_attn_ret, _ = jnp.split(fused_attn_func(*args, **kwargs),
+                                                (self.q_valid_len,),
+                                                axis=1)
+            return (jnp.mean(valid_fused_attn_ret, dtype=jnp.float32) *
                     gradient_multiplier).astype(dtype)
 
         kwargs = {
@@ -496,7 +494,7 @@ class TestCrossFusedAttnMax512():
         jitted_reference = jit(
             value_and_grad(
                 lambda q, kv, q_token, kv_token, dropout_rng: grad_func(
-                    jax_cross_fused_attn, q, kv, q_token, kv_token, dropout_rng, **kwargs), (0, 1)))
+                    jax_cross_attn, q, kv, q_token, kv_token, dropout_rng, **kwargs), (0, 1)))
 
         primitive_out, (primitive_dq,
                         primitive_dkv) = jitted_primitive(self.q, self.kv, self.q_token,
@@ -505,6 +503,10 @@ class TestCrossFusedAttnMax512():
         reference_out, (reference_dq,
                         reference_dkv) = jitted_reference(self.q, self.kv, self.q_token,
                                                           self.kv_token, self.dropout_rng)
+
+        # Dropout can't get the bitmatch result, skip the elementwise comparison
+        if dropout_probability > 0.:
+            return
 
         np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
                                    jnp.asarray(reference_out, np.float32),

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -204,7 +204,9 @@ class TestSelfFusedAttn():
 
     def test_forward(self, b, s, h, d, attn_bias_type, attn_mask_type, backend, dropout_probability,
                      dtype, is_training, pad_ratio):
-        """Test only forward"""
+        """
+        Test forward without using JIT
+        """
         self._set_inputs(b,
                          s,
                          h,
@@ -255,7 +257,9 @@ class TestSelfFusedAttn():
 
     def test_forward_backward(self, b, s, h, d, attn_bias_type, attn_mask_type, backend,
                               dropout_probability, dtype, is_training, pad_ratio):
-        """Test both forward and backward"""
+        """
+        Test forward, backward, and autodiff by jax.value_and_grad
+        """
         if not is_training:
             pytest.skip(f"Backward doesn't support {is_training=}")
 
@@ -398,7 +402,9 @@ class TestCrossFusedAttn():
 
     def test_forward(self, b, s_q, s_kv, h, d, attn_mask_type, dropout_probability, dtype,
                      is_training, pad_ratio):
-        """Test only forward"""
+        """
+        Test forward without using JIT
+        """
         self._set_inputs(b,
                          s_q,
                          s_kv,
@@ -448,7 +454,9 @@ class TestCrossFusedAttn():
 
     def test_forward_backward(self, b, s_q, s_kv, h, d, attn_mask_type, dropout_probability, dtype,
                               is_training, pad_ratio):
-        """Test both forward and backward"""
+        """
+        Test forward, backward, and autodiff by jax.value_and_grad
+        """
         if not is_training:
             pytest.skip(f"Backward doesn't support {is_training=}")
 

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -547,7 +547,7 @@ void fused_attn_arbitrary_seqlen_fwd_impl(
         NVTE_CHECK_CUDNN(cudnnSetStream(handle, stream));
 
         if (!is_training) {
-          dropout_probability == 0.0f;
+          dropout_probability = 0.0f;
         }
 
         FADescriptor descriptor{b,           h,

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1144,7 +1144,7 @@ void fused_attn_arbitrary_seqlen_bwd_impl(
         void *devPtrSoftmaxSum = static_cast<int8_t *>(workspace) + plan_workspace_size;
         void *devPtrdQAccumulator = static_cast<int8_t *>(devPtrSoftmaxSum)
                                     + softmaxSum_workspace_size;
-        NVTE_CHECK_CUDA(cudaMemset(devPtrdQAccumulator, 0, dqAccum_workspace_size));
+        NVTE_CHECK_CUDA(cudaMemsetAsync(devPtrdQAccumulator, 0, dqAccum_workspace_size, stream));
 
         std::set<std::pair<uint64_t, void *>> data_ptrs;
         // add all the data pointers to be used in the variant pack
@@ -1224,6 +1224,8 @@ void fused_attn_arbitrary_seqlen_fwd_qkvpacked(
         devPtrS = output_S->data.dptr;
         Tensor *output_rng_state = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[1]);
         output_rng_state->data.dptr = rng_state->data.dptr;
+    } else {
+        NVTE_ERROR("Unexpected Aux_CTX_Tensors->size.");
     }
 
     void* devPtrDropoutSeed = rng_state->data.dptr;
@@ -1250,6 +1252,8 @@ void fused_attn_arbitrary_seqlen_fwd_qkvpacked(
         workspace->data.shape = {1};
         workspace->data.dtype = DType::kByte;
         return;
+    } else {
+        NVTE_ERROR("Unexpected workspace_size.");
     }
 }
 
@@ -1312,6 +1316,8 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
         workspace->data.shape = {1};
         workspace->data.dtype = DType::kByte;
         return;
+    } else {
+        NVTE_ERROR("Unexpected workspace_size.");
     }
 }
 }  // namespace transformer_engine

--- a/transformer_engine/common/fused_attn/fused_attn_f16_max512_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_max512_seqlen.cu
@@ -1275,6 +1275,8 @@ void fused_attn_max_512_fwd_qkvpacked(
     } else if (Aux_CTX_Tensors->size == 1) {
         Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
         devPtrS = output_S->data.dptr;
+    } else {
+        NVTE_ERROR("Unexpected Aux_CTX_Tensors->size.");
     }
 
     void *devPtrCuSeqlen = cu_seqlens->data.dptr;
@@ -1304,6 +1306,8 @@ void fused_attn_max_512_fwd_qkvpacked(
         workspace->data.shape = {1};
         workspace->data.dtype = DType::kByte;
         return;
+    } else {
+        NVTE_ERROR("Unexpected workspace_size.");
     }
 }
 
@@ -1351,6 +1355,8 @@ void fused_attn_max_512_fwd_kvpacked(size_t batch, size_t q_max_seqlen, size_t k
     } else if (Aux_CTX_Tensors->size == 1) {
         Tensor *output_S = reinterpret_cast<Tensor *>(Aux_CTX_Tensors->tensors[0]);
         devPtrS = output_S->data.dptr;
+    } else {
+        NVTE_ERROR("Unexpected Aux_CTX_Tensors->size.");
     }
 
     void *devQCuSeqlen = q_cu_seqlens->data.dptr;
@@ -1380,6 +1386,8 @@ void fused_attn_max_512_fwd_kvpacked(size_t batch, size_t q_max_seqlen, size_t k
         workspace->data.shape = {1};
         workspace->data.dtype = DType::kByte;
         return;
+    } else {
+        NVTE_ERROR("Unexpected workspace_size.");
     }
 }
 
@@ -1440,6 +1448,8 @@ void fused_attn_max_512_bwd_qkvpacked(size_t batch, size_t max_seqlen, size_t nu
         workspace->data.shape = {1};
         workspace->data.dtype = DType::kByte;
         return;
+    } else {
+        NVTE_ERROR("Unexpected workspace_size.");
     }
 }
 
@@ -1503,6 +1513,8 @@ void fused_attn_max_512_bwd_kvpacked(size_t batch, size_t q_max_seqlen, size_t k
         workspace->data.shape = {1};
         workspace->data.dtype = DType::kByte;
         return;
+    } else {
+        NVTE_ERROR("Unexpected workspace_size.");
     }
 }
 }  // namespace transformer_engine

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -2018,11 +2018,11 @@ def _check_seed(seed, dropout_probability, is_training):
     return seed
 
 
-class SelfFusedAttnMax512FwdPrimitive(BasePrimitive):
+class SelfFusedAttnFwdPrimitive(BasePrimitive):
     """
-    Self Fused Attention Max Seqlen 512 Forward Primitive
+    Self Fused Attention Forward Primitive
     """
-    name = "te_self_fused_attn_max_512_forward"
+    name = "te_self_fused_attn_forward"
     multiple_results = True
 
     @staticmethod
@@ -2039,7 +2039,7 @@ class SelfFusedAttnMax512FwdPrimitive(BasePrimitive):
             is_training    # pylint: disable=unused-argument
     ):
         """
-        Self fused attention max seqlen 512 fwd abstract
+        Self fused attention fwd abstract
         """
         qkv_dtype = dtypes.canonicalize_dtype(qkv.dtype)
         batch, max_seqlen, nqkv, num_head, head_dim = qkv.shape
@@ -2080,7 +2080,7 @@ class SelfFusedAttnMax512FwdPrimitive(BasePrimitive):
     def lowering(ctx, qkv, bias, cu_seqlen, seed, *, attn_bias_type, attn_mask_type, scaling_factor,
                  dropout_probability, is_training):
         """
-        Self fused attention max seqlen 512 fwd lowering rules
+        Self fused attention fwd lowering rules
         """
         qkv_aval, _, _, _ = ctx.avals_in
 
@@ -2098,23 +2098,20 @@ class SelfFusedAttnMax512FwdPrimitive(BasePrimitive):
             batch, num_head, max_seqlen, max_seqlen, head_dim, scaling_factor, dropout_probability,
             attn_bias_type, attn_mask_type, jax_dtype_to_te_dtype(qkv_aval.dtype), is_training)
 
-        out = custom_caller(SelfFusedAttnMax512FwdPrimitive.name,
-                            args,
-                            opaque,
-                            has_side_effect=False)
+        out = custom_caller(SelfFusedAttnFwdPrimitive.name, args, opaque, has_side_effect=False)
 
         return out
 
 
-_self_fused_attn_max_512_fwd_p = register_primitive(SelfFusedAttnMax512FwdPrimitive)
+_self_fused_attn_fwd_p = register_primitive(SelfFusedAttnFwdPrimitive)
 
 
-def self_fused_attn_max_512_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, cu_seqlen: jnp.ndarray,
-                                seed: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
-                                attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                                dropout_probability: float, is_training: bool):
+def self_fused_attn_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, cu_seqlen: jnp.ndarray,
+                        seed: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
+                        attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
+                        dropout_probability: float, is_training: bool):
     """
-    Wrapper for TE self fused attention max seqlen 512 fwd
+    Wrapper for TE self fused attention fwd
     Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
     """
     seed = _check_seed(seed, dropout_probability, is_training)
@@ -2122,22 +2119,22 @@ def self_fused_attn_max_512_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, cu_seqlen: 
     if bias is None:
         assert attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS
         bias = jnp.zeros(0, dtype=qkv.dtype)
-    return _self_fused_attn_max_512_fwd_p.bind(qkv,
-                                               bias,
-                                               cu_seqlen,
-                                               seed,
-                                               attn_bias_type=attn_bias_type,
-                                               attn_mask_type=attn_mask_type,
-                                               scaling_factor=scaling_factor,
-                                               dropout_probability=dropout_probability,
-                                               is_training=is_training)
+    return _self_fused_attn_fwd_p.bind(qkv,
+                                       bias,
+                                       cu_seqlen,
+                                       seed,
+                                       attn_bias_type=attn_bias_type,
+                                       attn_mask_type=attn_mask_type,
+                                       scaling_factor=scaling_factor,
+                                       dropout_probability=dropout_probability,
+                                       is_training=is_training)
 
 
-class SelfFusedAttnMax512BwdPrimitive(BasePrimitive):
+class SelfFusedAttnBwdPrimitive(BasePrimitive):
     """
-    Self Fused Attention Max Seqlen 512 Backward Primitive
+    Self Fused Attention Backward Primitive
     """
-    name = "te_self_fused_attn_max_512_backward"
+    name = "te_self_fused_attn_backward"
     multiple_results = True
 
     @staticmethod
@@ -2174,7 +2171,7 @@ class SelfFusedAttnMax512BwdPrimitive(BasePrimitive):
     def lowering(ctx, qkv, softmax_aux, rng_state, output, doutput, cu_seqlen, *, attn_bias_type,
                  attn_mask_type, scaling_factor, dropout_probability, is_training):
         """
-        Self fused attention max seqlen 512 bwd lowering rules
+        Self fused attention bwd lowering rules
         """
         qkv_aval, _, _, _, _, _ = ctx.avals_in
 
@@ -2195,44 +2192,40 @@ class SelfFusedAttnMax512BwdPrimitive(BasePrimitive):
             batch, num_head, max_seqlen, max_seqlen, head_dim, scaling_factor, dropout_probability,
             attn_bias_type, attn_mask_type, jax_dtype_to_te_dtype(qkv_aval.dtype), is_training)
 
-        out = custom_caller(SelfFusedAttnMax512BwdPrimitive.name,
-                            args,
-                            opaque,
-                            has_side_effect=False)
+        out = custom_caller(SelfFusedAttnBwdPrimitive.name, args, opaque, has_side_effect=False)
 
         return out
 
 
-_self_fused_attn_max_512_bwd_p = register_primitive(SelfFusedAttnMax512BwdPrimitive)
+_self_fused_attn_bwd_p = register_primitive(SelfFusedAttnBwdPrimitive)
 
 
-def self_fused_attn_max_512_bwd(qkv: jnp.ndarray, softmax_aux: jnp.ndarray, rng_state: jnp.ndarray,
-                                output: jnp.ndarray, doutput: jnp.ndarray, cu_seqlen: jnp.ndarray,
-                                attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
-                                scaling_factor: float, dropout_probability: float,
-                                is_training: bool):
+def self_fused_attn_bwd(qkv: jnp.ndarray, softmax_aux: jnp.ndarray, rng_state: jnp.ndarray,
+                        output: jnp.ndarray, doutput: jnp.ndarray, cu_seqlen: jnp.ndarray,
+                        attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                        scaling_factor: float, dropout_probability: float, is_training: bool):
     """
-    Wrapper for TE self fused attention max seqlen 512 bwd
+    Wrapper for TE self fused attention bwd
     Return the gradients of self fused attention with packed qkv input
     """
-    return _self_fused_attn_max_512_bwd_p.bind(qkv,
-                                               softmax_aux,
-                                               rng_state,
-                                               output,
-                                               doutput,
-                                               cu_seqlen,
-                                               attn_bias_type=attn_bias_type,
-                                               attn_mask_type=attn_mask_type,
-                                               scaling_factor=scaling_factor,
-                                               dropout_probability=dropout_probability,
-                                               is_training=is_training)
+    return _self_fused_attn_bwd_p.bind(qkv,
+                                       softmax_aux,
+                                       rng_state,
+                                       output,
+                                       doutput,
+                                       cu_seqlen,
+                                       attn_bias_type=attn_bias_type,
+                                       attn_mask_type=attn_mask_type,
+                                       scaling_factor=scaling_factor,
+                                       dropout_probability=dropout_probability,
+                                       is_training=is_training)
 
 
-class CrossFusedAttnMax512FwdPrimitive(BasePrimitive):
+class CrossFusedAttnFwdPrimitive(BasePrimitive):
     """
-    Cross Fused Attention Forward Max Seqlen 512 Primitive
+    Cross Fused Attention Forward Primitive
     """
-    name = "te_cross_fused_attn_max_512_forward"
+    name = "te_cross_fused_attn_forward"
     multiple_results = True
 
     @staticmethod
@@ -2250,7 +2243,7 @@ class CrossFusedAttnMax512FwdPrimitive(BasePrimitive):
             is_training    # pylint: disable=unused-argument
     ):
         """
-        Cross fused attention max seqlen 512 fwd abstract
+        Cross fused attention fwd abstract
         """
         q_dtype = dtypes.canonicalize_dtype(q.dtype)
         batch_q, q_max_seqlen, num_head_q, head_dim_q = q.shape
@@ -2279,7 +2272,7 @@ class CrossFusedAttnMax512FwdPrimitive(BasePrimitive):
     def lowering(ctx, q, kv, q_cu_seqlen, kv_cu_seqlen, seed, *, attn_bias_type, attn_mask_type,
                  scaling_factor, dropout_probability, is_training):
         """
-        Cross fused attention max seqlen 512 fwd lowering rules
+        Cross fused attention fwd lowering rules
         """
         q_aval, kv_aval, _, _, _ = ctx.avals_in
         assert q_aval.dtype == kv_aval.dtype
@@ -2300,45 +2293,41 @@ class CrossFusedAttnMax512FwdPrimitive(BasePrimitive):
             scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(q_aval.dtype), is_training)
 
-        out = custom_caller(CrossFusedAttnMax512FwdPrimitive.name,
-                            args,
-                            opaque,
-                            has_side_effect=False)
+        out = custom_caller(CrossFusedAttnFwdPrimitive.name, args, opaque, has_side_effect=False)
 
         return out
 
 
-_cross_fused_attn_max_512_fwd_p = register_primitive(CrossFusedAttnMax512FwdPrimitive)
+_cross_fused_attn_fwd_p = register_primitive(CrossFusedAttnFwdPrimitive)
 
 
-def cross_fused_attn_max_512_fwd(q: jnp.ndarray, kv: jnp.ndarray, q_cu_seqlen: jnp.ndarray,
-                                 kv_cu_seqlen: jnp.ndarray, seed: jnp.ndarray,
-                                 attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
-                                 scaling_factor: float, dropout_probability: float,
-                                 is_training: bool):
+def cross_fused_attn_fwd(q: jnp.ndarray, kv: jnp.ndarray, q_cu_seqlen: jnp.ndarray,
+                         kv_cu_seqlen: jnp.ndarray, seed: jnp.ndarray,
+                         attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                         scaling_factor: float, dropout_probability: float, is_training: bool):
     """
-    Wrapper for TE cross fused attention max seqlen 512 fwd
+    Wrapper for TE cross fused attention fwd
     Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
     """
     seed = _check_seed(seed, dropout_probability, is_training)
 
-    return _cross_fused_attn_max_512_fwd_p.bind(q,
-                                                kv,
-                                                q_cu_seqlen,
-                                                kv_cu_seqlen,
-                                                seed,
-                                                attn_bias_type=attn_bias_type,
-                                                attn_mask_type=attn_mask_type,
-                                                scaling_factor=scaling_factor,
-                                                dropout_probability=dropout_probability,
-                                                is_training=is_training)
+    return _cross_fused_attn_fwd_p.bind(q,
+                                        kv,
+                                        q_cu_seqlen,
+                                        kv_cu_seqlen,
+                                        seed,
+                                        attn_bias_type=attn_bias_type,
+                                        attn_mask_type=attn_mask_type,
+                                        scaling_factor=scaling_factor,
+                                        dropout_probability=dropout_probability,
+                                        is_training=is_training)
 
 
-class CrossFusedAttnMax512BwdPrimitive(BasePrimitive):
+class CrossFusedAttnBwdPrimitive(BasePrimitive):
     """
-    Cross Fused Attention Max Seqlen 512 Backward Primitive
+    Cross Fused Attention Backward Primitive
     """
-    name = "te_cross_fused_attn_max_512_backward"
+    name = "te_cross_fused_attn_backward"
     multiple_results = True
 
     @staticmethod
@@ -2357,7 +2346,7 @@ class CrossFusedAttnMax512BwdPrimitive(BasePrimitive):
             is_training    # pylint: disable=unused-argument
     ):
         """
-        Cross fused attention max seqlen 512 bwd abstract
+        Cross fused attention bwd abstract
         """
         q_dtype = dtypes.canonicalize_dtype(q.dtype)
         kv_dtype = dtypes.canonicalize_dtype(kv.dtype)
@@ -2375,7 +2364,7 @@ class CrossFusedAttnMax512BwdPrimitive(BasePrimitive):
     def lowering(ctx, q, kv, softmax_aux, doutput, q_cu_seqlen, kv_cu_seqlen, *, attn_bias_type,
                  attn_mask_type, scaling_factor, dropout_probability, is_training):
         """
-        Cross fused attention max seqlen 512 bwd lowering rules
+        Cross fused attention bwd lowering rules
         """
         q_aval, kv_aval, _, _, _, _ = ctx.avals_in
         assert q_aval.dtype == kv_aval.dtype
@@ -2399,34 +2388,30 @@ class CrossFusedAttnMax512BwdPrimitive(BasePrimitive):
             scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(q_aval.dtype), is_training)
 
-        out = custom_caller(CrossFusedAttnMax512BwdPrimitive.name,
-                            args,
-                            opaque,
-                            has_side_effect=False)
+        out = custom_caller(CrossFusedAttnBwdPrimitive.name, args, opaque, has_side_effect=False)
 
         return out
 
 
-_cross_fused_attn_max_512_bwd_p = register_primitive(CrossFusedAttnMax512BwdPrimitive)
+_cross_fused_attn_bwd_p = register_primitive(CrossFusedAttnBwdPrimitive)
 
 
-def cross_fused_attn_max_512_bwd(q: jnp.ndarray, kv: jnp.ndarray, softmax_aux: jnp.ndarray,
-                                 doutput: jnp.ndarray, q_cu_seqlen: jnp.ndarray,
-                                 kv_cu_seqlen: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
-                                 attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                                 dropout_probability: float, is_training: bool):
+def cross_fused_attn_bwd(q: jnp.ndarray, kv: jnp.ndarray, softmax_aux: jnp.ndarray,
+                         doutput: jnp.ndarray, q_cu_seqlen: jnp.ndarray, kv_cu_seqlen: jnp.ndarray,
+                         attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                         scaling_factor: float, dropout_probability: float, is_training: bool):
     """
-    Wrapper for TE cross fused attention max seqlen 512 bwd
+    Wrapper for TE cross fused attention bwd
     Return the gradients of cross fused attention with packed kv input
     """
-    return _cross_fused_attn_max_512_bwd_p.bind(q,
-                                                kv,
-                                                softmax_aux,
-                                                doutput,
-                                                q_cu_seqlen,
-                                                kv_cu_seqlen,
-                                                attn_bias_type=attn_bias_type,
-                                                attn_mask_type=attn_mask_type,
-                                                scaling_factor=scaling_factor,
-                                                dropout_probability=dropout_probability,
-                                                is_training=is_training)
+    return _cross_fused_attn_bwd_p.bind(q,
+                                        kv,
+                                        softmax_aux,
+                                        doutput,
+                                        q_cu_seqlen,
+                                        kv_cu_seqlen,
+                                        attn_bias_type=attn_bias_type,
+                                        attn_mask_type=attn_mask_type,
+                                        scaling_factor=scaling_factor,
+                                        dropout_probability=dropout_probability,
+                                        is_training=is_training)

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -15,7 +15,7 @@ from jaxlib.hlo_helpers import custom_call
 import jax.numpy as jnp
 from jax.lib import xla_client
 from jax import core, dtypes
-from jax.abstract_arrays import ShapedArray
+from jax.core import ShapedArray
 from jax.interpreters import xla, mlir
 from jax.interpreters.mlir import ir, dtype_to_ir_type
 

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -25,7 +25,6 @@ from transformer_engine_jax import NVTE_Bias_Type
 from transformer_engine_jax import NVTE_Mask_Type
 from transformer_engine_jax import NVTE_QKV_Layout
 from transformer_engine_jax import NVTE_Fused_Attn_Backend
-from transformer_engine_jax import NVTEDType
 
 for _name, _value in transformer_engine_jax.registrations().items():
     xla_client.register_custom_call_target(_name, _value, platform="CUDA")
@@ -66,19 +65,6 @@ def jax_dtype_to_te_dtype(jax_dtype):
         return TEDType.kFloat16
     if jax_dtype == jnp.bfloat16:
         return TEDType.kBFloat16
-    raise ValueError(f"Not support the {jax_dtype=}")
-
-
-def jax_dtype_to_nvte_dtype(jax_dtype):
-    """
-    convert jax dtype to NVTE dtype
-    """
-    if jax_dtype == jnp.float32:
-        return NVTEDType.kNVTEFloat32
-    if jax_dtype == jnp.float16:
-        return NVTEDType.kNVTEFloat16
-    if jax_dtype == jnp.bfloat16:
-        return NVTEDType.kNVTEBFloat16
     raise ValueError(f"Not support the {jax_dtype=}")
 
 
@@ -2049,8 +2035,8 @@ class SelfFusedAttnFwdPrimitive(BasePrimitive):
         output_shape = (batch, max_seqlen, num_head, head_dim)
         output_dtype = qkv_dtype
 
-        backend = transformer_engine_jax.nvte_get_fused_attn_backend(
-            jax_dtype_to_nvte_dtype(qkv_dtype), jax_dtype_to_nvte_dtype(qkv_dtype),
+        backend = transformer_engine_jax.get_fused_attn_backend(
+            jax_dtype_to_te_dtype(qkv_dtype), jax_dtype_to_te_dtype(qkv_dtype),
             NVTE_QKV_Layout.NVTE_QKV_INTERLEAVED, attn_bias_type, attn_mask_type,
             dropout_probability, max_seqlen, max_seqlen, head_dim)
 

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -2102,8 +2102,8 @@ def self_fused_attn_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, cu_seqlen: jnp.ndar
     """
     seed = _check_seed(seed, dropout_probability, is_training)
 
-    if bias is None:
-        assert attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        assert bias is None
         bias = jnp.zeros(0, dtype=qkv.dtype)
     return _self_fused_attn_fwd_p.bind(qkv,
                                        bias,
@@ -2146,7 +2146,10 @@ class SelfFusedAttnBwdPrimitive(BasePrimitive):
 
         _, seqlen, _, num_head, _ = qkv.shape
 
-        bias_shape = (1, num_head, seqlen, seqlen)
+        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+            bias_shape = (0,)
+        else:
+            bias_shape = (1, num_head, seqlen, seqlen)
         bias_dtype = qkv_dtype
 
         return (

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -64,7 +64,7 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
     m.def("get_device_compute_capability", &GetDeviceComputeCapability);
     m.def("pack_fused_attn_descriptor", &PackCustomCallFusedAttnDescriptor);
     m.def("is_fused_attn_kernel_available", &IsFusedAttnKernelAvailable);
-    m.def("nvte_get_fused_attn_backend", &nvte_get_fused_attn_backend);
+    m.def("get_fused_attn_backend", &GetFusedAttnBackend);
 
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())
         .value("kByte", DType::kByte)
@@ -90,16 +90,6 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
         .value("NVTE_NOT_INTERLEAVED", NVTE_QKV_Layout::NVTE_NOT_INTERLEAVED)
         .value("NVTE_QKV_INTERLEAVED", NVTE_QKV_Layout::NVTE_QKV_INTERLEAVED)
         .value("NVTE_KV_INTERLEAVED", NVTE_QKV_Layout::NVTE_KV_INTERLEAVED);
-
-    pybind11::enum_<NVTEDType>(m, "NVTEDType", pybind11::module_local())
-        .value("kNVTEByte", NVTEDType::kNVTEByte)
-        .value("kNVTEInt32", NVTEDType::kNVTEInt32)
-        .value("kNVTEInt64", NVTEDType::kNVTEInt64)
-        .value("kNVTEFloat32", NVTEDType::kNVTEFloat32)
-        .value("kNVTEFloat16", NVTEDType::kNVTEFloat16)
-        .value("kNVTEBFloat16", NVTEDType::kNVTEBFloat16)
-        .value("kNVTEFloat8E4M3", NVTEDType::kNVTEFloat8E4M3)
-        .value("kNVTEFloat8E5M2", NVTEDType::kNVTEFloat8E5M2);
 
     pybind11::enum_<NVTE_Fused_Attn_Backend>(m, "NVTE_Fused_Attn_Backend", pybind11::module_local())
         .value("NVTE_No_Backend", NVTE_Fused_Attn_Backend::NVTE_No_Backend)

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -46,11 +46,10 @@ pybind11::dict Registrations() {
         EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxForward);
     dict["te_scaled_upper_triang_masked_softmax_backward"] =
         EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxBackward);
-    dict["te_self_fused_attn_max_512_forward"] = EncapsulateFunction(SelfFusedAttnMax512Forward);
-    dict["te_self_fused_attn_max_512_backward"] = EncapsulateFunction(SelfFusedAttnMax512Backward);
-    dict["te_cross_fused_attn_max_512_forward"] = EncapsulateFunction(CrossFusedAttnMax512Forward);
-    dict["te_cross_fused_attn_max_512_backward"] =
-        EncapsulateFunction(CrossFusedAttnMax512Backward);
+    dict["te_self_fused_attn_forward"] = EncapsulateFunction(SelfFusedAttnForward);
+    dict["te_self_fused_attn_backward"] = EncapsulateFunction(SelfFusedAttnBackward);
+    dict["te_cross_fused_attn_forward"] = EncapsulateFunction(CrossFusedAttnForward);
+    dict["te_cross_fused_attn_backward"] = EncapsulateFunction(CrossFusedAttnBackward);
     return dict;
 }
 

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -65,6 +65,7 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
     m.def("get_device_compute_capability", &GetDeviceComputeCapability);
     m.def("pack_fused_attn_descriptor", &PackCustomCallFusedAttnDescriptor);
     m.def("is_fused_attn_kernel_available", &IsFusedAttnKernelAvailable);
+    m.def("nvte_get_fused_attn_backend", &nvte_get_fused_attn_backend);
 
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())
         .value("kByte", DType::kByte)
@@ -85,6 +86,27 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
         .value("NVTE_NO_MASK", NVTE_Mask_Type::NVTE_NO_MASK)
         .value("NVTE_PADDING_MASK", NVTE_Mask_Type::NVTE_PADDING_MASK)
         .value("NVTE_CAUSAL_MASK", NVTE_Mask_Type::NVTE_CAUSAL_MASK);
+
+    pybind11::enum_<NVTE_QKV_Layout>(m, "NVTE_QKV_Layout", pybind11::module_local())
+        .value("NVTE_NOT_INTERLEAVED", NVTE_QKV_Layout::NVTE_NOT_INTERLEAVED)
+        .value("NVTE_QKV_INTERLEAVED", NVTE_QKV_Layout::NVTE_QKV_INTERLEAVED)
+        .value("NVTE_KV_INTERLEAVED", NVTE_QKV_Layout::NVTE_KV_INTERLEAVED);
+
+    pybind11::enum_<NVTEDType>(m, "NVTEDType", pybind11::module_local())
+        .value("kNVTEByte", NVTEDType::kNVTEByte)
+        .value("kNVTEInt32", NVTEDType::kNVTEInt32)
+        .value("kNVTEInt64", NVTEDType::kNVTEInt64)
+        .value("kNVTEFloat32", NVTEDType::kNVTEFloat32)
+        .value("kNVTEFloat16", NVTEDType::kNVTEFloat16)
+        .value("kNVTEBFloat16", NVTEDType::kNVTEBFloat16)
+        .value("kNVTEFloat8E4M3", NVTEDType::kNVTEFloat8E4M3)
+        .value("kNVTEFloat8E5M2", NVTEDType::kNVTEFloat8E5M2);
+
+    pybind11::enum_<NVTE_Fused_Attn_Backend>(m, "NVTE_Fused_Attn_Backend", pybind11::module_local())
+        .value("NVTE_No_Backend", NVTE_Fused_Attn_Backend::NVTE_No_Backend)
+        .value("NVTE_F16_max512_seqlen", NVTE_Fused_Attn_Backend::NVTE_F16_max512_seqlen)
+        .value("NVTE_F16_arbitrary_seqlen", NVTE_Fused_Attn_Backend::NVTE_F16_arbitrary_seqlen)
+        .value("NVTE_FP8", NVTE_Fused_Attn_Backend::NVTE_FP8);
 }
 
 }  // namespace jax

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -740,6 +740,17 @@ void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers,
         desc.scale_factor, stream);
 }
 
+NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
+                                            NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type,
+                                            NVTE_Mask_Type mask_type, float dropout_probability,
+                                            size_t q_max_seqlen, size_t kv_max_seqlen,
+                                            size_t head_dim) {
+    auto backend = nvte_get_fused_attn_backend(
+        static_cast<NVTEDType>(q_dtype), static_cast<NVTEDType>(kv_dtype), qkv_layout, bias_type,
+        mask_type, dropout_probability, q_max_seqlen, kv_max_seqlen, head_dim);
+    return backend;
+}
+
 void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
                           size_t opaque_len) {
     const CustomCallFusedAttnDescriptor &descriptor =

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -740,8 +740,8 @@ void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers,
         desc.scale_factor, stream);
 }
 
-void SelfFusedAttnMax512Forward(cudaStream_t stream, void **buffers, const char *opaque,
-                                size_t opaque_len) {
+void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
+                          size_t opaque_len) {
     const CustomCallFusedAttnDescriptor &descriptor =
         *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
 
@@ -823,8 +823,8 @@ void SelfFusedAttnMax512Forward(cudaStream_t stream, void **buffers, const char 
     nvte_tensor_pack_destroy(&aux_output_tensors);
 }
 
-void SelfFusedAttnMax512Backward(cudaStream_t stream, void **buffers, const char *opaque,
-                                 size_t opaque_len) {
+void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                           size_t opaque_len) {
     const CustomCallFusedAttnDescriptor &descriptor =
         *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
 
@@ -909,8 +909,8 @@ void SelfFusedAttnMax512Backward(cudaStream_t stream, void **buffers, const char
     nvte_tensor_pack_destroy(&aux_output_tensors);
 }
 
-void CrossFusedAttnMax512Forward(cudaStream_t stream, void **buffers, const char *opaque,
-                                 size_t opaque_len) {
+void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
+                           size_t opaque_len) {
     const CustomCallFusedAttnDescriptor &descriptor =
         *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
 
@@ -1000,8 +1000,8 @@ void CrossFusedAttnMax512Forward(cudaStream_t stream, void **buffers, const char
     nvte_tensor_pack_destroy(&aux_output_tensors);
 }
 
-void CrossFusedAttnMax512Backward(cudaStream_t stream, void **buffers, const char *opaque,
-                                  size_t opaque_len) {
+void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                            size_t opaque_len) {
     const CustomCallFusedAttnDescriptor &descriptor =
         *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
 

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -166,17 +166,17 @@ void ScaledUpperTriangMaskedSoftmaxForward(cudaStream_t stream, void **buffers, 
 void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers, const char *opaque,
                                             std::size_t opaque_len);
 
-void SelfFusedAttnMax512Forward(cudaStream_t stream, void **buffers, const char *opaque,
-                                size_t opaque_len);
+void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
+                          size_t opaque_len);
 
-void SelfFusedAttnMax512Backward(cudaStream_t stream, void **buffers, const char *opaque,
-                                 size_t opaque_len);
+void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                           size_t opaque_len);
 
-void CrossFusedAttnMax512Forward(cudaStream_t stream, void **buffers, const char *opaque,
-                                 size_t opaque_len);
+void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
+                           size_t opaque_len);
 
-void CrossFusedAttnMax512Backward(cudaStream_t stream, void **buffers, const char *opaque,
-                                  size_t opaque_len);
+void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
+                            size_t opaque_len);
 
 }  // namespace jax
 }  // namespace transformer_engine

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -116,6 +116,12 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
 
 bool IsFusedAttnKernelAvailable();
 
+NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
+                                            NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type,
+                                            NVTE_Mask_Type mask_type, float dropout_probability,
+                                            size_t q_max_seqlen, size_t kv_max_seqlen,
+                                            size_t head_dim);
+
 void Transpose(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 
 void CastTranspose(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);

--- a/transformer_engine/jax/csrc/utils.h
+++ b/transformer_engine/jax/csrc/utils.h
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include "transformer_engine/fused_attn.h"
 #include "transformer_engine/logging.h"
 
 namespace transformer_engine {
@@ -22,7 +23,8 @@ int GetCudaRuntimeVersion();
 int GetDeviceComputeCapability(int gpu_id);
 
 void PopulateRngStateAsync(void *rng_state_dst, const void *const seed, size_t q_max_seqlen,
-                           size_t kv_max_seqlen, cudaStream_t stream);
+                           size_t kv_max_seqlen, NVTE_Fused_Attn_Backend backend,
+                           cudaStream_t stream);
 
 class cublasLtMetaManager {
  public:

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -178,7 +178,8 @@ def core_attention(query: Array,
 
     attn_weights = Softmax(softmax_type=softmax_type,
                            scale_factor=fused_scale_factor,
-                           sharding_type=softmax_sharding_type)(attn_weights, mask, bias)
+                           sharding_type=softmax_sharding_type)(attn_weights, mask,
+                                                                bias).astype(dtype)
 
     if not deterministic and dropout_rate > 0.:
         keep_prob = 1.0 - dropout_rate

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -155,6 +155,9 @@ def _self_fused_attn_bwd(attn_bias_type, attn_mask_type, scaling_factor, dropout
                                               dropout_probability=dropout_probability,
                                               is_training=is_training)
 
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        grad_bias = None
+
     return grad_qkv, grad_bias, None, None
 
 

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -126,26 +126,28 @@ def _self_fused_attn_max_512_fwd(qkv, bias, mask, seed, attn_bias_type, attn_mas
     cu_seqlen = jnp.cumsum(seqlen)
     cu_seqlen = jnp.hstack((0, cu_seqlen))
 
-    output, softmax_aux = self_fused_attn_max_512_fwd(qkv,
-                                                      bias,
-                                                      cu_seqlen,
-                                                      seed,
-                                                      attn_bias_type=attn_bias_type.value,
-                                                      attn_mask_type=attn_mask_type.value,
-                                                      scaling_factor=scaling_factor,
-                                                      dropout_probability=dropout_probability,
-                                                      is_training=is_training)
-    return output, (qkv, softmax_aux, output, cu_seqlen)
+    output, softmax_aux, rng_state = self_fused_attn_max_512_fwd(
+        qkv,
+        bias,
+        cu_seqlen,
+        seed,
+        attn_bias_type=attn_bias_type.value,
+        attn_mask_type=attn_mask_type.value,
+        scaling_factor=scaling_factor,
+        dropout_probability=dropout_probability,
+        is_training=is_training)
+    return output, (qkv, softmax_aux, rng_state, output, cu_seqlen)
 
 
 def _self_fused_attn_max_512_bwd(attn_bias_type, attn_mask_type, scaling_factor,
                                  dropout_probability, is_training, ctx, grad):
-    qkv, softmax_aux, output, cu_seqlen = ctx
+    qkv, softmax_aux, rng_state, output, cu_seqlen = ctx
 
     doutput = grad
 
     grad_qkv, grad_bias = self_fused_attn_max_512_bwd(qkv,
                                                       softmax_aux,
+                                                      rng_state,
                                                       output,
                                                       doutput,
                                                       cu_seqlen,

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -135,17 +135,18 @@ def _self_fused_attn_max_512_fwd(qkv, bias, mask, seed, attn_bias_type, attn_mas
                                                       scaling_factor=scaling_factor,
                                                       dropout_probability=dropout_probability,
                                                       is_training=is_training)
-    return output, (qkv, softmax_aux, cu_seqlen)
+    return output, (qkv, softmax_aux, output, cu_seqlen)
 
 
 def _self_fused_attn_max_512_bwd(attn_bias_type, attn_mask_type, scaling_factor,
                                  dropout_probability, is_training, ctx, grad):
-    qkv, softmax_aux, cu_seqlen = ctx
+    qkv, softmax_aux, output, cu_seqlen = ctx
 
     doutput = grad
 
     grad_qkv, grad_bias = self_fused_attn_max_512_bwd(qkv,
                                                       softmax_aux,
+                                                      output,
                                                       doutput,
                                                       cu_seqlen,
                                                       attn_bias_type=attn_bias_type.value,


### PR DESCRIPTION
This PR exposes the cuDNN arbitrary seqlen fused attention backend to JAX.

Main changes:
- [x] Support `seqlen%64==0` and `head_dim=128` self attention
- [x] Remove `_max_512_` suffix in the related functions
- [x] Adding `output`, `rng_state` as the ctx tensors since flash attention requires them
- [x] Allocate different softmax ctx tensors size for different backends
- [x] Set different increment of offset for different backends
- [x] Add long sequence length fused attention unit tests
- [x] `jax.abstract_arrays.Shaped` is deprecated. Replace it with `jax.core.ShapedArray`