### PR TITLE
[JAX] Support arbitrary bias shape in fused attention custom ops

### DIFF
--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -1874,22 +1874,22 @@ class SelfFusedAttnFwdPrimitive(BasePrimitive):
         # outer_primitve is squeezed_mask, inner_primitive is cu_seqlen
         del seqlen_or_cu_seqlen_aval
         qkv_dtype = dtypes.canonicalize_dtype(qkv_aval.dtype)
-        *batch_shape, max_seqlen, nqkv, num_heads, head_dim = qkv_aval.shape
+        *input_batch_shape, max_seqlen, nqkv, attn_heads, head_dim = qkv_aval.shape
         assert nqkv == 3
         assert qkv_aval.dtype == bias_aval.dtype
 
-        output_shape = (*batch_shape, max_seqlen, num_heads, head_dim)
+        output_shape = (*input_batch_shape, max_seqlen, attn_heads, head_dim)
         out_aval = qkv_aval.update(shape=output_shape, dtype=qkv_dtype)
 
         # backend determines the softmax buffer shape/dtype
         backend = FusedAttnHelper(qkv_dtype, qkv_dtype, NVTE_QKV_Layout.NVTE_BS3HD, attn_bias_type,
-                                  attn_mask_type, dropout_probability, num_heads, num_heads,
+                                  attn_mask_type, dropout_probability, attn_heads, attn_heads,
                                   max_seqlen, max_seqlen, head_dim).get_fused_attn_backend()
         if backend == NVTE_Fused_Attn_Backend.NVTE_F16_max512_seqlen:
-            softmax_shape = (*batch_shape, num_heads, max_seqlen, max_seqlen)
+            softmax_shape = (*input_batch_shape, attn_heads, max_seqlen, max_seqlen)
             softmax_dtype = qkv_dtype
         elif backend == NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
-            softmax_shape = (*batch_shape, num_heads, max_seqlen, 1)
+            softmax_shape = (*input_batch_shape, attn_heads, max_seqlen, 1)
             softmax_dtype = dtypes.canonicalize_dtype(jnp.float32)
         else:
             raise ValueError(f'Unsupported {backend=}')
@@ -1903,12 +1903,21 @@ class SelfFusedAttnFwdPrimitive(BasePrimitive):
         rng_state_shape = (seed_aval.shape[0], checker.rng_state_size)
         rng_state_aval = seed_aval.update(shape=rng_state_shape, dtype=checker.rng_state_dtype)
 
+        # get bias shape if bias is enabled
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
+
         # do a dummy kernel call here to get workspace buffer shapes/dtypes that XLA needs to
         # prepare for the active fused-attn backend
-        batch_size = reduce(operator.mul, batch_shape)
+        input_batch = reduce(operator.mul, input_batch_shape)
         wkspace_info = transformer_engine_jax.get_self_fused_attn_fwd_workspace_sizes(
-            batch_size, max_seqlen, num_heads, head_dim, scaling_factor, dropout_probability,
-            attn_bias_type, attn_mask_type, jax_dtype_to_te_dtype(qkv_aval.dtype), is_training)
+            input_batch, bias_batch, max_seqlen, attn_heads, bias_heads, head_dim,
+            scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
+            jax_dtype_to_te_dtype(qkv_aval.dtype), is_training)
         wkspace_aval = qkv_aval.update(shape=wkspace_info[0],
                                        dtype=te_dtype_to_jax_dtype(wkspace_info[1]))
 
@@ -1937,14 +1946,22 @@ class SelfFusedAttnFwdPrimitive(BasePrimitive):
         ]
         args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
 
-        qkv_aval = ctx.avals_in[0]
-        *batch_shape, max_seqlen, _, num_heads, head_dim = qkv_aval.shape
-        batch_size = reduce(operator.mul, batch_shape)
+        qkv_aval, bias_aval, *_ = ctx.avals_in
+        *input_batch_shape, max_seqlen, _, attn_heads, head_dim = qkv_aval.shape
+        input_batch = reduce(operator.mul, input_batch_shape)
+
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
 
         wkspace_aval = ctx.avals_out[-1]
 
         opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            batch_size, max_seqlen, max_seqlen, num_heads, num_heads, head_dim, wkspace_aval.size,
