### PR TITLE
[JAX] Use FP8 tolerances in FP8 tests

### DIFF
--- a/examples/jax/mnist/test_single_gpu_mnist.py
+++ b/examples/jax/mnist/test_single_gpu_mnist.py
@@ -280,7 +280,7 @@ class TestMNIST(unittest.TestCase):
         """Check If loss and accuracy match target"""
         desired_traing_loss = 0.055
         desired_traing_accuracy = 0.98
-        desired_test_loss = 0.035
+        desired_test_loss = 0.04
         desired_test_accuracy = 0.098
         assert actual[0] < desired_traing_loss
         assert actual[1] > desired_traing_accuracy

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -121,7 +121,7 @@ class TestFP8Dot:
         primitive_out = fp8_dot(fp8_gemm_pkg, fwd_dtype, bwd_dtype)
         ref_out = jnp.dot(a, b)
 
-        assert_allclose(primitive_out, ref_out, dtype=DType.kFloat8E4M3)
+        assert_allclose(primitive_out, ref_out, dtype=fwd_dtype)
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)
     @pytest.mark.parametrize('m,n,k', GEMM_CASES)


### PR DESCRIPTION
We have had recent CI failures in `tests/jax/test_custom_call_compute.py::TestFP8Dot::test_grad_fp8_randint` when running on an L40 (e.g. [this recent build for #471](https://github.com/NVIDIA/TransformerEngine/actions/runs/6724992709/job/18278451411)). This is because this test requires bit-wise correct results. The GEMM kernel that executes on L40 can't achieve this level of accuracy, although it still within the expected numerical error for FP8.

This PR adds logic so that we can use dtype-specific tolerances within the `assert_allclose` helper function. Right now we only use it in JAX FP8 tests, but it could be applied to other tests. We can also consider porting this functionality to other framework tests.