### PR TITLE
[PyTorch] Fix incorrect variable name in LayerNormMLP backward

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -910,7 +910,7 @@ class _LayerNormMLP(torch.autograd.Function):
             # Handle custom DDP from mcore.
             if ctx.fuse_wgrad_accumulation and hasattr(fc1_weight, 'grad_added_to_main_grad'):
                 fc1_weight.grad_added_to_main_grad = True
-                if getattr(weight, 'zero_out_wgrad', False):
+                if getattr(fc1_weight, 'zero_out_wgrad', False):
                     fc1_wgrad = torch.zeros(fc1_weight.main_grad.shape,
                                             dtype=fc1_weight.dtype,
                                             device=torch.cuda.current_device(),
@@ -931,7 +931,7 @@ class _LayerNormMLP(torch.autograd.Function):
             # Handle custom DDP from mcore.
             if ctx.fuse_wgrad_accumulation and hasattr(fc2_weight, 'grad_added_to_main_grad'):
                 fc2_weight.grad_added_to_main_grad = True
-                if getattr(weight, 'zero_out_wgrad', False):
+                if getattr(fc2_weight, 'zero_out_wgrad', False):
                     fc2_wgrad = torch.zeros(fc2_weight.main_grad.shape,
                                             dtype=fc2_weight.dtype,
                                             device=torch.cuda.current_device(),


### PR DESCRIPTION
We mixed up a variable name in https://github.com/NVIDIA/TransformerEngine/pull/545.