### PR TITLE
[JAX][Common] Support GQA

### DIFF
--- a/qa/L0_jax_distributed_unittest/test.sh
+++ b/qa/L0_jax_distributed_unittest/test.sh
@@ -4,6 +4,9 @@
 
 set -xe
 
+# WAR(rewang) for the "Check failed: reduction_kind.has_value()"
+export XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_xla_runtime_executable=true"
+
 : ${TE_PATH:=/opt/transformerengine}
 pytest -Wignore -v $TE_PATH/tests/jax/test_distributed_*
 

--- a/qa/L0_jax_unittest/test.sh
+++ b/qa/L0_jax_unittest/test.sh
@@ -14,5 +14,7 @@ pytest -Wignore -v $TE_PATH/examples/jax/mnist
 
 # Make encoder tests to have run-to-run deterministic to have the stable CI results
 export XLA_FLAGS="${XLA_FLAGS} --xla_gpu_deterministic_ops"
+# WAR(rewang) for the "Check failed: reduction_kind.has_value()"
+export XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_xla_runtime_executable=true"
 pytest -Wignore -v $TE_PATH/examples/jax/encoder --ignore=$TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py
 pytest -Wignore -v $TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -3,8 +3,8 @@
 # See LICENSE for license information.
 """Tests for fused attention"""
 
-import os
-from enum import Enum
+from dataclasses import dataclass
+from functools import partial
 from math import sqrt
 
 import jax
@@ -13,18 +13,15 @@ import numpy as np
 import pytest
 
 from flax.linen import combine_masks
-from flax.linen import dot_product_attention
 from flax.linen import make_attention_mask
-from flax.linen import make_causal_mask
+from flax.linen.dtypes import promote_dtype
+from jax import Array
 from jax import value_and_grad, jit
+from jax.typing import ArrayLike, DTypeLike
 
 from transformer_engine.jax.fused_attn import AttnBiasType, AttnMaskType, QKVLayout
 from transformer_engine.jax.fused_attn import self_fused_attn, cross_fused_attn
 from transformer_engine.jax.fused_attn import is_fused_attn_kernel_available
-from transformer_engine_jax import get_device_compute_capability    # pylint: disable=wrong-import-order
-
-# Type annotations
-Array = jnp.ndarray
 
 
 @pytest.fixture(autouse=True, scope='function')
@@ -32,34 +29,55 @@ def clear_live_arrays():
     """
     Clear all live arrays to keep the resource clean
     """
+    # Calling customcalls before jax may cause CUDA uninitialize error
+    _ = jnp.zeros(0)
     yield
     for arr in jax.live_arrays():
         arr.delete()
 
 
-class Backend(Enum):
+def general_dot_product_attention(query: ArrayLike, key: ArrayLike, value: ArrayLike,
+                                  bias: ArrayLike, mask: ArrayLike, deterministic: bool,
+                                  dropout_rate: float, dropout_rng: ArrayLike,
+                                  dtype: DTypeLike) -> Array:
     """
-    Fused attn backend.
-    Unit tests only, transformer will auto dispatch to the best backend
+    Similar to flax.linen.dot_product_attention but with GQA support
     """
-    Max512 = "0"
-    Arbitrary = "1"
+    query, key, value, bias = promote_dtype(query, key, value, bias, dtype=dtype)
+    dtype = query.dtype
 
+    depth = query.shape[-1]
+    query = query / jnp.sqrt(depth).astype(dtype)
 
-@pytest.fixture(name="backend", params=[Backend.Max512, Backend.Arbitrary])
-def fixture_backend(request):
-    """
-    Fixture of setting up/tearing down backend
-    """
-    backend = request.param
-    os.environ["NVTE_FUSED_ATTN_BACKEND"] = backend.value
-    yield backend
-    os.environ["NVTE_FUSED_ATTN_BACKEND"] = ""
+    b, s_q, h_q, d = query.shape
+    _, _, h_kv, _ = key.shape
+    assert (h_q % h_kv == 0) and (h_q >= h_kv)
+    num_groups = h_q // h_kv
+    grouped_query = jnp.reshape(query, (b, s_q, h_kv, num_groups, d))
+    # logits with shape (b, h_kv, num_groups, s_q, s_kv)
+    logits = jnp.einsum('...qhgd,...khd->...hgqk', grouped_query, key)
 
+    if bias is not None:
+        if bias.ndim != logits.ndim:
+            bias = bias.reshape((1, *logits.shape[1:]))
+        logits = logits + bias
 
-SELF_CASES = [(32, 512, 16, 64), (32, 128, 16, 64), (4, 2048, 12, 64)]
-CROSS_CASES = [(32, 128, 512, 16, 64)]
-DTYPES = [jnp.bfloat16, jnp.float16]
+    if mask is not None:
+        if mask.ndim != logits.ndim:
+            mask = jnp.expand_dims(mask, axis=-3)
+        logits = jnp.where(mask, logits, jnp.finfo(dtype).min)
+
+    softmax_out = jax.nn.softmax(logits).astype(dtype)
+
+    if not deterministic and dropout_rate > 0.:
+        keep_prob = 1.0 - dropout_rate
+        keep = jax.random.bernoulli(dropout_rng, keep_prob, softmax_out.shape)
+        multiplier = keep.astype(dtype) / jnp.asarray(keep_prob, dtype=dtype)
+        softmax_out = softmax_out * multiplier
+
+    context = jnp.einsum('...hgqk,...khd->...qhgd', softmax_out, value)
+    context = jnp.reshape(context, query.shape)
+    return context
 
 
 def is_causal_mask(mask: AttnMaskType):
@@ -69,518 +87,266 @@ def is_causal_mask(mask: AttnMaskType):
     return mask in [AttnMaskType.CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_MASK]
 
 
-def make_decoder_mask(tokens: Array) -> Array:
+def make_decoder_mask(q_tokens: ArrayLike, kv_tokens: ArrayLike) -> Array:
     """
     Create padded causal mask
     """
-    causal_mask = make_causal_mask(tokens)
-    padding_mask = make_attention_mask(tokens > 0, tokens > 0)
+    q_idxs = jnp.broadcast_to(jnp.arange(q_tokens.shape[-1], dtype=jnp.int32), q_tokens.shape)
+    kv_idxs = jnp.broadcast_to(jnp.arange(kv_tokens.shape[-1], dtype=jnp.int32), kv_tokens.shape)
+    causal_mask = make_attention_mask(q_idxs, kv_idxs, jnp.greater_equal)
+    padding_mask = make_attention_mask(q_tokens > 0, kv_tokens > 0)
     return combine_masks(causal_mask, padding_mask)
 
 
-def jax_self_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwargs):
+def jax_dpa(query, key, value, bias, q_token, kv_token, dropout_rng, **kwargs):
     """
-    Self attention with JAX native implementation
+    JAX native dot product attention implementation
     """
     attn_mask_type = kwargs['attn_mask_type']
     if is_causal_mask(attn_mask_type):
-        mask = make_decoder_mask(q_token)
+        mask = make_decoder_mask(q_token, kv_token)
     else:
         mask = make_attention_mask(q_token > 0, kv_token > 0)
 
-    query, key, value = jnp.split(qkv, [1, 2], axis=-3)
-    query = jnp.squeeze(query)
-    key = jnp.squeeze(key)
-    value = jnp.squeeze(value)
-
-    output = dot_product_attention(query,
-                                   key,
-                                   value,
-                                   bias=bias,
-                                   mask=mask,
-                                   deterministic=not kwargs['is_training'],
-                                   dropout_rate=kwargs['dropout_probability'],
-                                   dropout_rng=dropout_rng,
-                                   dtype=jnp.float32)
-    return output.astype(qkv.dtype)
+    output = general_dot_product_attention(query,
+                                           key,
+                                           value,
+                                           bias=bias,
+                                           mask=mask,
+                                           deterministic=not kwargs['is_training'],
+                                           dropout_rate=kwargs['dropout_probability'],
+                                           dropout_rng=dropout_rng,
+                                           dtype=jnp.float32)
+    return output.astype(query.dtype)
 
 
-def jax_cross_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs):
-    """
-    Cross attention with JAX native implementation
-    """
-    assert q.dtype == kv.dtype
-
+def customcall_fused_dpa(query, key, value, bias, q_token, kv_token, dropout_rng, **kwargs):
     attn_mask_type = kwargs['attn_mask_type']
     if is_causal_mask(attn_mask_type):
-        raise NotImplementedError
-    mask = make_attention_mask(q_token > 0, kv_token > 0)
-
-    query = q
-    key, value = jnp.split(kv, [1], axis=-3)
-    key = jnp.squeeze(key)
-    value = jnp.squeeze(value)
-
-    output = dot_product_attention(query,
-                                   key,
-                                   value,
-                                   bias=None,
-                                   mask=mask,
-                                   deterministic=not kwargs['is_training'],
-                                   dropout_rate=kwargs['dropout_probability'],
-                                   dropout_rng=dropout_rng,
-                                   dtype=jnp.float32)
-    return output.astype(q.dtype)
-
-
-def customcall_self_fused_attn(qkv, bias, q_token, kv_token, dropout_rng, **kwargs):
-    """
-    Self fused attention
-    """
-    attn_mask_type = kwargs['attn_mask_type']
-    if is_causal_mask(attn_mask_type):
-        mask = make_decoder_mask(q_token)
+        mask = make_decoder_mask(q_token, kv_token)
     else:
         mask = make_attention_mask(q_token > 0, kv_token > 0)
 
     # mask invert
-    mask = (mask == 0)
+    mask = jnp.logical_not(mask)
 
-    return self_fused_attn(qkv, bias, mask, dropout_rng, **kwargs)
-
-
-def customcall_cross_fused_attn(q, kv, q_token, kv_token, dropout_rng, **kwargs):
-    """
-    Cross fused attention
-    """
-    assert q.dtype == kv.dtype
-
-    attn_mask_type = kwargs['attn_mask_type']
-    if is_causal_mask(attn_mask_type):
-        raise NotImplementedError
-    mask = make_attention_mask(q_token > 0, kv_token > 0)
-
-    # mask invert
-    mask = (mask == 0)
-
-    return cross_fused_attn(q, kv, None, mask, dropout_rng, **kwargs)
+    qkv_layout = kwargs.pop('qkv_layout')
+    match qkv_layout:
+        case QKVLayout.BS3HD:
+            query, key, value = map(partial(jnp.expand_dims, axis=-3), [query, key, value])
+            qkv = jnp.concatenate((query, key, value), axis=-3)
+            return self_fused_attn(qkv, bias, mask, dropout_rng, **kwargs).astype(query.dtype)
+        case QKVLayout.BSHD_BS2HD:
+            key, value = map(partial(jnp.expand_dims, axis=-3), [key, value])
+            kv = jnp.concatenate((key, value), axis=-3)
+            return cross_fused_attn(query, kv, bias, mask, dropout_rng,
+                                    **kwargs).astype(query.dtype)
 
 
-@pytest.mark.parametrize('b, s, h, d', SELF_CASES)
-@pytest.mark.parametrize('attn_bias_type', [AttnBiasType.NO_BIAS, AttnBiasType.POST_SCALE_BIAS])
-@pytest.mark.parametrize('attn_mask_type', [
-    AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK, AttnMaskType.CAUSAL_MASK,
-    AttnMaskType.PADDING_CAUSAL_MASK
-])
-@pytest.mark.parametrize('dropout_probability', [0., 0.1])
-@pytest.mark.parametrize('dtype', DTYPES)
-@pytest.mark.parametrize('is_training', [True, False])
-class TestSelfFusedAttn():
-    """Tests for transformer_engine.jax.fused_attn.self_fused_attn"""
+@dataclass
+class FusedAttnRunner:
+    batch_size: int
+    max_seqlen_q: int
+    max_seqlen_kv: int
+    num_heads_q: int
+    num_heads_kv: int
+    head_dim: int
+    attn_bias_type: AttnBiasType
+    attn_mask_type: AttnMaskType
+    dropout_prob: float
+    dtype: DTypeLike
+    is_training: bool
+    qkv_layout: QKVLayout
 
