### PR TITLE
[PyTorch] Check that module inputs are in expected layout

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -671,7 +671,10 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             R4: bias gradient on R1.
 
         """
-        grad_output = grad_output.contiguous()
+        grad_output = grad_output.to(
+            device="cuda",
+            memory_format=torch.contiguous_format,
+        )
         grad_output_mat = grad_output.view((-1, grad_output.shape[-1]))
         gather_grad_output = row_parallel_mode and ctx.sequence_parallel
 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -84,21 +84,41 @@ class _LayerNormLinear(torch.autograd.Function):
         ub_split_ag: bool,
         normalization: str,
     ) -> Union[Tuple[torch.Tensor, ...], torch.Tensor]:
-        # Make sure input dimensions are compatible
+        # Make sure tensor dimensions are compatible
         in_features = ln_weight.numel()
-        assert inp.shape[-1] == in_features, "GEMM not possible"
+        if ln_bias is not None and ln_bias.numel() != in_features:
+            raise ValueError(
+                "Layer norm weight and bias shapes are not compatible "
+                f"(weight shape = {list(ln_weight.size())}, "
+                f"bias shape = {list(ln_bias.size())})"
+            )
+        if inp.shape[-1] != in_features:
+            raise ValueError(
+                "Layer norm and input shapes are not compatible "
+                f"(layer norm weight shape = {list(ln_weight.size())}, "
+                f"input shape = {list(inp.size())})"
+            )
+
+        # Make sure tensors are in expected format
+        to_kwargs = dict(
+            device="cuda",
+            memory_format=torch.contiguous_format,
+        )
+        inp = inp.to(dtype=activation_dtype, **to_kwargs)
         inputmat = inp.view((-1, in_features))
+        ln_weight = ln_weight.to(dtype=activation_dtype, **to_kwargs)
+        if ln_bias is not None:
+            ln_bias = ln_bias.to(dtype=activation_dtype, **to_kwargs)
+        weight = weight.to(**to_kwargs)
+        if use_bias:
+            bias = bias.to(**to_kwargs)
+
+        # Make sure tensor dimensions are compatible with FP8
         if fp8:
             assert_dim_for_fp8_exec(inputmat)
             assert_dim_for_fp8_exec(weight)
 
         update_fp8_weights = is_first_microbatch is None or is_first_microbatch
-
-        # Cast for native AMP
-        inputmat = cast_if_needed(inputmat, activation_dtype)
-        ln_weight = cast_if_needed(ln_weight, activation_dtype)
-        if ln_bias is not None:
-            ln_bias = cast_if_needed(ln_bias, activation_dtype)
 
         if ub_split_ag:
             tp_world_size = get_distributed_world_size(tp_group)


### PR DESCRIPTION
Transformer Engine generally expects data that is contiguous and resident on the currently active GPU. Deviations will result in confusing errors, segfaults, or data corruption. This PR adds some conversions so that the PyTorch modules can handle strange data. These should be no-ops in the case the data is already in the correct layout. While these modules can now handle non-contiguous data, users should still prefer contiguous data since Pytorch's reordering kernel is somewhat slow.

Closes https://github.com/NVIDIA/TransformerEngine/issues/417.