### PR TITLE
Keep previous FA version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
 
     # Framework-specific requirements
     if "pytorch" in frameworks():
-        add_unique(install_reqs, ["torch", "flash-attn>=1.0.6, <=2.2.2"])
+        add_unique(install_reqs, ["torch", "flash-attn>=1.0.6, <=2.0.4"])
         add_unique(test_reqs, ["numpy", "onnxruntime", "torchvision"])
     if "jax" in frameworks():
         if not found_pybind11():


### PR DESCRIPTION
Running `import flash_attn` with FAv 2.0.7 onwards A100 gives the following error:

```
ImportError: /usr/local/lib/python3.8/dist-packages/flash_attn_2_cuda.cpython-38-x86_64-linux-gnu.so: undefined symbol: _ZN3c104cuda9SetDeviceE
```

A bisect of the versions shows that [this](https://github.com/Dao-AILab/flash-attention/commit/f8dccfc90a115ce797fed7d5eaf8b066f2753d34) is the offending commit and that there is an issue with the uploaded wheels for FA.