### PR TITLE
Disable FAv2.1+ for causal mask in cross attention

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2135,11 +2135,14 @@ class DotProductAttention(torch.nn.Module):
         if not _flash_attn_2_available and self.num_gqa_groups != self.num_attention_heads:
             use_flash_attention = False
 
-        # Disable FAv2.1+ for causal mask in cross attention due to
-        # https://github.com/Dao-AILab/flash-attention#21-change-behavior-of-causal-flag
         if (_flash_attn_2_1_plus
             and attn_mask_type == "causal"
             and max_seqlen_q != max_seqlen_kv):
+            warnings.warn(
+                "Disabling the use of FlashAttention since version 2.1+ has changed its behavior"
+                "for causal mask in cross attention. See "
+                "https://github.com/Dao-AILab/flash-attention#21-change-behavior-of-causal-flag"
+            )
             use_flash_attention = False
 
         if core_attention_bias_type != "no_bias" or core_attention_bias is not None:

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2136,7 +2136,7 @@ class DotProductAttention(torch.nn.Module):
             use_flash_attention = False
 
         if (_flash_attn_2_1_plus
-            and attn_mask_type == "causal"
+            and causal_mask
             and max_seqlen_q != max_seqlen_kv):
             warnings.warn(
                 "Disabling the use of FlashAttention since version 2.1+ has changed its behavior"

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -56,6 +56,7 @@ from transformer_engine.pytorch.jit import jit_fuser
 _flash_attn_version = packaging.version.Version(version("flash-attn"))
 _flash_attn_version_required = packaging.version.Version("1.0.6")
 _flash_attn_2_available = _flash_attn_version >= packaging.version.Version("2")
+_flash_attn_2_1_plus = _flash_attn_version >= packaging.version.Version("2.1")
 
 if _flash_attn_2_available:
     from flash_attn.flash_attn_interface import flash_attn_varlen_func as flash_attn_forward_func # pylint: disable=no-name-in-module
@@ -2132,6 +2133,13 @@ class DotProductAttention(torch.nn.Module):
                 use_flash_attention = False
 
         if not _flash_attn_2_available and self.num_gqa_groups != self.num_attention_heads:
+            use_flash_attention = False
+
+        # Disable FAv2.1+ for causal mask in cross attention due to
+        # https://github.com/Dao-AILab/flash-attention#21-change-behavior-of-causal-flag
+        if (_flash_attn_2_1_plus
+            and attn_mask_type == "causal"
+            and max_seqlen_q != max_seqlen_kv):
             use_flash_attention = False
 
         if core_attention_bias_type != "no_bias" or core_attention_bias is not None:

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2139,7 +2139,7 @@ class DotProductAttention(torch.nn.Module):
             and causal_mask
             and max_seqlen_q != max_seqlen_kv):
             warnings.warn(
-                "Disabling the use of FlashAttention since version 2.1+ has changed its behavior"
+                "Disabling the use of FlashAttention since version 2.1+ has changed its behavior "
                 "for causal mask in cross attention. See "
                 "https://github.com/Dao-AILab/flash-attention#21-change-behavior-of-causal-flag"
             )


### PR DESCRIPTION
This PR disables the use of FAv2.1+ for causal mask and cross attention due to the change of behavior in FA: https://github.com/Dao-AILab/flash-attention#21-change-behavior-of-causal-flag