### PR TITLE
Use unsigned char when instantiating DType::kByte

### DIFF
--- a/transformer_engine/common/common.h
+++ b/transformer_engine/common/common.h
@@ -122,7 +122,7 @@ struct TypeInfo{
         using namespace transformer_engine; \
         case DType::kByte: \
             { \
-                using type = float; \
+                using type = unsigned char; \
                 {__VA_ARGS__} \
             } \
         break; \


### PR DESCRIPTION
@zlsh80826 has observed that our dtype instantiation macro instantiates `DType::kByte` as `float`, resulting in 4x excessive memory allocations for workspace buffers. This replaces that with `unsigned char`.