### PR TITLE
Update fp8_meta amax when copying into Float8Tensor

### DIFF
--- a/transformer_engine/pytorch/float8_tensor.py
+++ b/transformer_engine/pytorch/float8_tensor.py
@@ -563,16 +563,21 @@ class Float8Tensor(torch.Tensor):
                     dst._data.copy_(src._data)
                     dst._scale_inv = src._scale_inv.clone()
                     if dst._fp8_meta is not None:
+                        if src._fp8_meta is None:
+                            src_min, src_max = src.from_float8().aminmax()
+                            src_amax = torch.maximum(-src_min, src_max)
+                        else:
+                            fp8_meta_key = FP8GlobalStateManager.get_meta_tensor_key(
+                                forward=src._fp8_meta_forward,
+                            )
+                            fp8_meta_index = src._fp8_meta_index
+                            src_amax = src._fp8_meta[fp8_meta_key].amax_history[0][fp8_meta_index]
                         fp8_meta_key = FP8GlobalStateManager.get_meta_tensor_key(
                             forward=dst._fp8_meta_forward,
                         )
                         fp8_meta_index = dst._fp8_meta_index
-                        amax = dst._fp8_meta[fp8_meta_key].amax_history[0][fp8_meta_index]
-                        src_min, src_max = src.from_float8().aminmax()
-                        torch.max(
-                            torch.cat([-src_min.reshape(1), src_max.reshape(1), amax.reshape(1)]),
-                            out=amax,
-                        )
+                        dst_amax = dst._fp8_meta[fp8_meta_key].amax_history[0][fp8_meta_index]
+                        torch.maximum(src_amax, dst_amax, out=dst_amax)
                 else:
                     dst.copy_(src.from_float8())
 


### PR DESCRIPTION
While debugging a convergence issue with LLaMa SFT and https://github.com/NVIDIA/NeMo/pull/7909, I've identified a subtle bug when a model with FP8 params loads a checkpoint. When the model is first initialized, it generates random weights and stores the amax value in `fp8_meta`. However, this amax becomes meaningless when we load the checkpoint and overwrite the weight values. The amax histories are used in the forward pass to update the scaling factors, resulting in bogus scaling factors that clip many FP8 values to the maxval or underflow them to zero.

This PR changes the behavior of copying into a `Float8Tensor` so that it updates the latest amax history if it has an `fp8_meta`. This is similar to how the FP8 cast kernel updates the latest amax history. This should fix the issue I'm seeing with LLaMa SFT, but it's not an entirely clean solution. In particular, it can't protect the user from abusing `fp8_meta` (e.g. loading a checkpoint in the middle of training will result in a bogus amax history, with or without `Float8Tensor`). It might also result in unexpected amax updates when multiple tensors share the same `fp8_meta`, e.g. copying into a tensor subview will affect the full tensor's amax history.