### PR TITLE
[PyTorch] Support non-tensor inputs/outputs for te CheckpointFunction

### DIFF
--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -216,7 +216,6 @@ class CheckpointFunction(torch.autograd.Function):
             )
 
         # Store everything.
-
         ctx.inputs = []
         ctx.tensor_indices = []
         tensor_inputs = []
@@ -227,7 +226,6 @@ class CheckpointFunction(torch.autograd.Function):
                 ctx.inputs.append(None)
             else:
                 ctx.inputs.append(arg)
-
         ctx.save_for_backward(*tensor_inputs)
 
         ctx.get_cuda_rng_tracker = get_cuda_rng_tracker
@@ -294,9 +292,9 @@ class CheckpointFunction(torch.autograd.Function):
 
         outputs_with_grad = []
         args_with_grad = []
-        for i, item in enumerate(outputs):
-            if torch.is_tensor(item) and item.requires_grad:
-                outputs_with_grad.append(item)
+        for i, output in enumerate(outputs):
+            if torch.is_tensor(output) and output.requires_grad:
+                outputs_with_grad.append(output)
                 args_with_grad.append(args[i])
         if len(outputs_with_grad) == 0:
             raise RuntimeError(


### PR DESCRIPTION
This PR would support automatically checkpoint a model with non-tensors as its modules' inputs/outputs using PyTorch's apply_activation_checkpointing function together with te's checkpoint function.

Currently, te CheckpointFunction.forward/backward implementation assumes input args and outputs are nn.Tensors. 
This restriction only works when users incorporate te fp8/checkpoint in model definition. 
If users want to automatic convert a pytorch model to use te fp8 with checkpoint, this restriction may fail the checkpoint function. For example, when training with Huggingface's llama model , and checkpointing [LlamaDecoderLayer](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L764), which has inputs containing non-tensors, CheckpointFunction would fail, complaining about non-tensor args.

PyTorch's [CheckpointFunction](https://github.com/pytorch/pytorch/blob/main/torch/utils/checkpoint.py#L223) implementation supports non-tensor inputs/outputs by checking each input/output type and process it accordingly.

This PR adds CheckpointFunction non-tensor inputs/outputs support similar to PyTorch's CheckpointFunction. Thus, users can apply checkpoint to a model without adding checkpoint logic into model definition.

Example for automatic checkpointing huggingface's llama model (some modules such as nn.Linear  are already changed to te.Linear):

 ```
from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import apply_activation_checkpointing, checkpoint_wrapper
from transformer_engine.pytorch.distributed import CudaRNGStatesTracker
from transformer_engine.pytorch.distributed import checkpoint as te_checkpoint

def get_cuda_rng_tracker():
                   return _CUDA_RNG_STATE_TRACKER

def te_checkpoint_func(m, *args, **kargs):
      return te_checkpoint(m, False, get_cuda_rng_tracker, None, *args, **kargs)

def check_fn(module):
            return isinstance(module, LlamaDecoderLayer)

checkpoint_wrapper_fn = partial(checkpoint_wrapper, checkpoint_fn=te_checkpoint_func)
apply_activation_checkpointing = partial(
                        apply_activation_checkpointing, checkpoint_wrapper_fn=checkpoint_wrapper_fn
)

apply_activation_checkpointing(llama_model, check_fn=check_fn)

 ```
