### PR TITLE
Incorrect use of extend_fsdp_sharding_meta() in cross_fused_attn()

### DIFF
--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -206,7 +206,7 @@ def cross_fused_attn(q: jnp.ndarray,
             tp_dims=([2, 3, None, None], [2]),
             dp_axis_name=dp_axis_name,
             tp_axis_name=tp_axis_name)
-        sharding_meta = extend_fsdp_sharding_meta(sharding_meta, {0: 0, 2: 0})
+        sharding_meta, _ = extend_fsdp_sharding_meta(sharding_meta, {0: 0, 2: 0})
 
         inputs_ = tuple(
             jnp.reshape(x, new_shape) if x is not None else None


### PR DESCRIPTION
`extend_fsdp_sharding_meta()` was updated in 6464ced to return a tuple of both the sharding meta and the FSDP axis name.

`self_fused_attn()` was updated to accommodate this API change, but `cross_fused_attn()` was not.

This PR applies the same fix from `self_fused_attn()` to `cross_fused_attn()`.

Bug reported by @terrykong.