### PR TITLE
Fix UB names in MHA

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2737,6 +2737,7 @@ class MultiheadAttention(torch.nn.Module):
                     ub_split_ag=ub_split_ag,
                     normalization=normalization,
                     ub_atomic_gemm_ag=ub_atomic_gemm_ag,
+                    ub_name="qkv",
                     **common_gemm_kwargs,
                 )
             else:
@@ -2768,6 +2769,7 @@ class MultiheadAttention(torch.nn.Module):
                     ub_split_ag=ub_split_ag,
                     normalization=normalization,
                     ub_atomic_gemm_ag=ub_atomic_gemm_ag,
+                    ub_name="qkv",
                     **common_gemm_kwargs,
                 )
             else:
@@ -2816,6 +2818,7 @@ class MultiheadAttention(torch.nn.Module):
             ub_split_ag=ub_split_ag,
             ub_atomic_gemm_rs=ub_atomic_gemm_rs,
             ub_atomic_gemm_ag=ub_atomic_gemm_ag,
+            ub_name="proj",
             **common_gemm_kwargs,
         )
 


### PR DESCRIPTION
PR #499 introduces `ub_name` parameter, which is not optional when using UB, but did not update MHA to actually pass it. This PR fixes that.