### PR TITLE
Optimize calls to .cpu() during checkpointing

### DIFF
--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -87,13 +87,7 @@ def get_amax_reduce_handle_fwd() -> Union[bool, None]:
 
 def get_global_fp8_buffer() -> Dict[str, List[torch.Tensor]]:
     """Returns global fp8 buffer."""
-    buffer = {}
-
-    # Map all tensors to CPU.
-    for k, v in _global_fp8_buffer.items():
-        buffer[k] = [tensor.cpu() for tensor in v]
-
-    return buffer
+    return _global_fp8_buffer
 
 
 def set_global_fp8_buffer(buffer: Dict[str, List[torch.Tensor]]) -> None:


### PR DESCRIPTION
This is a better way to solving the problem in #351 as we have since observed that the number of `.cpu()` calls during saving and loading the checkpoint results in a non-negligible overhead. Just for the state tensors, there are 18 calls per transformer layer and this is excluding `.cpu()` calls to the global fp8 buffer.