-    @staticmethod
-    def _check_inputs(s, *, attn_bias_type, attn_mask_type, backend, dropout_probability, dtype,
-                      num_heads_q, num_heads_kv, head_dim):
+    def _check_configs(self):
+        if self.qkv_layout == QKVLayout.BS3HD and self.num_heads_q != self.num_heads_kv:
+            pytest.skip("BS3HD layout requires num_heads_q and num_heads_kv to be equal.")
 
-        assert isinstance(backend, Backend)
+        if self.qkv_layout == QKVLayout.BS3HD and self.max_seqlen_q != self.max_seqlen_kv:
+            pytest.skip("BS3HD layout requires max_seqlen_q and max_seqlen_kv to be equal.")
 
-        if not is_fused_attn_kernel_available(dtype, dtype, QKVLayout.BS3HD, attn_bias_type,
-                                              attn_mask_type, dropout_probability,
-                                              num_heads_q, num_heads_kv,
-                                              s, s, head_dim):
+        if not is_fused_attn_kernel_available(
+                self.dtype, self.dtype, self.qkv_layout, self.attn_bias_type, self.attn_mask_type,
+                self.dropout_prob, self.num_heads_q, self.num_heads_kv, self.max_seqlen_q,
+                self.max_seqlen_kv, self.head_dim):
             pytest.skip("Unsupported inputs combination or device compute capability.")
 
-    def _set_inputs(self, b, s, h, d, *, attn_bias_type, attn_mask_type, backend,
-                    dropout_probability, dtype, is_training):
-        """Setup the test inputs"""
-        self.__class__._check_inputs(s,
-                                     attn_bias_type=attn_bias_type,
-                                     attn_mask_type=attn_mask_type,
-                                     backend=backend,
-                                     dropout_probability=dropout_probability,
-                                     dtype=dtype,
-                                     num_heads_q=h,
-                                     num_heads_kv=h,
-                                     head_dim=d)
+    def _setup_inputs(self):
+        self._check_configs()
+        key = jax.random.PRNGKey(0)
+        q_key, k_key, v_key, bias_key, dropout_key = jax.random.split(key, 5)
 
-        if attn_mask_type in [AttnMaskType.NO_MASK, AttnMaskType.CAUSAL_MASK]:
+        q_shape = (self.batch_size, self.max_seqlen_q, self.num_heads_q, self.head_dim)
+        k_shape = v_shape = (self.batch_size, self.max_seqlen_kv, self.num_heads_kv, self.head_dim)
+        bias_shape = (1, self.num_heads_q, self.max_seqlen_q, self.max_seqlen_kv)
+
+        self.q = jax.random.uniform(q_key, q_shape, self.dtype, -1)
+        self.k = jax.random.uniform(k_key, k_shape, self.dtype, -1)
+        self.v = jax.random.uniform(v_key, v_shape, self.dtype, -1)
+
+        with_bias = self.attn_bias_type != AttnBiasType.NO_BIAS
+        self.bias = jax.random.uniform(bias_key, bias_shape, self.dtype, -1) if with_bias else None
+
+        if self.attn_mask_type in [AttnMaskType.NO_MASK, AttnMaskType.CAUSAL_MASK]:
             pad_ratio = 0.0
         else:
             pad_ratio = 0.3
 
-        key = jax.random.PRNGKey(0)
-        subkeys = jax.random.split(key, 2)
+        def gen_valid(bs, max_seqlen, pad_ratio):
+            pad_len = int(max_seqlen * pad_ratio)
+            valid_len = max_seqlen - pad_len
+            tokens = jnp.concatenate([jnp.ones((bs, valid_len)), jnp.zeros((bs, pad_len))], axis=-1)
+            return valid_len, tokens
 
-        qkv_shape = (b, s, 3, h, d)
-        bias_shape = (1, h, s, s)
+        self.valid_len_q, self.token_q = gen_valid(self.batch_size, self.max_seqlen_q, pad_ratio)
+        self.valid_len_kv, self.token_kv = gen_valid(self.batch_size, self.max_seqlen_kv, pad_ratio)
 
-        pad_len = int(s * pad_ratio)
-        self.valid_len = s - pad_len
+        self.dropout_rng = dropout_key if self.dropout_prob > 0 else None
+        self.scaling_factor = 1. / sqrt(self.head_dim)
 
-        min_val, max_val = -1, 1
-        self.qkv = jax.random.uniform(subkeys[0], qkv_shape, dtype, min_val, max_val)
+    def test_forward(self):
+        self._setup_inputs()
 
-        with_bias = attn_bias_type != AttnBiasType.NO_BIAS
-        self.bias = jax.random.uniform(subkeys[1], bias_shape, dtype, min_val,
-                                       max_val) if with_bias else None
-
-        self.q_token = jnp.concatenate((jnp.ones((b, self.valid_len)), jnp.zeros((b, pad_len))),
-                                       axis=-1)
-        self.kv_token = self.q_token
-
-        self.scaling_factor = 1. / sqrt(d)
-        self.dropout_probability = dropout_probability
-        self.dropout_rng = jax.random.PRNGKey(0) if self.dropout_probability > 0 else None
-        self.attn_bias_type = attn_bias_type
-        self.attn_mask_type = attn_mask_type
-        self.is_training = is_training
-
-    def test_forward(self, b, s, h, d, attn_bias_type, attn_mask_type, backend, dropout_probability,
-                     dtype, is_training):
-        """
-        Test forward without using JIT
-        """
-        self._set_inputs(b,
-                         s,
-                         h,
-                         d,
-                         attn_bias_type=attn_bias_type,
-                         attn_mask_type=attn_mask_type,
-                         backend=backend,
-                         dropout_probability=dropout_probability,
-                         dtype=dtype,
-                         is_training=is_training)
-
-        primitive_out = customcall_self_fused_attn(self.qkv,
-                                                   self.bias,
-                                                   self.q_token,
-                                                   self.kv_token,
-                                                   self.dropout_rng,
-                                                   attn_bias_type=self.attn_bias_type,
-                                                   attn_mask_type=attn_mask_type,
-                                                   scaling_factor=self.scaling_factor,
-                                                   dropout_probability=self.dropout_probability,
-                                                   is_training=self.is_training)
-
-        reference_out = jax_self_attn(self.qkv,
-                                      self.bias,
-                                      self.q_token,
-                                      self.kv_token,
-                                      self.dropout_rng,
-                                      attn_mask_type=attn_mask_type,
-                                      scaling_factor=self.scaling_factor,
-                                      dropout_probability=self.dropout_probability,
-                                      is_training=self.is_training)
-
-        ref_valid, _ = jnp.split(reference_out, (self.valid_len,), axis=1)
-        pri_valid, pri_invalid = jnp.split(primitive_out, (self.valid_len,), axis=1)
-
-        # Dropout can't get the bitmatch result, skip the elementwise comparison
-        if is_training and dropout_probability > 0.:
-            return
-
-        np.testing.assert_allclose(jnp.asarray(pri_valid, np.float32),
-                                   jnp.asarray(ref_valid, np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-2)
-
-        np.testing.assert_allclose(jnp.asarray(pri_invalid, jnp.float32),
-                                   jnp.zeros_like(pri_invalid, jnp.float32))
-
-    def test_forward_backward(self, b, s, h, d, attn_bias_type, attn_mask_type, backend,
-                              dropout_probability, dtype, is_training):
-        """
-        Test forward, backward, and autodiff by jax.value_and_grad
-        """
-        if not is_training:
-            pytest.skip(f"Backward doesn't support {is_training=}")
-
-        self._set_inputs(b,
-                         s,
-                         h,
-                         d,
-                         attn_bias_type=attn_bias_type,
-                         attn_mask_type=attn_mask_type,
-                         backend=backend,
-                         dropout_probability=dropout_probability,
-                         dtype=dtype,
-                         is_training=is_training)
-
-        def grad_func(fused_attn_func, *args, **kwargs):
-            # Gradient is small, use a gradient multiplier to amplify the graident
-            gradient_multiplier = 1000 if dtype == jnp.bfloat16 else 10000
-            if is_causal_mask(attn_mask_type):
-                gradient_multiplier = gradient_multiplier / 10
-            # Keep only valid result for the gradient
-            # fused_attn output has shape (b, s, h, d)
-            valid_fused_attn_ret, _ = jnp.split(fused_attn_func(*args, **kwargs), (self.valid_len,),
-                                                axis=1)
-            return (jnp.mean(valid_fused_attn_ret, dtype=jnp.float32) *
-                    gradient_multiplier).astype(dtype)
-
+        args = [self.q, self.k, self.v, self.bias, self.token_q, self.token_kv, self.dropout_rng]
         kwargs = {
             'attn_bias_type': self.attn_bias_type,
-            'attn_mask_type': attn_mask_type,
+            'attn_mask_type': self.attn_mask_type,
             'scaling_factor': self.scaling_factor,
-            'dropout_probability': self.dropout_probability,
-            'is_training': self.is_training
+            'dropout_probability': self.dropout_prob,
+            'is_training': self.is_training,
+            'qkv_layout': self.qkv_layout,
+        }
+
+        # Convert the outputs to float32 for the elementwise comparison
+        primitive_out = customcall_fused_dpa(*args, **kwargs).astype(jnp.float32)
+        reference_out = jax_dpa(*args, **kwargs).astype(jnp.float32)
+
+        primitive_valid, primitive_invalid = jnp.split(primitive_out, (self.valid_len_q,), axis=1)
+        reference_valid, _ = jnp.split(reference_out, (self.valid_len_q,), axis=1)
+
+        # Skip elementwise comparison when dropout enabled
+        if self.is_training and self.dropout_prob > 0.:
+            return
+
+        np.testing.assert_allclose(primitive_valid, reference_valid, atol=1e-2, rtol=1e-4)
+        np.testing.assert_allclose(primitive_invalid, jnp.zeros_like(primitive_invalid))
+
+    def test_backward(self):
+        if not self.is_training:
+            pytest.skip("Backward doesn't support inference")
+
+        self._setup_inputs()
+
+        def grad_func(func, *args, **kwargs):
+            # Gradient is small, use a gradient multiplier to amplify the graident
+            gradient_multiplier = self.valid_len_q * self.num_heads_q
+            if is_causal_mask(self.attn_mask_type):
+                gradient_multiplier /= 10
+            # Keep only valid result for the gradient
+            ret_valid, _ = jnp.split(func(*args, **kwargs), (self.valid_len_q,), axis=1)
+            return (jnp.mean(ret_valid, dtype=jnp.float32) * gradient_multiplier).astype(self.dtype)
+
+        args = [self.q, self.k, self.v, self.bias, self.token_q, self.token_kv, self.dropout_rng]
+        kwargs = {
+            'attn_bias_type': self.attn_bias_type,
+            'attn_mask_type': self.attn_mask_type,
+            'scaling_factor': self.scaling_factor,
+            'dropout_probability': self.dropout_prob,
+            'is_training': self.is_training,
+            'qkv_layout': self.qkv_layout,
         }
 
         # Use FP16/BF16 to sum the results may cause overflow, use FP32 for the summation
         jitted_primitive = jit(
             value_and_grad(
-                lambda qkv, bias, q_token, kv_token, dropout_rng: grad_func(
-                    customcall_self_fused_attn, qkv, bias, q_token, kv_token, dropout_rng, **kwargs
-                ), (0, 1)))
-
+                lambda q, k, v, bias, *args: grad_func(customcall_fused_dpa, q, k, v, bias, *args,
+                                                       **kwargs), (0, 1, 2, 3)))
         jitted_reference = jit(
             value_and_grad(
-                lambda qkv, bias, q_token, kv_token, dropout_rng: grad_func(
-                    jax_self_attn, qkv, bias, q_token, kv_token, dropout_rng, **kwargs), (0, 1)))
+                lambda q, k, v, bias, *args: grad_func(jax_dpa, q, k, v, bias, *args, **kwargs),
+                (0, 1, 2, 3)))
 
