### PR TITLE
[PyTorch] fix attn_mask_type for inter_attention

### DIFF
--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -619,7 +619,6 @@ class TransformerLayer(torch.nn.Module):
             inter_attention_outputs = self.inter_attention(
                 hidden_states,
                 attention_mask=enc_dec_attn_mask,
-                attn_mask_type=self_attn_mask_type,
                 encoder_output=encoder_output,
                 is_first_microbatch=is_first_microbatch,
                 checkpoint_core_attention=checkpoint_core_attention,


### PR DESCRIPTION
In the transformer layer the inter-attention is initialized with `attn_mask_type="padding"` (see https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/pytorch/transformer.py#L367). This is overriden in the forward call with `self_attn_mask_type`, which is typically causal. This seems wrong to us. In fact this means that in a encoder-decoder architecture, the decoder would look with a causal mask on the encoder.

I would propose to remove the override in the forward pass. This is a clean and simple solution, but it might destroy existing models. Do you have other suggestions?

Looking forward to get this fixed ;-) 

