### PR TITLE
[C/PyTorch] Add workspace optimization for fused attention arbitrary_seqlen backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
 
     # Framework-specific requirements
     if "pytorch" in frameworks():
-        add_unique(install_reqs, ["torch", "flash-attn>=1.0.6, <=2.0.4"])
+        add_unique(install_reqs, ["torch", "flash-attn>=1.0.6, <=2.2.1"])
         add_unique(test_reqs, ["numpy", "onnxruntime", "torchvision"])
     if "jax" in frameworks():
         if not found_pybind11():

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -107,7 +107,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
   return backend;
 }
 
-// NVTE fused attention FWD FP8 with packed QKV
+// NVTE fused attention FWD with packed QKV
 void nvte_fused_attn_fwd_qkvpacked(
             const NVTETensor QKV,
             const NVTETensor Bias,
@@ -192,7 +192,7 @@ void nvte_fused_attn_fwd_qkvpacked(
     NVTE_ERROR("Invalid combination of data type and sequence length for fused attention. \n");
   }
 }
-// NVTE fused attention BWD FP8 with packed QKV
+// NVTE fused attention BWD with packed QKV
 void nvte_fused_attn_bwd_qkvpacked(
             const NVTETensor QKV,
             const NVTETensor O,
@@ -291,7 +291,7 @@ void nvte_fused_attn_bwd_qkvpacked(
     NVTE_ERROR("Invalid combination of data type and sequence length for fused attention. \n");
   }
 }
-// NVTE fused attention FWD FP8 with packed KV
+// NVTE fused attention FWD with packed KV
 void nvte_fused_attn_fwd_kvpacked(
             const NVTETensor Q,
             const NVTETensor KV,
@@ -361,7 +361,7 @@ void nvte_fused_attn_fwd_kvpacked(
     NVTE_ERROR("Invalid combination of data type and sequence length for fused attention. \n");
   }
 }