-        primitive_out, (primitive_dqkv,
-                        primitive_dbias) = jitted_primitive(self.qkv, self.bias, self.q_token,
-                                                            self.kv_token, self.dropout_rng)
+        primitive_out, primitive_dgrad = jitted_primitive(*args)
+        reference_out, reference_dgrad = jitted_reference(*args)
 
-        reference_out, (reference_dqkv,
-                        reference_dbias) = jitted_reference(self.qkv, self.bias, self.q_token,
-                                                            self.kv_token, self.dropout_rng)
-
-        # Dropout can't get the bitmatch result, skip the elementwise comparison
-        if dropout_probability > 0.:
+        # Skip elementwise comparison when dropout enabled
+        if self.dropout_prob > 0.:
             return
 
-        np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
-                                   jnp.asarray(reference_out, np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
+        np.testing.assert_allclose(primitive_out.astype(jnp.float32),
+                                   reference_out.astype(jnp.float32),
+                                   atol=1e-5,
+                                   rtol=1e-3)
 
-        valid_primitive_dqkv, invalid_primitive_dqkv = \
-            jnp.split(primitive_dqkv.astype(jnp.float32), (self.valid_len,), axis=1)
-        valid_reference_dqkv, invalid_reference_dqkv = \
-            jnp.split(reference_dqkv.astype(jnp.float32), (self.valid_len,), axis=1)
+        # Convert the outputs to float32 for the elementwise comparison
+        primitive_dq, primitive_dk, primitive_dv, primitive_dbias = map(
+            jnp.float32, primitive_dgrad)
+        reference_dq, reference_dk, reference_dv, reference_dbias = map(
+            jnp.float32, reference_dgrad)
 
-        valid_primitive_dq, valid_primitive_dk, valid_primitive_dv = \
-            jnp.split(valid_primitive_dqkv, 3, axis=2)
-        valid_reference_dq, valid_reference_dk, valid_reference_dv = \
-            jnp.split(valid_reference_dqkv, 3, axis=2)
+        def check_dqkv(primitive, reference, valid_len):
+            primitive_valid, primitive_invalid = jnp.split(primitive, (valid_len,), axis=1)
+            reference_valid, reference_invalid = jnp.split(reference, (valid_len,), axis=1)
 
-        np.testing.assert_allclose(valid_primitive_dq, valid_reference_dq, rtol=1e-4, atol=1e-5)
-        np.testing.assert_allclose(valid_primitive_dk, valid_reference_dk, rtol=1e-4, atol=1e-5)
-        np.testing.assert_allclose(valid_primitive_dv, valid_reference_dv, rtol=1e-4, atol=1e-5)
+            np.testing.assert_allclose(primitive_valid, reference_valid, atol=1e-4, rtol=1e-3)
+            assert jnp.allclose(primitive_invalid, reference_invalid)
+            assert jnp.allclose(primitive_invalid, jnp.zeros_like(primitive_invalid))
 
-        assert jnp.allclose(invalid_primitive_dqkv, invalid_reference_dqkv)
-
-        # Padded part should be 0s
-        assert jnp.allclose(invalid_primitive_dqkv, jnp.zeros_like(invalid_primitive_dqkv))
+        check_dqkv(primitive_dq, reference_dq, self.valid_len_q)
+        check_dqkv(primitive_dk, reference_dk, self.valid_len_kv)
+        check_dqkv(primitive_dv, reference_dv, self.valid_len_kv)
 
         if self.attn_bias_type != AttnBiasType.NO_BIAS:
             # dbias valid part
-            np.testing.assert_allclose(
-                jnp.asarray(primitive_dbias[:, :, :self.valid_len, :self.valid_len], np.float32),
-                jnp.asarray(reference_dbias[:, :, :self.valid_len, :self.valid_len], np.float32),
-                rtol=1e-4,
-                atol=3e-5)
+            np.testing.assert_allclose(primitive_dbias[..., :self.valid_len_q, :self.valid_len_kv],
+                                       reference_dbias[..., :self.valid_len_q, :self.valid_len_kv],
+                                       atol=3e-5,
+                                       rtol=1e-4)
 
             # dbias padded part
-            np.testing.assert_allclose(
-                jnp.asarray(primitive_dbias[:, :, self.valid_len:, self.valid_len:], np.float32),
-                jnp.asarray(reference_dbias[:, :, self.valid_len:, self.valid_len:], np.float32))
+            np.testing.assert_allclose(primitive_dbias[..., self.valid_len_q:, self.valid_len_kv:],
+                                       reference_dbias[..., self.valid_len_q:, self.valid_len_kv:])
 
             assert jnp.allclose(
-                primitive_dbias[:, :, self.valid_len:, self.valid_len:],
-                jnp.zeros_like(primitive_dbias[:, :, self.valid_len:, self.valid_len:]))
+                primitive_dbias[..., self.valid_len_q:, self.valid_len_kv:],
+                jnp.zeros_like(primitive_dbias[..., self.valid_len_q:, self.valid_len_kv:]))
 
 
-@pytest.mark.skipif(get_device_compute_capability(0) not in [80, 90],
-                    reason="Fused attention kernel is not supported.")
-@pytest.mark.parametrize('b, s_q, s_kv, h, d', CROSS_CASES)
-@pytest.mark.parametrize('attn_mask_type', [AttnMaskType.PADDING_MASK])
-@pytest.mark.parametrize('dropout_probability', [0., 0.1])
-@pytest.mark.parametrize('dtype', DTYPES)
-@pytest.mark.parametrize('is_training', [True, False])
-@pytest.mark.parametrize('pad_ratio', [0.3])
-class TestCrossFusedAttn():
-    """Tests for transformer_engine.jax.fused_attn.cross_fused_attn"""
+@pytest.mark.parametrize('attn_bias_type', [
+    pytest.param(AttnBiasType.NO_BIAS, id='NO_BIAS'),
+    pytest.param(AttnBiasType.POST_SCALE_BIAS, id='POST_SCALE_BIAS'),
+])
+@pytest.mark.parametrize('attn_mask_type', [
+    pytest.param(AttnMaskType.NO_MASK, id='NO_MASK'),
+    pytest.param(AttnMaskType.PADDING_MASK, id='PADDING'),
+    pytest.param(AttnMaskType.CAUSAL_MASK, id='CAUSAL'),
+    pytest.param(AttnMaskType.PADDING_CAUSAL_MASK, id='PADDING_CAUSAL'),
+])
+@pytest.mark.parametrize('qkv_layout', [
+    pytest.param(QKVLayout.BS3HD, id='qkvpacked'),
+    pytest.param(QKVLayout.BSHD_BS2HD, id='kvpacked'),
+])
+@pytest.mark.parametrize('dropout_prob', [0., 0.1])
+@pytest.mark.parametrize('is_training',
+                         [pytest.param(True, id='training'),
+                          pytest.param(False, id='inference')])
+@pytest.mark.parametrize(
+    'dtype', [pytest.param(jnp.bfloat16, id="BF16"),
+              pytest.param(jnp.float16, id="FP16")])
+@pytest.mark.parametrize('b, s_q, s_kv, h_q, h_kv, d',
+                         [(32, 128, 128, 16, 16, 64), (4, 2048, 2048, 12, 12, 64),
+                          pytest.param(32, 512, 128, 16, 16, 64, id='32-512-128-16-16-64-cross'),
+                          pytest.param(4, 2048, 2048, 12, 6, 64, id='4-2048-2048-12-6-64-GQA')])
+class TestFusedAttn:
 
-    def _set_inputs(self, b, s_q, s_kv, h, d, *, attn_mask_type, dropout_probability, dtype,
-                    is_training, pad_ratio):
-        key = jax.random.PRNGKey(0)
-        subkeys = jax.random.split(key, 2)
+    def test_forward(self, b, s_q, s_kv, h_q, h_kv, d, attn_bias_type, attn_mask_type, dropout_prob,
+                     dtype, is_training, qkv_layout):
+        runner = FusedAttnRunner(b, s_q, s_kv, h_q, h_kv, d, attn_bias_type, attn_mask_type,
+                                 dropout_prob, dtype, is_training, qkv_layout)
+        runner.test_forward()
 
