### PR TITLE
Fix for the RMSNorm tests/doc/ONNX export to match the actual implementation

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -333,13 +333,14 @@ class TorchRMSNorm(nn.Module):
         self.register_parameter("weight", self.weight)
 
     def forward(self, x):
-        norm_x = x.norm(2, dim=-1, keepdim=True)
+        norm_x2 = torch.sum(x.float()**2, dim=-1, keepdim=True)
         d_x = self.in_features
 
-        rms_x = norm_x * d_x ** (-1. / 2)
-        x_normed = x / (rms_x + self.eps)
+        rms_x2 = norm_x2 / d_x + self.eps
+        r_rms_x = rms_x2 ** (-1. / 2)
+        x_normed = x * r_rms_x
 
-        return self.weight * x_normed
+        return (self.weight.float() * x_normed).to(x.dtype)
 
 class TorchLayerNormLinear(nn.Module):
     def __init__(self, in_features: int, out_features: int,
@@ -877,12 +878,14 @@ def test_linear_accuracy(dtype, bs, model):
 @pytest.mark.parametrize("dtype", param_types)
 @pytest.mark.parametrize("bs", batch_sizes)
 @pytest.mark.parametrize("model", model_configs.keys())
-def test_rmsnorm_accuracy(dtype, bs, model):
+@pytest.mark.parametrize("eps", [1e-1, 1e-3, 1e-5, 1e-7])
+def test_rmsnorm_accuracy(dtype, bs, model, eps):
     config = model_configs[model]
 
     te_rmsnorm = (
         RMSNorm(
             config.hidden_size,
+            eps=eps,
         )
         .to(dtype=dtype)
         .cuda()
@@ -892,6 +895,7 @@ def test_rmsnorm_accuracy(dtype, bs, model):
     torch_rmsnorm = (
         TorchRMSNorm(
             config.hidden_size,
+            eps=eps,
         )
         .to(dtype=dtype)
         .cuda()

--- a/transformer_engine/pytorch/module/rmsnorm.py
+++ b/transformer_engine/pytorch/module/rmsnorm.py
@@ -79,12 +79,12 @@ class RMSNorm(torch.nn.Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/abs/1910.07467>`__
 
     .. math::
-        y = \frac{x}{RMS(x) + \varepsilon} * \gamma
+        y = \frac{x}{RMS_\varepsilon(x)} * \gamma
 
     where
 
     .. math::
-        RMS(x) = \sqrt{\frac{1}{n}\sum_{i=0}^nx_i^2}
+        RMS_\varepsilon(x) = \sqrt{\frac{1}{n}\sum_{i=0}^nx_i^2 + \varepsilon}
 
     :math:`\gamma` is a learnable affine transform parameter of size :attr:`hidden_size`
 


### PR DESCRIPTION
In the kernel we use epsilon inside the square root, rather than outside (as in the original paper). Our behavior is consistent with the implementation in Llama and T5 in HuggingFace.