### PR TITLE
[JAX] Fix incorrect sharding when only enable FSDP and Mem Misaligned in LN_BWD.

### DIFF
--- a/transformer_engine/common/util/cuda_runtime.h
+++ b/transformer_engine/common/util/cuda_runtime.h
@@ -8,6 +8,7 @@
 #define TRANSFORMER_ENGINE_COMMON_UTIL_CUDA_RUNTIME_H_
 
 #include <cuda_runtime_api.h>
+#include <string>
 
 namespace transformer_engine {
 

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -282,7 +282,7 @@ void Gemm(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque
     auto null_tensor = TensorWrapper(nullptr, std::vector<size_t>{0}, DType::kFloat32);
 
     size_t workspace_size = kCublasLtForwardWorkspaceSize;
-    auto *workspace = cublasLtMetaManager::Instance().GetWorkspace(workspace_size);
+    auto *workspace = WorkspaceManager::Instance().GetWorkspace(workspace_size);
     auto wk_tensor = TensorWrapper(workspace, std::vector<size_t>{workspace_size}, DType::kByte);
 
     nvte_cublas_gemm(A_tensor.data(), B_tensor.data(), D_tensor.data(), null_tensor.data(),
@@ -336,7 +336,7 @@ void LayerNormForwardImpl(size_t n, size_t hidden, bool zero_centered_gamma, flo
         dummy_workspace_tensor.shape().data[0] * typeToSize(dummy_workspace_tensor.dtype()) +
         dummy_barrier_tensor.shape().data[0] * typeToSize(dummy_barrier_tensor.dtype());
 
-    void *workspace = cublasLtMetaManager::Instance().GetWorkspace(workspace_size);
+    void *workspace = WorkspaceManager::Instance().GetWorkspace(workspace_size);
 
     auto workspace_tensor =
         TensorWrapper(workspace, dummy_workspace_tensor.shape(), dummy_workspace_tensor.dtype());
@@ -421,13 +421,14 @@ void LayerNormBackwardImpl(size_t n, size_t hidden, bool zero_centered_gamma, fl
     size_t dgamma_part_size = dummy_dgamma_part_tensor.shape().data[0] *
                               dummy_dgamma_part_tensor.shape().data[1] *
                               typeToSize(dummy_dgamma_part_tensor.dtype());
-    size_t total_workspace_size =
-        (workspace_size + barrier_size + dgamma_part_size + dbeta_part_size);
 
-    void *workspace = cublasLtMetaManager::Instance().GetWorkspace(total_workspace_size);
-    void *dgamma_part = static_cast<char *>(workspace) + workspace_size;
-    void *dbeta_part = static_cast<char *>(dgamma_part) + dgamma_part_size;
-    void *barrier = static_cast<char *>(dbeta_part) + dbeta_part_size;
+    auto workspace_ptrs = WorkspaceManager::Instance().GetWorkspace(
+        {workspace_size, dgamma_part_size, dbeta_part_size, barrier_size});
+
+    void *workspace = workspace_ptrs[0];
+    void *dgamma_part = workspace_ptrs[1];
+    void *dbeta_part = workspace_ptrs[2];
+    void *barrier = workspace_ptrs[3];
 
     auto workspace_tensor =
         TensorWrapper(workspace, dummy_workspace_tensor.shape(), dummy_workspace_tensor.dtype());
@@ -820,7 +821,7 @@ void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaqu
     output_s->data.dptr = softmax_aux;
 
     auto workspace_size = query_workspace_tensor.shape().data[0];
-    auto *workspace = cublasLtMetaManager::Instance().GetWorkspace(workspace_size);
+    auto *workspace = WorkspaceManager::Instance().GetWorkspace(workspace_size);
     auto workspace_tensor =
         TensorWrapper(workspace, query_workspace_tensor.shape(), query_workspace_tensor.dtype());
 
@@ -903,7 +904,7 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
                                   query_workspace_tensor.data(), stream);
 
     size_t workspace_size = query_workspace_tensor.shape().data[0];
-    auto *workspace = cublasLtMetaManager::Instance().GetWorkspace(workspace_size);
+    auto *workspace = WorkspaceManager::Instance().GetWorkspace(workspace_size);
     auto workspace_tensor =
         TensorWrapper(workspace, query_workspace_tensor.shape(), query_workspace_tensor.dtype());
 
@@ -987,7 +988,7 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
         query_workspace_tensor.shape().data[0] * typeToSize(query_workspace_tensor.dtype());
     auto rng_workspace_size = 2 * sizeof(int64_t);
     auto total_workspace_size = plan_workspace_size + rng_workspace_size;
-    auto *workspace = cublasLtMetaManager::Instance().GetWorkspace(total_workspace_size);
+    auto *workspace = WorkspaceManager::Instance().GetWorkspace(total_workspace_size);
     auto workspace_tensor =
         TensorWrapper(workspace, query_workspace_tensor.shape(), query_workspace_tensor.dtype());
 
@@ -1083,7 +1084,7 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
 
     size_t workspace_size =
         query_workspace_tensor.shape().data[0] * typeToSize(query_workspace_tensor.dtype());
-    auto *workspace = cublasLtMetaManager::Instance().GetWorkspace(workspace_size);
+    auto *workspace = WorkspaceManager::Instance().GetWorkspace(workspace_size);
 
     auto workspace_tensor =
         TensorWrapper(workspace, query_workspace_tensor.shape(), query_workspace_tensor.dtype());

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -425,9 +425,9 @@ void LayerNormBackwardImpl(size_t n, size_t hidden, bool zero_centered_gamma, fl
         (workspace_size + barrier_size + dgamma_part_size + dbeta_part_size);
 
     void *workspace = cublasLtMetaManager::Instance().GetWorkspace(total_workspace_size);
-    void *barrier = static_cast<char *>(workspace) + workspace_size;
-    void *dgamma_part = static_cast<char *>(barrier) + barrier_size;
+    void *dgamma_part = static_cast<char *>(workspace) + workspace_size;
     void *dbeta_part = static_cast<char *>(dgamma_part) + dgamma_part_size;
+    void *barrier = static_cast<char *>(dbeta_part) + dbeta_part_size;
 
     auto workspace_tensor =
         TensorWrapper(workspace, dummy_workspace_tensor.shape(), dummy_workspace_tensor.dtype());

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -422,13 +422,8 @@ void LayerNormBackwardImpl(size_t n, size_t hidden, bool zero_centered_gamma, fl
                               dummy_dgamma_part_tensor.shape().data[1] *
                               typeToSize(dummy_dgamma_part_tensor.dtype());
 
-    auto workspace_ptrs = WorkspaceManager::Instance().GetWorkspace(
-        {workspace_size, dgamma_part_size, dbeta_part_size, barrier_size});
-
-    void *workspace = workspace_ptrs[0];
-    void *dgamma_part = workspace_ptrs[1];
-    void *dbeta_part = workspace_ptrs[2];
-    void *barrier = workspace_ptrs[3];
+    auto [workspace, dgamma_part, dbeta_part, barrier] = WorkspaceManager::Instance().GetWorkspace(
+        workspace_size, dgamma_part_size, dbeta_part_size, barrier_size);
 
     auto workspace_tensor =
         TensorWrapper(workspace, dummy_workspace_tensor.shape(), dummy_workspace_tensor.dtype());

--- a/transformer_engine/jax/csrc/utils.cu
+++ b/transformer_engine/jax/csrc/utils.cu
@@ -6,6 +6,7 @@
 #include <cuda_runtime_api.h>
 #include <cassert>
 
+#include "common/util/cuda_runtime.h"
 #include "utils.h"
 
 namespace transformer_engine {
@@ -17,20 +18,7 @@ int GetCudaRuntimeVersion() {
     return ver;
 }
 
-int GetDeviceComputeCapability(int gpu_id) {
-    int max_num_gpu = 0;
-    NVTE_CHECK_CUDA(cudaGetDeviceCount(&max_num_gpu));
-    assert(gpu_id < max_num_gpu);
-
-    int major = 0;
-    NVTE_CHECK_CUDA(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, gpu_id));
-
-    int minor = 0;
-    NVTE_CHECK_CUDA(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, gpu_id));
-
-    int gpu_arch = major * 10 + minor;
-    return gpu_arch;
-}
+int GetDeviceComputeCapability(int gpu_id) { return transformer_engine::cuda::sm_arch(gpu_id); }
 
 __global__ void populate_rng_state_kernel(int64_t *rng_state_dst, const int64_t *const seed,
                                           int64_t offset) {


### PR DESCRIPTION
1. When running with only FSDP, `infer_major_sharding_type` cannot correctly infer the right `MajorShardingType`, then custom calls are unble to apply `xmap` to manually shard tensors. That makes XLA to insert unexpected all-gathers for all custom calls. Therefore, submit this PR to fix.
2. Fix memory misaligned issue on LN BWD when 1 CTA handling more than 1 row.
3. Apply `sm_arch` to replace the implementation of `GetDeviceComputeCapability`.