### PR TITLE
Disable GitHub CI jobs using NGC PyTorch container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   pytorch:
     name: 'PyTorch'
     runs-on: ubuntu-latest
+    if: false  # NGC PyTorch container does not fit on GitHub runner
     container:
       image: nvcr.io/nvidia/pytorch:23.03-py3
       options: --user root

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
   pytorch_pylint:
     name: 'PyTorch Python'
     runs-on: ubuntu-latest
+    if: false  # NGC PyTorch container does not fit on GitHub runner
     container:
       image: nvcr.io/nvidia/pytorch:23.03-py3
       options: --user root


### PR DESCRIPTION
We have been experiencing spurious test failures in some of our GitHub CI tests (namely "Build / PyTorch" and "Lint / PyTorch Python"). The [GitHub runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) have 7 GB RAM and 14 GB SSD available, but the NGC PyTorch containers have been growing in size:

| Container version | Compressed size | Uncompressed size |
|----|----|----|
| 22.09 | 7.67 GB | 16.8 GB |
| 23.03 | 9.13 GB | 20.4 GB
| 23.09 | 9.85 GB | 22 GB |

The fix is to disable the tests using the PyTorch container and rely on our internal CI.