### PR TITLE
[PyTorch] Fix MultiheadAttention docstring

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2909,8 +2909,8 @@ class MultiheadAttention(torch.nn.Module):
                              together with the output of the linear transformation.
                              Example use case: residual connection for transformer module is
                              taken post layernorm.
-    input_layernorm: bool, default = `True`
-                     if set to `False`, layer normalization to the input is not applied.
+    input_layernorm: bool, default = `False`
+                     if set to `True`, layer normalization to the input is applied.
     attention_type: { 'self', 'cross' }, default = 'self'
                    type of attention applied.
     zero_centered_gamma : bool, default = 'False'


### PR DESCRIPTION
Fixes the docstring for the `MultiheadAttention.__init__`. It currently states that the default value for `input_layernorm` is `True`, but it should be `False`.