### PR TITLE
[PyTorch] Re-enable bias+GELU fusion for non-reentrant checkpointing -- WIP

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -558,18 +558,10 @@ def test_gpt_full_activation_recompute(dtype, bs, model, fp8, fp8_model_params, 
 
     config = model_configs[model]
 
-    if not use_reentrant:
-        # Non-reentrant checkpoint becomes non-deterministic with bias+GELU fusion
-        os.environ["NVTE_BIAS_GELU_NVFUSION"] = "0"
-
     outputs, names = _test_e2e_full_recompute(bs, dtype, config, fp8, fp8_model_params,
                                               recompute=False, use_reentrant=use_reentrant)
     outputs_recompute, _ = _test_e2e_full_recompute(bs, dtype, config, fp8, fp8_model_params,
                                                     recompute=True, use_reentrant=use_reentrant)
-
-    if not use_reentrant:
-        # Reset bias+GELU fusion flag to avoid contaminating other tests
-        del os.environ["NVTE_BIAS_GELU_NVFUSION"]
 
     assert_all_equal(outputs, outputs_recompute, names=names)
 

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -43,7 +43,6 @@ from ..distributed import (
     gather_along_first_dim,
     is_fp8_activation_recompute_enabled,
     in_fp8_activation_recompute_phase,
-    use_reentrant_activation_recompute,
 )
 
 from .. import cpp_extensions as tex
@@ -1415,11 +1414,6 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self.get_fp8_weights_scratchpad(
                         is_first_microbatch
                 )
-
-            # Disable bias_gelu_nvfusion for determinism checkpointing in non-reentrant mode
-            if (self.bias_gelu_nvfusion
-                and not use_reentrant_activation_recompute()):
-                self.bias_gelu_nvfusion = False
 
             from ..cpu_offload import CPUOffloadEnabled
 


### PR DESCRIPTION
TorchDynamo has known limitations for `autograd.Function` implementations and `autograd.graph` hooks. Activation recompute utilizes *both* of those mechanisms, so this PR disables TorchDynamo on `te.distributed.checkpoint()` via the `@no_torch_dynamo()` decorator. 