+            input_batch, bias_batch, max_seqlen, max_seqlen,
+            attn_heads, attn_heads, bias_heads, head_dim, wkspace_aval.size,
             scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(qkv_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
             is_training)
@@ -2068,15 +2085,22 @@ class SelfFusedAttnBwdPrimitive(BasePrimitive):
         del softmax_aux_aval, rng_state_aval, seqlen_or_cu_seqlen_aval
 
         assert qkv_aval.dtype == bias_aval.dtype == output_aval.dtype == doutput_aval.dtype
-        *batch_shape, max_seqlen, nqkv, num_heads, head_dim = qkv_aval.shape
+        *input_batch_shape, max_seqlen, nqkv, attn_heads, head_dim = qkv_aval.shape
         assert nqkv == 3
         qkv_dtype = dtypes.canonicalize_dtype(qkv_aval.dtype)
         bias_dtype = dtypes.canonicalize_dtype(bias_aval.dtype)
 
-        batch_size = reduce(operator.mul, batch_shape)
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
+
+        input_batch = reduce(operator.mul, input_batch_shape)
         wkspace_shape, wkspace_dtype = \
             transformer_engine_jax.get_self_fused_attn_bwd_workspace_sizes(
-                batch_size, max_seqlen, num_heads, head_dim,
+                input_batch, bias_batch, max_seqlen, attn_heads, bias_heads, head_dim,
                 scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
                 jax_dtype_to_te_dtype(qkv_aval.dtype), is_training
             )
@@ -2110,14 +2134,22 @@ class SelfFusedAttnBwdPrimitive(BasePrimitive):
         ]
         args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
 
-        qkv_aval = ctx.avals_in[0]
-        *batch_shape, max_seqlen, _, num_heads, head_dim = qkv_aval.shape
-        batch_size = reduce(operator.mul, batch_shape)
+        qkv_aval, bias_aval, *_ = ctx.avals_in
+        *input_batch_shape, max_seqlen, _, attn_heads, head_dim = qkv_aval.shape
+        input_batch = reduce(operator.mul, input_batch_shape)
+
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
 
         wkspace_aval = ctx.avals_out[-1]
 
         opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            batch_size, max_seqlen, max_seqlen, num_heads, num_heads, head_dim, wkspace_aval.size,
+            input_batch, bias_batch, max_seqlen, max_seqlen,
+            attn_heads, attn_heads, bias_heads, head_dim, wkspace_aval.size,
             scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(qkv_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
             is_training)
@@ -2261,7 +2293,7 @@ class CrossFusedAttnFwdPrimitive(BasePrimitive):
         assert q_dtype == kv_dtype == bias_dtype
         assert q_seqlen_or_cu_seqlen_aval.dtype == kv_seqlen_or_cu_seqlen_aval.dtype
 
-        *q_batch_shape, q_max_seqlen, num_heads, q_head_dim = q_aval.shape
+        *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
         *kv_batch_shape, kv_max_seqlen, nkv, num_gqa_groups, kv_head_dim = kv_aval.shape
         assert q_batch_shape == kv_batch_shape
         assert q_head_dim == kv_head_dim
@@ -2270,14 +2302,14 @@ class CrossFusedAttnFwdPrimitive(BasePrimitive):
 
         # backend determines the softmax buffer shape/dtype
         backend = FusedAttnHelper(q_dtype, kv_dtype, NVTE_QKV_Layout.NVTE_BSHD_BS2HD,
-                                  attn_bias_type, attn_mask_type, dropout_probability, num_heads,
+                                  attn_bias_type, attn_mask_type, dropout_probability, attn_heads,
                                   num_gqa_groups, q_max_seqlen, kv_max_seqlen,
                                   q_head_dim).get_fused_attn_backend()
         if backend == NVTE_Fused_Attn_Backend.NVTE_F16_max512_seqlen:
-            softmax_shape = (*q_batch_shape, num_heads, q_max_seqlen, kv_max_seqlen)
+            softmax_shape = (*q_batch_shape, attn_heads, q_max_seqlen, kv_max_seqlen)
             softmax_dtype = q_dtype
         elif backend == NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
-            softmax_shape = (*q_batch_shape, num_heads, q_max_seqlen, 1)
+            softmax_shape = (*q_batch_shape, attn_heads, q_max_seqlen, 1)
             softmax_dtype = dtypes.canonicalize_dtype(jnp.float32)
         else:
             raise ValueError(f'Unsupported {backend=}')
@@ -2291,11 +2323,20 @@ class CrossFusedAttnFwdPrimitive(BasePrimitive):
         rng_state_shape = (seed_aval.shape[0], checker.rng_state_size)
         rng_state_aval = seed_aval.update(shape=rng_state_shape, dtype=checker.rng_state_dtype)
 
+        # get bias shape if bias is enabled
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
+
         # do a dummy kernel call here to get workspace buffer shapes/dtypes that XLA needs to
         # prepare for the active fused-attn backend
-        batch_size = reduce(operator.mul, q_batch_shape)
+        input_batch = reduce(operator.mul, q_batch_shape)
         wkspace_info = transformer_engine_jax.get_cross_fused_attn_fwd_workspace_sizes(
-            batch_size, q_max_seqlen, kv_max_seqlen, num_heads, num_gqa_groups, q_head_dim,
+            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
+            attn_heads, num_gqa_groups, bias_heads, q_head_dim,
             scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(q_aval.dtype), is_training)
         wkspace_aval = q_aval.update(shape=wkspace_info[0],
@@ -2326,15 +2367,23 @@ class CrossFusedAttnFwdPrimitive(BasePrimitive):
         ]
         args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
 
-        q_aval, kv_aval, *_ = ctx.avals_in
-        *batch_shape, q_max_seqlen, num_heads, head_dim = q_aval.shape
+        q_aval, kv_aval, bias_aval, *_ = ctx.avals_in
+        *input_batch_shape, q_max_seqlen, attn_heads, head_dim = q_aval.shape
         *_, kv_max_seqlen, _, num_gqa_groups, _ = kv_aval.shape
-        batch_size = reduce(operator.mul, batch_shape)
+        input_batch = reduce(operator.mul, input_batch_shape)
+
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
 
         wkspace_aval = ctx.avals_out[-1]
 
         opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            batch_size, q_max_seqlen, kv_max_seqlen, num_heads, num_gqa_groups, head_dim,
+            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
+            attn_heads, num_gqa_groups, bias_heads, head_dim,
             wkspace_aval.size, scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(q_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
             is_training)
@@ -2474,16 +2523,24 @@ class CrossFusedAttnBwdPrimitive(BasePrimitive):
         assert q_dtype == kv_dtype == bias_dtype == doutput_dtype
         assert q_cu_seqlen_aval.dtype == kv_cu_seqlen_aval.dtype
 
-        *q_batch_shape, q_max_seqlen, num_heads, q_head_dim = q_aval.shape
+        *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
         *kv_batch_shape, kv_max_seqlen, nkv, num_gqa_groups, kv_head_dim = kv_aval.shape
         assert q_batch_shape == kv_batch_shape
         assert q_head_dim == kv_head_dim
         assert nkv == 2
 
-        batch_size = reduce(operator.mul, q_batch_shape)
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
+
+        input_batch = reduce(operator.mul, q_batch_shape)
         wkspace_shape, wkspace_dtype = \
             transformer_engine_jax.get_cross_fused_attn_bwd_workspace_sizes(
-                batch_size, q_max_seqlen, kv_max_seqlen, num_heads, num_gqa_groups, q_head_dim,
+                input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
+                attn_heads, num_gqa_groups, bias_heads, q_head_dim,
                 scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
                 jax_dtype_to_te_dtype(q_aval.dtype), is_training
             )
