### PR TITLE
Fixed offloading for PyT version/ Added Attention activation offloading support/ Native FP8 support

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -1752,6 +1752,14 @@ class FlashAttention(torch.nn.Module):
                     deterministic=self.deterministic
                 )
         else:
+
+            from .cpu_offload import CPUOffloadEnabled
+            if CPUOffloadEnabled:
+                tensor_list = [query_layer, key_layer, value_layer, cu_seqlens_q, cu_seqlens_kv]
+                for tensor in tensor_list:
+                    if tensor is not None:
+                        tensor.activation_offloading = True
+
             with self.attention_dropout_ctx():
                 fa_optional_forward_kwargs = {}
                 if _flash_attn_2_3_plus:
@@ -1937,6 +1945,13 @@ class FusedAttnFunc(torch.autograd.Function):
             None, None, None, None, None,
             attn_scale, dropout_p, fast_zero_fill, qkv_layout, attn_bias_type, attn_mask_type,
             rng_gen)
+
+        from .cpu_offload import CPUOffloadEnabled
+        if CPUOffloadEnabled:
+            tensor_list = [v, out, cu_seqlens_q, cu_seqlens_kv] # Can offload Q/K tensors, but CUDNN fused_attn_bwd fails
+            for tensor in tensor_list:
+                if tensor is not None:
+                    tensor.activation_offloading = True
 
         ctx.save_for_backward(q, k, v, out, cu_seqlens_q, cu_seqlens_kv)
         ctx.aux_ctx_tensors = aux_ctx_tensors
@@ -2817,6 +2832,10 @@ class DotProductAttention(torch.nn.Module):
 
         assert (not context_parallel), \
             "Context parallelism is only implemented with Flash Attention and Fused Attention!"
+
+        from .cpu_offload import CPUOffloadEnabled
+        assert (not CPUOffloadEnabled), \
+            "CPU Offloading is only implemented with Flash Attention and Fused Attention!"
 
         if _NVTE_DEBUG:
             print("[DotProductAttention]: using unfused DPA")

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -1946,13 +1946,6 @@ class FusedAttnFunc(torch.autograd.Function):
             attn_scale, dropout_p, fast_zero_fill, qkv_layout, attn_bias_type, attn_mask_type,
             rng_gen)
 
-        from .cpu_offload import CPUOffloadEnabled
-        if CPUOffloadEnabled:
-            tensor_list = [v, out, cu_seqlens_q, cu_seqlens_kv] # Can offload Q/K tensors, but CUDNN fused_attn_bwd fails
-            for tensor in tensor_list:
-                if tensor is not None:
-                    tensor.activation_offloading = True
-
         ctx.save_for_backward(q, k, v, out, cu_seqlens_q, cu_seqlens_kv)
         ctx.aux_ctx_tensors = aux_ctx_tensors
         ctx.max_seqlen_q = max_seqlen_q

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2836,8 +2836,11 @@ class DotProductAttention(torch.nn.Module):
             "Context parallelism is only implemented with Flash Attention and Fused Attention!"
 
         from .cpu_offload import CPUOffloadEnabled
-        assert (not CPUOffloadEnabled), \
-            "CPU Offloading is only implemented with Flash Attention and Fused Attention!"
+        if CPUOffloadEnabled:  
+            warnings.warn(
+                           "Attention activation Offloading is only implemented" 
+                           "with Flash Attention and Fused Attention!"
+                         )
 
         if _NVTE_DEBUG:
             print("[DotProductAttention]: using unfused DPA")

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -1946,6 +1946,15 @@ class FusedAttnFunc(torch.autograd.Function):
             attn_scale, dropout_p, fast_zero_fill, qkv_layout, attn_bias_type, attn_mask_type,
             rng_gen)
 
+        from .cpu_offload import CPUOffloadEnabled
+        if CPUOffloadEnabled:
+            tensor_list = [q, k, v, out, cu_seqlens_q, cu_seqlens_kv]
+            qkv_layout = 'sbhd_sbhd_sbhd'
+            for tensor in tensor_list:
+                if tensor is not None:
+                    tensor.activation_offloading = True
+
+
         ctx.save_for_backward(q, k, v, out, cu_seqlens_q, cu_seqlens_kv)
         ctx.aux_ctx_tensors = aux_ctx_tensors
         ctx.max_seqlen_q = max_seqlen_q

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2836,9 +2836,9 @@ class DotProductAttention(torch.nn.Module):
             "Context parallelism is only implemented with Flash Attention and Fused Attention!"
 
         from .cpu_offload import CPUOffloadEnabled
