### PR TITLE
[JAX] Fix unfused GQA performance

### DIFF
--- a/qa/L0_jax_distributed_unittest/test.sh
+++ b/qa/L0_jax_distributed_unittest/test.sh
@@ -4,9 +4,6 @@
 
 set -xe
 
-# WAR(rewang) for the "Check failed: reduction_kind.has_value()"
-export XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_xla_runtime_executable=true"
-
 : ${TE_PATH:=/opt/transformerengine}
 pytest -Wignore -v $TE_PATH/tests/jax/test_distributed_*
 

--- a/qa/L0_jax_unittest/test.sh
+++ b/qa/L0_jax_unittest/test.sh
@@ -14,7 +14,5 @@ pytest -Wignore -v $TE_PATH/examples/jax/mnist
 
 # Make encoder tests to have run-to-run deterministic to have the stable CI results
 export XLA_FLAGS="${XLA_FLAGS} --xla_gpu_deterministic_ops"
-# WAR(rewang) for the "Check failed: reduction_kind.has_value()"
-export XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_xla_runtime_executable=true"
 pytest -Wignore -v $TE_PATH/examples/jax/encoder --ignore=$TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py
 pytest -Wignore -v $TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py


### PR DESCRIPTION
In the previous GQA PR (https://github.com/NVIDIA/TransformerEngine/pull/578), we added the GQA support for the native JAX attention implementation. However, the new impl results the performance regression. This PR seperates the GQA and MQA to two different implementations so that both of them can keep the best performance.