### PR TITLE
Fix bug when compiling in CUDA12.1

### DIFF
--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
@@ -4,18 +4,21 @@
  * See LICENSE for license information.
  ************************************************************************/
 
+#include <stdio.h>
+#include <assert.h>
+
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <cuda_fp8.h>
+
 #if __CUDA_ARCH__ >= 800
 #include <cuda_bf16.h>
 #define half nv_bfloat16
 #else
 #include <cuda_fp16.h>
 #endif
+
 #include "userbuffers.h"
-#include <assert.h>
-#include <cuda_fp8.h>
-#include <stdio.h>
 
 #define MAX_THREADS 1024
 #define TIMEOUT 200000000000ull


### PR DESCRIPTION
Avoid redeclaration of "nv_bfloat16" when Compiling in CUDA12.1

`#define half nv_bfloat16` will redeclared `nv_bfloa16` in the file included by `#include<cuda_fp8.h>`. Putting `#include <cuda_fp8.h>` in front of `define half nv_bfloat16` can avoid this problem.

Error log: `/usr/local/cuda/include/cuda_fp16.hpp(2724): error: invalid redeclaration of type name "nv_bfloat16" (declared at line 2837 of /usr/local/cuda/include/cuda_bf16.hpp)`