### PR TITLE
[Paddle] Add control of RNG state

### DIFF
--- a/tests/paddle/parallel_tests/linear_pp.py
+++ b/tests/paddle/parallel_tests/linear_pp.py
@@ -107,6 +107,7 @@ class TestLinearPipelineParallel(unittest.TestCase):
     def test_pipeline_train(self):
         """Test pipeline parallel training"""
         set_random_seed(1024)
+        np.random.seed(1024)
 
         weight1_np = np.random.normal(size=[self.in_features, self.hidden_features])
         weight2_np = np.random.normal(size=[self.hidden_features, self.in_features])

--- a/tests/paddle/test_layers.py
+++ b/tests/paddle/test_layers.py
@@ -1085,7 +1085,7 @@ def test_transformer_decoder_layer(bs, hidden_size, num_heads, ffn_hidden_size, 
             assert_allclose(layer_te.self_attention.qkv.bias.grad,
                             layer_pd.self_attention.qkv.bias.grad,
                             rtol=0.01,
-                            atol=0.5)
+                            atol=0.6)
         else:
             assert_allclose(layer_te.self_attention.layernorm_qkv.bias.grad,
                             layer_pd.self_attention.layernorm_qkv.bias.grad,

--- a/tests/paddle/utils.py
+++ b/tests/paddle/utils.py
@@ -3,9 +3,12 @@
 # See LICENSE for license information.
 """Utils for testing"""
 
+import random
 import numpy as np
 
 import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import get_rng_state_tracker
 
 import transformer_engine    # pylint: disable=unused-import
 
@@ -49,6 +52,43 @@ def is_devices_enough(required):
 
 def set_random_seed(seed):
     """Set random seed for reproducability."""
-    np.random.seed(seed)
-    paddle.seed(seed)
-    paddle.distributed.fleet.meta_parallel.model_parallel_random_seed(seed)
+
+    hcg = fleet.get_hybrid_communicate_group()
+    if paddle.distributed.get_world_size() > 1:
+        # obtain rank message of hybrid parallel
+
+        mp_rank = hcg.get_model_parallel_rank()
+        mp_size = hcg.get_model_parallel_world_size()
+
+        pp_rank = hcg.get_stage_id()
+        pp_size = hcg.get_pipe_parallel_world_size()
+
+        dp_rank = hcg.get_data_parallel_rank()
+        dp_size = hcg.get_data_parallel_world_size()
+
+        sharding_rank = hcg.get_sharding_parallel_rank()
+    else:
+        mp_rank, mp_size = 0, 1
+        pp_rank, pp_size = 0, 1
+        dp_rank, dp_size = 0, 1
+        sharding_rank, _ = 0, 1
+
+    random.seed(seed + 100 * pp_rank)
+    np.random.seed(seed + 100 * pp_rank)
+
+    seed_offset = seed + 1024 + paddle.distributed.get_world_size()
+    global_seed = (seed_offset + pp_rank * (mp_size) + dp_rank * (mp_size * pp_size) +
+                   sharding_rank * (mp_size * pp_size * dp_size))
+
+    seed_offset += paddle.distributed.get_world_size()
+    local_seed = (seed_offset + mp_rank + pp_rank * (mp_size) + dp_rank * (mp_size * pp_size) +
+                  sharding_rank * (mp_size * pp_size * dp_size))
+
+    tracker = get_rng_state_tracker()
+    # tracker.reset()
+    if "global_seed" not in tracker.states_:
+        tracker.add("global_seed", global_seed)
+    if "local_seed" not in tracker.states_:
+        tracker.add("local_seed", local_seed)
+
+    paddle.seed(global_seed)

--- a/transformer_engine/paddle/distributed.py
+++ b/transformer_engine/paddle/distributed.py
@@ -39,13 +39,13 @@ def get_tp_group_and_world_size(tp_group: Union[dist_group_type, None],
 
 
 @contextmanager
-def track_rng_state(enable: bool) -> None:
+def track_rng_state(enable: bool, **kwargs) -> None:
     """
     Applies get_rng_state_tracker().rng_state() to the context.
     If not enabled, it does nothing.
     """
     if enable:
-        with get_rng_state_tracker().rng_state():
+        with get_rng_state_tracker().rng_state(**kwargs):
             yield
     else:
         yield


### PR DESCRIPTION
This PR allows user to control the RNG state of attention dropout and hidden dropout. Referring to [PaddleNLP](https://github.com/PaddlePaddle/PaddleNLP/blob/2aa58d83a68ccae29c2c740867e98762e608c559/paddlenlp/trainer/trainer_utils.py#L77), attention dropout uses `local_seed` and hidden dropout uses `global_seed`. 