### PR TITLE
Fix capture during FP8 training

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -540,7 +540,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 "necessary when using sequence parallelism with FP8."
 
             # Previous iteration was grad_enabled
-            if self.fp8_meta.get("update_amax_and_scale_fwd", False):
+            if self.fp8 and self.fp8_meta.get("update_amax_and_scale_fwd", True):
                 if self.fp8_meta["recipe"].reduce_amax:
                     FP8GlobalStateManager.copy_amax_from_global_buffer(self.fp8_meta, forward=True)
                     amax_and_scale_update(


### PR DESCRIPTION
This ensures that all FP8 training iterations run identical kernels for cases such as tracing and graph capture. For the first iteration, the amax /scale update, and the ops on global buffers are no-ops giving the same results numerically.