@@ -2521,15 +2578,23 @@ class CrossFusedAttnBwdPrimitive(BasePrimitive):
 
         args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
 
-        q_aval, kv_aval, *_ = ctx.avals_in
-        *batch_shape, q_max_seqlen, num_heads, head_dim = q_aval.shape
+        q_aval, kv_aval, bias_aval, *_ = ctx.avals_in
+        *input_batch_shape, q_max_seqlen, attn_heads, head_dim = q_aval.shape
         *_, kv_max_seqlen, _, num_gqa_groups, _ = kv_aval.shape
-        batch_size = reduce(operator.mul, batch_shape)
+        input_batch = reduce(operator.mul, input_batch_shape)
+
+        bias_shape = bias_aval.shape
+        if len(bias_shape) == 1:
+            bias_batch = bias_heads = 0
+        else:
+            *bias_batch_shape, bias_heads, _, _ = bias_shape
+            bias_batch = reduce(operator.mul, bias_batch_shape)
 
         wkspace_aval = ctx.avals_out[-1]
 
         opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            batch_size, q_max_seqlen, kv_max_seqlen, num_heads, num_gqa_groups, head_dim,
+            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
+            attn_heads, num_gqa_groups, bias_heads, head_dim,
             wkspace_aval.size, scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
             jax_dtype_to_te_dtype(q_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
             is_training)

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -1141,7 +1141,7 @@ pybind11::tuple GetSelfFusedAttnBackwardWorkspaceSizes(
     size_t input_batch, size_t bias_batch, size_t max_seqlen,
     size_t attn_heads, size_t bias_heads, size_t head_dim,
     float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,DType dtype, bool is_training) {
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
 
     auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -94,14 +94,15 @@ pybind11::bytes PackCustomCallSoftmaxDescriptor(size_t batch_size, size_t paddin
 }
 
 pybind11::bytes PackCustomCallFusedAttnDescriptor(
-    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t num_heads,
-    size_t num_gqa_groups, size_t head_dim, size_t wkspace_size, float scaling_factor,
-    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype,
-    DType wkspace_dtype, bool is_training) {
+    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
+    size_t wkspace_size, float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
+    DType dtype, DType wkspace_dtype, bool is_training) {
     return PackOpaque(CustomCallFusedAttnDescriptor{
-        batch_size, q_max_seqlen, kv_max_seqlen, num_heads, num_gqa_groups, head_dim, wkspace_size,
-        scaling_factor, dropout_probability, bias_type, mask_type, dtype, wkspace_dtype,
-        is_training});
+        input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups,
+        bias_heads, head_dim, wkspace_size, scaling_factor, dropout_probability,
+        bias_type, mask_type, dtype, wkspace_dtype, is_training});
 }
 
 void TransposeImpl(void *input, size_t rows, size_t cols, DType dtype, cudaStream_t stream,
@@ -962,8 +963,10 @@ void PrepareFusedAttnForwardAuxTensors(NVTETensorPack *tensor_pack,
                                        NVTE_Bias_Type bias_type, NVTE_Fused_Attn_Backend backend,
                                        void *softmax_buf, void *rng_state_buf = nullptr,
                                        void *bias_buf = nullptr) {
-    auto batch_size = desc->batch_size;
-    auto num_heads = desc->num_heads;
+    auto input_batch = desc->input_batch;
+    auto bias_batch = desc->bias_batch;
+    auto attn_heads = desc->attn_heads;
+    auto bias_heads = desc->bias_heads;
     auto q_max_seqlen = desc->q_max_seqlen;
     auto kv_max_seqlen = desc->kv_max_seqlen;
 
@@ -973,7 +976,7 @@ void PrepareFusedAttnForwardAuxTensors(NVTETensorPack *tensor_pack,
     Tensor *softmax_aux = reinterpret_cast<Tensor *>(tensor_pack->tensors[0]);
     softmax_aux->data.dptr = softmax_buf;
     softmax_aux->data.shape =
-        std::vector<size_t>{batch_size, num_heads, q_max_seqlen, kv_max_seqlen};
+        std::vector<size_t>{input_batch, attn_heads, q_max_seqlen, kv_max_seqlen};
     softmax_aux->data.dtype = desc->dtype;
 
     // arbitrary sequence length backend needs the RNG state and a different shape/dtype softmax
@@ -992,7 +995,8 @@ void PrepareFusedAttnForwardAuxTensors(NVTETensorPack *tensor_pack,
             tensor_pack->size = 3;
             Tensor *bias_aux = reinterpret_cast<Tensor *>(tensor_pack->tensors[2]);
             bias_aux->data.dptr = bias_buf;
-            bias_aux->data.shape = std::vector<size_t>{1, num_heads, q_max_seqlen, kv_max_seqlen};
+            bias_aux->data.shape =
+                std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
             bias_aux->data.dtype = desc->dtype;
         }
     }
@@ -1026,26 +1030,27 @@ void PrepareFusedAttnBackwardAuxTensors(NVTETensorPack *tensor_pack,
 }
 
 pybind11::tuple GetSelfFusedAttnForwardWorkspaceSizes(
-    size_t batch_size, size_t max_seqlen, size_t num_heads, size_t head_dim, float scaling_factor,
-    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype,
-    bool is_training) {
+    size_t input_batch, size_t bias_batch, size_t max_seqlen,
+    size_t attn_heads, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
 
-    auto qkv_shape = std::vector<size_t>{batch_size * max_seqlen, 3, num_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, max_seqlen, max_seqlen};
+    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
 
     auto qkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
     auto bias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
     auto cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto o_tensor = TensorWrapper(
-        nullptr, std::vector<size_t>{batch_size * max_seqlen, num_heads, head_dim}, dtype);
+        nullptr, std::vector<size_t>{input_batch, max_seqlen, attn_heads, head_dim}, dtype);
     auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);
     auto rng_state_tensor = TensorWrapper(nullptr, std::vector<size_t>{2}, DType::kInt64);
 
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_heads, num_heads, max_seqlen, max_seqlen, head_dim);
+        mask_type, dropout_probability, attn_heads, attn_heads, max_seqlen, max_seqlen, head_dim);
 
     NVTETensorPack aux_output_tensors;
     nvte_tensor_pack_create(&aux_output_tensors);
