### PR TITLE
Fix rng_state issue and minor compiler warning

### DIFF
--- a/transformer_engine/common/transpose/transpose_fusion.cu
+++ b/transformer_engine/common/transpose/transpose_fusion.cu
@@ -293,8 +293,6 @@ transpose_dbias_kernel_notaligned(const Param param,
       }
     }
     OVec out_trans[nvec_in];  // NOLINT(*)
-    const bool valid_store = my_place < tile_length &&
-                             warp_id_in_tile * n_iterations + i < tile_height;
     transpose_regs_partial_dbias(
                     in[current_in ^ 1],
                     out_trans,

--- a/transformer_engine/pytorch/csrc/extensions/attention.cu
+++ b/transformer_engine/pytorch/csrc/extensions/attention.cu
@@ -194,7 +194,13 @@ std::vector<at::Tensor> fused_attn_fwd_qkvpacked(
   for (size_t i = 0; i < nvte_aux_tensor_pack.size; ++i) {
     auto tensor = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[i]);
     // allocate memory for nvte_aux_tensor_pack.tensors
-    auto output_tensor = allocateSpace(tensor->data.shape, tensor->data.dtype, false);
+    at::Tensor output_tensor;
+    if (nvte_aux_tensor_pack.size >= 2) {
+        output_tensor = (i < nvte_aux_tensor_pack.size-1)
+            ? allocateSpace(tensor->data.shape, tensor->data.dtype, false) : rng_state;
+    } else {
+        output_tensor = allocateSpace(tensor->data.shape, tensor->data.dtype, false);
+    }
     output_tensors.push_back(output_tensor);
     tensor->data.dptr = output_tensor.data_ptr();
   }
@@ -497,7 +503,13 @@ std::vector<at::Tensor> fused_attn_fwd_kvpacked(
   for (size_t i = 0; i < nvte_aux_tensor_pack.size; ++i) {
     auto tensor = reinterpret_cast<transformer_engine::Tensor*>(nvte_aux_tensor_pack.tensors[i]);
     // allocate memory for nvte_aux_tensor_pack.tensors
-    auto output_tensor = allocateSpace(tensor->data.shape, tensor->data.dtype, false);
+    at::Tensor output_tensor;
+    if (nvte_aux_tensor_pack.size >= 2) {
+        output_tensor = (i < nvte_aux_tensor_pack.size-1)
+            ? allocateSpace(tensor->data.shape, tensor->data.dtype, false) : rng_state;
+    } else {
+        output_tensor = allocateSpace(tensor->data.shape, tensor->data.dtype, false);
+    }
     output_tensors.push_back(output_tensor);
     tensor->data.dptr = output_tensor.data_ptr();
   }


### PR DESCRIPTION
This PR fixes two issues:

- [ ] `rng_state` being overwritten by newly created auxiliary tensors for arbitrary_seqlen backend of fused attn, affecting results in later iterations of training
- [ ] variable "valid_store" being declared but never referenced