-        if CPUOffloadEnabled:  
+        if CPUOffloadEnabled:
             warnings.warn(
-                           "Attention activation Offloading is only implemented" 
+                           "Attention activation Offloading is only implemented"
                            "with Flash Attention and Fused Attention!"
                          )
 

--- a/transformer_engine/pytorch/cpu_offload.py
+++ b/transformer_engine/pytorch/cpu_offload.py
@@ -312,8 +312,8 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
     def tensor_push(self, tensor: torch.Tensor, **kwargs) -> Any:
 
-        torch_stray_tensor = isinstance(tensor,torch._subclasses.fake_tensor.FakeTensor,
-                                        torch._subclasses.functional_tensor.FunctionalTensor)
+        torch_stray_tensor = isinstance(tensor,(torch._subclasses.fake_tensor.FakeTensor,
+                                        torch._subclasses.functional_tensor.FunctionalTensor))
 
         if not torch_stray_tensor:
             # obtain a unique tensor tag

--- a/transformer_engine/pytorch/cpu_offload.py
+++ b/transformer_engine/pytorch/cpu_offload.py
@@ -312,8 +312,8 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
     def tensor_push(self, tensor: torch.Tensor, **kwargs) -> Any:
 
-        torch_stray_tensor = (isinstance(tensor,torch._subclasses.fake_tensor.FakeTensor) or
-                            isinstance(tensor,torch._subclasses.functional_tensor.FunctionalTensor))
+        torch_stray_tensor = isinstance(tensor,torch._subclasses.fake_tensor.FakeTensor,
+                                        torch._subclasses.functional_tensor.FunctionalTensor)
 
         if not torch_stray_tensor:
             # obtain a unique tensor tag
@@ -323,7 +323,7 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
             if (self.current_group < self.num_offload_group
                 and self.tensor_need_offloading_checker(tensor)):
-                # first copy the tensor to tensorbuf, 
+                # first copy the tensor to tensorbuf,
                 # so that the original tensor will not be deleted
                 tensor_buf = self.get_tensor_buf_for_offloaded_tensor(tensor, tensor_tag)
                 tensor_buf.copy_(tensor)

--- a/transformer_engine/pytorch/cpu_offload.py
+++ b/transformer_engine/pytorch/cpu_offload.py
@@ -11,6 +11,15 @@ from .float8_tensor import Float8Tensor
 
 __all__ = ['get_cpu_offload_context']
 
+TORCH_MAJOR = int(torch.__version__.split(".")[0])
+TORCH_MINOR = int(torch.__version__.split(".")[1])
+
+# nvFuser is deprecated in PyTorch JIT starting from 2.2
+if (TORCH_MAJOR > 2) or (TORCH_MAJOR == 2 and TORCH_MINOR >= 2):
+    check_torch_stray_tensor = True
+else:
+    check_torch_stray_tensor = False
+
 CPUOffloadEnabled = False
 
 
@@ -184,6 +193,7 @@ class SynchronizedGroupOffloadHandler(OffloadHandler):
         # the tensor back to gpu and deletes the cpu tensor.
         # These will increment whenever `group_commit()` is invoked
         self.current_group, self.tensor_count_current_group = (0, 0)
+        self.torch_tensor_count = 0
         self.tensor_tag_to_state = {}
 
     def on_group_commit_forward(self):
@@ -310,25 +320,33 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
 
     def tensor_push(self, tensor: torch.Tensor, **kwargs) -> Any:
-        # obtain a unique tensor tag
-        tensor_tag = (self.current_group, self.tensor_count_current_group)
-        self.tensor_count_current_group += 1
-        assert tensor_tag not in self.tensor_tag_to_state
+        torch_stray_tensor = (type(tensor) != torch.Tensor) and check_torch_stray_tensor
+        if not torch_stray_tensor:
+            # obtain a unique tensor tag
+            tensor_tag = (self.current_group, self.tensor_count_current_group)
+            self.tensor_count_current_group += 1
+            assert tensor_tag not in self.tensor_tag_to_state
 
-        if (self.current_group < self.num_offload_group
-            and self.tensor_need_offloading_checker(tensor)):
-            # first copy the tensor to tensorbuf, so that the original tensor will not be deleted
-            tensor_buf = self.get_tensor_buf_for_offloaded_tensor(tensor, tensor_tag)
-            tensor_buf.copy_(tensor)
-            if hasattr(tensor,"weight_offloading"):
-                tensor_buf.weight_offloading = True
-            if hasattr(tensor,"activation_offloading"):
-                tensor_buf.activation_offloading = True
-           # Here we just save it, and at commit, bulk_offload_group will handle it
-            self.tensor_tag_to_state[tensor_tag] = tensor_buf
+            if (self.current_group < self.num_offload_group
+                and self.tensor_need_offloading_checker(tensor)):
+                # first copy the tensor to tensorbuf, so that the original tensor will not be deleted
+                tensor_buf = self.get_tensor_buf_for_offloaded_tensor(tensor, tensor_tag)
+                tensor_buf.copy_(tensor)
+                if hasattr(tensor,"weight_offloading"):
+                    tensor_buf.weight_offloading = True
+                if hasattr(tensor,"activation_offloading"):
+                    tensor_buf.activation_offloading = True
+                # Here we just save it, and at commit, bulk_offload_group will handle it
+                self.tensor_tag_to_state[tensor_tag] = tensor_buf
+            else:
+                self.tensor_tag_to_state[tensor_tag] = tensor
+            return tensor_tag
         else:
