### PR TITLE
Add GPT-NeoX "coming soon" to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,7 @@ Transformer Engine has been integrated with popular LLM frameworks such as:
 * `Amazon SageMaker Model Parallel Library <https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel.html>`_ - Coming soon!
 * `Colossal-AI <https://github.com/hpcaitech/ColossalAI>`_ - Coming soon!
 * `PeriFlow <https://github.com/friendliai/periflow-python-sdk>`_ - Coming soon!
+* `GPT-NeoX <https://github.com/EleutherAI/gpt-neox>`_ - Coming soon!
 
 
 Contributing


### PR DESCRIPTION
We at EleutherAI are going to integrate the TransformerEngine into our GPT-NeoX library, and wanted to go ahead and indicate this in the README.

Look forward to completing full support within the next month!


(picked up from https://github.com/NVIDIA/TransformerEngine/pull/573 instead of continuing to wrestle with DCO and commit histories)