### PR TITLE
[PyTorch] Add Float8Tensor option to avoid updating transpose cache when possible

### DIFF
--- a/tests/pytorch/test_float8tensor.py
+++ b/tests/pytorch/test_float8tensor.py
@@ -310,7 +310,7 @@ class TestFloat8Tensor:
                 **tols,
             )
             x_fp8_data = x_fp8._data.clone()
-            x_fp8._data.zero()
+            x_fp8._data.zero_()
             torch.testing.assert_close(
                 x_fp8.transpose(*transpose_dims),
                 x_ref.transpose(*transpose_dims),
@@ -322,9 +322,6 @@ class TestFloat8Tensor:
                 x_ref.transpose(*transpose_dims),
                 **tols,
             )
-
-            # Check that non-lazy transpose caching recalculates
-            # transpose
             x_fp8._lazy_transpose_cache = False
             torch.testing.assert_close(
                 x_fp8.transpose(*transpose_dims, update_cache=True),
@@ -333,6 +330,7 @@ class TestFloat8Tensor:
                 atol=0,
             )
             x_fp8._data.copy_(x_fp8_data)
+            x_fp8._reset_caches()
 
             # Make sure cache is reset after in-place operation
             x_fp8.transpose(*transpose_dims, update_cache=True)

--- a/tests/pytorch/test_float8tensor.py
+++ b/tests/pytorch/test_float8tensor.py
@@ -305,7 +305,7 @@ class TestFloat8Tensor:
             x_fp8 += 0.5
             x_ref = x_fp8.from_float8()
             torch.testing.assert_close(
-                x_fp8.transpose(*transpose_dims, update_cache=True),
+                x_fp8.transpose(*transpose_dims, update_cache="lazy"),
                 x_ref.transpose(*transpose_dims),
                 **tols,
             )
@@ -316,15 +316,13 @@ class TestFloat8Tensor:
                 x_ref.transpose(*transpose_dims),
                 **tols,
             )
-            x_fp8._lazy_transpose_cache = True
             torch.testing.assert_close(
-                x_fp8.transpose(*transpose_dims, update_cache=True),
+                x_fp8.transpose(*transpose_dims, update_cache="lazy"),
                 x_ref.transpose(*transpose_dims),
                 **tols,
             )