+            tensor_tag = (-1,self.torch_tensor_count)
+            self.torch_tensor_count += 1
             self.tensor_tag_to_state[tensor_tag] = tensor
-        return tensor_tag
+
+            return tensor_tag
 
     def tensor_pop(self, tensor_tag, **kwargs):
         """Tensor pop."""
@@ -350,6 +368,10 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
                     # if offload, return the reference to cpu copy
                     if self.tensor_need_offloading_checker(tensor_on_device):
+                        if hasattr(tensor_on_device,"weight_offloading"):
+                            delattr(tensor_on_device,"weight_offloading")
+                        if hasattr(tensor_on_device,"activation_offloading"):
+                            delattr(tensor_on_device,"activation_offloading")
                         state = SynchronizedGroupOffloadHandler.offload(tensor_on_device)
                         self.tensor_tag_to_state[tensor_tag] = state
 

--- a/transformer_engine/pytorch/cpu_offload.py
+++ b/transformer_engine/pytorch/cpu_offload.py
@@ -11,15 +11,6 @@ from .float8_tensor import Float8Tensor
 
 __all__ = ['get_cpu_offload_context']
 
-TORCH_MAJOR = int(torch.__version__.split(".")[0])
-TORCH_MINOR = int(torch.__version__.split(".")[1])
-
-# nvFuser is deprecated in PyTorch JIT starting from 2.2
-if (TORCH_MAJOR > 2) or (TORCH_MAJOR == 2 and TORCH_MINOR >= 2):
-    check_torch_stray_tensor = True
-else:
-    check_torch_stray_tensor = False
-
 CPUOffloadEnabled = False
 
 
@@ -320,7 +311,7 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
 
     def tensor_push(self, tensor: torch.Tensor, **kwargs) -> Any:
-        torch_stray_tensor = (type(tensor) != torch.Tensor) and check_torch_stray_tensor
+        torch_stray_tensor = (type(tensor) == torch._subclasses.fake_tensor.FakeTensor or type(tensor) == torch._subclasses.functional_tensor.FunctionalTensor)
         if not torch_stray_tensor:
             # obtain a unique tensor tag
             tensor_tag = (self.current_group, self.tensor_count_current_group)

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -242,7 +242,7 @@ class _LayerNormLinear(torch.autograd.Function):
             if cpu_offloading:
                 if fuse_wgrad_accumulation:
                     weight.main_grad.weight_offloading = True
-                if fp8:
+                if fp8 and weight_t_fp8 is not None:
                     weight_t_fp8.weight_offloading = True
                 ln_weight.weight_offloading = True
                 weight.weight_offloading = True

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -424,8 +424,9 @@ class _LayerNormMLP(torch.autograd.Function):
                 if fuse_wgrad_accumulation:
                     fc1_weight.main_grad.weight_offloading = True
                     fc2_weight.main_grad.weight_offloading = True
-                if fp8:
+                if fp8 and fc1_weight_t_fp8 is not None:
                     fc1_weight_t_fp8.weight_offloading = True
+                if fp8 and fc2_weight_t_fp8 is not None:
                     fc2_weight_t_fp8.weight_offloading = True
                 ln_weight.weight_offloading = True
                 fc1_weight.weight_offloading = True

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -275,7 +275,7 @@ class _Linear(torch.autograd.Function):
                 if cpu_offloading:
                     if fuse_wgrad_accumulation:
                         weight.main_grad.weight_offloading = True
-                    if fp8:
+                    if fp8 and weight_t_fp8 is not None:
                         weight_t_fp8.weight_offloading = True
                     weight.weight_offloading = True
 


### PR DESCRIPTION
PR does the following:

1) Offloading was breaking for the latest PyTorch versions because torch.compile tried to save some stray tensors which shouldn't be considered for offloading. Added that filter and fixed the issue.

2) Flash Attention and Fused attention can have it's input activations offloaded which wasn't supported before. Added support for that.

3) Native FP8 doesn't use transposed FP8 weights in a cache. Added None guards so that this doesn't break.