### PR TITLE
[PyTorch/C] Fix compiling warnings and backend selection logic for fused attention

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -131,11 +131,13 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
                 || (cudnn_runtime_version >= 8907))
             && ((head_dim <= 128) && (head_dim % 8 == 0))
             && ((cudnn_runtime_version < 8906 && bias_type == NVTE_Bias_Type::NVTE_NO_BIAS)
-                || ((cudnn_runtime_version >= 8906 && sm_arch_ == 90)
+                || ((cudnn_runtime_version >= 8906)
                     && (bias_type == NVTE_Bias_Type::NVTE_NO_BIAS
                         || (bias_type == NVTE_Bias_Type::NVTE_ALIBI
-                            && attn_mask_type != NVTE_Mask_Type::NVTE_NO_MASK)
-                        || bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS)))
+                            && attn_mask_type != NVTE_Mask_Type::NVTE_NO_MASK
+                            && sm_arch_ == 90)
+                        || (bias_type == NVTE_Bias_Type::NVTE_POST_SCALE_BIAS
+                            && sm_arch_ == 90))))
             && ((cudnn_runtime_version < 8906 && attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK)
                 || ((cudnn_runtime_version >= 8906)
                     && (attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -221,11 +221,21 @@ void fused_attn_arbitrary_seqlen_fwd_impl(
                 std::make_tuple(nullptr), key_tensors_tuple,
                 Stats_tuple, bias_tuple, padding_tuple, dropout_tuple);
 
-            auto a = mha_graph->validate().is_good();
-            mha_graph->build_operation_graph(handle).is_good();
-            mha_graph->create_execution_plans({fe::HeurMode_t::A}).is_good();
-            mha_graph->check_support(handle).is_good();
-            mha_graph->build_plans(handle).is_good();
+	    if (!mha_graph->validate().is_good()) {
+                NVTE_ERROR("MHA Graph (fwd) validation is unsuccessful.");
+            }
+            if (!mha_graph->build_operation_graph(handle).is_good()) {
+                NVTE_ERROR("MHA Graph (fwd) graph build is unsuccessful.");
+            }
+            if (!mha_graph->create_execution_plans({fe::HeurMode_t::A}).is_good()) {
+                NVTE_ERROR("MHA Graph (fwd) plan creation is unsuccessful.");
+            }
+            if (!mha_graph->check_support(handle).is_good()) {
+                NVTE_ERROR("MHA Graph (fwd) support check is unsuccessful.");
+            }
+            if (!mha_graph->build_plans(handle).is_good()) {
+                NVTE_ERROR("MHA Graph (fwd) plan build is unsuccessful.");
+            }
 
             auto return_tuple = std::tuple_cat(
                 std::make_tuple(mha_graph), key_tensors_tuple,
@@ -283,7 +293,9 @@ void fused_attn_arbitrary_seqlen_fwd_impl(
             variant_pack[dropout_offset] = devPtrDropoutOffset;
         }
 
-        mha_graph->execute(handle, variant_pack, workspace).is_good();
+        if (!mha_graph->execute(handle, variant_pack, workspace).is_good()) {
+            NVTE_ERROR("MHA Graph (fwd) execution is unsuccessful.");
+        }
     } catch (cudnn_frontend::cudnnException &e) {
         NVTE_ERROR(e.what());
     }
@@ -492,11 +504,21 @@ void fused_attn_arbitrary_seqlen_bwd_impl(
                 std::make_tuple(nullptr), key_tensors_tuple,
                 bias_tuple, padding_tuple, dropout_tuple);
 
-            mha_graph->validate().is_good();
-            mha_graph->build_operation_graph(handle).is_good();
-            mha_graph->create_execution_plans({fe::HeurMode_t::A}).is_good();
-            mha_graph->check_support(handle).is_good();
-            mha_graph->build_plans(handle).is_good();
+	    if (!mha_graph->validate().is_good()) {
+                NVTE_ERROR("MHA Graph (bwd) validation is unsuccessful.");
+            }
+            if (!mha_graph->build_operation_graph(handle).is_good()) {
+                NVTE_ERROR("MHA Graph (bwd) graph build is unsuccessful.");
+            }
+            if (!mha_graph->create_execution_plans({fe::HeurMode_t::A}).is_good()) {
+                NVTE_ERROR("MHA Graph (bwd) plan creation is unsuccessful.");
+            }
+            if (!mha_graph->check_support(handle).is_good()) {
+                NVTE_ERROR("MHA Graph (bwd) support check is unsuccessful.");
+            }
+            if (!mha_graph->build_plans(handle).is_good()) {
+                NVTE_ERROR("MHA Graph (bwd) plan build is unsuccessful.");
+            }
 
             auto return_tuple = std::tuple_cat(
                 std::make_tuple(mha_graph), key_tensors_tuple,
@@ -557,7 +579,9 @@ void fused_attn_arbitrary_seqlen_bwd_impl(
             variant_pack[dropout_offset] = devPtrDropoutOffset;
         }
 
-        mha_graph->execute(handle, variant_pack, workspace).is_good();
+        if (!mha_graph->execute(handle, variant_pack, workspace).is_good()) {
+            NVTE_ERROR("MHA Graph (bwd) execution is unsuccessful.");
+        }
     } catch (cudnn_frontend::cudnnException &e) {
         NVTE_ERROR(e.what());
     }

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -221,21 +221,11 @@ void fused_attn_arbitrary_seqlen_fwd_impl(
                 std::make_tuple(nullptr), key_tensors_tuple,
                 Stats_tuple, bias_tuple, padding_tuple, dropout_tuple);
 
-            if (!mha_graph->validate().is_good()) {
-                NVTE_ERROR("MHA Graph (fwd) validation is unsuccessful.");
-            }
-            if (!mha_graph->build_operation_graph(handle).is_good()) {
-                NVTE_ERROR("MHA Graph (fwd) graph build is unsuccessful.");
-            }
-            if (!mha_graph->create_execution_plans({fe::HeurMode_t::A}).is_good()) {
-                NVTE_ERROR("MHA Graph (fwd) plan creation is unsuccessful.");
-            }
-            if (!mha_graph->check_support(handle).is_good()) {
-                NVTE_ERROR("MHA Graph (fwd) support check is unsuccessful.");
-            }
-            if (!mha_graph->build_plans(handle).is_good()) {
-                NVTE_ERROR("MHA Graph (fwd) plan build is unsuccessful.");
-            }
+            NVTE_CHECK_CUDNN_FE(mha_graph->validate());
+            NVTE_CHECK_CUDNN_FE(mha_graph->build_operation_graph(handle));
+            NVTE_CHECK_CUDNN_FE(mha_graph->create_execution_plans({fe::HeurMode_t::A}));
+            NVTE_CHECK_CUDNN_FE(mha_graph->check_support(handle));
+            NVTE_CHECK_CUDNN_FE(mha_graph->build_plans(handle));
 
             auto return_tuple = std::tuple_cat(
                 std::make_tuple(mha_graph), key_tensors_tuple,
@@ -293,9 +283,7 @@ void fused_attn_arbitrary_seqlen_fwd_impl(
             variant_pack[dropout_offset] = devPtrDropoutOffset;
         }
 
-        if (!mha_graph->execute(handle, variant_pack, workspace).is_good()) {
-            NVTE_ERROR("MHA Graph (fwd) execution is unsuccessful.");
-        }
+        NVTE_CHECK_CUDNN_FE(mha_graph->execute(handle, variant_pack, workspace));
     } catch (cudnn_frontend::cudnnException &e) {
         NVTE_ERROR(e.what());
     }
@@ -504,21 +492,11 @@ void fused_attn_arbitrary_seqlen_bwd_impl(
                 std::make_tuple(nullptr), key_tensors_tuple,
                 bias_tuple, padding_tuple, dropout_tuple);
 
-            if (!mha_graph->validate().is_good()) {
-                NVTE_ERROR("MHA Graph (bwd) validation is unsuccessful.");
-            }
-            if (!mha_graph->build_operation_graph(handle).is_good()) {
-                NVTE_ERROR("MHA Graph (bwd) graph build is unsuccessful.");
-            }
-            if (!mha_graph->create_execution_plans({fe::HeurMode_t::A}).is_good()) {
-                NVTE_ERROR("MHA Graph (bwd) plan creation is unsuccessful.");
-            }
-            if (!mha_graph->check_support(handle).is_good()) {
-                NVTE_ERROR("MHA Graph (bwd) support check is unsuccessful.");
-            }
-            if (!mha_graph->build_plans(handle).is_good()) {
-                NVTE_ERROR("MHA Graph (bwd) plan build is unsuccessful.");
-            }
+            NVTE_CHECK_CUDNN_FE(mha_graph->validate());
+            NVTE_CHECK_CUDNN_FE(mha_graph->build_operation_graph(handle));
+            NVTE_CHECK_CUDNN_FE(mha_graph->create_execution_plans({fe::HeurMode_t::A}));
+            NVTE_CHECK_CUDNN_FE(mha_graph->check_support(handle));
+            NVTE_CHECK_CUDNN_FE(mha_graph->build_plans(handle));
 
             auto return_tuple = std::tuple_cat(
                 std::make_tuple(mha_graph), key_tensors_tuple,
@@ -579,9 +557,7 @@ void fused_attn_arbitrary_seqlen_bwd_impl(
             variant_pack[dropout_offset] = devPtrDropoutOffset;
         }
 
-        if (!mha_graph->execute(handle, variant_pack, workspace).is_good()) {
-            NVTE_ERROR("MHA Graph (bwd) execution is unsuccessful.");
-        }
+        NVTE_CHECK_CUDNN_FE(mha_graph->execute(handle, variant_pack, workspace));
     } catch (cudnn_frontend::cudnnException &e) {
         NVTE_ERROR(e.what());
     }

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -221,7 +221,7 @@ void fused_attn_arbitrary_seqlen_fwd_impl(
                 std::make_tuple(nullptr), key_tensors_tuple,
                 Stats_tuple, bias_tuple, padding_tuple, dropout_tuple);
 
-	    if (!mha_graph->validate().is_good()) {
+            if (!mha_graph->validate().is_good()) {
                 NVTE_ERROR("MHA Graph (fwd) validation is unsuccessful.");
             }
             if (!mha_graph->build_operation_graph(handle).is_good()) {
@@ -504,7 +504,7 @@ void fused_attn_arbitrary_seqlen_bwd_impl(
                 std::make_tuple(nullptr), key_tensors_tuple,
                 bias_tuple, padding_tuple, dropout_tuple);
 
-	    if (!mha_graph->validate().is_good()) {
+            if (!mha_graph->validate().is_good()) {
                 NVTE_ERROR("MHA Graph (bwd) validation is unsuccessful.");
             }
             if (!mha_graph->build_operation_graph(handle).is_good()) {

--- a/transformer_engine/common/util/logging.h
+++ b/transformer_engine/common/util/logging.h
@@ -64,6 +64,19 @@
     }                                                                   \
   } while (false)
 
+#define NVTE_CHECK_CUDNN_FE(expr)                                       \
+  do {                                                                  \
+    const auto error = (expr);                                          \
+    if (error.is_bad()) {                                               \
+      NVTE_ERROR("cuDNN Error: ",                                       \
+                 error.err_msg,                                         \
+                 ". "                                                   \
+                 "For more information, enable cuDNN error logging "    \
+                 "by setting CUDNN_LOGERR_DBG=1 and "                   \
+                 "CUDNN_LOGDEST_DBG=stderr in the environment.");       \
+    }                                                                   \
+  } while (false)
+
 #define NVTE_CHECK_NVRTC(expr)                                  \
   do {                                                          \
     const nvrtcResult status_NVTE_CHECK_NVRTC = (expr);         \

--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -32,5 +32,5 @@ from .te_onnx_extensions import (
 try:
     import torch
     torch._dynamo.config.error_on_nested_jit_trace = False
-except:
+except: # pylint: disable=bare-except
     pass


### PR DESCRIPTION
This PR fixes the compiling warnings in SDPA flash after upgrading to cuDNN frontend v1. It also fixes the logic for selecting the SDPA flash backend on sm80 when cuDNN runtime version is >8.9.6.