### PR TITLE
Support building using the manylinux docker image.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 from subprocess import CalledProcessError
 import sys
+import sysconfig
 import tempfile
 from typing import List, Optional, Tuple, Union
 
@@ -327,6 +328,8 @@ class CMakeExtension(setuptools.Extension):
             cmake_path,
             "-B",
             build_dir,
+            f"-DPython_EXECUTABLE={sys.executable}",
+            f"-DPython_INCLUDE_DIR={sysconfig.get_path('include')}",
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
         ]

--- a/transformer_engine/CMakeLists.txt
+++ b/transformer_engine/CMakeLists.txt
@@ -22,7 +22,12 @@ endif()
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 find_package(CUDAToolkit REQUIRED cublas nvToolsExt)
 find_package(CUDNN REQUIRED cudnn)
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
+
+if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
+  find_package(Python COMPONENTS Interpreter Development REQUIRED)
+else()
+  find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR})
 

--- a/transformer_engine/CMakeLists.txt
+++ b/transformer_engine/CMakeLists.txt
@@ -22,12 +22,7 @@ endif()
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 find_package(CUDAToolkit REQUIRED cublas nvToolsExt)
 find_package(CUDNN REQUIRED cudnn)
-
-if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
-  find_package(Python COMPONENTS Interpreter Development REQUIRED)
-else()
-  find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
-endif()
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR})
 


### PR DESCRIPTION
Two changes:
- libpython is only required for embedded python, not for python extensions.
- tell cmake explicitly to use the current interpreter (and includes)

See related issues:
- https://gitlab.kitware.com/cmake/cmake/-/issues/20425
- https://github.com/pypa/manylinux/issues/484