### PR TITLE
[Paddle] Replace paddle.fluid imports with paddle.base

### DIFF
--- a/qa/L0_paddle_lint/test.sh
+++ b/qa/L0_paddle_lint/test.sh
@@ -22,5 +22,5 @@ then
   cp $TE_PATH/qa/L0_paddle_lint/pylintrc $TE_PATH
   cd $TE_PATH
   echo "Checking Python files"
-  pylint --recursive=y transformer_engine/common transformer_engine/paddle
+  python -m pylint --recursive=y transformer_engine/common transformer_engine/paddle
 fi

--- a/tests/paddle/dist_launcher.py
+++ b/tests/paddle/dist_launcher.py
@@ -10,7 +10,10 @@ import subprocess
 import time
 import unittest
 
-from paddle import fluid
+try:
+    from paddle.base import core
+except ImportError:
+    from paddle.fluid import core
 from paddle.distributed.utils.launch_utils import (
     TrainerProc,
     find_free_ports,
@@ -114,7 +117,7 @@ class TestDistributed(unittest.TestCase):
         allocator_strategy="auto_growth",
     ):
         """Run target file in subprocesses"""
-        if (not fluid.core.is_compiled_with_cuda() or fluid.core.get_cuda_device_count() == 0):
+        if (not core.is_compiled_with_cuda() or core.get_cuda_device_count() == 0):
             return
 
         selected_gpus = get_gpus('0,1')

--- a/transformer_engine/paddle/layer/base.py
+++ b/transformer_engine/paddle/layer/base.py
@@ -12,8 +12,12 @@ from typing import Generator, Dict, Tuple, Union, Any, List, Optional
 import numpy as np
 
 import paddle
-from paddle.fluid import core
-from paddle.fluid.framework import _dygraph_tracer
+try:
+    from paddle.base import core
+    from paddle.base.framework import _dygraph_tracer
+except ImportError:
+    from paddle.fluid import core
+    from paddle.fluid.framework import _dygraph_tracer
 
 from ..constants import FP8BwdTensors, dist_group_type
 from ..cpp_extensions import cast_transpose, cast_transpose_bgrad, cast_to_fp8, transpose

--- a/transformer_engine/paddle/profile.py
+++ b/transformer_engine/paddle/profile.py
@@ -5,7 +5,10 @@
 
 from contextlib import contextmanager
 
-from paddle.fluid import core
+try:
+    from paddle.base import core
+except ImportError:
+    from paddle.fluid import core
 
 
 @contextmanager


### PR DESCRIPTION
Paddle 2.6.0 renamed `paddle.fluid` to `paddle.base` (see https://github.com/PaddlePaddle/Paddle/pull/56576).