### PR TITLE
[PyTorch] Disable large test cases for Transformer layer

### DIFF
--- a/tests/pytorch/test_fused_attn.py
+++ b/tests/pytorch/test_fused_attn.py
@@ -415,6 +415,12 @@ def test_transformer_layer(dtype, bs, model, bias_type, fused_qkv_params, RoPE):
     config = model_configs_lean[model]
     tols = dict(atol=5e-1, rtol=5e-2)
 
+    # TODO @cyanguwa: Handle test cases more cleanly
+    if config.hidden_size > 1024:
+        pytest.skip(
+            "Tolerances for test_transformer_layer are intended for small test cases"
+        )
+
     # Skip if only unfused backend is supported
     fused_attn_supported = _is_fused_attention_supported(
         config,


### PR DESCRIPTION
As discussed in https://github.com/NVIDIA/TransformerEngine/pull/503, the Transformer layer tests involve excessively large hidden sizes, which makes it hard to have tight numerical tolerances. This is a quick hack to disable the offending tests and @cyanguwa will remove it in an upcoming PR. She will refactor the attention tests so each test has its own set of test cases, e.g. dot product attention will be tested with many configurations to test the numerics of the cuDNN kernels while the Transformer layer tests will only have a few small configurations to validate the Python infrastructure.

See https://github.com/NVIDIA/TransformerEngine/pull/503 and https://github.com/cyanguwa/TransformerEngine/blob/fused_attn/graph_api_v1/tests/pytorch/test_fused_attn.py.