### PR TITLE
[JAX] Prepare cross flash attention

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -192,6 +192,7 @@ class TestDistributedCrossAttn:
             return jnp.mean(
                 cross_fused_attn(q,
                                  kv,
+                                 None,
                                  mask,
                                  None,
                                  attn_bias_type=attn_bias_type,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -163,7 +163,7 @@ def customcall_cross_fused_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs)
     # mask invert
     mask = (mask == 0)
 
-    return cross_fused_attn(q, kv, mask, dropout_rng, **kwargs)
+    return cross_fused_attn(q, kv, None, mask, dropout_rng, **kwargs)
 
 
 @pytest.mark.parametrize('b, s, h, d', SELF_CASES)

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -2390,7 +2390,7 @@ class CrossFusedAttnBwdPrimitive(BasePrimitive):
     def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
                                      dropout_probability, is_training, mesh, arg_infos,
                                      result_infos):
-        del attn_bias_type, attn_mask_type, scaling_factor
+        del attn_mask_type, scaling_factor
         del dropout_probability, is_training, result_infos
         q_spec = get_padded_spec(arg_infos[0])
         kv_spec = get_padded_spec(arg_infos[1])

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -837,15 +837,16 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
 
     // input
     void *qkv = buffers[0];
-    void *softmax_aux = buffers[1];
-    void *rng_state = buffers[2];
-    void *output = buffers[3];
-    void *doutput = buffers[4];
-    void *cu_seqlens = buffers[5];
+    void *bias = buffers[1];
+    void *softmax_aux = buffers[2];
+    void *rng_state = buffers[3];
+    void *output = buffers[4];
+    void *doutput = buffers[5];
+    void *cu_seqlens = buffers[6];
 
     // output
-    void *dqkv = buffers[6];
-    void *dbias = buffers[7];
+    void *dqkv = buffers[7];
+    void *dbias = buffers[8];
 
     auto batch = descriptor.batch;
     auto num_head = descriptor.num_head;
@@ -881,13 +882,15 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
     NVTETensorPack aux_output_tensors;
     nvte_tensor_pack_create(&aux_output_tensors);
 
-    aux_output_tensors.size = 2;
+    aux_output_tensors.size = 3;
     auto *output_s = reinterpret_cast<Tensor *>(aux_output_tensors.tensors[0]);
     output_s->data.dptr = softmax_aux;
     auto *rng_state_tensor = reinterpret_cast<Tensor *>(aux_output_tensors.tensors[1]);
     rng_state_tensor->data.shape = std::vector<size_t>{2};
     rng_state_tensor->data.dtype = DType::kInt64;
     rng_state_tensor->data.dptr = rng_state;
+    auto *bias_tensor = reinterpret_cast<Tensor *>(aux_output_tensors.tensors[2]);
+    bias_tensor->data = SimpleTensor(bias, bias_shape, dtype);
 
     TensorWrapper query_workspace_tensor;
 
@@ -1013,17 +1016,18 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
     // input
     void *q = buffers[0];
     void *kv = buffers[1];
-    void *softmax_aux = buffers[2];
-    void *rng_state = buffers[3];
-    void *output = buffers[4];
-    void *doutput = buffers[5];
-    void *q_cu_seqlens = buffers[6];
-    void *kv_cu_seqlens = buffers[7];
+    void *bias = buffers[2];
+    void *softmax_aux = buffers[3];
+    void *rng_state = buffers[4];
+    void *output = buffers[5];
+    void *doutput = buffers[6];
+    void *q_cu_seqlens = buffers[7];
+    void *kv_cu_seqlens = buffers[8];
 
     // output
-    void *dq = buffers[8];
-    void *dkv = buffers[9];
-    void *dbias = buffers[10];
+    void *dq = buffers[9];
+    void *dkv = buffers[10];
+    void *dbias = buffers[11];
 
     auto batch = descriptor.batch;
     auto num_head = descriptor.num_head;
@@ -1061,13 +1065,15 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
     NVTETensorPack aux_output_tensors;
     nvte_tensor_pack_create(&aux_output_tensors);
 