@@ -1079,35 +1084,37 @@ void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaqu
     void *workspace = buffers[7];
 
     // tensor sizes
-    auto batch_size = descriptor.batch_size;
+    auto input_batch = descriptor.input_batch;
+    auto bias_batch = descriptor.bias_batch;
     auto max_seqlen = descriptor.q_max_seqlen;
-    auto num_heads = descriptor.num_heads;
+    auto attn_heads = descriptor.attn_heads;
+    auto bias_heads = descriptor.bias_heads;
     auto head_dim = descriptor.head_dim;
     auto dropout_probability = descriptor.dropout_probability;
     auto bias_type = descriptor.bias_type;
     auto mask_type = descriptor.mask_type;
 
     auto dtype = descriptor.dtype;
-    auto qkv_shape = std::vector<size_t>{batch_size * max_seqlen, 3, num_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, max_seqlen, max_seqlen};
+    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
 
     // input tensors
     auto qkv_tensor = TensorWrapper(qkv, qkv_shape, dtype);
     auto bias_tensor = TensorWrapper(bias, bias_shape, dtype);
     auto cu_seqlens_tensor =
-        TensorWrapper(cu_seqlens, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     // output tensors
     auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in FP16/BF16
     auto o_tensor = TensorWrapper(
-        output, std::vector<size_t>{batch_size * max_seqlen, num_heads, head_dim}, dtype);
+        output, std::vector<size_t>{input_batch * max_seqlen, attn_heads, head_dim}, dtype);
 
     // prep RNG state
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
     auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_heads, num_heads, max_seqlen, max_seqlen, head_dim);
