### PR TITLE
Error handle for non-sm80/sm90 GPUs when using fused attention

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -164,7 +164,11 @@ class TestSelfFusedAttn():
                                                           attn_mask_type != AttnMaskType.CAUSAL_MASK
                                                           or pad_ratio != 0):
             pytest.skip("Unsupported inputs combination.")
+
         if backend == Backend.Max512 and get_device_compute_capability(0) not in [80, 90]:
+            pytest.skip("Unsupported device compute capability.")
+
+        if backend == Backend.Arbitrary and get_device_compute_capability(0) < 80:
             pytest.skip("Unsupported device compute capability.")
 
     def _set_inputs(self, b, s, h, d, *, attn_bias_type, attn_mask_type, backend,

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -55,7 +55,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
                 || (qkv_layout == NVTE_QKV_Layout::NVTE_KV_INTERLEAVED))) {
       flag_m512 = true;
     }
-    if ((sm_arch_ == 80 || sm_arch_ == 90)
+    if ((sm_arch_ >= 80)
             && (max_seqlen_q == max_seqlen_kv)
             && ((head_dim == 64) || (head_dim == 128))
             && (bias_type == NVTE_Bias_Type::NVTE_NO_BIAS)

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -44,7 +44,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
   } else if ((q_dtype == NVTEDType::kNVTEFloat16) || (q_dtype == NVTEDType::kNVTEBFloat16)) {
     bool flag_m512 = false;
     bool flag_arb = false;
-    if ((sm_arch_ >= 80)
+    if ((sm_arch_ == 80 || sm_arch_ == 90)
             && (head_dim == 64)
             && ((bias_type == NVTE_Bias_Type::NVTE_NO_BIAS)
                 || (bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS))
@@ -55,7 +55,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
                 || (qkv_layout == NVTE_QKV_Layout::NVTE_KV_INTERLEAVED))) {
       flag_m512 = true;
     }
-    if ((sm_arch_ >= 80)
+    if ((sm_arch_ == 80 || sm_arch_ == 90)
             && (max_seqlen_q == max_seqlen_kv)
             && ((head_dim == 64) || (head_dim == 128))
             && (bias_type == NVTE_Bias_Type::NVTE_NO_BIAS)

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -55,7 +55,12 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
                 || (qkv_layout == NVTE_QKV_Layout::NVTE_KV_INTERLEAVED))) {
       flag_m512 = true;
     }
-    if ((sm_arch_ >= 80)
+    if (
+#if (CUDNN_VERSION >= 8903)
+        (sm_arch_ >= 80)
+#else
+        (sm_arch_ == 80 || sm_arch_ == 90)
+#endif
             && (max_seqlen_q == max_seqlen_kv)
             && ((head_dim == 64) || (head_dim == 128))
             && (bias_type == NVTE_Bias_Type::NVTE_NO_BIAS)

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -63,7 +63,6 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
     m.def("get_cuda_version", &GetCudaRuntimeVersion);
     m.def("get_device_compute_capability", &GetDeviceComputeCapability);
     m.def("pack_fused_attn_descriptor", &PackCustomCallFusedAttnDescriptor);
-    m.def("is_fused_attn_kernel_available", &IsFusedAttnKernelAvailable);
     m.def("get_fused_attn_backend", &GetFusedAttnBackend);
 
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -90,19 +90,6 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
                                                     bias_type, mask_type, dtype, is_training});
 }
 
-bool IsFusedAttnKernelAvailable() {
-#if (CUDNN_VERSION < 8901)
-    return false;
-#else
-    const int sm_arch = cuda::sm_arch();
-#if (CUDNN_VERSION >= 8903)
-    return sm_arch >= 80;
-#else
-    return sm_arch == 80 || sm_arch == 90;
-#endif
-#endif
-}
-
 void TransposeImpl(void *input, size_t rows, size_t cols, DType dtype, cudaStream_t stream,
                    void *output) {
     auto input_shape = std::vector<size_t>{rows, cols};

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -92,10 +92,7 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
 
 bool IsFusedAttnKernelAvailable() {
 #if (CUDNN_VERSION >= 8901)
-    int device_id = -1;
-    NVTE_CHECK_CUDA(cudaGetDevice(&device_id));
-    NVTE_CHECK(device_id >= 0, "device_id should >= 0");
-    const int sm_arch = cuda::sm_arch(device_id);
+    const int sm_arch = cuda::sm_arch();
     return sm_arch == 80 || sm_arch == 90;
 #else
     return false;

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -91,11 +91,15 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
 }
 
 bool IsFusedAttnKernelAvailable() {
-#if (CUDNN_VERSION >= 8901)
-    const int sm_arch = cuda::sm_arch();
-    return sm_arch == 80 || sm_arch == 90;
-#else
+#if (CUDNN_VERSION < 8901)
     return false;
+#else
+    const int sm_arch = cuda::sm_arch();
+#if (CUDNN_VERSION >= 8903)
+    return sm_arch >= 80;
+#else
+    return sm_arch == 80 || sm_arch == 90;
+#endif
 #endif
 }
 

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -114,8 +114,6 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
     float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
     NVTE_Mask_Type mask_type, DType dtype, bool is_training);
 
-bool IsFusedAttnKernelAvailable();
-
 NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
                                             NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type,
                                             NVTE_Mask_Type mask_type, float dropout_probability,

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -24,7 +24,6 @@ from jax import lax, vmap
 from .module import DenseGeneral, LayerNormDenseGeneral, LayerNormMLP
 from .module import LayerNorm, Softmax
 from ..fused_attn import AttnBiasType, AttnMaskType
-from ..fused_attn import is_fused_attn_kernel_available
 from ..fused_attn import self_fused_attn, cross_fused_attn
 from ..softmax import SoftmaxType
 from ..sharding import infer_major_sharding_type, infer_sharding_type
@@ -431,7 +430,6 @@ class MultiHeadAttention(nn.Module):
             canonicalize_dtype in [jnp.bfloat16, jnp.float16] and \
             _check_seqlen(q_seqlen) and _check_seqlen(kv_seqlen) and \
             _check_head_dim(self.head_dim) and \
-            is_fused_attn_kernel_available() and \
             enable_fused_attn
 
         if enable_fused_attn and not use_fused_attn:
@@ -454,8 +452,6 @@ class MultiHeadAttention(nn.Module):
                           f"but got {kv_seqlen=}, "
             if not _check_head_dim(self.head_dim):
                 reason += f"head_dim should be 64 or 128 but got {self.head_dim}, "
-            if not is_fused_attn_kernel_available():
-                reason += "GPU arch >= Ampere and cuDNN >= 8.9.1 are required, "
 
             warnings.warn(
                 f"Fused attention is not enabled, " \

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -24,6 +24,7 @@ from jax import lax, vmap
 from .module import DenseGeneral, LayerNormDenseGeneral, LayerNormMLP
 from .module import LayerNorm, Softmax
 from ..fused_attn import AttnBiasType, AttnMaskType
+from ..fused_attn import is_fused_attn_kernel_available
 from ..fused_attn import self_fused_attn, cross_fused_attn
 from ..softmax import SoftmaxType
 from ..sharding import infer_major_sharding_type, infer_sharding_type
@@ -413,7 +414,21 @@ class MultiHeadAttention(nn.Module):
 
             return jnp.stack([k_kernel, v_kernel], axis=-2, dtype=dtype)
 
-        first_sharding_type, second_sharding_type = infer_sharding_type()
+        # TODO(rewang): make it configurable for pre_scale_bias
+        attn_bias_type = AttnBiasType.NO_BIAS if bias is None else AttnBiasType.POST_SCALE_BIAS
+
+        def canonicalize_attn_mask_type(attn_mask_type):
+            """
+            Convert the string to AttnMaskType
+            """
+            if attn_mask_type == 'causal':
+                return AttnMaskType.CAUSAL_MASK
+            if attn_mask_type == 'padding':
+                return AttnMaskType.PADDING_MASK
+            raise ValueError(f"Unsupported {attn_mask_type=}, "
+                             "supported attn_mask_type = {'causal', 'padding'}")
+
+        attn_mask_type = canonicalize_attn_mask_type(self.attn_mask_type)
 
         canonicalize_dtype = dtypes.canonicalize_dtype(self.dtype)
         q_seqlen = inputs_q.shape[0] if self.transpose_batch_sequence else inputs_q.shape[1]
@@ -426,10 +441,16 @@ class MultiHeadAttention(nn.Module):
         def _check_head_dim(head_dim):
             return head_dim in [64, 128]
 
+        has_fused_attn_kernel = is_fused_attn_kernel_available(self.dtype, self.dtype,
+                                                               attn_bias_type, attn_mask_type,
+                                                               self.dropout_rate, q_seqlen,
+                                                               kv_seqlen, self.head_dim)
+
         use_fused_attn = not decode and not self.transpose_batch_sequence and self.fuse_qkv and \
             canonicalize_dtype in [jnp.bfloat16, jnp.float16] and \
             _check_seqlen(q_seqlen) and _check_seqlen(kv_seqlen) and \
             _check_head_dim(self.head_dim) and \
+            has_fused_attn_kernel and \
             enable_fused_attn
 
         if enable_fused_attn and not use_fused_attn:
@@ -452,10 +473,14 @@ class MultiHeadAttention(nn.Module):
                           f"but got {kv_seqlen=}, "
             if not _check_head_dim(self.head_dim):
                 reason += f"head_dim should be 64 or 128 but got {self.head_dim}, "
+            if not has_fused_attn_kernel:
+                reason += "no fused attention kernel is available, "
 
             warnings.warn(
-                f"Fused attention is not enabled, " \
-                f"{reason}fall back to unfused attention")
+                f"Fused attention is not enabled. Because " \
+                f"{reason}fall back to unfused attention.")
+
+        first_sharding_type, second_sharding_type = infer_sharding_type()
 
         residual = inputs_q
         if self.fuse_qkv:
@@ -624,22 +649,6 @@ class MultiHeadAttention(nn.Module):
                 seed = jax.random.split(dropout_rng, len(jax.devices()))
                 # ensure the old key never used
                 del dropout_rng
-
-            # TODO(rewang): make it configurable for pre_scale_bias
-            attn_bias_type = AttnBiasType.NO_BIAS if bias is None else AttnBiasType.POST_SCALE_BIAS
-
-            def canonicalize_attn_mask_type(attn_mask_type):
-                """
-                Convert the string to AttnMaskType
-                """
-                if attn_mask_type == 'causal':
-                    return AttnMaskType.CAUSAL_MASK
-                if attn_mask_type == 'padding':
-                    return AttnMaskType.PADDING_MASK
-                raise ValueError(f"Unsupported {attn_mask_type=}, "
-                                 "supported attn_mask_type = {'causal', 'padding'}")
-
-            attn_mask_type = canonicalize_attn_mask_type(self.attn_mask_type)
 
             if inputs_q is inputs_kv:
                 qkv_proj = qkv_proj.reshape((*qkv_proj.shape[:-1], self.num_heads, self.head_dim))


### PR DESCRIPTION
cuDNN max 512 seqlen fused kernel only supports sm80 and sm90, and arbitrary seqlen requires 8.9.3 to support all CC >= 80.

- [x] Disable max 512 seqlen fused kernel when CC is not 80 or 90
- [x] Update `is_fused_attn_available` API for different attention setup