-            x_fp8._lazy_transpose_cache = False
             torch.testing.assert_close(
-                x_fp8.transpose(*transpose_dims, update_cache=True),
+                x_fp8.transpose(*transpose_dims, update_cache="force"),
                 torch.zeros_like(x_ref.transpose(*transpose_dims)),
                 rtol=0,
                 atol=0,
@@ -333,7 +331,7 @@ class TestFloat8Tensor:
             x_fp8._reset_caches()
 
             # Make sure cache is reset after in-place operation
-            x_fp8.transpose(*transpose_dims, update_cache=True)
+            x_fp8.transpose(*transpose_dims, update_cache="force")
             x_fp8 += 0.5
             x_ref = x_fp8.from_float8()
             torch.testing.assert_close(

--- a/transformer_engine/pytorch/float8_tensor.py
+++ b/transformer_engine/pytorch/float8_tensor.py
@@ -442,7 +442,7 @@ class Float8Tensor(torch.Tensor):
         dim0: int = 0,
         dim1: int = 1,
         *,
-        update_cache: bool = False,
+        update_cache: str | bool = "reuse_only",
     ) -> torch.Tensor:
         """
         Swap tensor dimensions
@@ -456,18 +456,28 @@ class Float8Tensor(torch.Tensor):
               The first dimension to be transposed
         dim1: int, default = 1
               The second dimension to be transposed
-        update_cache: bool, default = False
-                      If `True`, the transpose is computed and stored
-                      in a cache. If `False`, a cached version is
-                      returned if available and otherwise the
-                      transpose is computed. Caching is only supported
+        update_cache: str or bool, default = "reuse_only"
+                      Memoization behavior. Options are
+                      "reuse_only"/`False` (reuse cached value if
+                      available, otherwise calculate transpose without
+                      caching), "force"/`True` (calculate transpose
+                      and cache), "lazy" (reuse cached value if
+                      available, otherwise calculate transpose and
+                      cache if possible). Caching is only supported
                       for basic 2D transposes and the cache is reset
-                      after any in-place operations. Setting
-                      `_lazy_transpose_cache=True` as an attribute
-                      changes the behavior so that the cache is not
-                      updated if it is already available.
+                      after any in-place operations.
 
         """
+
+        # Check caching mode
+        if not isinstance(update_cache, str):
+            update_cache = "force" if update_cache else "reuse_only"
+        if update_cache not in ("force", "reuse_only", "lazy"):
+            raise ValueError(
+                "Supported values for update_cache are "
+                '"force" (True), "reuse_only" (False), "lazy" '
+                f"(got {update_cache})"
+            )
 
         # Handle non-2D transposes
         if -self.dim() <= dim0 < 0:
@@ -475,7 +485,7 @@ class Float8Tensor(torch.Tensor):
         if -self.dim() <= dim1 < 0:
             dim1 += self.dim()
         if self.dim() != 2 or dim0 == dim1:
-            if update_cache:
+            if update_cache == "force":
                 raise ValueError(
                     "Transpose caching is only supported for basic 2D transposes "
                     f"(ndims={self.dim()}, dim0={dim0}, dim1={dim1})"
@@ -483,7 +493,7 @@ class Float8Tensor(torch.Tensor):
             return super().transpose(dim0, dim1)
 
         # Clear cache if needed
-        if update_cache and not self._lazy_transpose_cache:
+        if update_cache == "force":
             self._transpose = None
 
         # Compute transpose if needed
@@ -498,7 +508,7 @@ class Float8Tensor(torch.Tensor):
             )
 
         # Update cache if needed
-        if update_cache:
+        if update_cache in ("force", "lazy"):
             self._transpose = out
         return out
 

--- a/transformer_engine/pytorch/float8_tensor.py
+++ b/transformer_engine/pytorch/float8_tensor.py
@@ -309,8 +309,6 @@ class Float8Tensor(torch.Tensor):
 
         # Cached transpose
         self._transpose: Optional[Float8Tensor] = None
-        # Avoid recalculating cached transpose if possible
-        self._lazy_transpose_cache: bool = False
 
         # FP8 scale-inverse
         self._scale_inv: Optional[torch.Tensor] = fp8_scale_inv

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -331,7 +331,9 @@ class _LayerNormLinear(torch.autograd.Function):
 
             # Primary weights are in FP8.
             if ctx.fp8 and weight_t_fp8 is None:
-                weight_t_fp8 = weight.transpose(update_cache=ctx.is_first_microbatch)
+                weight_t_fp8 = weight.transpose(
+                    update_cache="reuse_only" if ctx.is_first_microbatch is None else "lazy",
+                )
 
             if ctx.ub_bulk_dgrad:
                 tp_world_size = get_distributed_world_size(ctx.tp_group)

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -539,10 +539,11 @@ class _LayerNormMLP(torch.autograd.Function):
                 fc2_weight.main_grad = fc2_weight_main_grad
 
             # Primary weights are in FP8.
+            update_transpose_cache = "reuse_only" if ctx.is_first_microbatch is None else "lazy"
             if ctx.fp8 and fc1_weight_t_fp8 is None:
-                fc1_weight_t_fp8 = fc1_weight.transpose(update_cache=ctx.is_first_microbatch)
+                fc1_weight_t_fp8 = fc1_weight.transpose(update_cache=update_transpose_cache)
             if ctx.fp8 and fc2_weight_t_fp8 is None:
-                fc2_weight_t_fp8 = fc2_weight.transpose(update_cache=ctx.is_first_microbatch)
+                fc2_weight_t_fp8 = fc2_weight.transpose(update_cache=update_transpose_cache)
 
             activation_func = _act_func(ctx.activation)[1]
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -347,7 +347,9 @@ class _Linear(torch.autograd.Function):
 
             # Primary weights are in FP8.
             if ctx.fp8 and weight_t_fp8 is None:
-                weight_t_fp8 = weight.transpose(update_cache=ctx.is_first_microbatch)
+                weight_t_fp8 = weight.transpose(
+                    update_cache="reuse_only" if ctx.is_first_microbatch is None else "lazy",
+                )
 
             if ctx.ub_split_ag or ctx.ub_atomic_gemm_ag:
                 tp_world_size = get_distributed_world_size(ctx.tp_group)


### PR DESCRIPTION
The NeMo distributed optimizer manually fills the `Float8Tensor` transpose cache at some arbitrary point in the first microbatch:
https://github.com/NVIDIA/NeMo/blob/b100cd1f7c00ba266134b60c98ee7fb8821be5df/nemo/core/optim/distributed_adam.py#L442
This doesn't have much benefit for now, but it does open the door for some future optimizations (improving load balancing with pipeline parallelism, allowing for multi-tensor kernels). However, passing `is_first_microbatch=True` in the backward pass will cause the `Float8Tensor` to recompute the transpose:
https://github.com/NVIDIA/TransformerEngine/blob/a95006170cf36712dcfb4cb27e32431e73125a2c/transformer_engine/pytorch/module/linear.py#L350
~The solution is a `_lazy_transpose_cache` attribute in `Float8Tensor`. If `True`, then calling `transpose` with `update_cache=True` will just return the cached value if it already exists.~ The updated solution is to add more options to the `update_cache` kwarg: `"force"`/`True` (calculate transpose and cache), `"reuse_only"`/`False` (reuse cache if available, otherwise calculate transpose without caching), `"lazy"` (reuse cache if available, otherwise calculate transpose and cache).

There's an argument that `"lazy"` should be the default behavior with `update_cache=True`, but I'm uneasy since an arg name like `update_cache` implies that we update the cache.