+        mask_type, dropout_probability, attn_heads, attn_heads, max_seqlen, max_seqlen, head_dim);
     PopulateRngStateAsync(rng_state, seed, max_seqlen, max_seqlen, backend, stream);
 
     // auxiliary tensors (to be propagated to the backward pass later)
@@ -1131,14 +1138,15 @@ void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaqu
 }
 
 pybind11::tuple GetSelfFusedAttnBackwardWorkspaceSizes(
-    size_t batch_size, size_t max_seqlen, size_t num_heads, size_t head_dim, float scaling_factor,
-    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype,
-    bool is_training) {
+    size_t input_batch, size_t bias_batch, size_t max_seqlen,
+    size_t attn_heads, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,DType dtype, bool is_training) {
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
 
-    auto qkv_shape = std::vector<size_t>{batch_size * max_seqlen, 3, num_heads, head_dim};
-    auto output_shape = std::vector<size_t>{batch_size * max_seqlen, num_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, max_seqlen, max_seqlen};
+    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
+    auto output_shape = std::vector<size_t>{input_batch * max_seqlen, attn_heads, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
 
     auto qkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
     auto output_tensor = TensorWrapper(nullptr, output_shape, dtype);
@@ -1150,7 +1158,7 @@ pybind11::tuple GetSelfFusedAttnBackwardWorkspaceSizes(
     auto dbias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
 
     auto cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     NVTETensorPack aux_input_tensors;
     nvte_tensor_pack_create(&aux_input_tensors);
@@ -1188,9 +1196,11 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
     void *workspace = buffers[9];
 
     // tensor sizes
-    auto batch_size = descriptor.batch_size;
+    auto input_batch = descriptor.input_batch;
+    auto bias_batch = descriptor.bias_batch;
     auto max_seqlen = descriptor.q_max_seqlen;
-    auto num_heads = descriptor.num_heads;
+    auto attn_heads = descriptor.attn_heads;
+    auto bias_heads = descriptor.bias_heads;
     auto head_dim = descriptor.head_dim;
     auto scaling_factor = descriptor.scaling_factor;
     auto dropout_probability = descriptor.dropout_probability;
@@ -1198,9 +1208,9 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
     auto mask_type = descriptor.mask_type;
 
     auto dtype = descriptor.dtype;
-    auto qkv_shape = std::vector<size_t>{batch_size * max_seqlen, 3, num_heads, head_dim};
-    auto output_shape = std::vector<size_t>{batch_size * max_seqlen, num_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, max_seqlen, max_seqlen};
+    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
+    auto output_shape = std::vector<size_t>{input_batch * max_seqlen, attn_heads, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
 
     // input tensors
     auto qkv_tensor = TensorWrapper(qkv, qkv_shape, dtype);
@@ -1212,7 +1222,7 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
     auto dqkv_tensor = TensorWrapper(dqkv, qkv_shape, dtype);
     auto dbias_tensor = TensorWrapper(dbias, bias_shape, dtype);
     auto cu_seqlens_tensor =
-        TensorWrapper(cu_seqlens, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     // auxiliary tensors (propagated from the forward pass)
     NVTETensorPack aux_input_tensors;
@@ -1220,7 +1230,7 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_heads, num_heads, max_seqlen, max_seqlen, head_dim);
+        mask_type, dropout_probability, attn_heads, attn_heads, max_seqlen, max_seqlen, head_dim);
     PrepareFusedAttnBackwardAuxTensors(&aux_input_tensors, &descriptor, backend, softmax_aux,
                                        rng_state, bias);
 
@@ -1241,14 +1251,15 @@ void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaq
 }
 
 pybind11::tuple GetCrossFusedAttnForwardWorkspaceSizes(
-    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t num_heads,
-    size_t num_gqa_groups, size_t head_dim, float scaling_factor, float dropout_probability,
+    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
     NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
 
-    auto q_shape = std::vector<size_t>{batch_size * q_max_seqlen, num_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{batch_size * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, q_max_seqlen, kv_max_seqlen};
+    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
 
     auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
     auto kv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
@@ -1261,9 +1272,9 @@ pybind11::tuple GetCrossFusedAttnForwardWorkspaceSizes(
     auto o_tensor = TensorWrapper(nullptr, q_shape, dtype);
 
     auto q_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto kv_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     auto dummy_rng_state_tensor = TensorWrapper(nullptr, std::vector<size_t>{2}, DType::kInt64);
 
@@ -1302,20 +1313,22 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
     void *workspace = buffers[9];
 
     // tensor sizes
-    auto batch_size = descriptor.batch_size;
+    auto input_batch = descriptor.input_batch;
+    auto bias_batch = descriptor.bias_batch;
     auto q_max_seqlen = descriptor.q_max_seqlen;
     auto kv_max_seqlen = descriptor.kv_max_seqlen;
-    auto num_heads = descriptor.num_heads;
+    auto attn_heads = descriptor.attn_heads;
     auto num_gqa_groups = descriptor.num_gqa_groups;
+    auto bias_heads = descriptor.bias_heads;
     auto head_dim = descriptor.head_dim;
     auto scaling_factor = descriptor.scaling_factor;
     auto dropout_probability = descriptor.dropout_probability;
     auto bias_type = descriptor.bias_type;
     auto mask_type = descriptor.mask_type;
 
-    auto q_shape = std::vector<size_t>{batch_size * q_max_seqlen, num_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{batch_size * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, q_max_seqlen, kv_max_seqlen};
+    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
 
     // input tensors
     auto dtype = descriptor.dtype;
@@ -1327,16 +1340,16 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
     auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in FP16/BF16
     auto o_tensor = TensorWrapper(output, q_shape, dtype);
     auto q_cu_seqlens_tensor =
-        TensorWrapper(q_cu_seqlens, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(q_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto kv_cu_seqlens_tensor =
-        TensorWrapper(kv_cu_seqlens, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(kv_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     // prep RNG state
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
     auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
+        mask_type, dropout_probability, attn_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
         head_dim);
     PopulateRngStateAsync(rng_state, seed, q_max_seqlen, kv_max_seqlen, backend, stream);
 
@@ -1361,15 +1374,16 @@ void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaq
 }
 
 pybind11::tuple GetCrossFusedAttnBackwardWorkspaceSizes(
-    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t num_heads,
-    size_t num_gqa_groups, size_t head_dim, float scaling_factor, float dropout_probability,
+    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
     NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
 
-    auto q_shape = std::vector<size_t>{batch_size * q_max_seqlen, num_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{batch_size * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto output_shape = std::vector<size_t>{batch_size * q_max_seqlen, num_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, q_max_seqlen, kv_max_seqlen};
+    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+    auto output_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
 
     auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
     auto kv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
@@ -1383,9 +1397,9 @@ pybind11::tuple GetCrossFusedAttnBackwardWorkspaceSizes(
     auto dbias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
 
     auto q_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto kv_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     NVTETensorPack aux_input_tensors;
     nvte_tensor_pack_create(&aux_input_tensors);
@@ -1427,21 +1441,23 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
     void *workspace = buffers[12];
 
     // tensor sizes
-    auto batch_size = descriptor.batch_size;
+    auto input_batch = descriptor.input_batch;
+    auto bias_batch = descriptor.bias_batch;
     auto q_max_seqlen = descriptor.q_max_seqlen;
     auto kv_max_seqlen = descriptor.kv_max_seqlen;
-    auto num_heads = descriptor.num_heads;
+    auto attn_heads = descriptor.attn_heads;
     auto num_gqa_groups = descriptor.num_gqa_groups;
+    auto bias_heads = descriptor.bias_heads;
     auto head_dim = descriptor.head_dim;
     auto scaling_factor = descriptor.scaling_factor;
     auto dropout_probability = descriptor.dropout_probability;
     auto bias_type = descriptor.bias_type;
     auto mask_type = descriptor.mask_type;
 
-    auto q_shape = std::vector<size_t>{batch_size * q_max_seqlen, num_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{batch_size * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto output_shape = std::vector<size_t>{batch_size * q_max_seqlen, num_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{1, num_heads, q_max_seqlen, kv_max_seqlen};
+    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+    auto output_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
 
     // input tensors
     auto dtype = descriptor.dtype;
@@ -1456,9 +1472,9 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
     auto dkv_tensor = TensorWrapper(dkv, kv_shape, dtype);
     auto dbias_tensor = TensorWrapper(dbias, bias_shape, dtype);
     auto q_cu_seqlens_tensor =
-        TensorWrapper(q_cu_seqlens, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(q_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto kv_cu_seqlens_tensor =
-        TensorWrapper(kv_cu_seqlens, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+        TensorWrapper(kv_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
     // auxiliary tensors (propagated from the forward pass)
     NVTETensorPack aux_input_tensors;
@@ -1466,7 +1482,7 @@ void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opa
     constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, num_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
+        mask_type, dropout_probability, attn_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
         head_dim);
     PrepareFusedAttnBackwardAuxTensors(&aux_input_tensors, &descriptor, backend, softmax_aux,
                                        rng_state, bias);

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -105,11 +105,13 @@ pybind11::bytes PackCustomCallSoftmaxDescriptor(size_t batch_size, size_t paddin
                                                 DType dtype, float scale_factor);
 
 struct CustomCallFusedAttnDescriptor {
-    size_t batch_size;
+    size_t input_batch;
+    size_t bias_batch;
     size_t q_max_seqlen;
     size_t kv_max_seqlen;
-    size_t num_heads;
+    size_t attn_heads;
     size_t num_gqa_groups;
+    size_t bias_heads;
     size_t head_dim;
     size_t wkspace_size;
     float scaling_factor;
@@ -122,10 +124,11 @@ struct CustomCallFusedAttnDescriptor {
 };
 
 pybind11::bytes PackCustomCallFusedAttnDescriptor(
-    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t num_heads,
-    size_t num_gqa_groups, size_t head_dim, size_t wkspace_size, float scaling_factor,
-    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype,
-    DType wkspace_dtype, bool is_training);
+    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
+    size_t wkspace_size, float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
+    DType dtype, DType wkspace_dtype, bool is_training);
 
 NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
                                             NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type,
@@ -205,32 +208,36 @@ void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers,
                                             std::size_t opaque_len);
 
 pybind11::tuple GetSelfFusedAttnForwardWorkspaceSizes(
-    size_t batch_size, size_t max_seqlen, size_t num_heads, size_t head_dim, float scaling_factor,
-    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype,
-    bool is_training);
+    size_t input_batch, size_t bias_batch, size_t max_seqlen,
+    size_t attn_heads, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
 
 void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
                           size_t opaque_len);
 
 pybind11::tuple GetSelfFusedAttnBackwardWorkspaceSizes(
-    size_t batch_size, size_t max_seqlen, size_t num_heads, size_t head_dim, float scaling_factor,
-    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype,
-    bool is_training);
+    size_t input_batch, size_t bias_batch, size_t max_seqlen,
+    size_t attn_heads, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
 
 void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
                            size_t opaque_len);
 
 pybind11::tuple GetCrossFusedAttnForwardWorkspaceSizes(
-    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t num_heads,
-    size_t num_gqa_groups, size_t head_dim, float scaling_factor, float dropout_probability,
+    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
     NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
 
 void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
                            size_t opaque_len);
 
 pybind11::tuple GetCrossFusedAttnBackwardWorkspaceSizes(
-    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t num_heads,
-    size_t num_gqa_groups, size_t head_dim, float scaling_factor, float dropout_probability,
+    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
+    float scaling_factor, float dropout_probability,
     NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
 
 void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,


### PR DESCRIPTION
This PR replaces hard-coded bias shape in fused attention custom ops with inferred shapes from input tensors.

Changes in this PR need to be reconciled with changes in #674 and #653. Ultimately we might not merge this one and instead incorporate the changes into one of the other two (#674 seems like the best candidate for this), but I am still filing a PR to track the work.