### PR TITLE
[PyTorch] Float8Tensor uses cached transpose if available

### DIFF
--- a/tests/pytorch/test_float8tensor.py
+++ b/tests/pytorch/test_float8tensor.py
@@ -263,7 +263,7 @@ class TestFloat8Tensor:
         dims: DimsType,
         transpose_dims: Tuple[int, int],
         fp8_dtype: tex.DType = tex.DType.kFloat8E4M3,
-        scale: float = 1,
+        scale: float = 0.5,
         dtype: torch.dtype = torch.float32,
     ) -> None:
         """Test transpose"""


### PR DESCRIPTION
This PR changes the transpose behavior of `Float8Tensor`:
- If `update_cache == True`, it will compute the transpose and update the cache
- If `update_cache == False` and the cache is empty, it will compute the transpose
- If `update_cache == False` and the cache is populated, it will return the cached transpose

This is somewhat of a kludge to support transpose caching with Megatron GPT (see https://github.com/NVIDIA/NeMo/pull/7909). Its `forward` function doesn't keep track of gradient accumulation steps, so it doesn't pass `is_first_microbatch` to `LayerNormLinear` or `Linear`. E.g.:
https://github.com/NVIDIA/Megatron-LM/blob/9290c730d04b482be8fae92a4186fe4ff0c95270/megatron/core/transformer/attention.py#L271C31-L271C31
Compare to NeMo GPT, which contains TE-specific logic like `is_first_microbatch`:
https://github.com/NVIDIA/NeMo/blob/d81beac52423dbd04b48e4e04567b17df2428e3a/nemo/collections/nlp/modules/common/megatron/transformer.py#L1556

Discussion would be appreciated. This design ping-ponged a few times in https://github.com/NVIDIA/NeMo/pull/7885, e.g. https://github.com/NVIDIA/TransformerEngine/pull/452/commits/00b9c311e2f71c405f49ea8ef19da46fc01515b2. This approach is convenient with an FP8-aware optimizer since the optimizer doesn't need any access to the TE modules, just the FP8 params. There are also some alternative approaches:
- Add TE logic to Megatron, especially `is_first_microbatch`, to keep the current API
- Add arguments to the TE module constructors to control transpose caching
- Add attributes to the TE modules or FP8 tensors to control transpose caching