### PR TITLE
Fix incorrect dtype in LayerNormLinear

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -112,7 +112,7 @@ class _LayerNormLinear(torch.autograd.Function):
             ub_obj_lnout = get_ub("qkv_fprop")
             ln_out = ub_obj_lnout.get_ubuf_output(0)
         else:
-            ln_out_dtype = torch.uint8 if fp8 else inputmat.dtype
+            ln_out_dtype = torch.uint8 if (fp8 and not return_layernorm_output) else inputmat.dtype
             ln_out = torch.empty_like(inputmat, dtype=ln_out_dtype)
         if ub_atomic_gemm_ag:
             assert fp8, "AtomicGemm overlap supported only for FP8 GEMM."


### PR DESCRIPTION
We've encountered a runtime error in LayerNormLinear when training LLaMa since RMSNorm is outputting to a buffer with an invalid dtype. In particular, we are not properly handling the case where the RMSNorm output is returned in bf16.

Note that LayerNormMLP handles this correctly:
https://github.com/NVIDIA/TransformerEngine/blob/f456ba19d97e2ce3a4906f631631d0d63e13040a/transformer_engine/pytorch/module/layernorm_mlp.py#L146