### PR TITLE
[PyTorch] Support pickling Float8Tensor

### DIFF
--- a/transformer_engine/pytorch/float8_tensor.py
+++ b/transformer_engine/pytorch/float8_tensor.py
@@ -482,8 +482,7 @@ class Float8Tensor(torch.Tensor):
         # Compute transpose if needed
         out = self._transpose
         if out is None:
-            out = Float8Tensor.make_like(
-                self,
+            out = self.make_like(
                 data=tex.fp8_transpose(
                     self._data.contiguous(),
                     self._fp8_dtype,

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -819,19 +819,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             )
         return fp8_weight_tensors
 
-    def state_dict(self, *args, **kwargs) -> Dict:
-        """Get dictionary containing module state"""
-        state = super().state_dict(*args, **kwargs)
-
-        # Convert Float8Tensors to plain tensors
-        # Note: Float8Tensors don't serialize well, especially if they
-        # contain references to FP8 metadata.
-        for key, val in state.items():
-            if isinstance(val, Float8Tensor):
-                state[key] = val.from_float8()
-
-        return state
-
     @abstractmethod
     def forward(self):
         """Needs override."""


### PR DESCRIPTION
We've experienced some problems when trying to checkpoint FP8 models (https://github.com/NVIDIA/NeMo/pull/7909#issuecomment-1818827845). The root cause is because we cast FP8 params to higher precision when checkpointing TE modules:

https://github.com/NVIDIA/TransformerEngine/blob/886498384f414b3a627503e60c9be809bb7d88db/transformer_engine/pytorch/module/base.py#L831

This messes with some of the bookkeeping for checkpointing in Megatron-core, e.g. to figure out corresponding tensors in the model and optimizer `state_dict` s. I've modified the behavior so that pickling `Float8Tensor` s will save the FP8 data, dtypes, and scale-inv (but not `fp8_meta`). This fixes the error for me when I run some quick tests.

This is built on top of https://github.com/NVIDIA/TransformerEngine/pull/524. Closes https://github.com/NVIDIA/TransformerEngine/pull/524.