-    aux_output_tensors.size = 2;
+    aux_output_tensors.size = 3;
     auto *output_s = reinterpret_cast<Tensor *>(aux_output_tensors.tensors[0]);
     output_s->data.dptr = softmax_aux;
     auto *rng_state_tensor = reinterpret_cast<Tensor *>(aux_output_tensors.tensors[1]);
     rng_state_tensor->data.shape = std::vector<size_t>{2};
     rng_state_tensor->data.dtype = DType::kInt64;
     rng_state_tensor->data.dptr = rng_state;
+    auto *bias_tensor = reinterpret_cast<Tensor *>(aux_output_tensors.tensors[2]);
+    bias_tensor->data = SimpleTensor(bias, bias_shape, dtype);
 
     TensorWrapper query_workspace_tensor;
 

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -923,14 +923,15 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
     // input
     void *q = buffers[0];
     void *kv = buffers[1];
-    void *q_cu_seqlens = buffers[2];
-    void *kv_cu_seqlens = buffers[3];
-    void *seed = buffers[4];
+    void *bias = buffers[2];
+    void *q_cu_seqlens = buffers[3];
+    void *kv_cu_seqlens = buffers[4];
+    void *seed = buffers[5];
 
     // output
-    void *output = buffers[5];
-    void *softmax_aux = buffers[6];
-    void *rng_state = buffers[7];
+    void *output = buffers[6];
+    void *softmax_aux = buffers[7];
+    void *rng_state = buffers[8];
 
     auto batch = descriptor.batch;
     auto num_head = descriptor.num_head;
@@ -951,8 +952,7 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
     auto q_tensor = TensorWrapper(q, q_shape, dtype);
     auto kv_tensor = TensorWrapper(kv, kv_shape, dtype);
 
-    // TODO(rewang): add bias for cross attn?
-    auto bias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
+    auto bias_tensor = TensorWrapper(bias, bias_shape, dtype);
 
     auto q_cu_seqlens_tensor =
         TensorWrapper(q_cu_seqlens, std::vector<size_t>{batch + 1}, DType::kInt32);
@@ -1023,6 +1023,7 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
     // output
     void *dq = buffers[8];
     void *dkv = buffers[9];
+    void *dbias = buffers[10];
 
     auto batch = descriptor.batch;
     auto num_head = descriptor.num_head;
@@ -1049,8 +1050,7 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
 
     auto dq_tensor = TensorWrapper(dq, q_shape, dtype);
     auto dkv_tensor = TensorWrapper(dkv, kv_shape, dtype);
-    // TODO(rewang): generalize cross attn
-    auto dbias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
+    auto dbias_tensor = TensorWrapper(dbias, bias_shape, dtype);
 
     auto q_cu_seqlens_tensor =
         TensorWrapper(q_cu_seqlens, std::vector<size_t>{batch + 1}, DType::kInt32);

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -667,6 +667,7 @@ class MultiHeadAttention(nn.Module):    # pylint: disable=too-few-public-methods
 
                 x = cross_fused_attn(query,
                                      kv_proj,
+                                     bias,
                                      mask,
                                      seed,
                                      attn_bias_type=attn_bias_type,

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -91,14 +91,15 @@ def _self_fused_attn_fwd_rule(qkv: jnp.ndarray, bias: jnp.ndarray, mask: jnp.nda
                                                          scaling_factor=scaling_factor,
                                                          dropout_probability=dropout_probability,
                                                          is_training=is_training)
-    return output, (qkv, softmax_aux, rng_state, output, squeezed_mask)
+    return output, (qkv, bias, softmax_aux, rng_state, output, squeezed_mask)
 
 
 def _self_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
                               is_training, ctx, dz):
