### PR TITLE
[PyTorch] forward attention_type in MultiHeadAttention

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -3050,6 +3050,7 @@ class MultiheadAttention(torch.nn.Module):
             sequence_parallel=sequence_parallel,
             tp_group=tp_group,
             layer_number=self.layer_number,
+            attention_type=self.attention_type,
         )
 
         # Linear


### PR DESCRIPTION
In `MultiHeadAttention`, the `attention_type` is not properly forwarded to `DotProductionAttention`.