### PR TITLE
[JAX] Fixing custom op test failures due to changes in JAX lowering internals

### DIFF
--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -18,7 +18,6 @@ from transformer_engine_jax import NVTE_QKV_Layout
 from transformer_engine_jax import NVTE_Fused_Attn_Backend
 
 import numpy as np
-import jax
 import jax.numpy as jnp
 from jax.lib import xla_client
 from jax import core, dtypes
@@ -33,12 +32,6 @@ from .sharding import all_reduce_max_along_all_axes_except_PP
 from .sharding import all_reduce_sum_along_dp_fsdp
 from .sharding import get_all_mesh_axes, num_of_devices
 from .sharding import get_padded_spec as te_get_padded_spec
-
-try:
-    # TE-specific flag in JAX nightlies. Will be removed when JAX lowering changes are upstreamed.
-    jax.config.update('jax_require_devices_during_lowering', False)
-except AttributeError:
-    pass
 
 try:
     from jaxlib.hlo_helpers import custom_call

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -22,7 +22,11 @@ from jax.interpreters.mlir import ir, dtype_to_ir_type
 from jax.sharding import PartitionSpec, NamedSharding
 from jax._src.interpreters import batching
 from jax._src import dispatch
-jax.config.update('jax_require_devices_during_lowering', False)
+try:
+    # TE-specific flag in JAX nightlies. Will be removed when JAX lowering changes are upstreamed.
+    jax.config.update('jax_require_devices_during_lowering', False)
+except AttributeError:
+    pass
 
 try:
     from jaxlib.hlo_helpers import custom_call


### PR DESCRIPTION
Latest JAX changes for lowering caused our custom op tests to fail due to a device dispatch bug. This PR implements the fix needed to make our primitives work correctly with the latest JAX changes.