-    qkv, softmax_aux, rng_state, output, squeezed_mask = ctx
+    qkv, bias, softmax_aux, rng_state, output, squeezed_mask = ctx
 
     grad_qkv, grad_bias = self_fused_attn_bwd(qkv,
+                                              bias,
                                               softmax_aux,
                                               rng_state,
                                               output,
@@ -168,15 +169,16 @@ def _cross_fused_attn_fwd_rule(q, kv, bias, mask, seed, attn_bias_type, attn_mas
                                                           dropout_probability=dropout_probability,
                                                           is_training=is_training)
 
-    return output, (q, kv, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask)
+    return output, (q, kv, bias, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask)
 
 
 def _cross_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
                                is_training, ctx, dz):
-    q, kv, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask = ctx
+    q, kv, bias, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask = ctx
 
     grad_q, grad_kv, grad_bias = cross_fused_attn_bwd(q,
                                                       kv,
+                                                      bias,
                                                       softmax_aux,
                                                       rng_state,
                                                       output,

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -172,11 +172,12 @@ def _cross_fused_attn_fwd_rule(q, kv, mask, seed, attn_bias_type, attn_mask_type
 def _cross_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
                                is_training, ctx, dz):
     q, kv, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask = ctx
-    del rng_state, output
 
     grad_q, grad_kv = cross_fused_attn_bwd(q,
                                            kv,
                                            softmax_aux,
+                                           rng_state,
+                                           output,
                                            dz,
                                            q_squeezed_mask,
                                            kv_squeezed_mask,

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -119,8 +119,8 @@ def _self_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dr
 _self_fused_attn.defvjp(_self_fused_attn_fwd_rule, _self_fused_attn_bwd_rule)
 
 
-def cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, mask: jnp.ndarray, seed: jnp.ndarray,
-                     attn_bias_type: AttnBiasType, attn_mask_type: AttnMaskType,
+def cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray, mask: jnp.ndarray,
+                     seed: jnp.ndarray, attn_bias_type: AttnBiasType, attn_mask_type: AttnMaskType,
                      scaling_factor: float, dropout_probability: float, is_training: bool):
     """
     Cross multi-head attention wrapper
@@ -128,6 +128,7 @@ def cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, mask: jnp.ndarray, seed: j
 
     output = _cross_fused_attn(q,
                                kv,
+                               bias,
                                mask,
                                seed,
                                attn_bias_type=attn_bias_type,
@@ -139,24 +140,25 @@ def cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, mask: jnp.ndarray, seed: j
     return output
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(4, 5, 6, 7, 8))
-def _cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, mask: jnp.ndarray, seed: jnp.ndarray,
-                      attn_bias_type: AttnBiasType, attn_mask_type: AttnMaskType,
+@partial(jax.custom_vjp, nondiff_argnums=(5, 6, 7, 8, 9))
+def _cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray, mask: jnp.ndarray,
+                      seed: jnp.ndarray, attn_bias_type: AttnBiasType, attn_mask_type: AttnMaskType,
                       scaling_factor: float, dropout_probability: float, is_training: bool):
 
-    output, _ = _cross_fused_attn_fwd_rule(q, kv, mask, seed, attn_bias_type, attn_mask_type,
+    output, _ = _cross_fused_attn_fwd_rule(q, kv, bias, mask, seed, attn_bias_type, attn_mask_type,
                                            scaling_factor, dropout_probability, is_training)
     return output
 
 
-def _cross_fused_attn_fwd_rule(q, kv, mask, seed, attn_bias_type, attn_mask_type, scaling_factor,
-                               dropout_probability, is_training):
+def _cross_fused_attn_fwd_rule(q, kv, bias, mask, seed, attn_bias_type, attn_mask_type,
+                               scaling_factor, dropout_probability, is_training):
 
     q_squeezed_mask = mask[..., 0]
     kv_squeezed_mask = mask[..., 0, :]
 
     output, softmax_aux, rng_state = cross_fused_attn_fwd(q,
                                                           kv,
+                                                          bias,
                                                           q_squeezed_mask,
                                                           kv_squeezed_mask,
                                                           seed,
@@ -173,21 +175,24 @@ def _cross_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, d
                                is_training, ctx, dz):
     q, kv, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask = ctx
 
-    grad_q, grad_kv = cross_fused_attn_bwd(q,
-                                           kv,
-                                           softmax_aux,
-                                           rng_state,
-                                           output,
-                                           dz,
-                                           q_squeezed_mask,
-                                           kv_squeezed_mask,
-                                           attn_bias_type=attn_bias_type.value,
-                                           attn_mask_type=attn_mask_type.value,
-                                           scaling_factor=scaling_factor,
-                                           dropout_probability=dropout_probability,
-                                           is_training=is_training)
+    grad_q, grad_kv, grad_bias = cross_fused_attn_bwd(q,
+                                                      kv,
+                                                      softmax_aux,
+                                                      rng_state,
+                                                      output,
+                                                      dz,
+                                                      q_squeezed_mask,
+                                                      kv_squeezed_mask,
+                                                      attn_bias_type=attn_bias_type.value,
+                                                      attn_mask_type=attn_mask_type.value,
+                                                      scaling_factor=scaling_factor,
+                                                      dropout_probability=dropout_probability,
+                                                      is_training=is_training)
 
-    return grad_q, grad_kv, None, None
+    if attn_bias_type == AttnBiasType.NO_BIAS:
+        grad_bias = None
+
+    return grad_q, grad_kv, grad_bias, None, None
 
 
 _cross_fused_attn.defvjp(_cross_fused_attn_fwd_rule, _cross_fused_attn_bwd_rule)

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -81,7 +81,7 @@ def _self_fused_attn_fwd_rule(qkv: jnp.ndarray, bias: jnp.ndarray, mask: jnp.nda
                               seed: jnp.ndarray, attn_bias_type: AttnBiasType,
                               attn_mask_type: AttnMaskType, scaling_factor: float,
                               dropout_probability: float, is_training: bool):
-    squeezed_mask = mask[:, :, :, 0]
+    squeezed_mask = mask[..., 0]
     output, softmax_aux, rng_state = self_fused_attn_fwd(qkv,
                                                          bias,
                                                          squeezed_mask,
@@ -152,25 +152,27 @@ def _cross_fused_attn(q: jnp.ndarray, kv: jnp.ndarray, mask: jnp.ndarray, seed: 
 def _cross_fused_attn_fwd_rule(q, kv, mask, seed, attn_bias_type, attn_mask_type, scaling_factor,
                                dropout_probability, is_training):
 
-    q_squeezed_mask = mask[:, :, :, 0]
-    kv_squeezed_mask = mask[:, :, 0, :]
+    q_squeezed_mask = mask[..., 0]
+    kv_squeezed_mask = mask[..., 0, :]
 
-    output, softmax_aux = cross_fused_attn_fwd(q,
-                                               kv,
-                                               q_squeezed_mask,
-                                               kv_squeezed_mask,
-                                               seed,
-                                               attn_bias_type=attn_bias_type.value,
-                                               attn_mask_type=attn_mask_type.value,
-                                               scaling_factor=scaling_factor,
-                                               dropout_probability=dropout_probability,
-                                               is_training=is_training)
-    return output, (softmax_aux, q, kv, q_squeezed_mask, kv_squeezed_mask)
+    output, softmax_aux, rng_state = cross_fused_attn_fwd(q,
+                                                          kv,
+                                                          q_squeezed_mask,
+                                                          kv_squeezed_mask,
+                                                          seed,
+                                                          attn_bias_type=attn_bias_type.value,
+                                                          attn_mask_type=attn_mask_type.value,
+                                                          scaling_factor=scaling_factor,
+                                                          dropout_probability=dropout_probability,
+                                                          is_training=is_training)
+
+    return output, (q, kv, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask)
 
 
 def _cross_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
                                is_training, ctx, dz):
-    softmax_aux, q, kv, q_squeezed_mask, kv_squeezed_mask = ctx
+    q, kv, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask = ctx
+    del rng_state, output
 
     grad_q, grad_kv = cross_fused_attn_bwd(q,
                                            kv,


### PR DESCRIPTION
This PR does
- Prepare the arbitrary attention backend I/O (requires forward output in the backward)
- Add bias support for the JAX bridge code