### PR TITLE
[PyTorch] Workaround for incorrect output from torch.cuda.is_bf16_compatible() on V100s and TU102s

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -41,6 +41,7 @@ from transformer_engine.pytorch.utils import (
     get_device_compute_capability,
     init_method_normal,
     scaled_init_method_normal,
+    is_bf16_compatible,
 )
 import transformer_engine_extensions as tex
 from transformer_engine_extensions import NVTE_Fused_Attn_Backend
@@ -193,10 +194,8 @@ model_configs_base = {
     "base_2_1": ModelConfig(1, 24, 24, 128, 2048, 4096, 0.0, "no_mask", "no_bias"), # cross, 1
 }
 
-# NOTE: torch.cuda.is_bf16_compatible() returns incorrect information for V100s and TU102s.
-#       Directly checking device capability is more reliable for detecting Bf16 support.
 param_types = [torch.float16]
-if torch.cuda.get_device_capability()[0] >= 8:  # bf16 requires sm_80 or higher
+if is_bf16_compatible():  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 param_types_lean = [torch.bfloat16]
 

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -193,8 +193,10 @@ model_configs_base = {
     "base_2_1": ModelConfig(1, 24, 24, 128, 2048, 4096, 0.0, "no_mask", "no_bias"), # cross, 1
 }
 
+# NOTE: torch.cuda.is_bf16_compatible() returns incorrect information for V100s and TU102s.
+#       Directly checking device capability is more reliable for detecting Bf16 support.
 param_types = [torch.float16]
-if torch.cuda.is_bf16_supported():
+if torch.cuda.get_device_capability()[0] >= 8:  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 param_types_lean = [torch.bfloat16]
 

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -52,8 +52,10 @@ model_configs = {
     "126m": ModelConfig(768, 1e-5, 12, 64, 12, 2048),
 }
 
+# NOTE: torch.cuda.is_bf16_compatible() returns incorrect information for V100s and TU102s.
+#       Directly checking device capability is more reliable for detecting Bf16 support.
 param_types = [torch.float32, torch.float16]
-if torch.cuda.is_bf16_supported():
+if torch.cuda.get_device_capability()[0] >= 8:  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 
 batch_sizes = [1, 2]

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -17,6 +17,7 @@ from transformer_engine.pytorch.utils import (
     init_method_normal,
     scaled_init_method_normal,
     attention_mask_func,
+    is_bf16_compatible,
 )
 from transformer_engine.pytorch import (
     DotProductAttention, LayerNormLinear, LayerNormMLP, Linear,
@@ -52,10 +53,8 @@ model_configs = {
     "126m": ModelConfig(768, 1e-5, 12, 64, 12, 2048),
 }
 
-# NOTE: torch.cuda.is_bf16_compatible() returns incorrect information for V100s and TU102s.
-#       Directly checking device capability is more reliable for detecting Bf16 support.
 param_types = [torch.float32, torch.float16]
-if torch.cuda.get_device_capability()[0] >= 8:  # bf16 requires sm_80 or higher
+if is_bf16_compatible():  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 
 batch_sizes = [1, 2]

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -13,6 +13,7 @@ from transformer_engine.pytorch.fp8 import fp8_autocast, FP8GlobalStateManager
 from transformer_engine.pytorch.utils import (
     init_method_normal,
     scaled_init_method_normal,
+    is_bf16_compatible,
 )
 from transformer_engine.pytorch import (
     LayerNormLinear,
@@ -100,10 +101,8 @@ fp8_recipes = [
     ),
 ]
 
-# NOTE: torch.cuda.is_bf16_compatible() returns incorrect information for V100s and TU102s.
-#       Directly checking device capability is more reliable for detecting Bf16 support.
 param_types = [torch.float32, torch.float16]
-if torch.cuda.get_device_capability()[0] >= 8:  # bf16 requires sm_80 or higher
+if is_bf16_compatible():  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 
 all_boolean = [True, False]

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -100,8 +100,10 @@ fp8_recipes = [
     ),
 ]
 
+# NOTE: torch.cuda.is_bf16_compatible() returns incorrect information for V100s and TU102s.
+#       Directly checking device capability is more reliable for detecting Bf16 support.
 param_types = [torch.float32, torch.float16]
-if torch.cuda.is_bf16_supported():
+if torch.cuda.get_device_capability()[0] >= 8:  # bf16 requires sm_80 or higher
     param_types.append(torch.bfloat16)
 
 all_boolean = [True, False]

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -222,3 +222,9 @@ def assert_dim_for_fp8_exec(tensor: torch.Tensor) -> None:
         "Tensor dimensions are not compatible for FP8 execution: "
         f"({tensor.shape[0]} % 8 != 0, {tensor.shape[1]} % 16 != 0)"
     )
+
+def is_bf16_compatible() -> None:
+    """Replaces torch.cuda.is_bf16_compatible() with an explicit
+       check on device compute capability to enforce sm_80 or higher.
+    """
+    return torch.cuda.get_device_capability()[0] >= 8


### PR DESCRIPTION
[A recent PyTorch API change for `torch.cuda.is_bf16_compatible()`](https://github.com/pytorch/pytorch/commit/fc5fda14bcc41008e5610bf39c53eb066933ea4e) makes the check intentionally more permissive to support `torch.bfloat16` Tensors on some older GPUs. This has caused CI failures for us on V100 and TU102 nodes because TorchInductor supports `torch.bfloat16` only for sm_80 or higher.

This PR replaces `torch.cuda.is_bf16_compatible()` checks with explicit checks on `torch.cuda.get_device_capability()[0] >= 8` to comply with TorchInductor limitations.