-// NVTE fused attention BWD FP8 with packed KV
+// NVTE fused attention BWD with packed KV
 void nvte_fused_attn_bwd_kvpacked(
             const NVTETensor Q,
             const NVTETensor KV,

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1326,6 +1326,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
     size_t workspace_size = 0;
 
     bool use_workspace_opt = false;
+    std::cout << "enter danger zone: " << std::endl;
 #if (CUDNN_VERSION >= 8905)
     const int device_id = cuda::current_device();
     const int sm_arch_ = cuda::sm_arch(device_id);
@@ -1337,12 +1338,16 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
         (batch * num_head * max_seqlen_div_up_q * max_seqlen_div_up_kv * 2 + 1048576 - 1) / 1048576;
         // default upper limit for dp workspace 256MB
         size_t max_allowed_dp_workspace = 256;
-        std::string env_dp_workspace_limit(std::getenv("NVTE_FUSED_ATTN_DP_WORKSPACE_LIMIT"));
-        if (!env_dp_workspace_limit.empty()) {
+        const char* env_workspace_limit_char = std::getenv("NVTE_FUSED_ATTN_DP_WORKSPACE_LIMIT");
+        if (env_workspace_limit_char != nullptr) {
+    std::cout << "const char is not nullptr: " << std::endl;
             try {
+                std::string env_dp_workspace_limit(env_workspace_limit_char);
                 int dp_workspace_limit = std::stoi(env_dp_workspace_limit);
+    std::cout << "dp limit is: " << dp_workspace_limit << std::endl;
                 if (dp_workspace_limit > max_allowed_dp_workspace) {
                     max_allowed_dp_workspace = dp_workspace_limit;
+    std::cout << "max is updated: " << std::endl;
                 }
             } catch (...) {
                 NVTE_ERROR(

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1354,7 +1354,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
         }
     }
 #endif
-    std::cout << "use opt: " << (int)use_workspace_opt << std::endl;
+    std::cout << "use opt: " << static_cast<int>(use_workspace_opt) << std::endl;
 
     fused_attn_arbitrary_seqlen_bwd_impl(batch, num_head, max_seqlen, max_seqlen, head_dim,
                                 attn_scale, p_dropout, qkv_layout,

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1331,8 +1331,8 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
     const int sm_arch_ = cuda::sm_arch(device_id);
     if (sm_arch_ >= 90) {
         // quick estimate of dp workspace size
-        size_t max_seqlen_div_up_q = ((max_seqlen_q + 64 - 1) / 64) * 64;
-        size_t max_seqlen_div_up_kv = ((max_seqlen_kv + 64 - 1) / 64) * 64;
+        size_t max_seqlen_div_up_q = ((max_seqlen + 64 - 1) / 64) * 64;
+        size_t max_seqlen_div_up_kv = ((max_seqlen + 64 - 1) / 64) * 64;
         size_t required_dp_workspace =
         (batch * num_head * max_seqlen_div_up_q * max_seqlen_div_up_kv * 2 + 1048576 - 1) / 1048576;
         // default upper limit for dp workspace 256MB
@@ -1344,7 +1344,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
                 if (dp_workspace_limit > max_allowed_dp_workspace) {
                     max_allowed_dp_workspace = dp_workspace_limit;
                 }
-            } catch {
+            } catch (...) {
                 NVTE_ERROR(
                 "Invalid argument for NVTE_FUSED_ATTN_DP_WORKSPACE_LIMIT (integer; in MBytes)! \n");
             }

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1350,7 +1350,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
                 "Invalid argument for NVTE_FUSED_ATTN_DP_WORKSPACE_LIMIT (integer; in MBytes)! \n");
             }
         }
-        if (required_dp_workspace < max_allowed_dp_workspace) {
+        if (required_dp_workspace <= max_allowed_dp_workspace) {
                 use_workspace_opt = true;
         }
     }

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1327,7 +1327,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
 #if (CUDNN_VERSION >= 8905)
     const int device_id = cuda::current_device();
     const int sm_arch_ = cuda::sm_arch(device_id);
-    if (sm_arch_ >= 90) { 
+    if (sm_arch_ >= 90) {
         // quick estimate of workspace size for qkv, dqkv, o, do, softmaxStats, softmaxSum, dp
         // plus buffer size 128MB
         size_t free_byte;

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -1326,7 +1326,6 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
     size_t workspace_size = 0;
 
     bool use_workspace_opt = false;
-    std::cout << "enter danger zone: " << std::endl;
 #if (CUDNN_VERSION >= 8905)
     const int device_id = cuda::current_device();
     const int sm_arch_ = cuda::sm_arch(device_id);
@@ -1340,14 +1339,11 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
         size_t max_allowed_dp_workspace = 256;
         const char* env_workspace_limit_char = std::getenv("NVTE_FUSED_ATTN_DP_WORKSPACE_LIMIT");
         if (env_workspace_limit_char != nullptr) {
-    std::cout << "const char is not nullptr: " << std::endl;
             try {
                 std::string env_dp_workspace_limit(env_workspace_limit_char);
                 int dp_workspace_limit = std::stoi(env_dp_workspace_limit);
-    std::cout << "dp limit is: " << dp_workspace_limit << std::endl;
                 if (dp_workspace_limit > max_allowed_dp_workspace) {
                     max_allowed_dp_workspace = dp_workspace_limit;
-    std::cout << "max is updated: " << std::endl;
                 }
             } catch (...) {
                 NVTE_ERROR(
@@ -1359,7 +1355,6 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t max_seqlen, 
         }
     }
 #endif
-    std::cout << "use opt: " << static_cast<int>(use_workspace_opt) << std::endl;
 
     fused_attn_arbitrary_seqlen_bwd_impl(batch, num_head, max_seqlen, max_seqlen, head_dim,
                                 attn_scale, p_dropout, qkv_layout,

--- a/transformer_engine/common/fused_attn/fused_attn_f16_max512_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_max512_seqlen.cu
@@ -647,7 +647,8 @@ void fused_attn_max_512_fwd_impl(
                                 d,           scaling_factor,
                                 is_training, dropout_probability,
                                 layout,      bias_type,
-                                mask_type,   tensorType};
+                                mask_type,   tensorType,
+                                false};
 
         using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
         static thread_local CacheType fmha_fprop_cache;
@@ -846,7 +847,7 @@ void fused_attn_max_512_bwd_impl(int64_t b, int64_t h, int64_t s_q, int64_t s_kv
 
         FADescriptor descriptor{
             b,      h,         s_q,       s_kv,      d, scaling_factor, true, dropout_probability,
-            layout, bias_type, mask_type, tensorType};
+            layout, bias_type, mask_type, tensorType, false};
 
         using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
         static thread_local CacheType fmha_bprop_cache;

--- a/transformer_engine/common/fused_attn/fused_attn_fp8.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_fp8.cu
@@ -1013,7 +1013,7 @@ void fused_attn_fp8_fwd_impl(int64_t b, int64_t s_q, int64_t s_kv, int64_t h, in
       FADescriptor descriptor{
               b, h, s_q, s_kv, d,
               attnScale, isTraining, dropoutProbability, layout,
-              NVTE_Bias_Type::NVTE_NO_BIAS, NVTE_Mask_Type::NVTE_PADDING_MASK, tensorType};
+              NVTE_Bias_Type::NVTE_NO_BIAS, NVTE_Mask_Type::NVTE_PADDING_MASK, tensorType, false};
 
       using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
       static thread_local CacheType fa_fprop_cache;
@@ -1329,7 +1329,7 @@ void fused_attn_fp8_bwd_impl(int64_t b, int64_t s_q, int64_t s_kv, int64_t h, in
       FADescriptor descriptor{
               b, h, s_q, s_kv, d,
               attnScale, false, dropoutProbability, layout,
-              NVTE_Bias_Type::NVTE_NO_BIAS, NVTE_Mask_Type::NVTE_PADDING_MASK, tensorType};
+              NVTE_Bias_Type::NVTE_NO_BIAS, NVTE_Mask_Type::NVTE_PADDING_MASK, tensorType, false};
 
       using CacheType = std::map<FADescriptor, cudnn_frontend::ExecutionPlan>;
       static thread_local CacheType fa_bprop_cache;

--- a/transformer_engine/common/fused_attn/utils.h
+++ b/transformer_engine/common/fused_attn/utils.h
@@ -80,16 +80,18 @@ struct FADescriptor {
   NVTE_Bias_Type bias_type;
   NVTE_Mask_Type mask_type;
   cudnnDataType_t tensor_type;
+  bool use_workspace_opt;
 
   bool operator<(const FADescriptor &rhs) const {
     return std::tie(b, h, s_q, s_kv, d,
                     attnScale, isTraining, dropoutProbability,
-                    layout, mask_type, bias_type, tensor_type)
+                    layout, mask_type, bias_type, tensor_type, use_workspace_opt)
                     < std::tie(
                       rhs.b, rhs.h, rhs.s_q, rhs.s_kv, rhs.d,
                       rhs.attnScale, rhs.isTraining,
                       rhs.dropoutProbability, rhs.layout,
-                      rhs.mask_type, rhs.bias_type, rhs.tensor_type);
+                      rhs.mask_type, rhs.bias_type,
+                      rhs.tensor_type, rhs.use_workspace_opt);
   }
 };
 

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -455,7 +455,7 @@ def _check_kv_layout(k, v):
 
 class FlashAttention(torch.nn.Module):
     """Dot product attention, using HazyResearch flash-attn package:
-    https://github.com/HazyResearch/flash-attention
+    https://github.com/Dao-AILab/flash-attention
     """
 
     def __init__(
@@ -709,7 +709,7 @@ class FusedAttention(torch.nn.Module):
         self.attention_dropout = attention_dropout
         self.attention_dropout_ctx = attention_dropout_ctx
         self.attention_type = attention_type
-        self.use_FAv2_bwd = (os.getenv("NVTE_FUSED_ATTN_USE_FAv2_BWD", "1") == "1"
+        self.use_FAv2_bwd = (os.getenv("NVTE_FUSED_ATTN_USE_FAv2_BWD", "0") == "1"
                         and _flash_attn_2_available
                         and get_device_compute_capability() == 9.0)
 
@@ -1055,14 +1055,27 @@ class DotProductAttention(torch.nn.Module):
 
         .. note::
 
-            `DotProductAttention` supports three backends: 1) `FlashAttention` which calls
-            HazyResearch's FlashAttention PyTorch API, 2) `FusedAttention` which has multiple
-            fused attention implementations as its backends (see `FusedAttention` for
-            more details), and 3) `UnfusedDotProductAttention` which is the native PyTorch
-            implementation with fused scaled masked softmax. Users can use environment variables
-            `NVTE_FLASH_ATTN`, `NVTE_FUSED_ATTN`, and `NVTE_FUSED_ATTN_BACKEND` to control
-            which DotProductAttention backend, and FusedAttention backend if applicable, to use.
-            The default DotProductAttention backend is 1.
+            DotProductAttention supports three backends: 1) FlashAttention which calls
+            HazyResearch/Dao-AILab's `flash-attn <https://arxiv.org/pdf/2305.13245.pdf>`_
+            PyTorch API, 2) FusedAttention which has multiple fused attention implementations
+            based on `cuDNN Graph API
+            <https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#op-fusion>`_
+            (see :attr:`FusedAttention` for more details on FusedAttention backends), and 3)
+            UnfusedDotProductAttention which is the native PyTorch implementation
+            with fused scaled masked softmax.
+
+        .. note::
+
+            Users can use environment variables :attr:`NVTE_FLASH_ATTN`, :attr:`NVTE_FUSED_ATTN`,
+            and :attr:`NVTE_FUSED_ATTN_BACKEND` to control which DotProductAttention backend,
+            and FusedAttention backend if applicable, to use. TransformerEngine prioritizes
+            FlashAttention over FusedAttention and over UnfusedDotProductAttention.
+            If FusedAttention is being used, users can also choose to switch to flash-attn's
+            implementation for backward by setting :attr:`NVTE_FUSED_ATTN_USE_FAv2_BWD=1`
+            (default: 0), because of the performance differences between various versions of
+            flash-attn and FusedAttention. Further, :attr:`NVTE_FUSED_ATTN_DP_WORKSPACE_LIMIT`
+            can be used to enable the workspace related optimizations in FusedAttention
+            (default: 256MB; raise the limit to enable these performance optimizations).
 
         Parameters
         ----------
@@ -1085,7 +1098,7 @@ class DotProductAttention(torch.nn.Module):
                     Bias type, {`no_bias`, `pre_scale_bias`, 'post_scale_bias`}
         core_attention_bias: Optional[torch.Tensor], default = `None`
                     Bias tensor for Q * K.T
-        fast_zero_fill: bool, defautl = `True`
+        fast_zero_fill: bool, default = `True`
                     Whether to use the fast path to set output tensors to 0 or not.
         """
 


### PR DESCRIPTION
This PR:

- adds workspace optimizations for fused attention arbitrary_seqlen backend in cuDNN 8.9.5+
- changes the default of `NVTE_FUSED_ATTN_USE_FAv2_BWD` to 0 as this is the majority of the use cases
- moves zero fill algorithms to FP8 only (other backends do not need zero initialization)