-        q_shape = (b, s_q, h, d)
-        kv_shape = (b, s_kv, 2, h, d)
-        q_pad_len = int(s_q * pad_ratio)
-        kv_pad_len = int(s_kv * pad_ratio)
-        self.q_valid_len = s_q - q_pad_len
-        self.kv_valid_len = s_kv - kv_pad_len
-
-        min_val, max_val = -1, 1
-        self.q = jax.random.uniform(subkeys[0], q_shape, dtype, min_val, max_val)
-        self.kv = jax.random.uniform(subkeys[1], kv_shape, dtype, min_val, max_val)
-
-        self.q_token = jnp.concatenate((jnp.ones((b, self.q_valid_len)), jnp.zeros((b, q_pad_len))),
-                                       axis=-1)
-        self.kv_token = jnp.concatenate((jnp.ones((b, self.kv_valid_len)), jnp.zeros(
-            (b, kv_pad_len))),
-                                        axis=-1)
-        self.scaling_factor = 1. / sqrt(d)
-        self.dropout_probability = dropout_probability
-        self.dropout_rng = jax.random.PRNGKey(0) if self.dropout_probability > 0 else None
-        self.attn_bias_type = AttnBiasType.NO_BIAS
-        self.attn_mask_type = attn_mask_type
-        self.is_training = is_training
-
-    def test_forward(self, b, s_q, s_kv, h, d, attn_mask_type, dropout_probability, dtype,
-                     is_training, pad_ratio):
-        """
-        Test forward without using JIT
-        """
-        self._set_inputs(b,
-                         s_q,
-                         s_kv,
-                         h,
-                         d,
-                         attn_mask_type=attn_mask_type,
-                         dropout_probability=dropout_probability,
-                         dtype=dtype,
-                         is_training=is_training,
-                         pad_ratio=pad_ratio)
-
-        primitive_out = customcall_cross_fused_attn(self.q,
-                                                    self.kv,
-                                                    self.q_token,
-                                                    self.kv_token,
-                                                    self.dropout_rng,
-                                                    attn_bias_type=self.attn_bias_type,
-                                                    attn_mask_type=attn_mask_type,
-                                                    scaling_factor=self.scaling_factor,
-                                                    dropout_probability=self.dropout_probability,
-                                                    is_training=self.is_training)
-
-        reference_out = jax_cross_attn(self.q,
-                                       self.kv,
-                                       self.q_token,
-                                       self.kv_token,
-                                       self.dropout_rng,
-                                       attn_mask_type=attn_mask_type,
-                                       scaling_factor=self.scaling_factor,
-                                       dropout_probability=self.dropout_probability,
-                                       is_training=self.is_training)
-
-        # Dropout can't get the bitmatch result, skip the elementwise comparison
-        if is_training and dropout_probability > 0.:
-            return
-
-        ref_valid, _ = jnp.split(reference_out, (self.q_valid_len,), axis=1)
-        pri_valid, pri_invalid = jnp.split(primitive_out, (self.q_valid_len,), axis=1)
-
-        np.testing.assert_allclose(jnp.asarray(pri_valid, np.float32),
-                                   jnp.asarray(ref_valid, np.float32),
-                                   rtol=1e-4,
-                                   atol=2e-3)
-
-        np.testing.assert_allclose(jnp.asarray(pri_invalid, jnp.float32),
-                                   jnp.zeros_like(pri_invalid, jnp.float32))
-
-    def test_forward_backward(self, b, s_q, s_kv, h, d, attn_mask_type, dropout_probability, dtype,
-                              is_training, pad_ratio):
-        """
-        Test forward, backward, and autodiff by jax.value_and_grad
-        """
-        if not is_training:
-            pytest.skip(f"Backward doesn't support {is_training=}")
-
-        self._set_inputs(b,
-                         s_q,
-                         s_kv,
-                         h,
-                         d,
-                         attn_mask_type=attn_mask_type,
-                         dropout_probability=dropout_probability,
-                         dtype=dtype,
-                         is_training=is_training,
-                         pad_ratio=pad_ratio)
-
-        def grad_func(fused_attn_func, *args, **kwargs):
-            # Gradient is small, use a gradient multiplier to amplify the graident
-            gradient_multiplier = 1e4
-            # Keep only valid result for the gradient
-            # fused_attn output has shape (b, s_q, h, d)
-            valid_fused_attn_ret, _ = jnp.split(fused_attn_func(*args, **kwargs),
-                                                (self.q_valid_len,),
-                                                axis=1)
-            return (jnp.mean(valid_fused_attn_ret, dtype=jnp.float32) *
-                    gradient_multiplier).astype(dtype)
-
-        kwargs = {
-            'attn_bias_type': self.attn_bias_type,
-            'attn_mask_type': attn_mask_type,
-            'scaling_factor': self.scaling_factor,
-            'dropout_probability': self.dropout_probability,
-            'is_training': self.is_training
-        }
-
-        # Use FP16/BF16 to sum the results may cause overflow, use FP32 for the summation
-        jitted_primitive = jit(
-            value_and_grad(
-                lambda q, kv, q_token, kv_token, dropout_rng: grad_func(
-                    customcall_cross_fused_attn, q, kv, q_token, kv_token, dropout_rng, **kwargs),
-                (0, 1)))
-
-        jitted_reference = jit(
-            value_and_grad(
-                lambda q, kv, q_token, kv_token, dropout_rng: grad_func(
-                    jax_cross_attn, q, kv, q_token, kv_token, dropout_rng, **kwargs), (0, 1)))
-
-        primitive_out, (primitive_dq,
-                        primitive_dkv) = jitted_primitive(self.q, self.kv, self.q_token,
-                                                          self.kv_token, self.dropout_rng)
-
-        reference_out, (reference_dq,
-                        reference_dkv) = jitted_reference(self.q, self.kv, self.q_token,
-                                                          self.kv_token, self.dropout_rng)
-
-        # Dropout can't get the bitmatch result, skip the elementwise comparison
-        if dropout_probability > 0.:
-            return
-
-        np.testing.assert_allclose(jnp.asarray(primitive_out, np.float32),
-                                   jnp.asarray(reference_out, np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
-
-        valid_primitive_dq, invalid_primitive_dq = jnp.split(primitive_dq, (self.q_valid_len,),
-                                                             axis=1)
-        valid_reference_dq, invalid_reference_dq = jnp.split(reference_dq, (self.q_valid_len,),
-                                                             axis=1)
-
-        valid_primitive_dkv, invalid_primitive_dkv = jnp.split(primitive_dkv, (self.kv_valid_len,),
-                                                               axis=1)
-        valid_reference_dkv, invalid_reference_dkv = jnp.split(reference_dkv, (self.kv_valid_len,),
-                                                               axis=1)
-
-        # dQ
-        np.testing.assert_allclose(jnp.asarray(valid_primitive_dq, np.float32),
-                                   jnp.asarray(valid_reference_dq, np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
-
-        # dK
-        np.testing.assert_allclose(jnp.asarray(valid_primitive_dkv[:, :, 0], np.float32),
-                                   jnp.asarray(valid_reference_dkv[:, :, 0], np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
-
-        # dV
-        np.testing.assert_allclose(jnp.asarray(valid_primitive_dkv[:, :, 1], np.float32),
-                                   jnp.asarray(valid_reference_dkv[:, :, 1], np.float32),
-                                   rtol=1e-4,
-                                   atol=1e-5)
-
-        assert jnp.allclose(invalid_primitive_dq, invalid_reference_dq)
-        assert jnp.allclose(invalid_primitive_dkv, invalid_reference_dkv)
-
-        # Padded part should be 0s
-        assert jnp.allclose(invalid_primitive_dq, jnp.zeros_like(invalid_primitive_dq))
-        assert jnp.allclose(invalid_primitive_dkv, jnp.zeros_like(invalid_primitive_dkv))
+    def test_backward(self, b, s_q, s_kv, h_q, h_kv, d, attn_bias_type, attn_mask_type,
+                      dropout_prob, dtype, is_training, qkv_layout):
+        runner = FusedAttnRunner(b, s_q, s_kv, h_q, h_kv, d, attn_bias_type, attn_mask_type,
+                                 dropout_prob, dtype, is_training, qkv_layout)
+        runner.test_backward()

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -85,8 +85,13 @@ _KEY_OF_LAYERNORM_TYPE = 'layernorm_type'
 _KEY_OF_ZERO_CENTERED_GAMMA = 'zero_centered_gamma'
 _KEY_OF_TRANSPOSE_BS = 'transpose_batch_sequence'
 _KEY_OF_SCALE_ATTN_LOGITS = "scale_attn_logits"
+_KEY_OF_NUM_HEADS = 'num_attention_heads'
+_KEY_OF_NUM_GQA_GROUPS = 'num_gqa_groups'
 
-BASE_ATTRS = {_KEY_OF_TRANSPOSE_BS: True}
+BASE_ATTRS = {
+    _KEY_OF_TRANSPOSE_BS: True,
+    _KEY_OF_NUM_HEADS: 8,
+}
 
 ATTRS = [{
     _KEY_OF_LAYERNORM_TYPE: 'rmsnorm',
@@ -129,6 +134,9 @@ ATTRS = [{
     _KEY_OF_DROPOUT_RATE: 0.0,
     _KEY_OF_MLP_ACTIVATIONS: (('gelu', 'linear')),
     _KEY_OF_FUSE_MLP_WI: True
+}, {
+    _KEY_OF_NUM_HEADS: 8,
+    _KEY_OF_NUM_GQA_GROUPS: 4
 }]
 
 ATTRS = [{**BASE_ATTRS, **attr} for attr in ATTRS]
@@ -138,20 +146,12 @@ class TestEncoderLayer:
 
     @staticmethod
     def sync_params(ref, target, attrs):
-        fuse_qkv = attrs.get(_KEY_OF_FUSE_QKV_PARAMS, True)
-
         unfreeze_target = flax.core.unfreeze(target)
-        if fuse_qkv:
-            unfreeze_target['attention']['qkv']['kernel'] = \
-                jnp.reshape(ref['attention']['qkv']['kernel'],
-                unfreeze_target['attention']['qkv']['kernel'].shape)
-        else:
-            unfreeze_target['attention']['query']['kernel'] = \
-                ref['attention']['query']['kernel']
-            unfreeze_target['attention']['key']['kernel'] = \
-                ref['attention']['key']['kernel']
-            unfreeze_target['attention']['value']['kernel'] = \
-                ref['attention']['value']['kernel']
+        unfreeze_attn_scope = unfreeze_target['attention']
+        ref_attn_scope = ref['attention']
+        for key in ref_attn_scope.keys():
+            unfreeze_attn_scope[key]['kernel'] = \
+                ref_attn_scope[key]['kernel'].reshape(unfreeze_attn_scope[key]['kernel'].shape)
         unfreeze_target['mlp']['wi_kernel'] = \
             jnp.reshape(ref['mlp']['wi']['kernel'], unfreeze_target['mlp']['wi_kernel'].shape)
         unfreeze_target['mlp']['wo_kernel'] = \
@@ -266,7 +266,10 @@ class TestEncoderLayer:
         assert_allclose(ref_grads[0][0], test_grads[0][0], rtol=rtol, atol=atol)    # dgrad
 
         def reorganize_test_wgrad(test_wgrad, attrs):
-            fuse_qkv = attrs.get(_KEY_OF_FUSE_QKV_PARAMS, True)
+            num_heads = attrs.get(_KEY_OF_NUM_HEADS)
+            num_gqa_groups = attrs.get(_KEY_OF_NUM_GQA_GROUPS, num_heads)
+            fuse_qkv = attrs.get(_KEY_OF_FUSE_QKV_PARAMS, True) and \
+                       num_heads == num_gqa_groups
 
             attn_name = 'attention'
             unfreeze_test_wgrad = flax.core.unfreeze(test_wgrad)
@@ -280,10 +283,12 @@ class TestEncoderLayer:
                     unfreeze_test_wgrad['pre_attention_layer_norm']['ln_bias'] = \
                         unfreeze_test_wgrad[attn_name][pre_attn_layer_key]['ln_bias']
                     del unfreeze_test_wgrad[attn_name][pre_attn_layer_key]['ln_bias']
-            if fuse_qkv:
-                unfreeze_test_wgrad[attn_name]['qkv']['kernel'] = \
-                    jnp.reshape(unfreeze_test_wgrad[attn_name]['qkv']['kernel'],
-                        (unfreeze_test_wgrad[attn_name]['qkv']['kernel'].shape[0], -1))
+
+            for key in unfreeze_test_wgrad[attn_name].keys():
+                unfreeze_test_wgrad[attn_name][key]['kernel'] = \
+                    jnp.reshape(unfreeze_test_wgrad[attn_name][key]['kernel'],
+                        (unfreeze_test_wgrad[attn_name][key]['kernel'].shape[0], -1))
+
             unfreeze_test_wgrad['pre_mlp_layer_norm'] = {}
             unfreeze_test_wgrad['pre_mlp_layer_norm']['scale'] = \
                 unfreeze_test_wgrad['mlp']['scale']
@@ -349,25 +354,13 @@ class TestDecoderLayer:
 
     @staticmethod
     def sync_params(ref, target, attrs):
-        fuse_qkv = attrs.get(_KEY_OF_FUSE_QKV_PARAMS, True)
-
         unfreeze_target = flax.core.unfreeze(target)
-        if fuse_qkv:
-            unfreeze_target['self_attention']['qkv']['kernel'] = \
-                jnp.reshape(ref['self_attention']['qkv']['kernel'],
-                unfreeze_target['self_attention']['qkv']['kernel'].shape)
-            unfreeze_target['encoder_decoder_attention']['kv']['kernel'] = \
-                jnp.reshape(ref['encoder_decoder_attention']['kv']['kernel'],
-                unfreeze_target['encoder_decoder_attention']['kv']['kernel'].shape)
-        else:
-            unfreeze_target['self_attention']['query']['kernel'] = \
-                ref['self_attention']['query']['kernel']
-            unfreeze_target['self_attention']['key']['kernel'] = \
-                ref['self_attention']['key']['kernel']
-            unfreeze_target['self_attention']['value']['kernel'] = \
-                ref['self_attention']['value']['kernel']
-        unfreeze_target['encoder_decoder_attention']['query']['kernel'] = \
-            ref['encoder_decoder_attention']['query']['kernel']
+        for scope in ['self_attention', 'encoder_decoder_attention']:
+            unfreeze_scope = unfreeze_target[scope]
+            ref_scope = ref[scope]
+            for key in unfreeze_scope.keys():
+                unfreeze_scope[key]['kernel'] = \
+                    ref_scope[key]['kernel'].reshape(unfreeze_scope[key]['kernel'].shape)
         unfreeze_target['mlp']['wi_kernel'] = \
             jnp.reshape(ref['mlp']['wi']['kernel'], unfreeze_target['mlp']['wi_kernel'].shape)
         unfreeze_target['mlp']['wo_kernel'] = \
@@ -483,11 +476,14 @@ class TestDecoderLayer:
         assert_allclose(ref_grads[0][0], test_grads[0][0], rtol=rtol, atol=atol)    # dgrad
 
         def reorganize_test_wgrad(test_wgrad, attrs):
-            fuse_qkv = attrs.get(_KEY_OF_FUSE_QKV_PARAMS, True)
-            attn_name = 'self_attention'
+            num_heads = attrs.get(_KEY_OF_NUM_HEADS)
+            num_gqa_groups = attrs.get(_KEY_OF_NUM_GQA_GROUPS, num_heads)
+            fuse_qkv = attrs.get(_KEY_OF_FUSE_QKV_PARAMS, True) and \
+                       num_heads == num_gqa_groups
 
             unfreeze_test_wgrad = flax.core.unfreeze(test_wgrad)
             if "output_layernorm" not in attrs:
+                attn_name = 'self_attention'
                 unfreeze_test_wgrad['pre_self_attention_layer_norm'] = {}
                 pre_attn_layer_key = 'qkv' if fuse_qkv else 'query'
                 unfreeze_test_wgrad['pre_self_attention_layer_norm']['scale'] = \
@@ -498,14 +494,11 @@ class TestDecoderLayer:
                         unfreeze_test_wgrad[attn_name][pre_attn_layer_key]['ln_bias']
                     del unfreeze_test_wgrad[attn_name][pre_attn_layer_key]['ln_bias']
 
-            if fuse_qkv:
-                unfreeze_test_wgrad[attn_name]['qkv']['kernel'] = \
-                    jnp.reshape(unfreeze_test_wgrad[attn_name]['qkv']['kernel'],
-                        (unfreeze_test_wgrad[attn_name]['qkv']['kernel'].shape[0], -1))
-                attn_name = 'encoder_decoder_attention'
-                unfreeze_test_wgrad[attn_name]['kv']['kernel'] = \
-                    jnp.reshape(unfreeze_test_wgrad[attn_name]['kv']['kernel'],
-                        (unfreeze_test_wgrad[attn_name]['kv']['kernel'].shape[0], -1))
+            for scope in ['self_attention', 'encoder_decoder_attention']:
+                for key in unfreeze_test_wgrad[scope].keys():
+                    unfreeze_test_wgrad[scope][key]['kernel'] = \
+                        jnp.reshape(unfreeze_test_wgrad[scope][key]['kernel'],
+                            (unfreeze_test_wgrad[scope][key]['kernel'].shape[0], -1))
 
             unfreeze_test_wgrad['pre_cross_attention_layer_norm'] = {}
             unfreeze_test_wgrad['pre_cross_attention_layer_norm']['scale'] = \

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -9,12 +9,13 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from transformer_engine.common.recipe import Format
-from transformer_engine.jax.flax import TransformerLayer, TransformerLayerType
-from transformer_engine.jax.fp8 import FP8Helper, is_fp8_available
 from utils import assert_allclose
 from utils import DecoderLayer as RefDecoderLayer
 from utils import EncoderLayer as RefEncoderLayer
+
+from transformer_engine.common.recipe import Format
+from transformer_engine.jax.flax import TransformerLayer, TransformerLayerType
+from transformer_engine.jax.fp8 import FP8Helper, is_fp8_available
 
 is_fp8_supported, reason = is_fp8_available()
 
@@ -145,7 +146,7 @@ ATTRS = [{**BASE_ATTRS, **attr} for attr in ATTRS]
 class TestEncoderLayer:
 
     @staticmethod
-    def sync_params(ref, target, attrs):
+    def sync_params(ref, target):
         unfreeze_target = flax.core.unfreeze(target)
         unfreeze_attn_scope = unfreeze_target['attention']
         ref_attn_scope = ref['attention']
@@ -196,7 +197,7 @@ class TestEncoderLayer:
         test_layer, test_params, test_others = generate_layer(layer_cls, init_rng, inputs,
                                                               test_masks)
 
-        ref_params, test_params = TestEncoderLayer.sync_params(ref_params, test_params, attrs)
+        ref_params, test_params = TestEncoderLayer.sync_params(ref_params, test_params)
 
         ref_out = loss_fn(inputs, ref_masks, ref_params, ref_others, ref_layer, apply_rng)
         test_out = loss_fn(inputs, test_masks, test_params, test_others, test_layer, apply_rng)
@@ -242,7 +243,7 @@ class TestEncoderLayer:
         test_layer, test_params, test_others = generate_layer(layer_cls, init_rng, inputs,
                                                               test_masks)
 
-        ref_params, test_params = TestEncoderLayer.sync_params(ref_params, test_params, attrs)
+        ref_params, test_params = TestEncoderLayer.sync_params(ref_params, test_params)
 
         if FP8Helper.is_fp8_enabled():
             for _ in range(4):
@@ -353,7 +354,7 @@ class TestEncoderLayer:
 class TestDecoderLayer:
 
     @staticmethod
-    def sync_params(ref, target, attrs):
+    def sync_params(ref, target):
         unfreeze_target = flax.core.unfreeze(target)
         for scope in ['self_attention', 'encoder_decoder_attention']:
             unfreeze_scope = unfreeze_target[scope]
@@ -405,7 +406,7 @@ class TestDecoderLayer:
         test_layer, test_params, test_others = generate_layer(layer_cls, init_rng, inputs,
                                                               test_masks)
 
-        ref_params, test_params = TestDecoderLayer.sync_params(ref_params, test_params, attrs)
+        ref_params, test_params = TestDecoderLayer.sync_params(ref_params, test_params)
 
         ref_out = loss_fn(inputs, ref_masks, ref_params, ref_others, ref_layer, apply_rng)
         test_out = loss_fn(inputs, test_masks, test_params, test_others, test_layer, apply_rng)
@@ -452,7 +453,7 @@ class TestDecoderLayer:
         test_layer, test_params, test_others = generate_layer(layer_cls, init_rng, inputs,
                                                               test_masks)
 
-        ref_params, test_params = TestDecoderLayer.sync_params(ref_params, test_params, attrs)
+        ref_params, test_params = TestDecoderLayer.sync_params(ref_params, test_params)
 
         if FP8Helper.is_fp8_enabled():
             for _ in range(4):

--- a/tests/jax/test_praxis_layers.py
+++ b/tests/jax/test_praxis_layers.py
@@ -674,6 +674,8 @@ class MultiHeadAttnAttr:
     LN_TYPE = 'layernorm_type'
     ATTN_MASK_TYPE = 'attn_mask_type'
     ZERO_CEN = 'zero_centered_gamma'
+    NUM_ATTN_HEADS = 'num_attention_heads'
+    NUM_GQA_GROUPS = 'num_gqa_groups'
     ATTRS = [{
         USE_BIAS: True,
         LN_TYPE: 'layernorm',
@@ -703,6 +705,13 @@ class MultiHeadAttnAttr:
         USE_BIAS: True,
         LN_TYPE: 'rmsnorm',
         ZERO_CEN: False,
+        ATTN_MASK_TYPE: 'causal'
+    }, {
+        USE_BIAS: True,
+        LN_TYPE: 'rmsnorm',
+        ZERO_CEN: False,
+        NUM_ATTN_HEADS: 8,
+        NUM_GQA_GROUPS: 4,
         ATTN_MASK_TYPE: 'causal'
     }]
 

--- a/tests/jax/test_praxis_layers.py
+++ b/tests/jax/test_praxis_layers.py
@@ -12,6 +12,8 @@ from praxis import pax_fiddle
 from praxis.base_layer import WeightInit, DEFAULT_INIT_MUTABLE_LIST
 import pytest
 
+from utils import assert_allclose
+
 from transformer_engine.common.recipe import DelayedScaling, Format
 from transformer_engine.jax import fp8_autocast, update_fp8_metas, update_collections
 from transformer_engine.jax.flax import DenseGeneral, LayerNormDenseGeneral
@@ -23,12 +25,12 @@ from transformer_engine.jax.flax import TransformerLayer as flax_TransformerLaye
 from transformer_engine.jax.flax.module import Softmax
 from transformer_engine.jax.fp8 import FP8Helper, is_fp8_available
 from transformer_engine.jax.praxis import LayerNorm
-from transformer_engine.jax.praxis import FusedSoftmax, LayerNorm
+from transformer_engine.jax.praxis import FusedSoftmax
 from transformer_engine.jax.praxis import LayerNormLinear, LayerNormMLP, Linear
 from transformer_engine.jax.praxis import MultiHeadAttention, RelativePositionBiases
-from transformer_engine.jax.praxis import TransformerEngineBaseLayer, TransformerLayer, TransformerLayerType
+from transformer_engine.jax.praxis import TransformerEngineBaseLayer
+from transformer_engine.jax.praxis import TransformerLayer, TransformerLayerType
 from transformer_engine.jax.softmax import SoftmaxType
-from utils import assert_allclose
 
 is_fp8_supported, reason = is_fp8_available()
 
@@ -662,7 +664,7 @@ class TestRelativePositionBias(TestLayer):
             praxis_variables, flax_variables = self.sync_variables(praxis_variables, flax_variables)
 
             praxis_loss= \
-                    TestLayer.loss(praxis_variables, *test_input, module=praxis_layer, mean_out=False)
+                TestLayer.loss(praxis_variables, *test_input, module=praxis_layer, mean_out=False)
             flax_loss = \
                 TestLayer.loss(flax_variables, *test_input, module=flax_layer, mean_out=False)
 

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -158,8 +158,8 @@ def dot_product_attention(query: Array,
     # `attn_weights`: [batch, num_heads, groups, q_length, kv_length]
     h_q, h_kv = query.shape[-2], key.shape[-2]
     assert (h_q % h_kv == 0) and (h_q >= h_kv)
-    num_groups = h_q // h_kv
-    grouped_query = query.reshape((*query.shape[:2], h_kv, num_groups, query.shape[-1]))
+    group_size = h_q // h_kv
+    grouped_query = query.reshape((*query.shape[:2], h_kv, group_size, query.shape[-1]))
 
     if transpose_batch_sequence:
         attn_weights = jnp.einsum('qbhgd,kbhd->bhgqk', grouped_query, key)

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -121,9 +121,9 @@ def dot_product_attention(query: Array,
     query: queries for calculating attention with shape of `[batch, q_length,
       num_heads, qk_depth_per_head]`.
     key: keys for calculating attention with shape of `[batch, kv_length,
-      num_heads, qk_depth_per_head]`.
+      num_gqa_groups, qk_depth_per_head]`.
     value: values to be used in attention with shape of `[batch, kv_length,
-      num_heads, v_depth_per_head]`.
+      num_gqa_groups, v_depth_per_head]`.
     bias: bias for the attention weights. This should be broadcastable to the
       shape `[batch, num_heads, q_length, kv_length]` This can be used for
       incorporating causal masks, padding masks, proximity bias, etc.
@@ -141,21 +141,31 @@ def dot_product_attention(query: Array,
     batch_dim = 1 if transpose_batch_sequence else 0
     assert query.shape[batch_dim] == key.shape[batch_dim] == value.shape[batch_dim], (
         'q, k, v batch dims must match.')
-    assert query.shape[-2] == key.shape[-2] == value.shape[-2], ('q, k, v num_heads must match.')
     sequence_dim = 0 if transpose_batch_sequence else 1
     assert key.shape[sequence_dim] == value.shape[sequence_dim], 'k, v lengths must match.'
-    assert query.shape[-1] == key.shape[-1], 'q, k depths must match.'
+    assert key.shape[-2] == value.shape[-2], 'k, v num_heads must match.'
+    assert query.shape[-1] == key.shape[-1], 'q, k head_dim must match.'
 
     # Casting logits and softmax computation for float32 for model stability.
     if float32_logits:
         query = query.astype(jnp.float32)
         key = key.astype(jnp.float32)
 
-    # `attn_weights`: [batch, num_heads, q_length, kv_length]
+    # `attn_weights`: [batch, num_heads, groups, q_length, kv_length]
+    h_q, h_kv = query.shape[-2], key.shape[-2]
+    assert (h_q % h_kv == 0) and (h_q >= h_kv)
+    num_groups = h_q // h_kv
+    grouped_query = query.reshape((*query.shape[:2], h_kv, num_groups, query.shape[-1]))
+
     if transpose_batch_sequence:
-        attn_weights = jnp.einsum('qbhd,kbhd->bhqk', query, key)
+        attn_weights = jnp.einsum('qbhgd,kbhd->bhgqk', grouped_query, key)
     else:
-        attn_weights = jnp.einsum('bqhd,bkhd->bhqk', query, key)
+        attn_weights = jnp.einsum('bqhgd,bkhd->bhgqk', grouped_query, key)
+
+    # reshape back to normal DPA shape for bias/softmax/dropout
+    b, h, g, q, k = attn_weights_with_groups_shape = attn_weights.shape
+    attn_weights_without_groups_shape = (b, h * g, q, k)
+    attn_weights = attn_weights.reshape(attn_weights_without_groups_shape)
 
     # Apply attention bias: masking, dropout, proximity bias, etc.
     if bias is not None:
@@ -174,11 +184,13 @@ def dot_product_attention(query: Array,
         multiplier = (keep.astype(attn_weights.dtype) / jnp.asarray(keep_prob, dtype=dtype))
         attn_weights = attn_weights * multiplier
 
+    attn_weights = attn_weights.reshape(attn_weights_with_groups_shape)
+
     # Take the linear combination of `value`.
     if transpose_batch_sequence:
-        return jnp.einsum('bhqk,kbhd->qbhd', attn_weights, value)
+        return jnp.einsum('bhgqk,kbhd->qbhgd', attn_weights, value).reshape(query.shape)
 
-    return jnp.einsum('bhqk,bkhd->bqhd', attn_weights, value)
+    return jnp.einsum('bhgqk,bkhd->bqhgd', attn_weights, value).reshape(query.shape)
 
 
 class DenseGeneral(nn.Module):
@@ -235,7 +247,8 @@ class DenseGeneral(nn.Module):
 
         if self.use_bias:
             bias = nn_partitioning.param_with_axes('bias',
-                                                   self.bias_init, (self.features,),
+                                                   self.bias_init,
+                                                   self.features,
                                                    self.dtype,
                                                    axes=self.bias_axes)
         else:
@@ -332,6 +345,7 @@ class MultiHeadAttention(nn.Module):
     Attributes:
       num_heads: number of attention heads. Features (i.e. inputs_q.shape[-1])
         should be divisible by the number of heads.
+      num_gqa_groups: number of kv attention heads
       head_dim: dimension of each head.
       dtype: the dtype of the computation.
       dropout_rate: dropout rate
@@ -340,9 +354,10 @@ class MultiHeadAttention(nn.Module):
         numerical issues with bfloat16.
   """
 
-    num_heads: int
-    head_dim: int
-    transpose_batch_sequence: bool
+    num_heads: int = 8
+    num_gqa_groups: int | None = None
+    head_dim: int = 64
+    transpose_batch_sequence: bool = True
     dtype: DType = jnp.float32
     dropout_rate: float = 0.
     kernel_init: Initializer = None
@@ -354,6 +369,8 @@ class MultiHeadAttention(nn.Module):
     def __post_init__(self):
         if self.kernel_init is None:
             self.kernel_init = nn.initializers.variance_scaling(1.0, 'fan_in', 'normal')
+        if self.num_gqa_groups is None:
+            self.num_gqa_groups = self.num_attention_heads
         super().__post_init__()
 
     @nn.compact
@@ -393,11 +410,17 @@ class MultiHeadAttention(nn.Module):
     Returns:
       output of shape `[batch, length, q_features]`.
     """
-        projection = functools.partial(DenseGeneral,
-                                       axis=-1,
-                                       features=self.num_heads * self.head_dim,
-                                       kernel_axes=('embed', 'joined_kv'),
-                                       dtype=self.dtype)
+        q_projection = functools.partial(DenseGeneral,
+                                         axis=-1,
+                                         features=self.num_heads * self.head_dim,
+                                         kernel_axes=('embed', 'joined_kv'),
+                                         dtype=self.dtype)
+
+        kv_projection = functools.partial(DenseGeneral,
+                                          axis=-1,
+                                          features=self.num_gqa_groups * self.head_dim,
+                                          kernel_axes=('embed', 'joined_kv'),
+                                          dtype=self.dtype)
 
         # NOTE: T5 does not explicitly rescale the attention logits by
         #       1/sqrt(depth_kq)!  This is folded into the initializers of the
@@ -422,8 +445,12 @@ class MultiHeadAttention(nn.Module):
 
             return jnp.concatenate([q_kernel, k_kernel, v_kernel], axis=-1, dtype=dtype)
 
+        is_self_attn = (inputs_q is inputs_kv)
+        is_gqa = (self.num_heads != self.num_gqa_groups)
+        is_qkvpack = (is_self_attn and not is_gqa)
+
         if self.fuse_qkv:
-            if inputs_q is inputs_kv:
+            if is_qkvpack:
                 qkv_proj = DenseGeneral(axis=-1,
                                         features=self.num_heads * self.head_dim * 3,
                                         kernel_axes=('embed', 'joined_kv'),
@@ -436,24 +463,24 @@ class MultiHeadAttention(nn.Module):
                 if self.scale_attn_logits:
                     query = query / depth_scaling
             else:
-                query = projection(kernel_init=query_init, name='query')( \
+                query = q_projection(kernel_init=query_init, name='query')( \
                         (inputs_q / depth_scaling) if self.scale_attn_logits else inputs_q)
                 kv_proj = DenseGeneral(axis=-1,
-                                       features=self.num_heads * self.head_dim * 2,
+                                       features=self.num_gqa_groups * self.head_dim * 2,
                                        kernel_axes=('embed', 'joined_kv'),
                                        kernel_init=self.kernel_init,
                                        name='kv',
                                        dtype=self.dtype)(inputs_kv)
-                key, value = jnp.split(kv_proj, [self.num_heads * self.head_dim], axis=-1)
+                key, value = jnp.split(kv_proj, [self.num_gqa_groups * self.head_dim], axis=-1)
         else:
-            query = projection(kernel_init=query_init, name='query')( \
+            query = q_projection(kernel_init=query_init, name='query')( \
                     (inputs_q / depth_scaling) if self.scale_attn_logits else inputs_q)
-            key = projection(kernel_init=self.kernel_init, name='key')(inputs_kv)
-            value = projection(kernel_init=self.kernel_init, name='value')(inputs_kv)
+            key = kv_projection(kernel_init=self.kernel_init, name='key')(inputs_kv)
+            value = kv_projection(kernel_init=self.kernel_init, name='value')(inputs_kv)
 
-        query = query.reshape((query.shape[0], query.shape[1], self.num_heads, self.head_dim))
-        key = key.reshape((key.shape[0], key.shape[1], self.num_heads, self.head_dim))
-        value = value.reshape((value.shape[0], value.shape[1], self.num_heads, self.head_dim))
+        query = query.reshape((*query.shape[:2], self.num_heads, self.head_dim))
+        key = key.reshape((*key.shape[:2], self.num_gqa_groups, self.head_dim))
+        value = value.reshape((*value.shape[:2], self.num_gqa_groups, self.head_dim))
 
         if self.transpose_batch_sequence:
             query = nn_partitioning.with_sharding_constraint(query,
@@ -755,7 +782,8 @@ class RelativePositionBiases(nn.Module):
 class EncoderLayer(nn.Module):
     """Transformer encoder layer."""
     relative_embedding: nn.Module = None
-    num_heads: int = 8
+    num_attention_heads: int = 8
+    num_gqa_groups: int | None = None
     head_dim: int = 64
     dropout_rate: float = 0.1
     transpose_batch_sequence: bool = True
@@ -773,6 +801,11 @@ class EncoderLayer(nn.Module):
     fuse_qkv_params: bool = True
     fuse_mlp_wi: bool = False
 
+    def __post_init__(self):
+        if self.num_gqa_groups is None:
+            self.num_gqa_groups = self.num_attention_heads
+        super().__post_init__()
+
     @nn.compact
     def __call__(self, inputs, encoder_mask=None, deterministic=False):
         # Relative position embedding as attention biases.
@@ -782,7 +815,7 @@ class EncoderLayer(nn.Module):
         if self.relative_embedding is None:
             rel_emb = RelativePositionBiases(num_buckets=32,
                                              max_distance=128,
-                                             num_heads=self.num_heads,
+                                             num_heads=self.num_attention_heads,
                                              dtype=self.dtype,
                                              embedding_init=nn.initializers.variance_scaling(
                                                  1.0, 'fan_avg', 'uniform'),
@@ -807,7 +840,8 @@ class EncoderLayer(nn.Module):
             x = inputs
 
         # [batch, length, emb_dim] -> [batch, length, emb_dim]
-        x = MultiHeadAttention(num_heads=self.num_heads,
+        x = MultiHeadAttention(num_heads=self.num_attention_heads,
+                               num_gqa_groups=self.num_gqa_groups,
                                dtype=self.dtype,
                                head_dim=self.head_dim,
                                transpose_batch_sequence=self.transpose_batch_sequence,
@@ -868,7 +902,8 @@ class EncoderLayer(nn.Module):
 class DecoderLayer(nn.Module):
     """Transformer decoder layer that attends to the encoder."""
     relative_embedding: nn.Module = None
-    num_heads: int = 8
+    num_attention_heads: int = 8
+    num_gqa_groups: int | None = None
     head_dim: int = 64
     dropout_rate: float = 0.1
     transpose_batch_sequence: bool = True
@@ -885,6 +920,11 @@ class DecoderLayer(nn.Module):
     drop_path: float = 0.0
     fuse_qkv_params: bool = True
     fuse_mlp_wi: bool = False
+
+    def __post_init__(self):
+        if self.num_gqa_groups is None:
+            self.num_gqa_groups = self.num_attention_heads
+        super().__post_init__()
 
     @nn.compact
     def __call__(self,
@@ -903,7 +943,7 @@ class DecoderLayer(nn.Module):
         if self.relative_embedding is None:
             rel_emb = RelativePositionBiases(num_buckets=32,
                                              max_distance=128,
-                                             num_heads=self.num_heads,
+                                             num_heads=self.num_attention_heads,
                                              dtype=self.dtype,
                                              embedding_init=nn.initializers.variance_scaling(
                                                  1.0, 'fan_avg', 'uniform'),
@@ -928,7 +968,8 @@ class DecoderLayer(nn.Module):
             x = inputs
 
         # Self-attention block
-        x = MultiHeadAttention(num_heads=self.num_heads,
+        x = MultiHeadAttention(num_heads=self.num_attention_heads,
+                               num_gqa_groups=self.num_gqa_groups,
                                dtype=self.dtype,
                                head_dim=self.head_dim,
                                transpose_batch_sequence=self.transpose_batch_sequence,
@@ -960,7 +1001,8 @@ class DecoderLayer(nn.Module):
 
         if self.apply_residual_connection_post_layernorm:
             residual = y
-        y = MultiHeadAttention(num_heads=self.num_heads,
+        y = MultiHeadAttention(num_heads=self.num_attention_heads,
+                               num_gqa_groups=self.num_gqa_groups,
                                dtype=self.dtype,
                                head_dim=self.head_dim,
                                transpose_batch_sequence=self.transpose_batch_sequence,

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -573,7 +573,7 @@ void fused_attn_arbitrary_seqlen_fwd_qkvpacked(
     Tensor *workspace, cudaStream_t stream, cudnnHandle_t handle) {
     using namespace transformer_engine;
 
-    const DType QKV_type = input_QKV->data.dtype;
+    const auto QKV_type = input_QKV->data.dtype;
     void *devPtrQKV = input_QKV->data.dptr;
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
     size_t stride = 0;
@@ -677,7 +677,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t num_attn_hea
                                   Tensor *workspace, cudaStream_t stream, cudnnHandle_t handle) {
     using namespace transformer_engine;
 
-    const DType QKV_type = input_QKV->data.dtype;
+    const auto QKV_type = input_QKV->data.dtype;
     void *devPtrQKV = input_QKV->data.dptr;
 
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
@@ -713,7 +713,6 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t num_attn_hea
     void* devPtrDropoutOffset = reinterpret_cast<void *>(
                     reinterpret_cast<uint64_t*>(rng_state->data.dptr) + 1);
 
-    const auto qkv_type = input_QKV->data.dtype;
     size_t workspace_size = 0;
 
     fused_attn_arbitrary_seqlen_bwd_impl(batch, num_attn_heads, num_attn_heads,
@@ -724,7 +723,7 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t num_attn_hea
                                 devPtrdQ, devPtrdK, devPtrdV, devPtrdO, devPtrdBias,
                                 devPtrDropoutSeed, devPtrDropoutOffset,
                                 devPtrCuSeqlens, devPtrCuSeqlens,
-                                get_cudnn_fe_dtype(qkv_type), workspace->data.dptr,
+                                get_cudnn_fe_dtype(QKV_type), workspace->data.dptr,
                                 &workspace_size, stream, handle);
 
     if (workspace_size > 0) {
@@ -751,7 +750,7 @@ void fused_attn_arbitrary_seqlen_fwd_kvpacked(
     const Tensor *rng_state, Tensor *workspace, cudaStream_t stream, cudnnHandle_t handle) {
     using namespace transformer_engine;
 
-    const DType QKV_type = input_Q->data.dtype;
+    const auto QKV_type = input_Q->data.dtype;
     void *devPtrQ = input_Q->data.dptr;
     void *devPtrKV = input_KV->data.dptr;
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
@@ -861,7 +860,6 @@ void fused_attn_arbitrary_seqlen_bwd_kvpacked(
     using namespace transformer_engine;
 
     const auto QKV_type = input_Q->data.dtype;
-
     void *devPtrQ = input_Q->data.dptr;
     void *devPtrKV = input_KV->data.dptr;
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
@@ -936,7 +934,7 @@ void fused_attn_arbitrary_seqlen_fwd(
     Tensor *workspace, cudaStream_t stream, cudnnHandle_t handle) {
     using namespace transformer_engine;
 
-    const DType QKV_type = input_Q->data.dtype;
+    const auto QKV_type = input_Q->data.dtype;
     void *devPtrQ = input_Q->data.dptr;
     void *devPtrK = input_K->data.dptr;
     void *devPtrV = input_V->data.dptr;

--- a/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu
@@ -576,11 +576,11 @@ void fused_attn_arbitrary_seqlen_fwd_qkvpacked(
     const DType QKV_type = input_QKV->data.dtype;
     void *devPtrQKV = input_QKV->data.dptr;
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
-    auto stride = 0;
+    size_t stride = 0;
     if (layout_group == NVTE_QKV_Layout_Group::NVTE_3HD) {
-        stride = 2 * num_attn_heads * head_dim;
+        stride = typeToSize(QKV_type) * num_attn_heads * head_dim;
     } else if (layout_group == NVTE_QKV_Layout_Group::NVTE_H3D) {
-        stride = 2 * head_dim;
+        stride = typeToSize(QKV_type) * head_dim;
     }
     void *devPtrQ = static_cast<void *>(devPtrQKV);
     void *devPtrK = static_cast<void *>(static_cast<int8_t *>(devPtrQKV) + stride);
@@ -677,14 +677,15 @@ void fused_attn_arbitrary_seqlen_bwd_qkvpacked(size_t batch, size_t num_attn_hea
                                   Tensor *workspace, cudaStream_t stream, cudnnHandle_t handle) {
     using namespace transformer_engine;
 
+    const DType QKV_type = input_QKV->data.dtype;
     void *devPtrQKV = input_QKV->data.dptr;
 
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
-    auto stride = 0;
+    size_t stride = 0;
     if (layout_group == NVTE_QKV_Layout_Group::NVTE_3HD) {
-        stride = 2 * num_attn_heads * head_dim;
+        stride = typeToSize(QKV_type) * num_attn_heads * head_dim;
     } else if (layout_group == NVTE_QKV_Layout_Group::NVTE_H3D) {
-        stride = 2 * head_dim;
+        stride = typeToSize(QKV_type) * head_dim;
     }
     void *devPtrQ = devPtrQKV;
     void *devPtrK = static_cast<void *>(static_cast<int8_t *>(devPtrQKV) + stride);
@@ -754,11 +755,11 @@ void fused_attn_arbitrary_seqlen_fwd_kvpacked(
     void *devPtrQ = input_Q->data.dptr;
     void *devPtrKV = input_KV->data.dptr;
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
-    auto stride = 0;
+    size_t stride = 0;
     if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_2HD) {
-        stride = 2 * num_attn_heads * head_dim;
+        stride = typeToSize(QKV_type) * num_gqa_groups * head_dim;
     } else if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_H2D) {
-        stride = 2 * head_dim;
+        stride = typeToSize(QKV_type) * head_dim;
     }
     void *devPtrK = devPtrKV;
     void *devPtrV = static_cast<void *>(static_cast<int8_t *>(devPtrKV) + stride);
@@ -864,11 +865,11 @@ void fused_attn_arbitrary_seqlen_bwd_kvpacked(
     void *devPtrQ = input_Q->data.dptr;
     void *devPtrKV = input_KV->data.dptr;
     NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
-    auto stride = 0;
+    size_t stride = 0;
     if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_2HD) {
-        stride = 2 * num_attn_heads * head_dim;
+        stride = typeToSize(QKV_type) * num_gqa_groups * head_dim;
     } else if (layout_group == NVTE_QKV_Layout_Group::NVTE_HD_H2D) {
-        stride = 2 * head_dim;
+        stride = typeToSize(QKV_type) * head_dim;
     }
     void *devPtrK = devPtrKV;
     void *devPtrV = static_cast<void *>(static_cast<int8_t *>(devPtrKV) + stride);

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -1705,7 +1705,7 @@ def generate_cu_seqlen(mask):
     """
     Generating cumsum seqlen for a batch
     """
-    seqlen = jnp.sum(mask == 0, axis=(-1, -2), dtype=jnp.int32)
+    seqlen = jnp.sum(mask, axis=(-1, -2), dtype=jnp.int32)
     cu_seqlen = jnp.cumsum(seqlen)
     cu_seqlen = jnp.hstack((0, cu_seqlen))
     return cu_seqlen

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -85,9 +85,9 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
     size_t batch, size_t num_head, size_t num_gqa_groups, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t head_dim, float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
     NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    return PackOpaque(CustomCallFusedAttnDescriptor{batch, num_head, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
-                                                    head_dim, scaling_factor, dropout_probability,
-                                                    bias_type, mask_type, dtype, is_training});
+    return PackOpaque(CustomCallFusedAttnDescriptor{
+        batch, num_head, num_gqa_groups, q_max_seqlen, kv_max_seqlen, head_dim, scaling_factor,
+        dropout_probability, bias_type, mask_type, dtype, is_training});
 }
 
 void TransposeImpl(void *input, size_t rows, size_t cols, DType dtype, cudaStream_t stream,
@@ -745,8 +745,8 @@ NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
                                             size_t head_dim) {
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(q_dtype), static_cast<NVTEDType>(kv_dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, q_num_heads, kv_num_heads,
-        q_max_seqlen, kv_max_seqlen, head_dim);
+        mask_type, dropout_probability, q_num_heads, kv_num_heads, q_max_seqlen, kv_max_seqlen,
+        head_dim);
     return backend;
 }
 
@@ -803,10 +803,10 @@ void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaqu
     // aux tensors
     auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
 
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_head, num_gqa_groups,
-        q_max_seqlen, kv_max_seqlen, head_dim);
+    auto backend =
+        nvte_get_fused_attn_backend(static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype),
+                                    qkv_layout, bias_type, mask_type, dropout_probability, num_head,
+                                    num_gqa_groups, q_max_seqlen, kv_max_seqlen, head_dim);
     PopulateRngStateAsync(rng_state, seed, q_max_seqlen, kv_max_seqlen, backend, stream);
 
     NVTETensorPack aux_output_tensors;
@@ -985,10 +985,10 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
 
     auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
 
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_head, num_gqa_groups,
-        q_max_seqlen, kv_max_seqlen, head_dim);
+    auto backend =
+        nvte_get_fused_attn_backend(static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype),
+                                    qkv_layout, bias_type, mask_type, dropout_probability, num_head,
+                                    num_gqa_groups, q_max_seqlen, kv_max_seqlen, head_dim);
     PopulateRngStateAsync(rng_state, seed, q_max_seqlen, kv_max_seqlen, backend, stream);
 
     NVTETensorPack aux_output_tensors;

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -98,6 +98,7 @@ pybind11::bytes PackCustomCallSoftmaxDescriptor(size_t batch, size_t pad_batch, 
 struct CustomCallFusedAttnDescriptor {
     size_t batch;
     size_t num_head;
+    size_t num_gqa_groups;
     size_t q_max_seqlen;
     size_t kv_max_seqlen;
     size_t head_dim;
@@ -110,8 +111,8 @@ struct CustomCallFusedAttnDescriptor {
 };
 
 pybind11::bytes PackCustomCallFusedAttnDescriptor(
-    size_t batch, size_t num_head, size_t q_max_seqlen, size_t kv_max_seqlen, size_t head_dim,
-    float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    size_t batch, size_t num_head, size_t num_gqa_groups, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t head_dim, float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
     NVTE_Mask_Type mask_type, DType dtype, bool is_training);
 
 NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -272,6 +272,14 @@ class MultiHeadAttention(nn.Module):    # pylint: disable=too-few-public-methods
         The hidden dimension of each attention head.
     num_heads : int
         The number of attention heads
+    num_gqa_groups : int, default = `None`
+        Number of GQA groups. When `None` is present, it is equal to num_heads.
+        Grouped Query Attention is described in
+        `this paper <https://arxiv.org/pdf/2305.13245.pdf>`_.
+        This only affects the keys and values, not the querys.
+        GQA-1 is equivalent to Multi-Query Attention
+        (`MQA <https://arxiv.org/pdf/1911.02150.pdf>`_), while GQA-H
+        is equivalent to MHA, i.e. `num_gqa_groups = num_attention_heads`.
     dropout_rate : float, default = 0.0
         Dropout probability for the dropout op during multi-head attention.
     dropout_rng_name: str, default = 'dropout'
@@ -865,6 +873,14 @@ class TransformerLayer(nn.Module):    # pylint: disable=too-few-public-methods
         Intermediate size to which input samples are projected.
     num_attention_heads: int, default = 8
         Number of attention heads in the transformer layer.
+    num_gqa_groups : int, default = `None`
+        Number of GQA groups. When `None` is present, it is equal to num_attention_heads.
+        Grouped Query Attention is described in
+        `this paper <https://arxiv.org/pdf/2305.13245.pdf>`_.
+        This only affects the keys and values, not the querys.
+        GQA-1 is equivalent to Multi-Query Attention
+        (`MQA <https://arxiv.org/pdf/1911.02150.pdf>`_), while GQA-H
+        is equivalent to MHA, i.e. `num_gqa_groups = num_attention_heads`.
     layernorm_type : {'layernorm', 'rmsnorm'}, default = 'layernorm'
         Indicate the type of layer normalization.
     layernorm_epsilon: float, default = 1e-6

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -208,8 +208,8 @@ def core_attention(query: Array,
 
     h_q, h_kv = query.shape[-2], key.shape[-2]
     assert (h_q % h_kv == 0) and (h_q >= h_kv)
-    num_groups = h_q // h_kv
-    grouped_query = query.reshape((*query.shape[:2], h_kv, num_groups, query.shape[-1]))
+    group_size = h_q // h_kv
+    grouped_query = query.reshape((*query.shape[:2], h_kv, group_size, query.shape[-1]))
 
     if transpose_batch_sequence:
         attn_weights = jnp.einsum('qbhgd,kbhd->bhgqk', grouped_query, key)

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -84,10 +84,10 @@ def _self_fused_attn_fwd_rule(qkv: jnp.ndarray, bias: jnp.ndarray, mask: jnp.nda
                               attn_mask_type: AttnMaskType, scaling_factor: float,
                               dropout_probability: float, is_training: bool):
     mask = jnp.logical_not(mask)
-    squeezed_mask = mask[..., 0]
+    actual_seqlen = jnp.sum(mask, axis=-2, dtype=jnp.int32)[..., 0, 0]    # shape = (b,)
     output, softmax_aux, rng_state = self_fused_attn_fwd(qkv,
                                                          bias,
-                                                         squeezed_mask,
+                                                         actual_seqlen,
                                                          seed,
                                                          attn_bias_type=attn_bias_type.value,
                                                          attn_mask_type=attn_mask_type.value,
@@ -97,12 +97,12 @@ def _self_fused_attn_fwd_rule(qkv: jnp.ndarray, bias: jnp.ndarray, mask: jnp.nda
     output = checkpoint_name(output, 'context')
     softmax_aux = checkpoint_name(softmax_aux, 'context')
     rng_state = checkpoint_name(rng_state, 'context')
-    return output, (qkv, bias, softmax_aux, rng_state, output, squeezed_mask)
+    return output, (qkv, bias, softmax_aux, rng_state, output, actual_seqlen)
 
 
 def _self_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
                               is_training, ctx, dz):
-    qkv, bias, softmax_aux, rng_state, output, squeezed_mask = ctx
+    qkv, bias, softmax_aux, rng_state, output, actual_seqlen = ctx
 
     grad_qkv, grad_bias = self_fused_attn_bwd(qkv,
                                               bias,
@@ -110,7 +110,7 @@ def _self_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dr
                                               rng_state,
                                               output,
                                               dz,
-                                              squeezed_mask,
+                                              actual_seqlen,
                                               attn_bias_type=attn_bias_type.value,
                                               attn_mask_type=attn_mask_type.value,
                                               scaling_factor=scaling_factor,
@@ -161,20 +161,18 @@ def _cross_fused_attn_fwd_rule(q, kv, bias, mask, seed, attn_bias_type, attn_mas
                                scaling_factor, dropout_probability, is_training):
 
     mask = jnp.logical_not(mask)
+    q_actual_seqlen = jnp.sum(mask, axis=-2, dtype=jnp.int32)[..., 0, 0]    # shape = (b,)
     if attn_mask_type != AttnMaskType.PADDING_CAUSAL_MASK:
-        kv_squeezed_mask = mask[..., 0, :]
+        kv_actual_seqlen = jnp.sum(mask, axis=-1, dtype=jnp.int32)[..., 0, 0]    # shape = (b,)
     else:
-        # WAR, When mask is padding + causal, the actual seqlen is not the last row
-        # TODO(rewang): re-design the mask/seqlen/cu_seqlen of fused attn for the better perf
-        squeezed_mask = jnp.sum(mask, axis=-1)    # (b, 1, sq)
-        kv_squeezed_mask = jnp.max(squeezed_mask, axis=-1, keepdims=True)    # (b, 1, 1)
-    q_squeezed_mask = mask[..., 0].astype(kv_squeezed_mask.dtype)
+        # When mask is padding + causal, the actual seqlen is not the last row, use max to find it
+        kv_actual_seqlen = jnp.max(jnp.sum(mask, axis=-1, dtype=jnp.int32), axis=(-1, -2))
 
     output, softmax_aux, rng_state = cross_fused_attn_fwd(q,
                                                           kv,
                                                           bias,
-                                                          q_squeezed_mask,
-                                                          kv_squeezed_mask,
+                                                          q_actual_seqlen,
+                                                          kv_actual_seqlen,
                                                           seed,
                                                           attn_bias_type=attn_bias_type.value,
                                                           attn_mask_type=attn_mask_type.value,
@@ -182,12 +180,12 @@ def _cross_fused_attn_fwd_rule(q, kv, bias, mask, seed, attn_bias_type, attn_mas
                                                           dropout_probability=dropout_probability,
                                                           is_training=is_training)
 
-    return output, (q, kv, bias, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask)
+    return output, (q, kv, bias, softmax_aux, rng_state, output, q_actual_seqlen, kv_actual_seqlen)
 
 
 def _cross_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
                                is_training, ctx, dz):
-    q, kv, bias, softmax_aux, rng_state, output, q_squeezed_mask, kv_squeezed_mask = ctx
+    q, kv, bias, softmax_aux, rng_state, output, q_actual_seqlen, kv_actual_seqlen = ctx
 
     grad_q, grad_kv, grad_bias = cross_fused_attn_bwd(q,
                                                       kv,
@@ -196,8 +194,8 @@ def _cross_fused_attn_bwd_rule(attn_bias_type, attn_mask_type, scaling_factor, d
                                                       rng_state,
                                                       output,
                                                       dz,
-                                                      q_squeezed_mask,
-                                                      kv_squeezed_mask,
+                                                      q_actual_seqlen,
+                                                      kv_actual_seqlen,
                                                       attn_bias_type=attn_bias_type.value,
                                                       attn_mask_type=attn_mask_type.value,
                                                       scaling_factor=scaling_factor,

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -40,8 +40,8 @@ class QKVLayout(Enum):
 
 
 def is_fused_attn_kernel_available(q_type, kv_type, qkv_layout, attn_bias_type, attn_mask_type,
-                                   dropout_probability, num_heads_q, num_heads_kv,
-                                   max_seqlen_q, max_seqlen_kv, head_dim):
+                                   dropout_probability, num_heads_q, num_heads_kv, max_seqlen_q,
+                                   max_seqlen_kv, head_dim):
     """
     To check whether the fused attention kernel is available
     """

--- a/transformer_engine/jax/fused_attn.py
+++ b/transformer_engine/jax/fused_attn.py
@@ -162,7 +162,7 @@ def _cross_fused_attn_fwd_rule(q, kv, bias, mask, seed, attn_bias_type, attn_mas
 
     mask = jnp.logical_not(mask)
     q_actual_seqlen = jnp.sum(mask, axis=-2, dtype=jnp.int32)[..., 0, 0]    # shape = (b,)
-    if attn_mask_type != AttnMaskType.PADDING_CAUSAL_MASK:
+    if attn_mask_type not in [AttnMaskType.CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_MASK]:
         kv_actual_seqlen = jnp.sum(mask, axis=-1, dtype=jnp.int32)[..., 0, 0]    # shape = (b,)
     else:
         # When mask is padding + causal, the actual seqlen is not the last row, use max to find it

--- a/transformer_engine/jax/praxis/transformer.py
+++ b/transformer_engine/jax/praxis/transformer.py
@@ -64,6 +64,7 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
 
     head_dim: int = 64
     num_heads: int = 16
+    num_gqa_groups: int | None = None
     dropout_rate: float = 0.
     dropout_rng_name: str = 'dropout'
     layernorm_type: str = "layernorm"
@@ -80,6 +81,11 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
     scaled_query_init: bool = True
     float32_logits: bool = False
 
+    def __post_init__(self):
+        if self.num_gqa_groups is None:
+            self.num_gqa_groups = self.num_heads
+        super().__post_init__()
+
     def setup(self) -> None:
         """setup"""
         super().setup()
@@ -89,6 +95,7 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
             dtype=self.dtype,
             head_dim=self.head_dim,
             num_heads=self.num_heads,
+            num_gqa_groups=self.num_gqa_groups,
             dropout_rate=self.dropout_rate,
             dropout_rng_name=self.dropout_rng_name,
             layernorm_type=self.layernorm_type,
@@ -131,6 +138,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
     hidden_size: int = 512
     mlp_hidden_size: int = 2048
     num_attention_heads: int = 8
+    num_gqa_groups: int | None = None
     layernorm_type: str = 'layernorm'
     layernorm_epsilon: float = 1e-6
     zero_centered_gamma: bool = False
@@ -155,6 +163,11 @@ class TransformerLayer(TransformerEngineBaseLayer):
     transpose_batch_sequence: bool = False
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
+
+    def __post_init__(self):
+        if self.num_gqa_groups is None:
+            self.num_gqa_groups = self.num_attention_heads
+        super().__post_init__()
 
     def setup(self) -> None:
         """setup"""
@@ -186,6 +199,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
             hidden_size=self.hidden_size,
             mlp_hidden_size=self.mlp_hidden_size,
             num_attention_heads=self.num_attention_heads,
+            num_gqa_groups=self.num_gqa_groups,
             layernorm_type=self.layernorm_type,
             layernorm_epsilon=self.layernorm_epsilon,
             zero_centered_gamma=self.zero_centered_gamma,


### PR DESCRIPTION
- Support GQA/MQA (`num_gqa_groups`) for both fused attention and unfused attention implementation.
- Fix the `kv_stride` of the flash attention
- Refactor fused attention test and add GQA tests
- Calculate the seqlen before the primitive for the better perf (avoid to recompute it again in bwd)