### PR TITLE
Update reference scale calculation in TensorFlow test

### DIFF
--- a/tests/tensorflow/test_layers.py
+++ b/tests/tensorflow/test_layers.py
@@ -34,11 +34,9 @@ def get_fp8_recipe(override_wgrad=False):
 
 def compute_scale(amax, scale, fp8_max, margin):
     """Default function to convert amax to scaling factor."""
-    exp = tf.math.floor(tf.experimental.numpy.log2(fp8_max / amax)) - margin
-    sf = tf.math.round(tf.math.pow(2., tf.math.abs(exp)))
+    sf = (fp8_max / amax) / (2 ** margin)
     sf = tf.where(amax > 0.0, sf, scale)
     sf = tf.where(tf.math.is_finite(amax), sf, scale)
-    sf = tf.where(exp < 0, 1.0 / sf, sf)
     return sf
 
 


### PR DESCRIPTION
We've been seeing test failures since https://github.com/NVIDIA/TransformerEngine/pull/427 changed the calculation of scaling factors but it missed the TensorFlow test.

Closed by https://github.com/NVIDIA/TransformerEngine/pull/397 since I've also included this fix there.