### PR TITLE
[JAX] Refactor fused attention

### DIFF
--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -449,6 +449,7 @@ class TestDecoderLayer:
                             hidden_dropout_dims=(sequence_dim,),
                             intermediate_dropout_dims=(sequence_dim,),
                             layer_type=TransformerLayerType.DECODER,
+                            self_attn_mask_type='padding_causal',
                             dtype=dtype,
                             **te_layer_attrs)
         ref_layer, ref_params, ref_others = generate_layer(ref_layer_cls, init_rng, inputs,
@@ -497,6 +498,7 @@ class TestDecoderLayer:
                             hidden_dropout_dims=(sequence_dim,),
                             intermediate_dropout_dims=(sequence_dim,),
                             layer_type=TransformerLayerType.DECODER,
+                            self_attn_mask_type='padding_causal',
                             dtype=dtype,
                             **te_layer_attrs)
         ref_layer, ref_params, ref_others = generate_layer(ref_layer_cls, init_rng, inputs,

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -1368,14 +1368,13 @@ class ScaledSoftmaxFwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def infer_sharding_from_operands(scale_factor, mesh, arg_infos, result_infos):
         return ScaledSoftmaxFwdPrimitive.forward_infer_sharding_from_operands(
-            scale_factor, mesh, arg_infos, result_infos
-        )
+            scale_factor, mesh, arg_infos, result_infos)
 
     @staticmethod
     def partition(scale_factor, mesh, arg_infos, result_infos):
-        return ScaledSoftmaxFwdPrimitive.forward_partition(
-            ScaledSoftmaxFwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
-        )
+        return ScaledSoftmaxFwdPrimitive.forward_partition(ScaledSoftmaxFwdPrimitive.impl,
+                                                           scale_factor, mesh, arg_infos,
+                                                           result_infos)
 
 
 register_primitive(ScaledSoftmaxFwdPrimitive)
@@ -1444,14 +1443,13 @@ class ScaledSoftmaxBwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def infer_sharding_from_operands(scale_factor, mesh, arg_infos, result_infos):
         return ScaledSoftmaxBwdPrimitive.backward_infer_sharding_from_operands(
-            scale_factor, mesh, arg_infos, result_infos
-        )
+            scale_factor, mesh, arg_infos, result_infos)
 
     @staticmethod
     def partition(scale_factor, mesh, arg_infos, result_infos):
-        return ScaledSoftmaxBwdPrimitive.backward_partition(
-            ScaledSoftmaxBwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
-        )
+        return ScaledSoftmaxBwdPrimitive.backward_partition(ScaledSoftmaxBwdPrimitive.impl,
+                                                            scale_factor, mesh, arg_infos,
+                                                            result_infos)
 
 
 register_primitive(ScaledSoftmaxBwdPrimitive)
@@ -1581,14 +1579,12 @@ class ScaledMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def infer_sharding_from_operands(scale_factor, mesh, arg_infos, result_infos):
         return ScaledMaskedSoftmaxFwdPrimitive.forward_infer_sharding_from_operands(
-            scale_factor, mesh, arg_infos,result_infos
-        )
+            scale_factor, mesh, arg_infos, result_infos)
 
     @staticmethod
     def partition(scale_factor, mesh, arg_infos, result_infos):
         return ScaledMaskedSoftmaxFwdPrimitive.backward_partition(
-            ScaledMaskedSoftmaxFwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
-        )
+            ScaledMaskedSoftmaxFwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos)
 
 
 register_primitive(ScaledMaskedSoftmaxFwdPrimitive)
@@ -1660,14 +1656,12 @@ class ScaledMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def infer_sharding_from_operands(scale_factor, mesh, arg_infos, result_infos):
         return ScaledMaskedSoftmaxBwdPrimitive.backward_infer_sharding_from_operands(
-            scale_factor, mesh, arg_infos, result_infos
-        )
+            scale_factor, mesh, arg_infos, result_infos)
 
     @staticmethod
     def partition(scale_factor, mesh, arg_infos, result_infos):
         return ScaledMaskedSoftmaxBwdPrimitive.backward_partition(
-            ScaledMaskedSoftmaxBwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
-        )
+            ScaledMaskedSoftmaxBwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos)
 
 
 register_primitive(ScaledMaskedSoftmaxBwdPrimitive)
@@ -1749,15 +1743,13 @@ class ScaledUpperTriangMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def infer_sharding_from_operands(scale_factor, mesh, arg_infos, result_infos):
         return ScaledUpperTriangMaskedSoftmaxFwdPrimitive.forward_infer_sharding_from_operands(
-            scale_factor, mesh, arg_infos, result_infos
-        )
+            scale_factor, mesh, arg_infos, result_infos)
 
     @staticmethod
     def partition(scale_factor, mesh, arg_infos, result_infos):
         return ScaledUpperTriangMaskedSoftmaxFwdPrimitive.forward_partition(
-            ScaledUpperTriangMaskedSoftmaxFwdPrimitive.impl, scale_factor, mesh,
-            arg_infos, result_infos
-        )
+            ScaledUpperTriangMaskedSoftmaxFwdPrimitive.impl, scale_factor, mesh, arg_infos,
+            result_infos)
 
 
 register_primitive(ScaledUpperTriangMaskedSoftmaxFwdPrimitive)
@@ -1829,15 +1821,13 @@ class ScaledUpperTriangMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def infer_sharding_from_operands(scale_factor, mesh, arg_infos, result_infos):
         return ScaledUpperTriangMaskedSoftmaxBwdPrimitive.backward_infer_sharding_from_operands(
-            scale_factor, mesh, arg_infos, result_infos
-        )
+            scale_factor, mesh, arg_infos, result_infos)
 
     @staticmethod
     def partition(scale_factor, mesh, arg_infos, result_infos):
         return ScaledUpperTriangMaskedSoftmaxBwdPrimitive.backward_partition(
-            ScaledUpperTriangMaskedSoftmaxBwdPrimitive.impl, scale_factor, mesh,
-            arg_infos, result_infos
-        )
+            ScaledUpperTriangMaskedSoftmaxBwdPrimitive.impl, scale_factor, mesh, arg_infos,
+            result_infos)
 
 
 register_primitive(ScaledUpperTriangMaskedSoftmaxBwdPrimitive)
@@ -1859,16 +1849,16 @@ class FusedAttnHelper:
     Helper for the fused attention backend
     """
 
-    q_type: jnp.dtype
-    kv_type: jnp.dtype
+    q_dtype: jnp.dtype
+    kv_dtype: jnp.dtype
     qkv_layout: NVTE_QKV_Layout
     attn_bias_type: NVTE_Bias_Type
     attn_mask_type: NVTE_Mask_Type
     dropout_probability: float
-    num_heads_q: int
-    num_heads_kv: int
-    max_seqlen_q: int
-    max_seqlen_kv: int
+    q_num_heads: int
+    kv_num_heads: int
+    q_max_seqlen: int
+    kv_max_seqlen: int
     head_dim: int
 
     def is_fused_attn_kernel_available(self):
@@ -1878,10 +1868,37 @@ class FusedAttnHelper:
     def get_fused_attn_backend(self):
         """Get the fused attention kernel backend"""
         return transformer_engine_jax.get_fused_attn_backend(
-            jax_dtype_to_te_dtype(self.q_type), jax_dtype_to_te_dtype(self.kv_type),
+            jax_dtype_to_te_dtype(self.q_dtype), jax_dtype_to_te_dtype(self.kv_dtype),
             self.qkv_layout, self.attn_bias_type, self.attn_mask_type, self.dropout_probability,
-            self.num_heads_q, self.num_heads_kv, self.max_seqlen_q, self.max_seqlen_kv,
+            self.q_num_heads, self.kv_num_heads, self.q_max_seqlen, self.kv_max_seqlen,
             self.head_dim)
+
+    @staticmethod
+    def parse_qkv_aval(q_aval, k_aval, v_aval, qkv_layout):
+        """Parse qkv aval"""
+        match qkv_layout:
+            case NVTE_QKV_Layout.NVTE_BS3HD:
+                *q_batch_shape, q_max_seqlen, nqkv, attn_heads, q_head_dim = q_aval.shape
+                kv_batch_shape = q_batch_shape
+                kv_max_seqlen = q_max_seqlen
+                num_gqa_groups = attn_heads
+                kv_head_dim = q_head_dim
+                assert nqkv == 3
+            case NVTE_QKV_Layout.NVTE_BSHD_BS2HD:
+                *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
+                *kv_batch_shape, kv_max_seqlen, nkv, num_gqa_groups, kv_head_dim = k_aval.shape
+                assert nkv == 2
+            case NVTE_QKV_Layout.NVTE_BSHD_BSHD_BSHD:
+                *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
+                *kv_batch_shape, kv_max_seqlen, num_gqa_groups, kv_head_dim = k_aval.shape
+                assert k_aval.shape == v_aval.shape
+            case _:
+                raise ValueError(f"Unexpected {qkv_layout=}")
+        assert q_batch_shape == kv_batch_shape
+        assert q_head_dim == kv_head_dim
+        assert q_aval.dtype == k_aval.dtype == v_aval.dtype
+
+        return (q_batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, q_head_dim)
 
 
 @dataclass(frozen=True)
@@ -1933,889 +1950,20 @@ def generate_cu_seqlen(actual_seqlen):
     return cu_seqlen
 
 
-class SelfFusedAttnFwdPrimitive(BasePrimitive):
-    """
-    Self Fused Attention Forward Primitive
-    """
-    name = "te_self_fused_attn_forward"
-    multiple_results = True
-    impl_static_args = (4, 5, 6, 7, 8)
-    inner_primitive = None
-    outer_primitive = None
-
-    @staticmethod
-    def abstract(qkv_aval, bias_aval, seqlen_or_cu_seqlen_aval, seed_aval, *, attn_bias_type,
-                 attn_mask_type, scaling_factor, dropout_probability, is_training):
-        """
-        Self fused attention fwd inner primitive abstract
-        """
-        # outer_primitve is squeezed_mask, inner_primitive is cu_seqlen
-        del seqlen_or_cu_seqlen_aval
-        qkv_dtype = dtypes.canonicalize_dtype(qkv_aval.dtype)
-        *input_batch_shape, max_seqlen, nqkv, attn_heads, head_dim = qkv_aval.shape
-        assert nqkv == 3
-        assert qkv_aval.dtype == bias_aval.dtype
-
-        output_shape = (*input_batch_shape, max_seqlen, attn_heads, head_dim)
-        out_aval = qkv_aval.update(shape=output_shape, dtype=qkv_dtype)
-
-        # backend determines the softmax buffer shape/dtype
-        backend = FusedAttnHelper(qkv_dtype, qkv_dtype, NVTE_QKV_Layout.NVTE_BS3HD, attn_bias_type,
-                                  attn_mask_type, dropout_probability, attn_heads, attn_heads,
-                                  max_seqlen, max_seqlen, head_dim).get_fused_attn_backend()
-
-        if backend == NVTE_Fused_Attn_Backend.NVTE_F16_max512_seqlen:
-            softmax_shape = (*input_batch_shape, attn_heads, max_seqlen, max_seqlen)
-            softmax_dtype = qkv_dtype
-        elif backend == NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
-            softmax_shape = (*input_batch_shape, attn_heads, max_seqlen, 1)
-            softmax_dtype = dtypes.canonicalize_dtype(jnp.float32)
-        else:
-            raise ValueError(f'Unsupported {backend=}')
-        softmax_aux_aval = qkv_aval.update(shape=softmax_shape, dtype=softmax_dtype)
-
-        # JAX does not enable 64-bit int by default so we get XLA to allocate x8 memory with
-        # 32-bit unsigned int to get the buffer size we need in the C++ kernel
-        checker = _FusedAttnRNGStateChecker()
-        seed_dtype = dtypes.canonicalize_dtype(seed_aval.dtype)
-        assert seed_dtype == checker.rng_state_dtype
-        rng_state_shape = (seed_aval.shape[0], checker.rng_state_size)
-        rng_state_aval = seed_aval.update(shape=rng_state_shape, dtype=checker.rng_state_dtype)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        # do a dummy kernel call here to get workspace buffer shapes/dtypes that XLA needs to
-        # prepare for the active fused-attn backend
-        input_batch = reduce(operator.mul, input_batch_shape)
-        wkspace_info = transformer_engine_jax.get_self_fused_attn_fwd_workspace_sizes(
-            input_batch, bias_batch, max_seqlen, attn_heads, bias_heads, head_dim,
-            scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(qkv_aval.dtype), is_training)
-        wkspace_aval = qkv_aval.update(shape=wkspace_info[0],
-                                       dtype=te_dtype_to_jax_dtype(wkspace_info[1]))
-
-        return out_aval, softmax_aux_aval, rng_state_aval, wkspace_aval
-
-    @staticmethod
-    def outer_abstract(*args, **kwargs):
-        """
-        Self fused attention fwd outer primitive abstract
-        """
-        out_aval, softmax_aux_aval, rng_state_aval, _ = \
-            SelfFusedAttnFwdPrimitive.abstract(*args, **kwargs)
-        return out_aval, softmax_aux_aval, rng_state_aval
-
-    @staticmethod
-    def lowering(ctx, qkv, bias, cu_seqlen, seed, *, attn_bias_type, attn_mask_type, scaling_factor,
-                 dropout_probability, is_training):
-        """
-        Self fused attention fwd lowering rules
-        """
-        operands = [qkv, bias, cu_seqlen, seed]
-        operand_shapes = map(lambda x: x.type.shape, operands)
-        out_types = [
-            ir.RankedTensorType.get(output.shape, mlir.dtype_to_ir_type(output.dtype))
-            for output in ctx.avals_out
-        ]
-        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
-
-        qkv_aval, bias_aval, *_ = ctx.avals_in
-        *input_batch_shape, max_seqlen, _, attn_heads, head_dim = qkv_aval.shape
-        input_batch = reduce(operator.mul, input_batch_shape)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        wkspace_aval = ctx.avals_out[-1]
-
-        opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            input_batch, bias_batch, max_seqlen, max_seqlen,
-            attn_heads, attn_heads, bias_heads, head_dim, wkspace_aval.size,
-            scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(qkv_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
-            is_training)
-
-        out = custom_caller(SelfFusedAttnFwdPrimitive.name, args, opaque, has_side_effect=False)
-
-        return out
-
-    @staticmethod
-    def impl(qkv, bias, seqlen, seed, attn_bias_type, attn_mask_type, scaling_factor,
-             dropout_probability, is_training):
-        assert SelfFusedAttnFwdPrimitive.inner_primitive is not None
-
-        cu_seqlen = generate_cu_seqlen(seqlen)
-
-        output, softmax_aux, rng_state, _ = SelfFusedAttnFwdPrimitive.inner_primitive.bind(
-            qkv,
-            bias,
-            cu_seqlen,
-            seed,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training)
-        return output, softmax_aux, rng_state
-
-    @staticmethod
-    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, scaling_factor,
-                dropout_probability, is_training):
-        _check_valid_batch_dims(batch_dims)
-        assert SelfFusedAttnFwdPrimitive.outer_primitive is not None
-        qkv_bdim, _, _, seed_bdim = batch_dims
-
-        out_bdims = qkv_bdim, qkv_bdim, seed_bdim
-        return SelfFusedAttnFwdPrimitive.outer_primitive.bind(
-            *batched_args,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training), out_bdims
-
-    @staticmethod
-    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
-                                     dropout_probability, is_training, mesh, arg_infos,
-                                     result_infos):
-        del attn_bias_type, attn_mask_type, scaling_factor
-        del dropout_probability, is_training, result_infos
-        x_spec = get_padded_spec(arg_infos[0])    # (...batch, seqlen, 3, head, hidden)
-        out_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-3], *x_spec[-2:]))
-        softmax_aux_sharding = NamedSharding(
-            mesh, PartitionSpec(*x_spec[:-4], x_spec[-2], x_spec[-4], None))
-        rng_state_sharding = NamedSharding(mesh, PartitionSpec(get_all_mesh_axes(), None))
-        return (out_sharding, softmax_aux_sharding, rng_state_sharding)
-
-    @staticmethod
-    def partition(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training,
-                  mesh, arg_infos, result_infos):
-        del result_infos
-        x_spec = get_padded_spec(arg_infos[0])    # (...batch, seqlen, 3, head, hidden)
-        out_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-3], *x_spec[-2:]))
-        softmax_aux_sharding = NamedSharding(
-            mesh, PartitionSpec(*x_spec[:-4], x_spec[-2], x_spec[-4], None))
-        rng_state_sharding = NamedSharding(mesh, PartitionSpec(get_all_mesh_axes(), None))
-        arg_shardings = tuple([arg_i.sharding for arg_i in arg_infos[:-1]] + [rng_state_sharding])
-        out_shardings = (out_sharding, softmax_aux_sharding, rng_state_sharding)
-        impl = partial(SelfFusedAttnFwdPrimitive.impl,
-                       attn_bias_type=attn_bias_type,
-                       attn_mask_type=attn_mask_type,
-                       scaling_factor=scaling_factor,
-                       dropout_probability=dropout_probability,
-                       is_training=is_training)
-        return mesh, impl, out_shardings, arg_shardings
-
-
-register_primitive(SelfFusedAttnFwdPrimitive)
-
-
-def self_fused_attn_fwd(qkv: jnp.ndarray, bias: jnp.ndarray | None, seqlen: jnp.ndarray,
-                        seed: jnp.ndarray | None, attn_bias_type: NVTE_Bias_Type,
-                        attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                        dropout_probability: float, is_training: bool):
-    """
-    Wrapper for TE self fused attention fwd
-    Return BMM1 -> (PreScaleBias) -> Scale -> (PostScaleBias) -> Softmax -> (Dropout) -> BMM2
-    """
-    checker = _FusedAttnRNGStateChecker()
-    seed = checker.check_seed(seed, dropout_probability, is_training)
-
-    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-        assert bias is None
-        bias = jnp.zeros(0, dtype=qkv.dtype)
-
-    return SelfFusedAttnFwdPrimitive.outer_primitive.bind(qkv,
-                                                          bias,
-                                                          seqlen,
-                                                          seed,
-                                                          attn_bias_type=attn_bias_type,
-                                                          attn_mask_type=attn_mask_type,
-                                                          scaling_factor=scaling_factor,
-                                                          dropout_probability=dropout_probability,
-                                                          is_training=is_training)
-
-
-class SelfFusedAttnBwdPrimitive(BasePrimitive):
-    """
-    Self Fused Attention Backward Primitive
-    """
-    name = "te_self_fused_attn_backward"
-    multiple_results = True
-    impl_static_args = (7, 8, 9, 10, 11)
-    inner_primitive = None
-    outer_primitive = None
-
-    @staticmethod
-    def abstract(qkv_aval, bias_aval, softmax_aux_aval, rng_state_aval, output_aval, doutput_aval,
-                 seqlen_or_cu_seqlen_aval, *, attn_bias_type, attn_mask_type, scaling_factor,
-                 dropout_probability, is_training):
-        """
-        Self fused attention bwd abstract
-        """
-        del softmax_aux_aval, rng_state_aval, seqlen_or_cu_seqlen_aval
-
-        assert qkv_aval.dtype == bias_aval.dtype == output_aval.dtype == doutput_aval.dtype
-        *input_batch_shape, max_seqlen, nqkv, attn_heads, head_dim = qkv_aval.shape
-        assert nqkv == 3
-        qkv_dtype = dtypes.canonicalize_dtype(qkv_aval.dtype)
-        bias_dtype = dtypes.canonicalize_dtype(bias_aval.dtype)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        input_batch = reduce(operator.mul, input_batch_shape)
-        wkspace_shape, wkspace_dtype = \
-            transformer_engine_jax.get_self_fused_attn_bwd_workspace_sizes(
-                input_batch, bias_batch, max_seqlen, attn_heads, bias_heads, head_dim,
-                scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-                jax_dtype_to_te_dtype(qkv_aval.dtype), is_training
-            )
-
-        dqkv_aval = qkv_aval.update(shape=qkv_aval.shape, dtype=qkv_dtype)
-        dbias_aval = bias_aval.update(shape=bias_aval.shape, dtype=bias_dtype)
-        wkspace_aval = qkv_aval.update(shape=wkspace_shape,
-                                       dtype=te_dtype_to_jax_dtype(wkspace_dtype))
-
-        return dqkv_aval, dbias_aval, wkspace_aval
-
-    @staticmethod
-    def outer_abstract(*args, **kwargs):
-        """
-        Self fused attention bwd outer primitive abstract
-        """
-        dqkv_aval, dbias_aval, _ = SelfFusedAttnBwdPrimitive.abstract(*args, **kwargs)
-        return dqkv_aval, dbias_aval
-
-    @staticmethod
-    def lowering(ctx, qkv, bias, softmax_aux, rng_state, output, doutput, cu_seqlen, *,
-                 attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training):
-        """
-        Self fused attention bwd lowering rules
-        """
-        operands = [qkv, bias, softmax_aux, rng_state, output, doutput, cu_seqlen]
-        operand_shapes = map(lambda x: x.type.shape, operands)
-        out_types = [
-            ir.RankedTensorType.get(output.shape, mlir.dtype_to_ir_type(output.dtype))
-            for output in ctx.avals_out
-        ]
-        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
-
-        qkv_aval, bias_aval, *_ = ctx.avals_in
-        *input_batch_shape, max_seqlen, _, attn_heads, head_dim = qkv_aval.shape
-        input_batch = reduce(operator.mul, input_batch_shape)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        wkspace_aval = ctx.avals_out[-1]
-
-        opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            input_batch, bias_batch, max_seqlen, max_seqlen,
-            attn_heads, attn_heads, bias_heads, head_dim, wkspace_aval.size,
-            scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(qkv_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
-            is_training)
-
-        out = custom_caller(SelfFusedAttnBwdPrimitive.name, args, opaque, has_side_effect=False)
-
-        return out
-
-    @staticmethod
-    def impl(qkv, bias, softmax_aux, rng_state, output, doutput, seqlen, attn_bias_type,
-             attn_mask_type, scaling_factor, dropout_probability, is_training):
-        assert SelfFusedAttnBwdPrimitive.inner_primitive is not None
-
-        cu_seqlen = generate_cu_seqlen(seqlen)
-
-        dqkv, dbias, _ = SelfFusedAttnBwdPrimitive.inner_primitive.bind(
-            qkv,
-            bias,
-            softmax_aux,
-            rng_state,
-            output,
-            doutput,
-            cu_seqlen,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training)
-        return dqkv, dbias
-
-    @staticmethod
-    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, scaling_factor,
-                dropout_probability, is_training):
-        _check_valid_batch_dims(batch_dims)
-        assert SelfFusedAttnBwdPrimitive.outer_primitive is not None
-        qkv_bdim, *_ = batch_dims
-
-        out_bdims = qkv_bdim, qkv_bdim
-        return SelfFusedAttnBwdPrimitive.outer_primitive.bind(
-            *batched_args,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training), out_bdims
-
-    @staticmethod
-    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
-                                     dropout_probability, is_training, mesh, arg_infos,
-                                     result_infos):
-        del attn_bias_type, attn_mask_type, scaling_factor, dropout_probability,
-        del is_training, result_infos
-        x_spec = get_padded_spec(arg_infos[0])
-        bias_spec = get_padded_spec(arg_infos[1])
-        dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec))
-        dbias_sharding = NamedSharding(mesh, PartitionSpec(*bias_spec))
-        return (dx_sharding, dbias_sharding)
-
-    @staticmethod
-    def partition(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training,
-                  mesh, arg_infos, result_infos):
-        del result_infos
-        x_spec = get_padded_spec(arg_infos[0])
-        bias_spec = get_padded_spec(arg_infos[1])
-        dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec))
-        dbias_sharding = NamedSharding(mesh, PartitionSpec(*bias_spec))
-        arg_shardings = tuple(arg_i.sharding for arg_i in arg_infos)
-        out_shardings = (dx_sharding, dbias_sharding)
-
-        def sharded_impl(qkv, bias, softmax_aux, rng_state, output, doutput, cu_seqlen):
-            local_dx, local_dbias = SelfFusedAttnBwdPrimitive.impl(
-                qkv,
-                bias,
-                softmax_aux,
-                rng_state,
-                output,
-                doutput,
-                cu_seqlen,
-                attn_bias_type=attn_bias_type,
-                attn_mask_type=attn_mask_type,
-                scaling_factor=scaling_factor,
-                dropout_probability=dropout_probability,
-                is_training=is_training)
-            global_dbias = local_dbias
-            if attn_bias_type is not NVTE_Bias_Type.NVTE_NO_BIAS:
-                global_dbias = all_reduce_sum_along_dp_fsdp(local_dbias)
-            return local_dx, global_dbias
-
-        return mesh, sharded_impl, out_shardings, arg_shardings
-
-
-register_primitive(SelfFusedAttnBwdPrimitive)
-
-
-def self_fused_attn_bwd(qkv: jnp.ndarray, bias: jnp.ndarray, softmax_aux: jnp.ndarray,
-                        rng_state: jnp.ndarray, output: jnp.ndarray, doutput: jnp.ndarray,
-                        seqlen: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
-                        attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                        dropout_probability: float, is_training: bool):
-    """
-    Wrapper for TE self fused attention bwd
-    Return the gradients of self fused attention with packed qkv input
-    """
-    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-        assert bias is None
-        bias = jnp.zeros(0, dtype=qkv.dtype)
-
-    return SelfFusedAttnBwdPrimitive.outer_primitive.bind(qkv,
-                                                          bias,
-                                                          softmax_aux,
-                                                          rng_state,
-                                                          output,
-                                                          doutput,
-                                                          seqlen,
-                                                          attn_bias_type=attn_bias_type,
-                                                          attn_mask_type=attn_mask_type,
-                                                          scaling_factor=scaling_factor,
-                                                          dropout_probability=dropout_probability,
-                                                          is_training=is_training)
-
-
-class CrossFusedAttnFwdPrimitive(BasePrimitive):
-    """
-    Cross Fused Attention Forward Primitive
-    """
-    name = "te_cross_fused_attn_forward"
-    multiple_results = True
-    impl_static_args = (6, 7, 8, 9, 10)
-    inner_primitive = None
-    outer_primitive = None
-
-    @staticmethod
-    def abstract(q_aval, kv_aval, bias_aval, q_seqlen_or_cu_seqlen_aval,
-                 kv_seqlen_or_cu_seqlen_aval, seed_aval, *, attn_bias_type, attn_mask_type,
-                 scaling_factor, dropout_probability, is_training):
-        """
-        Cross fused attention fwd abstract
-        """
-        q_dtype = dtypes.canonicalize_dtype(q_aval.dtype)
-        kv_dtype = dtypes.canonicalize_dtype(kv_aval.dtype)
-        bias_dtype = dtypes.canonicalize_dtype(bias_aval.dtype)
-        assert q_dtype == kv_dtype == bias_dtype
-        assert q_seqlen_or_cu_seqlen_aval.dtype == kv_seqlen_or_cu_seqlen_aval.dtype
-
-        *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
-        *kv_batch_shape, kv_max_seqlen, nkv, num_gqa_groups, kv_head_dim = kv_aval.shape
-        assert q_batch_shape == kv_batch_shape
-        assert q_head_dim == kv_head_dim
-        assert nkv == 2
-        out_aval = q_aval.update(shape=q_aval.shape, dtype=q_dtype)
-
-        # backend determines the softmax buffer shape/dtype
-        backend = FusedAttnHelper(q_dtype, kv_dtype, NVTE_QKV_Layout.NVTE_BSHD_BS2HD,
-                                  attn_bias_type, attn_mask_type, dropout_probability, attn_heads,
-                                  num_gqa_groups, q_max_seqlen, kv_max_seqlen,
-                                  q_head_dim).get_fused_attn_backend()
-
-        if backend == NVTE_Fused_Attn_Backend.NVTE_F16_max512_seqlen:
-            softmax_shape = (*q_batch_shape, attn_heads, q_max_seqlen, kv_max_seqlen)
-            softmax_dtype = q_dtype
-        elif backend == NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
-            softmax_shape = (*q_batch_shape, attn_heads, q_max_seqlen, 1)
-            softmax_dtype = dtypes.canonicalize_dtype(jnp.float32)
-        else:
-            raise ValueError(f'Unsupported {backend=}')
-        softmax_aux_aval = q_aval.update(shape=softmax_shape, dtype=softmax_dtype)
-
-        # JAX does not enable 64-bit int by default so we get XLA to allocate x8 memory with
-        # 32-bit unsigned int to get the buffer size we need in the C++ kernel
-        checker = _FusedAttnRNGStateChecker()
-        seed_dtype = dtypes.canonicalize_dtype(seed_aval.dtype)
-        assert seed_dtype == checker.rng_state_dtype
-        rng_state_shape = (seed_aval.shape[0], checker.rng_state_size)
-        rng_state_aval = seed_aval.update(shape=rng_state_shape, dtype=checker.rng_state_dtype)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        # do a dummy kernel call here to get workspace buffer shapes/dtypes that XLA needs to
-        # prepare for the active fused-attn backend
-        input_batch = reduce(operator.mul, q_batch_shape)
-        wkspace_info = transformer_engine_jax.get_cross_fused_attn_fwd_workspace_sizes(
-            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-            attn_heads, num_gqa_groups, bias_heads, q_head_dim,
-            scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(q_aval.dtype), is_training)
-        wkspace_aval = q_aval.update(shape=wkspace_info[0],
-                                     dtype=te_dtype_to_jax_dtype(wkspace_info[1]))
-
-        return out_aval, softmax_aux_aval, rng_state_aval, wkspace_aval
-
-    @staticmethod
-    def outer_abstract(*args, **kwargs):
-        """
-        Cross fused attention fwd outer primitive abstract
-        """
-        out_aval, softmax_aux_aval, rng_state_aval, _ = \
-            CrossFusedAttnFwdPrimitive.abstract(*args, **kwargs)
-        return out_aval, softmax_aux_aval, rng_state_aval
-
-    @staticmethod
-    def lowering(ctx, q, kv, bias, q_cu_seqlen, kv_cu_seqlen, seed, *, attn_bias_type,
-                 attn_mask_type, scaling_factor, dropout_probability, is_training):
-        """
-        Cross fused attention fwd lowering rules
-        """
-        operands = [q, kv, bias, q_cu_seqlen, kv_cu_seqlen, seed]
-        operand_shapes = map(lambda x: x.type.shape, operands)
-        out_types = [
-            ir.RankedTensorType.get(output.shape, mlir.dtype_to_ir_type(output.dtype))
-            for output in ctx.avals_out
-        ]
-        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
-
-        q_aval, kv_aval, bias_aval, *_ = ctx.avals_in
-        *input_batch_shape, q_max_seqlen, attn_heads, head_dim = q_aval.shape
-        *_, kv_max_seqlen, _, num_gqa_groups, _ = kv_aval.shape
-        input_batch = reduce(operator.mul, input_batch_shape)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        wkspace_aval = ctx.avals_out[-1]
-
-        opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-            attn_heads, num_gqa_groups, bias_heads, head_dim,
-            wkspace_aval.size, scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(q_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
-            is_training)
-
-        out = custom_caller(CrossFusedAttnFwdPrimitive.name, args, opaque, has_side_effect=False)
-
-        return out
-
-    @staticmethod
-    def impl(q, kv, bias, q_seqlen, kv_seqlen, seed, attn_bias_type, attn_mask_type, scaling_factor,
-             dropout_probability, is_training):
-        assert CrossFusedAttnFwdPrimitive.inner_primitive is not None
-
-        q_cu_seqlen = generate_cu_seqlen(q_seqlen)
-        kv_cu_seqlen = generate_cu_seqlen(kv_seqlen)
-
-        output, softmax_aux, rng_state, _ = CrossFusedAttnFwdPrimitive.inner_primitive.bind(
-            q,
-            kv,
-            bias,
-            q_cu_seqlen,
-            kv_cu_seqlen,
-            seed,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training)
-        return output, softmax_aux, rng_state
-
-    @staticmethod
-    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, scaling_factor,
-                dropout_probability, is_training):
-        _check_valid_batch_dims(batch_dims)
-        assert CrossFusedAttnFwdPrimitive.outer_primitive is not None
-        q_bdim, *_, seed_bdim = batch_dims
-
-        out_bdims = q_bdim, q_bdim, seed_bdim
-        return CrossFusedAttnFwdPrimitive.outer_primitive.bind(
-            *batched_args,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training), out_bdims
-
-    @staticmethod
-    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
-                                     dropout_probability, is_training, mesh, arg_infos,
-                                     result_infos):
-        del attn_bias_type, attn_mask_type, scaling_factor
-        del dropout_probability, is_training, result_infos
-        q_spec = get_padded_spec(arg_infos[0])    # (...batch, q_seqlen, head, hidden)
-        kv_spec = get_padded_spec(arg_infos[1])    # (...batch, kv_seqlen, 2, head, hidden)
-        out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
-        softmax_aux_sharding = NamedSharding(
-            mesh, PartitionSpec(*q_spec[:-3], q_spec[-2], q_spec[-3], kv_spec[-4]))
-        rng_state_sharding = NamedSharding(mesh, PartitionSpec(get_all_mesh_axes(), None))
-        return (out_sharding, softmax_aux_sharding, rng_state_sharding)
-
-    @staticmethod
-    def partition(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training,
-                  mesh, arg_infos, result_infos):
-        del result_infos
-        q_spec = get_padded_spec(arg_infos[0])    # (...batch, q_seqlen, head, hidden)
-        kv_spec = get_padded_spec(arg_infos[1])    # (...batch, kv_seqlen, 2, head, hidden)
-        out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
-        softmax_aux_sharding = NamedSharding(
-            mesh, PartitionSpec(*q_spec[:-3], q_spec[-2], q_spec[-3], kv_spec[-4]))
-        rng_state_sharding = seed_sharding = NamedSharding(mesh,
-                                                           PartitionSpec(get_all_mesh_axes(), None))
-        arg_shardings = tuple([arg_i.sharding for arg_i in arg_infos[:-1]] + [seed_sharding])
-        out_shardings = (out_sharding, softmax_aux_sharding, rng_state_sharding)
-        impl = partial(CrossFusedAttnFwdPrimitive.impl,
-                       attn_bias_type=attn_bias_type,
-                       attn_mask_type=attn_mask_type,
-                       scaling_factor=scaling_factor,
-                       dropout_probability=dropout_probability,
-                       is_training=is_training)
-        return mesh, impl, out_shardings, arg_shardings
-
-
-register_primitive(CrossFusedAttnFwdPrimitive)
-
-
-def cross_fused_attn_fwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray, q_seqlen: jnp.ndarray,
-                         kv_seqlen: jnp.ndarray, seed: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
-                         attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                         dropout_probability: float, is_training: bool):
-    """
-    Wrapper for TE cross fused attention fwd
-    Return BMM1 -> (PreScaleBias) -> Scale -> (PostScaleBias) -> Softmax -> (Dropout) -> BMM2
-    """
-    checker = _FusedAttnRNGStateChecker()
-    seed = checker.check_seed(seed, dropout_probability, is_training)
-
-    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-        assert bias is None
-        bias = jnp.zeros(0, dtype=q.dtype)
-
-    return CrossFusedAttnFwdPrimitive.outer_primitive.bind(q,
-                                                           kv,
-                                                           bias,
-                                                           q_seqlen,
-                                                           kv_seqlen,
-                                                           seed,
-                                                           attn_bias_type=attn_bias_type,
-                                                           attn_mask_type=attn_mask_type,
-                                                           scaling_factor=scaling_factor,
-                                                           dropout_probability=dropout_probability,
-                                                           is_training=is_training)
-
-
-class CrossFusedAttnBwdPrimitive(BasePrimitive):
-    """
-    Cross Fused Attention Backward Primitive
-    """
-    name = "te_cross_fused_attn_backward"
-    multiple_results = True
-    impl_static_args = (9, 10, 11, 12, 13)
-    inner_primitive = None
-    outer_primitive = None
-
-    @staticmethod
-    def abstract(q_aval, kv_aval, bias_aval, softmax_aux_aval, rng_state_aval, output_aval,
-                 doutput_aval, q_cu_seqlen_aval, kv_cu_seqlen_aval, *, attn_bias_type,
-                 attn_mask_type, scaling_factor, dropout_probability, is_training):
-        """
-        Cross fused attention bwd abstract
-        """
-        del softmax_aux_aval, rng_state_aval, output_aval
-
-        q_dtype = dtypes.canonicalize_dtype(q_aval.dtype)
-        kv_dtype = dtypes.canonicalize_dtype(kv_aval.dtype)
-        bias_dtype = dtypes.canonicalize_dtype(bias_aval.dtype)
-        doutput_dtype = dtypes.canonicalize_dtype(doutput_aval.dtype)
-        assert q_dtype == kv_dtype == bias_dtype == doutput_dtype
-        assert q_cu_seqlen_aval.dtype == kv_cu_seqlen_aval.dtype
-
-        *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
-        *kv_batch_shape, kv_max_seqlen, nkv, num_gqa_groups, kv_head_dim = kv_aval.shape
-        assert q_batch_shape == kv_batch_shape
-        assert q_head_dim == kv_head_dim
-        assert nkv == 2
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        input_batch = reduce(operator.mul, q_batch_shape)
-        wkspace_shape, wkspace_dtype = \
-            transformer_engine_jax.get_cross_fused_attn_bwd_workspace_sizes(
-                input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-                attn_heads, num_gqa_groups, bias_heads, q_head_dim,
-                scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-                jax_dtype_to_te_dtype(q_aval.dtype), is_training
-            )
-
-        dq_aval = q_aval.update(shape=q_aval.shape, dtype=q_dtype)
-        dkv_aval = kv_aval.update(shape=kv_aval.shape, dtype=kv_dtype)
-        dbias_aval = bias_aval.update(shape=bias_aval.shape, dtype=bias_dtype)
-        wkspace_aval = q_aval.update(shape=wkspace_shape,
-                                     dtype=te_dtype_to_jax_dtype(wkspace_dtype))
-
-        return dq_aval, dkv_aval, dbias_aval, wkspace_aval
-
-    @staticmethod
-    def outer_abstract(*args, **kwargs):
-        """
-        Cross fused attention fwd outer primitive abstract
-        """
-        dq_aval, dkv_aval, dbias_aval, _ = \
-            CrossFusedAttnBwdPrimitive.abstract(*args, **kwargs)
-        return dq_aval, dkv_aval, dbias_aval
-
-    @staticmethod
-    def lowering(ctx, q, kv, bias, softmax_aux, rng_state, output, doutput, q_cu_seqlen,
-                 kv_cu_seqlen, *, attn_bias_type, attn_mask_type, scaling_factor,
-                 dropout_probability, is_training):
-        """
-        Cross fused attention bwd lowering rules
-        """
-        operands = [q, kv, bias, softmax_aux, rng_state, output, doutput, q_cu_seqlen, kv_cu_seqlen]
-        operand_shapes = map(lambda x: x.type.shape, operands)
-        out_types = [
-            ir.RankedTensorType.get(output.shape, mlir.dtype_to_ir_type(output.dtype))
-            for output in ctx.avals_out
-        ]
-
-        args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
-
-        q_aval, kv_aval, bias_aval, *_ = ctx.avals_in
-        *input_batch_shape, q_max_seqlen, attn_heads, head_dim = q_aval.shape
-        *_, kv_max_seqlen, _, num_gqa_groups, _ = kv_aval.shape
-        input_batch = reduce(operator.mul, input_batch_shape)
-
-        if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-            bias_batch = bias_heads = 0
-        else:
-            *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
-            bias_batch = reduce(operator.mul, bias_batch_shape)
-
-        wkspace_aval = ctx.avals_out[-1]
-
-        opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-            attn_heads, num_gqa_groups, bias_heads, head_dim,
-            wkspace_aval.size, scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(q_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
-            is_training)
-
-        out = custom_caller(CrossFusedAttnBwdPrimitive.name, args, opaque, has_side_effect=False)
-
-        return out
-
-    @staticmethod
-    def impl(q, kv, bias, softmax_aux, rng_state, output, doutput, q_seqlen, kv_seqlen,
-             attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training):
-        assert CrossFusedAttnBwdPrimitive.inner_primitive is not None
-
-        q_cu_seqlen = generate_cu_seqlen(q_seqlen)
-        kv_cu_seqlen = generate_cu_seqlen(kv_seqlen)
-
-        dq, dkv, dbias, _ = CrossFusedAttnBwdPrimitive.inner_primitive.bind(
-            q,
-            kv,
-            bias,
-            softmax_aux,
-            rng_state,
-            output,
-            doutput,
-            q_cu_seqlen,
-            kv_cu_seqlen,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training)
-        return dq, dkv, dbias
-
-    @staticmethod
-    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, scaling_factor,
-                dropout_probability, is_training):
-        _check_valid_batch_dims(batch_dims)
-        assert CrossFusedAttnBwdPrimitive.outer_primitive is not None
-        q_bdim, kv_bdim, *_ = batch_dims
-
-        out_bdims = q_bdim, kv_bdim, q_bdim
-        return CrossFusedAttnBwdPrimitive.outer_primitive.bind(
-            *batched_args,
-            attn_bias_type=attn_bias_type,
-            attn_mask_type=attn_mask_type,
-            scaling_factor=scaling_factor,
-            dropout_probability=dropout_probability,
-            is_training=is_training), out_bdims
-
-    @staticmethod
-    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
-                                     dropout_probability, is_training, mesh, arg_infos,
-                                     result_infos):
-        del attn_bias_type, attn_mask_type, scaling_factor
-        del dropout_probability, is_training, result_infos
-        q_spec = get_padded_spec(arg_infos[0])
-        kv_spec = get_padded_spec(arg_infos[1])
-        bias_spec = get_padded_spec(arg_infos[2])
-        dq_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
-        dkv_sharding = NamedSharding(mesh, PartitionSpec(*kv_spec))
-        dbias_sharding = NamedSharding(mesh, PartitionSpec(*bias_spec))
-        return (dq_sharding, dkv_sharding, dbias_sharding)
-
-    @staticmethod
-    def partition(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training,
-                  mesh, arg_infos, result_infos):
-        del result_infos
-        q_spec = get_padded_spec(arg_infos[0])
-        kv_spec = get_padded_spec(arg_infos[1])
-        bias_spec = get_padded_spec(arg_infos[2])
-        dq_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
-        dkv_sharding = NamedSharding(mesh, PartitionSpec(*kv_spec))
-        dbias_sharding = NamedSharding(mesh, PartitionSpec(*bias_spec))
-        arg_shardings = tuple(arg_i.sharding for arg_i in arg_infos)
-        out_shardings = (dq_sharding, dkv_sharding, dbias_sharding)
-
-        def sharded_impl(q, kv, bias, softmax_aux, rng_state, output, doutput, q_cu_seqlen,
-                         kv_cu_seqlen):
-            local_dq, local_dkv, local_dbias = CrossFusedAttnBwdPrimitive.impl(
-                q,
-                kv,
-                bias,
-                softmax_aux,
-                rng_state,
-                output,
-                doutput,
-                q_cu_seqlen,
-                kv_cu_seqlen,
-                attn_bias_type=attn_bias_type,
-                attn_mask_type=attn_mask_type,
-                scaling_factor=scaling_factor,
-                dropout_probability=dropout_probability,
-                is_training=is_training)
-            global_dbias = local_dbias
-            if attn_bias_type is not NVTE_Bias_Type.NVTE_NO_BIAS:
-                global_dbias = all_reduce_sum_along_dp_fsdp(local_dbias)
-            return local_dq, local_dkv, global_dbias
-
-        return mesh, sharded_impl, out_shardings, arg_shardings
-
-
-register_primitive(CrossFusedAttnBwdPrimitive)
-
-
-def cross_fused_attn_bwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray,
-                         softmax_aux: jnp.ndarray, rng_state: jnp.ndarray, output: jnp.ndarray,
-                         doutput: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
-                         attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
-                         scaling_factor: float, dropout_probability: float, is_training: bool):
-    """
-    Wrapper for TE cross fused attention bwd
-    Return the gradients of cross fused attention with packed kv input
-    """
-    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-        assert bias is None
-        bias = jnp.zeros(0, dtype=q.dtype)
-
-    return CrossFusedAttnBwdPrimitive.outer_primitive.bind(q,
-                                                           kv,
-                                                           bias,
-                                                           softmax_aux,
-                                                           rng_state,
-                                                           output,
-                                                           doutput,
-                                                           q_seqlen,
-                                                           kv_seqlen,
-                                                           attn_bias_type=attn_bias_type,
-                                                           attn_mask_type=attn_mask_type,
-                                                           scaling_factor=scaling_factor,
-                                                           dropout_probability=dropout_probability,
-                                                           is_training=is_training)
-
-
 class FusedAttnFwdPrimitive(BasePrimitive):
     """
     Fused Attention Forward Primitive
-    Query, key, value are seperated tensors
     """
     name = "te_fused_attn_forward"
     multiple_results = True
-    impl_static_args = (7, 8, 9, 10, 11)
+    impl_static_args = (7, 8, 9, 10, 11, 12)
     inner_primitive = None
     outer_primitive = None
 
     @staticmethod
     def abstract(q_aval, k_aval, v_aval, bias_aval, q_seqlen_or_cu_seqlen_aval,
                  kv_seqlen_or_cu_seqlen_aval, seed_aval, *, attn_bias_type, attn_mask_type,
-                 scaling_factor, dropout_probability, is_training):
+                 qkv_layout, scaling_factor, dropout_probability, is_training):
         """
         Fused attention fwd abstract
         """
@@ -2826,23 +1974,22 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         assert q_dtype == k_dtype == v_dtype == bias_dtype
         assert q_seqlen_or_cu_seqlen_aval.dtype == kv_seqlen_or_cu_seqlen_aval.dtype
 
-        *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
-        *kv_batch_shape, kv_max_seqlen, num_gqa_groups, kv_head_dim = k_aval.shape
-        assert q_batch_shape == kv_batch_shape
-        assert q_head_dim == kv_head_dim
-        assert k_aval.shape == v_aval.shape
-        out_aval = q_aval.update(shape=q_aval.shape, dtype=q_dtype)
+        batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, head_dim = \
+            FusedAttnHelper.parse_qkv_aval(q_aval, k_aval, v_aval, qkv_layout)
+
+        output_shape = (*batch_shape, q_max_seqlen, attn_heads, head_dim)
+        out_aval = q_aval.update(shape=output_shape, dtype=q_dtype)
 
         # backend determines the softmax buffer shape/dtype
-        backend = FusedAttnHelper(q_dtype, k_dtype, NVTE_QKV_Layout.NVTE_BSHD_BS2HD, attn_bias_type,
-                                  attn_mask_type, dropout_probability, attn_heads, num_gqa_groups,
-                                  q_max_seqlen, kv_max_seqlen, q_head_dim).get_fused_attn_backend()
+        backend = FusedAttnHelper(q_dtype, k_dtype, qkv_layout, attn_bias_type, attn_mask_type,
+                                  dropout_probability, attn_heads, num_gqa_groups, q_max_seqlen,
+                                  kv_max_seqlen, head_dim).get_fused_attn_backend()
 
         if backend == NVTE_Fused_Attn_Backend.NVTE_F16_max512_seqlen:
-            softmax_shape = (*q_batch_shape, attn_heads, q_max_seqlen, kv_max_seqlen)
+            softmax_shape = (*batch_shape, attn_heads, q_max_seqlen, kv_max_seqlen)
             softmax_dtype = q_dtype
         elif backend == NVTE_Fused_Attn_Backend.NVTE_F16_arbitrary_seqlen:
-            softmax_shape = (*q_batch_shape, attn_heads, q_max_seqlen, 1)
+            softmax_shape = (*batch_shape, attn_heads, q_max_seqlen, 1)
             softmax_dtype = dtypes.canonicalize_dtype(jnp.float32)
         else:
             raise ValueError(f'Unsupported {backend=}')
@@ -2864,12 +2011,11 @@ class FusedAttnFwdPrimitive(BasePrimitive):
 
         # do a dummy kernel call here to get workspace buffer shapes/dtypes that XLA needs to
         # prepare for the active fused-attn backend
-        input_batch = reduce(operator.mul, q_batch_shape)
+        input_batch = reduce(operator.mul, batch_shape)
         wkspace_info = transformer_engine_jax.get_fused_attn_fwd_workspace_sizes(
-            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-            attn_heads, num_gqa_groups, bias_heads, q_head_dim,
-            scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(q_aval.dtype), is_training)
+            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups,
+            bias_heads, head_dim, scaling_factor, dropout_probability, attn_bias_type,
+            attn_mask_type, qkv_layout, jax_dtype_to_te_dtype(q_aval.dtype), is_training)
         wkspace_aval = q_aval.update(shape=wkspace_info[0],
                                      dtype=te_dtype_to_jax_dtype(wkspace_info[1]))
 
@@ -2886,7 +2032,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
 
     @staticmethod
     def lowering(ctx, q, k, v, bias, q_cu_seqlen, kv_cu_seqlen, seed, *, attn_bias_type,
-                 attn_mask_type, scaling_factor, dropout_probability, is_training):
+                 attn_mask_type, qkv_layout, scaling_factor, dropout_probability, is_training):
         """
         Fused attention fwd lowering rules
         """
@@ -2899,9 +2045,10 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
 
         q_aval, k_aval, v_aval, bias_aval, *_ = ctx.avals_in
-        *batch_shape, q_max_seqlen, attn_heads, head_dim = q_aval.shape
-        *_, kv_max_seqlen, num_gqa_groups, _ = k_aval.shape
-        assert k_aval.shape == v_aval.shape
+
+        batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, head_dim = \
+            FusedAttnHelper.parse_qkv_aval(q_aval, k_aval, v_aval, qkv_layout)
+
         input_batch = reduce(operator.mul, batch_shape)
 
         if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
@@ -2913,18 +2060,17 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         wkspace_aval = ctx.avals_out[-1]
 
         opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-            attn_heads, num_gqa_groups, bias_heads, head_dim,
-            wkspace_aval.size, scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(q_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
-            is_training)
+            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups,
+            bias_heads, head_dim, wkspace_aval.size, scaling_factor, dropout_probability,
+            attn_bias_type, attn_mask_type, qkv_layout, jax_dtype_to_te_dtype(q_aval.dtype),
+            jax_dtype_to_te_dtype(wkspace_aval.dtype), is_training)
 
         out = custom_caller(FusedAttnFwdPrimitive.name, args, opaque, has_side_effect=False)
 
         return out
 
     @staticmethod
-    def impl(q, k, v, bias, q_seqlen, kv_seqlen, seed, attn_bias_type, attn_mask_type,
+    def impl(q, k, v, bias, q_seqlen, kv_seqlen, seed, attn_bias_type, attn_mask_type, qkv_layout,
              scaling_factor, dropout_probability, is_training):
         assert FusedAttnFwdPrimitive.inner_primitive is not None
 
@@ -2941,14 +2087,15 @@ class FusedAttnFwdPrimitive(BasePrimitive):
             seed,
             attn_bias_type=attn_bias_type,
             attn_mask_type=attn_mask_type,
+            qkv_layout=qkv_layout,
             scaling_factor=scaling_factor,
             dropout_probability=dropout_probability,
             is_training=is_training)
         return output, softmax_aux, rng_state
 
     @staticmethod
-    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, scaling_factor,
-                dropout_probability, is_training):
+    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, qkv_layout,
+                scaling_factor, dropout_probability, is_training):
         _check_valid_batch_dims(batch_dims)
         assert FusedAttnFwdPrimitive.outer_primitive is not None
         q_bdim, *_, seed_bdim = batch_dims
@@ -2957,33 +2104,47 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         return FusedAttnFwdPrimitive.outer_primitive.bind(*batched_args,
                                                           attn_bias_type=attn_bias_type,
                                                           attn_mask_type=attn_mask_type,
+                                                          qkv_layout=qkv_layout,
                                                           scaling_factor=scaling_factor,
                                                           dropout_probability=dropout_probability,
                                                           is_training=is_training), out_bdims
 
     @staticmethod
-    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
+    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, qkv_layout, scaling_factor,
                                      dropout_probability, is_training, mesh, arg_infos,
                                      result_infos):
         del attn_bias_type, attn_mask_type, scaling_factor
         del dropout_probability, is_training, result_infos
-        q_spec = get_padded_spec(arg_infos[0])    # (...batch, q_seqlen, head, hidden)
-        k_spec = get_padded_spec(arg_infos[1])    # (...batch, kv_seqlen, head, hidden)
-        out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
-        softmax_aux_sharding = NamedSharding(
-            mesh, PartitionSpec(*q_spec[:-3], q_spec[-2], q_spec[-3], k_spec[-3]))
+        q_spec = get_padded_spec(arg_infos[0])
+        k_spec = get_padded_spec(arg_infos[1])
+        match qkv_layout:
+            case NVTE_QKV_Layout.NVTE_BS3HD:
+                # q_spec = (...batch, q_seqlen, head, hidden)
+                out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec[:-3], *q_spec[-2:]))
+                softmax_aux_sharding = NamedSharding(
+                    mesh, PartitionSpec(*q_spec[:-4], q_spec[-2], q_spec[-4], None))
+            case NVTE_QKV_Layout.NVTE_BSHD_BS2HD:
+                # q_spec = (...batch, q_seqlen, head, hidden)
+                # k_spec = (...batch, kv_seqlen, 2, num_gqa_groups, hidden)
+                out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
+                softmax_aux_sharding = NamedSharding(
+                    mesh, PartitionSpec(*q_spec[:-3], q_spec[-2], q_spec[-3], k_spec[-4]))
+            case NVTE_QKV_Layout.NVTE_BSHD_BSHD_BSHD:
+                # q_spec = (...batch, q_seqlen, head, hidden)
+                # k_spec = (...batch, kv_seqlen, num_gqa_groups, hidden)
+                out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
+                softmax_aux_sharding = NamedSharding(
+                    mesh, PartitionSpec(*q_spec[:-3], q_spec[-2], q_spec[-3], k_spec[-3]))
+            case _:
+                raise ValueError(f"Unsupported {qkv_layout=}")
         rng_state_sharding = NamedSharding(mesh, PartitionSpec(get_all_mesh_axes(), None))
         return (out_sharding, softmax_aux_sharding, rng_state_sharding)
 
     @staticmethod
-    def partition(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training,
-                  mesh, arg_infos, result_infos):
-        del result_infos
-        q_spec = get_padded_spec(arg_infos[0])    # (...batch, q_seqlen, head, hidden)
-        k_spec = get_padded_spec(arg_infos[1])    # (...batch, kv_seqlen, head, hidden)
-        out_sharding = NamedSharding(mesh, PartitionSpec(*q_spec))
-        softmax_aux_sharding = NamedSharding(
-            mesh, PartitionSpec(*q_spec[:-3], q_spec[-2], q_spec[-3], k_spec[-3]))
+    def partition(attn_bias_type, attn_mask_type, qkv_layout, scaling_factor, dropout_probability,
+                  is_training, mesh, arg_infos, result_infos):
+        out_sharding = result_infos[0].sharding
+        softmax_aux_sharding = result_infos[1].sharding
         rng_state_sharding = seed_sharding = NamedSharding(mesh,
                                                            PartitionSpec(get_all_mesh_axes(), None))
         arg_shardings = tuple([arg_i.sharding for arg_i in arg_infos[:-1]] + [seed_sharding])
@@ -2991,6 +2152,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         impl = partial(FusedAttnFwdPrimitive.impl,
                        attn_bias_type=attn_bias_type,
                        attn_mask_type=attn_mask_type,
+                       qkv_layout=qkv_layout,
                        scaling_factor=scaling_factor,
                        dropout_probability=dropout_probability,
                        is_training=is_training)
@@ -3000,49 +2162,20 @@ class FusedAttnFwdPrimitive(BasePrimitive):
 register_primitive(FusedAttnFwdPrimitive)
 
 
-def fused_attn_fwd(q: jnp.ndarray, k: jnp.ndarray, v: jnp.ndarray, bias: jnp.ndarray,
-                   q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray, seed: jnp.ndarray,
-                   attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
-                   scaling_factor: float, dropout_probability: float, is_training: bool):
-    """
-    Wrapper for TE fused attention fwd, where query, key, value are seperated tensors
-    Return BMM1 -> (PreScaleBias) -> Scale -> (PostScaleBias) -> Softmax -> (Dropout) -> BMM2
-    """
-    checker = _FusedAttnRNGStateChecker()
-    seed = checker.check_seed(seed, dropout_probability, is_training)
-
-    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
-        assert bias is None
-        bias = jnp.zeros(0, dtype=q.dtype)
-
-    return FusedAttnFwdPrimitive.outer_primitive.bind(q,
-                                                      k,
-                                                      v,
-                                                      bias,
-                                                      q_seqlen,
-                                                      kv_seqlen,
-                                                      seed,
-                                                      attn_bias_type=attn_bias_type,
-                                                      attn_mask_type=attn_mask_type,
-                                                      scaling_factor=scaling_factor,
-                                                      dropout_probability=dropout_probability,
-                                                      is_training=is_training)
-
-
 class FusedAttnBwdPrimitive(BasePrimitive):
     """
     Fused Attention Backward Primitive
     """
     name = "te_fused_attn_backward"
     multiple_results = True
-    impl_static_args = (10, 11, 12, 13, 14)
+    impl_static_args = (10, 11, 12, 13, 14, 15)
     inner_primitive = None
     outer_primitive = None
 
     @staticmethod
     def abstract(q_aval, k_aval, v_aval, bias_aval, softmax_aux_aval, rng_state_aval, output_aval,
                  doutput_aval, q_cu_seqlen_aval, kv_cu_seqlen_aval, *, attn_bias_type,
-                 attn_mask_type, scaling_factor, dropout_probability, is_training):
+                 attn_mask_type, qkv_layout, scaling_factor, dropout_probability, is_training):
         """
         Fused attention bwd abstract
         """
@@ -3056,11 +2189,8 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         assert q_dtype == k_dtype == v_dtype == bias_dtype == doutput_dtype
         assert q_cu_seqlen_aval.dtype == kv_cu_seqlen_aval.dtype
 
-        *q_batch_shape, q_max_seqlen, attn_heads, q_head_dim = q_aval.shape
-        *kv_batch_shape, kv_max_seqlen, num_gqa_groups, kv_head_dim = k_aval.shape
-        assert q_batch_shape == kv_batch_shape
-        assert q_head_dim == kv_head_dim
-        assert k_aval.shape == v_aval.shape
+        batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, head_dim = \
+            FusedAttnHelper.parse_qkv_aval(q_aval, k_aval, v_aval, qkv_layout)
 
         if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
             bias_batch = bias_heads = 0
@@ -3068,14 +2198,12 @@ class FusedAttnBwdPrimitive(BasePrimitive):
             *bias_batch_shape, bias_heads, _, _ = bias_aval.shape
             bias_batch = reduce(operator.mul, bias_batch_shape)
 
-        input_batch = reduce(operator.mul, q_batch_shape)
+        input_batch = reduce(operator.mul, batch_shape)
         wkspace_shape, wkspace_dtype = \
             transformer_engine_jax.get_fused_attn_bwd_workspace_sizes(
-                input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-                attn_heads, num_gqa_groups, bias_heads, q_head_dim,
-                scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-                jax_dtype_to_te_dtype(q_aval.dtype), is_training
-            )
+                input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups,
+                bias_heads, head_dim, scaling_factor, dropout_probability, attn_bias_type,
+                attn_mask_type, qkv_layout, jax_dtype_to_te_dtype(q_aval.dtype), is_training)
 
         dq_aval = q_aval.update(shape=q_aval.shape, dtype=q_dtype)
         dk_aval = k_aval.update(shape=k_aval.shape, dtype=k_dtype)
@@ -3097,7 +2225,7 @@ class FusedAttnBwdPrimitive(BasePrimitive):
 
     @staticmethod
     def lowering(ctx, q, k, v, bias, softmax_aux, rng_state, output, doutput, q_cu_seqlen,
-                 kv_cu_seqlen, *, attn_bias_type, attn_mask_type, scaling_factor,
+                 kv_cu_seqlen, *, attn_bias_type, attn_mask_type, qkv_layout, scaling_factor,
                  dropout_probability, is_training):
         """
         Fused attention bwd lowering rules
@@ -3114,9 +2242,10 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         args = CustomCallArgsWrapper(out_types, operands, operand_shapes)
 
         q_aval, k_aval, v_aval, bias_aval, *_ = ctx.avals_in
-        *batch_shape, q_max_seqlen, attn_heads, head_dim = q_aval.shape
-        *_, kv_max_seqlen, num_gqa_groups, _ = k_aval.shape
-        assert k_aval.shape == v_aval.shape
+
+        batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, head_dim = \
+            FusedAttnHelper.parse_qkv_aval(q_aval, k_aval, v_aval, qkv_layout)
+
         input_batch = reduce(operator.mul, batch_shape)
 
         if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
@@ -3128,11 +2257,10 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         wkspace_aval = ctx.avals_out[-1]
 
         opaque = transformer_engine_jax.pack_fused_attn_descriptor(
-            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-            attn_heads, num_gqa_groups, bias_heads, head_dim,
-            wkspace_aval.size, scaling_factor, dropout_probability, attn_bias_type, attn_mask_type,
-            jax_dtype_to_te_dtype(q_aval.dtype), jax_dtype_to_te_dtype(wkspace_aval.dtype),
-            is_training)
+            input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups,
+            bias_heads, head_dim, wkspace_aval.size, scaling_factor, dropout_probability,
+            attn_bias_type, attn_mask_type, qkv_layout, jax_dtype_to_te_dtype(q_aval.dtype),
+            jax_dtype_to_te_dtype(wkspace_aval.dtype), is_training)
 
         out = custom_caller(FusedAttnBwdPrimitive.name, args, opaque, has_side_effect=False)
 
@@ -3140,7 +2268,8 @@ class FusedAttnBwdPrimitive(BasePrimitive):
 
     @staticmethod
     def impl(q, k, v, bias, softmax_aux, rng_state, output, doutput, q_seqlen, kv_seqlen,
-             attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training):
+             attn_bias_type, attn_mask_type, qkv_layout, scaling_factor, dropout_probability,
+             is_training):
         assert FusedAttnBwdPrimitive.inner_primitive is not None
 
         q_cu_seqlen = generate_cu_seqlen(q_seqlen)
@@ -3159,14 +2288,15 @@ class FusedAttnBwdPrimitive(BasePrimitive):
             kv_cu_seqlen,
             attn_bias_type=attn_bias_type,
             attn_mask_type=attn_mask_type,
+            qkv_layout=qkv_layout,
             scaling_factor=scaling_factor,
             dropout_probability=dropout_probability,
             is_training=is_training)
         return dq, dk, dv, dbias
 
     @staticmethod
-    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, scaling_factor,
-                dropout_probability, is_training):
+    def batcher(batched_args, batch_dims, *, attn_bias_type, attn_mask_type, qkv_layout,
+                scaling_factor, dropout_probability, is_training):
         _check_valid_batch_dims(batch_dims)
         assert FusedAttnBwdPrimitive.outer_primitive is not None
         q_bdim, k_bdim, v_bdim, *_ = batch_dims
@@ -3175,15 +2305,16 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         return FusedAttnBwdPrimitive.outer_primitive.bind(*batched_args,
                                                           attn_bias_type=attn_bias_type,
                                                           attn_mask_type=attn_mask_type,
+                                                          qkv_layout=qkv_layout,
                                                           scaling_factor=scaling_factor,
                                                           dropout_probability=dropout_probability,
                                                           is_training=is_training), out_bdims
 
     @staticmethod
-    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, scaling_factor,
+    def infer_sharding_from_operands(attn_bias_type, attn_mask_type, qkv_layout, scaling_factor,
                                      dropout_probability, is_training, mesh, arg_infos,
                                      result_infos):
-        del attn_bias_type, attn_mask_type, scaling_factor
+        del attn_bias_type, attn_mask_type, qkv_layout, scaling_factor
         del dropout_probability, is_training, result_infos
         q_spec = get_padded_spec(arg_infos[0])
         k_spec = get_padded_spec(arg_infos[1])
@@ -3196,8 +2327,8 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         return (dq_sharding, dk_sharding, dv_sharding, dbias_sharding)
 
     @staticmethod
-    def partition(attn_bias_type, attn_mask_type, scaling_factor, dropout_probability, is_training,
-                  mesh, arg_infos, result_infos):
+    def partition(attn_bias_type, attn_mask_type, qkv_layout, scaling_factor, dropout_probability,
+                  is_training, mesh, arg_infos, result_infos):
         del result_infos
         q_spec = get_padded_spec(arg_infos[0])
         k_spec = get_padded_spec(arg_infos[1])
@@ -3225,6 +2356,7 @@ class FusedAttnBwdPrimitive(BasePrimitive):
                 kv_cu_seqlen,
                 attn_bias_type=attn_bias_type,
                 attn_mask_type=attn_mask_type,
+                qkv_layout=qkv_layout,
                 scaling_factor=scaling_factor,
                 dropout_probability=dropout_probability,
                 is_training=is_training)
@@ -3239,6 +2371,163 @@ class FusedAttnBwdPrimitive(BasePrimitive):
 register_primitive(FusedAttnBwdPrimitive)
 
 
+def self_fused_attn_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, seqlen: jnp.ndarray, seed: jnp.ndarray,
+                        attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                        scaling_factor: float, dropout_probability: float, is_training: bool):
+    """
+    Wrapper for TE self fused attention fwd
+    Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
+    """
+    checker = _FusedAttnRNGStateChecker()
+    seed = checker.check_seed(seed, dropout_probability, is_training)
+
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        assert bias is None
+        bias = jnp.zeros(0, dtype=qkv.dtype)
+
+    _not_used = jnp.zeros(0, qkv.dtype)
+    return FusedAttnFwdPrimitive.outer_primitive.bind(qkv,
+                                                      _not_used,
+                                                      _not_used,
+                                                      bias,
+                                                      seqlen,
+                                                      seqlen,
+                                                      seed,
+                                                      attn_bias_type=attn_bias_type,
+                                                      attn_mask_type=attn_mask_type,
+                                                      qkv_layout=NVTE_QKV_Layout.NVTE_BS3HD,
+                                                      scaling_factor=scaling_factor,
+                                                      dropout_probability=dropout_probability,
+                                                      is_training=is_training)
+
+
+def self_fused_attn_bwd(qkv: jnp.ndarray, bias: jnp.ndarray, softmax_aux: jnp.ndarray,
+                        rng_state: jnp.ndarray, output: jnp.ndarray, doutput: jnp.ndarray,
+                        seqlen: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
+                        attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
+                        dropout_probability: float, is_training: bool):
+    """
+    Wrapper for TE self fused attention bwd
+    Return the gradients of self fused attention with packed qkv input
+    """
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        assert bias is None
+        bias = jnp.zeros(0, dtype=qkv.dtype)
+    dummy_input = jnp.zeros(0, dtype=qkv.dtype)
+    dqkv, *_, dbias = FusedAttnBwdPrimitive.outer_primitive.bind(
+        qkv,
+        dummy_input,
+        dummy_input,
+        bias,
+        softmax_aux,
+        rng_state,
+        output,
+        doutput,
+        seqlen,
+        seqlen,
+        attn_bias_type=attn_bias_type,
+        attn_mask_type=attn_mask_type,
+        qkv_layout=NVTE_QKV_Layout.NVTE_BS3HD,
+        scaling_factor=scaling_factor,
+        dropout_probability=dropout_probability,
+        is_training=is_training)
+    return dqkv, dbias
+
+
+def cross_fused_attn_fwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray, q_seqlen: jnp.ndarray,
+                         kv_seqlen: jnp.ndarray, seed: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
+                         attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
+                         dropout_probability: float, is_training: bool):
+    """
+    Wrapper for TE cross fused attention fwd
+    Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
+    """
+    checker = _FusedAttnRNGStateChecker()
+    seed = checker.check_seed(seed, dropout_probability, is_training)
+
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        assert bias is None
+        bias = jnp.zeros(0, dtype=q.dtype)
+
+    return FusedAttnFwdPrimitive.outer_primitive.bind(q,
+                                                      kv,
+                                                      jnp.zeros(0, q.dtype),
+                                                      bias,
+                                                      q_seqlen,
+                                                      kv_seqlen,
+                                                      seed,
+                                                      attn_bias_type=attn_bias_type,
+                                                      attn_mask_type=attn_mask_type,
+                                                      qkv_layout=NVTE_QKV_Layout.NVTE_BSHD_BS2HD,
+                                                      scaling_factor=scaling_factor,
+                                                      dropout_probability=dropout_probability,
+                                                      is_training=is_training)
+
+
+def cross_fused_attn_bwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray,
+                         softmax_aux: jnp.ndarray, rng_state: jnp.ndarray, output: jnp.ndarray,
+                         doutput: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
+                         attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                         scaling_factor: float, dropout_probability: float, is_training: bool):
+    """
+    Wrapper for TE cross fused attention bwd
+    Return the gradients of cross fused attention with packed kv input
+    """
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        assert bias is None
+        bias = jnp.zeros(0, dtype=q.dtype)
+    dummy_input = jnp.zeros(0, q.dtype)
+    dq, dkv, _, dbias = FusedAttnBwdPrimitive.outer_primitive.bind(
+        q,
+        kv,
+        dummy_input,
+        bias,
+        softmax_aux,
+        rng_state,
+        output,
+        doutput,
+        q_seqlen,
+        kv_seqlen,
+        attn_bias_type=attn_bias_type,
+        attn_mask_type=attn_mask_type,
+        qkv_layout=NVTE_QKV_Layout.NVTE_BSHD_BS2HD,
+        scaling_factor=scaling_factor,
+        dropout_probability=dropout_probability,
+        is_training=is_training)
+    return dq, dkv, dbias
+
+
+def fused_attn_fwd(q: jnp.ndarray, k: jnp.ndarray, v: jnp.ndarray, bias: jnp.ndarray,
+                   q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray, seed: jnp.ndarray,
+                   attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                   scaling_factor: float, dropout_probability: float, is_training: bool):
+    """
+    Wrapper for TE fused attention fwd, where query, key, value are seperated tensors
+    Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
+    """
+    checker = _FusedAttnRNGStateChecker()
+    seed = checker.check_seed(seed, dropout_probability, is_training)
+
+    if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
+        assert bias is None
+        bias = jnp.zeros(0, dtype=q.dtype)
+
+    return FusedAttnFwdPrimitive.outer_primitive.bind(
+        q,
+        k,
+        v,
+        bias,
+        q_seqlen,
+        kv_seqlen,
+        seed,
+        attn_bias_type=attn_bias_type,
+        attn_mask_type=attn_mask_type,
+        qkv_layout=NVTE_QKV_Layout.NVTE_BSHD_BSHD_BSHD,
+        scaling_factor=scaling_factor,
+        dropout_probability=dropout_probability,
+        is_training=is_training)
+
+
 def fused_attn_bwd(q: jnp.ndarray, k: jnp.ndarray, v: jnp.ndarray, bias: jnp.ndarray,
                    softmax_aux: jnp.ndarray, rng_state: jnp.ndarray, output: jnp.ndarray,
                    doutput: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
@@ -3251,22 +2540,23 @@ def fused_attn_bwd(q: jnp.ndarray, k: jnp.ndarray, v: jnp.ndarray, bias: jnp.nda
     if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
         assert bias is None
         bias = jnp.zeros(0, dtype=q.dtype)
-
-    return FusedAttnBwdPrimitive.outer_primitive.bind(q,
-                                                      k,
-                                                      v,
-                                                      bias,
-                                                      softmax_aux,
-                                                      rng_state,
-                                                      output,
-                                                      doutput,
-                                                      q_seqlen,
-                                                      kv_seqlen,
-                                                      attn_bias_type=attn_bias_type,
-                                                      attn_mask_type=attn_mask_type,
-                                                      scaling_factor=scaling_factor,
-                                                      dropout_probability=dropout_probability,
-                                                      is_training=is_training)
+    return FusedAttnBwdPrimitive.outer_primitive.bind(
+        q,
+        k,
+        v,
+        bias,
+        softmax_aux,
+        rng_state,
+        output,
+        doutput,
+        q_seqlen,
+        kv_seqlen,
+        attn_bias_type=attn_bias_type,
+        attn_mask_type=attn_mask_type,
+        qkv_layout=NVTE_QKV_Layout.NVTE_BSHD_BSHD_BSHD,
+        scaling_factor=scaling_factor,
+        dropout_probability=dropout_probability,
+        is_training=is_training)
 
 
 class GeluPrimitive(BasePrimitive):

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -2371,9 +2371,10 @@ class FusedAttnBwdPrimitive(BasePrimitive):
 register_primitive(FusedAttnBwdPrimitive)
 
 
-def self_fused_attn_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, seqlen: jnp.ndarray, seed: jnp.ndarray,
-                        attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
-                        scaling_factor: float, dropout_probability: float, is_training: bool):
+def fused_attn_fwd_qkvpacked(qkv: jnp.ndarray, bias: jnp.ndarray, seqlen: jnp.ndarray,
+                             seed: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
+                             attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
+                             dropout_probability: float, is_training: bool):
     """
     Wrapper for TE self fused attention fwd
     Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
@@ -2401,11 +2402,11 @@ def self_fused_attn_fwd(qkv: jnp.ndarray, bias: jnp.ndarray, seqlen: jnp.ndarray
                                                       is_training=is_training)
 
 
-def self_fused_attn_bwd(qkv: jnp.ndarray, bias: jnp.ndarray, softmax_aux: jnp.ndarray,
-                        rng_state: jnp.ndarray, output: jnp.ndarray, doutput: jnp.ndarray,
-                        seqlen: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
-                        attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                        dropout_probability: float, is_training: bool):
+def fused_attn_bwd_qkvpacked(qkv: jnp.ndarray, bias: jnp.ndarray, softmax_aux: jnp.ndarray,
+                             rng_state: jnp.ndarray, output: jnp.ndarray, doutput: jnp.ndarray,
+                             seqlen: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
+                             attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
+                             dropout_probability: float, is_training: bool):
     """
     Wrapper for TE self fused attention bwd
     Return the gradients of self fused attention with packed qkv input
@@ -2434,12 +2435,12 @@ def self_fused_attn_bwd(qkv: jnp.ndarray, bias: jnp.ndarray, softmax_aux: jnp.nd
     return dqkv, dbias
 
 
-def cross_fused_attn_fwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray, q_seqlen: jnp.ndarray,
-                         kv_seqlen: jnp.ndarray, seed: jnp.ndarray, attn_bias_type: NVTE_Bias_Type,
-                         attn_mask_type: NVTE_Mask_Type, scaling_factor: float,
-                         dropout_probability: float, is_training: bool):
+def fused_attn_fwd_kvpacked(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray,
+                            q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray, seed: jnp.ndarray,
+                            attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                            scaling_factor: float, dropout_probability: float, is_training: bool):
     """
-    Wrapper for TE cross fused attention fwd
+    Wrapper for TE fused attention fwd with kvpacked inputs
     Return BMM1 -> (PreBias) -> ScaleMaskSoftmax -> (PostBias) -> (Dropout) -> BMM2
     """
     checker = _FusedAttnRNGStateChecker()
@@ -2464,14 +2465,14 @@ def cross_fused_attn_fwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray, q_s
                                                       is_training=is_training)
 
 
-def cross_fused_attn_bwd(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray,
-                         softmax_aux: jnp.ndarray, rng_state: jnp.ndarray, output: jnp.ndarray,
-                         doutput: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
-                         attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
-                         scaling_factor: float, dropout_probability: float, is_training: bool):
+def fused_attn_bwd_kvpacked(q: jnp.ndarray, kv: jnp.ndarray, bias: jnp.ndarray,
+                            softmax_aux: jnp.ndarray, rng_state: jnp.ndarray, output: jnp.ndarray,
+                            doutput: jnp.ndarray, q_seqlen: jnp.ndarray, kv_seqlen: jnp.ndarray,
+                            attn_bias_type: NVTE_Bias_Type, attn_mask_type: NVTE_Mask_Type,
+                            scaling_factor: float, dropout_probability: float, is_training: bool):
     """
-    Wrapper for TE cross fused attention bwd
-    Return the gradients of cross fused attention with packed kv input
+    Wrapper for TE fused attention bwd with kvpacked inputs
+    Return the gradients of fused attention with packed kv input
     """
     if attn_bias_type == NVTE_Bias_Type.NVTE_NO_BIAS:
         assert bias is None

--- a/transformer_engine/jax/csrc/extensions.cpp
+++ b/transformer_engine/jax/csrc/extensions.cpp
@@ -49,10 +49,6 @@ pybind11::dict Registrations() {
         EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxForward);
     dict["te_scaled_upper_triang_masked_softmax_backward"] =
         EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxBackward);
-    dict["te_self_fused_attn_forward"] = EncapsulateFunction(SelfFusedAttnForward);
-    dict["te_self_fused_attn_backward"] = EncapsulateFunction(SelfFusedAttnBackward);
-    dict["te_cross_fused_attn_forward"] = EncapsulateFunction(CrossFusedAttnForward);
-    dict["te_cross_fused_attn_backward"] = EncapsulateFunction(CrossFusedAttnBackward);
     dict["te_fused_attn_forward"] = EncapsulateFunction(FusedAttnForward);
     dict["te_fused_attn_backward"] = EncapsulateFunction(FusedAttnBackward);
     return dict;
@@ -72,10 +68,6 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
     m.def("get_dgelu_dbias_ct_workspace_sizes", &GetDGeluDBiasCastTransposeWorkspaceSizes);
     m.def("get_layernorm_fwd_workspace_sizes", &GetLayerNormForwardWorkspaceSizes);
     m.def("get_layernorm_bwd_workspace_sizes", &GetLayerNormBackwardWorkspaceSizes);
-    m.def("get_self_fused_attn_fwd_workspace_sizes", &GetSelfFusedAttnForwardWorkspaceSizes);
-    m.def("get_self_fused_attn_bwd_workspace_sizes", &GetSelfFusedAttnBackwardWorkspaceSizes);
-    m.def("get_cross_fused_attn_fwd_workspace_sizes", &GetCrossFusedAttnForwardWorkspaceSizes);
-    m.def("get_cross_fused_attn_bwd_workspace_sizes", &GetCrossFusedAttnBackwardWorkspaceSizes);
     m.def("get_fused_attn_fwd_workspace_sizes", &GetFusedAttnForwardWorkspaceSizes);
     m.def("get_fused_attn_bwd_workspace_sizes", &GetFusedAttnBackwardWorkspaceSizes);
 

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -11,14 +11,11 @@
 #include <cuda_runtime_api.h>
 #include <cudnn.h>
 
-#include <functional>
-#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "common/common.h"
-#include "common/util/cuda_runtime.h"
 #include "transformer_engine/activation.h"
 #include "transformer_engine/cast.h"
 #include "transformer_engine/fused_attn.h"

--- a/transformer_engine/jax/csrc/modules.cpp
+++ b/transformer_engine/jax/csrc/modules.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "common/common.h"
+#include "common/util/logging.h"
 #include "transformer_engine/activation.h"
 #include "transformer_engine/cast.h"
 #include "transformer_engine/fused_attn.h"
@@ -93,13 +94,13 @@ pybind11::bytes PackCustomCallSoftmaxDescriptor(size_t batch_size, size_t paddin
 pybind11::bytes PackCustomCallFusedAttnDescriptor(
     size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    size_t wkspace_size, float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
-    DType dtype, DType wkspace_dtype, bool is_training) {
+    size_t wkspace_size, float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype,
+    bool is_training) {
     return PackOpaque(CustomCallFusedAttnDescriptor{
         input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups,
-        bias_heads, head_dim, wkspace_size, scaling_factor, dropout_probability,
-        bias_type, mask_type, dtype, wkspace_dtype, is_training});
+        bias_heads, head_dim, wkspace_size, scaling_factor, dropout_probability, bias_type,
+        mask_type, qkv_layout, dtype, wkspace_dtype, is_training});
 }
 
 void TransposeImpl(void *input, size_t rows, size_t cols, DType dtype, cudaStream_t stream,
@@ -939,12 +940,12 @@ void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers,
 NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
                                             NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type,
                                             NVTE_Mask_Type mask_type, float dropout_probability,
-                                            size_t q_num_heads, size_t kv_num_heads,
+                                            size_t q_attn_heads, size_t kv_attn_heads,
                                             size_t q_max_seqlen, size_t kv_max_seqlen,
                                             size_t head_dim) {
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(q_dtype), static_cast<NVTEDType>(kv_dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, q_num_heads, kv_num_heads, q_max_seqlen, kv_max_seqlen,
+        mask_type, dropout_probability, q_attn_heads, kv_attn_heads, q_max_seqlen, kv_max_seqlen,
         head_dim);
     return backend;
 }
@@ -1026,496 +1027,28 @@ void PrepareFusedAttnBackwardAuxTensors(NVTETensorPack *tensor_pack,
     }
 }
 
-pybind11::tuple GetSelfFusedAttnForwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t max_seqlen,
-    size_t attn_heads, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
-
-    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
-
-    auto qkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
-    auto bias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
-    auto cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-    auto o_tensor = TensorWrapper(
-        nullptr, std::vector<size_t>{input_batch, max_seqlen, attn_heads, head_dim}, dtype);
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);
-    auto rng_state_tensor = TensorWrapper(nullptr, std::vector<size_t>{2}, DType::kInt64);
-
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, attn_heads, attn_heads, max_seqlen, max_seqlen, head_dim);
-
-    NVTETensorPack aux_output_tensors;
-    nvte_tensor_pack_create(&aux_output_tensors);
-
-    TensorWrapper query_workspace_tensor;
-    nvte_fused_attn_fwd_qkvpacked(qkv_tensor.data(), bias_tensor.data(), s_tensor.data(),
-                                  o_tensor.data(), &aux_output_tensors, cu_seqlens_tensor.data(),
-                                  rng_state_tensor.data(), max_seqlen, is_training, scaling_factor,
-                                  dropout_probability, qkv_layout, bias_type, mask_type,
-                                  query_workspace_tensor.data(), nullptr);
-
-    auto work_shape = MakeShapeVector(query_workspace_tensor.shape());
-    return pybind11::make_tuple(work_shape, query_workspace_tensor.dtype());
-}
-
-void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
-                          size_t opaque_len) {
-    const CustomCallFusedAttnDescriptor &descriptor =
-        *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
-
-    // input buffers from XLA
-    void *qkv = buffers[0];
-    void *bias = buffers[1];
-    void *cu_seqlens = buffers[2];
-    void *seed = buffers[3];
-
-    // output buffers from XLA
-    void *output = buffers[4];
-    void *softmax_aux = buffers[5];
-    void *rng_state = buffers[6];
-    void *workspace = buffers[7];
-
-    // tensor sizes
-    auto input_batch = descriptor.input_batch;
-    auto bias_batch = descriptor.bias_batch;
-    auto max_seqlen = descriptor.q_max_seqlen;
-    auto attn_heads = descriptor.attn_heads;
-    auto bias_heads = descriptor.bias_heads;
-    auto head_dim = descriptor.head_dim;
-    auto dropout_probability = descriptor.dropout_probability;
-    auto bias_type = descriptor.bias_type;
-    auto mask_type = descriptor.mask_type;
-
-    auto dtype = descriptor.dtype;
-    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
-
-    // input tensors
-    auto qkv_tensor = TensorWrapper(qkv, qkv_shape, dtype);
-    auto bias_tensor = TensorWrapper(bias, bias_shape, dtype);
-    auto cu_seqlens_tensor =
-        TensorWrapper(cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    // output tensors
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in FP16/BF16
-    auto o_tensor = TensorWrapper(
-        output, std::vector<size_t>{input_batch * max_seqlen, attn_heads, head_dim}, dtype);
-
-    // prep RNG state
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
-    auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, attn_heads, attn_heads, max_seqlen, max_seqlen, head_dim);
-    PopulateRngStateAsync(rng_state, seed, max_seqlen, max_seqlen, backend, stream);
-
-    // auxiliary tensors (to be propagated to the backward pass later)
-    NVTETensorPack aux_output_tensors;
-    nvte_tensor_pack_create(&aux_output_tensors);
-    PrepareFusedAttnForwardAuxTensors(&aux_output_tensors, &descriptor, bias_type, backend,
-                                      softmax_aux);
-
-    // cuDNN workspace
-    auto wkspace_size = std::vector<size_t>{descriptor.wkspace_size};
-    auto wkspace_dtype = descriptor.wkspace_dtype;
-    auto workspace_tensor = TensorWrapper(workspace, wkspace_size, wkspace_dtype);
-
-    nvte_fused_attn_fwd_qkvpacked(qkv_tensor.data(), bias_tensor.data(), s_tensor.data(),
-                                  o_tensor.data(), &aux_output_tensors, cu_seqlens_tensor.data(),
-                                  rng_state_tensor.data(), max_seqlen, descriptor.is_training,
-                                  descriptor.scaling_factor, dropout_probability, qkv_layout,
-                                  bias_type, mask_type, workspace_tensor.data(), stream);
-
-    nvte_tensor_pack_destroy(&aux_output_tensors);
-}
-
-pybind11::tuple GetSelfFusedAttnBackwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t max_seqlen,
-    size_t attn_heads, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
-
-    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
-    auto output_shape = std::vector<size_t>{input_batch * max_seqlen, attn_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
-
-    auto qkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
-    auto output_tensor = TensorWrapper(nullptr, output_shape, dtype);
-    auto doutput_tensor = TensorWrapper(nullptr, output_shape, dtype);
-    // F16 doesn't use this tensor
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);
-
-    auto dqkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
-    auto dbias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
-
-    auto cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    NVTETensorPack aux_input_tensors;
-    nvte_tensor_pack_create(&aux_input_tensors);
-
-    TensorWrapper query_workspace_tensor;
-    nvte_fused_attn_bwd_qkvpacked(qkv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
-                                  s_tensor.data(),  // not used for F16
-                                  s_tensor.data(),  // not used for F16
-                                  &aux_input_tensors, dqkv_tensor.data(), dbias_tensor.data(),
-                                  cu_seqlens_tensor.data(), max_seqlen, scaling_factor,
-                                  dropout_probability, qkv_layout, bias_type, mask_type,
-                                  query_workspace_tensor.data(), nullptr);
-
-    auto work_shape = MakeShapeVector(query_workspace_tensor.shape());
-    return pybind11::make_tuple(work_shape, query_workspace_tensor.dtype());
-}
-
-void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
-                           size_t opaque_len) {
-    const CustomCallFusedAttnDescriptor &descriptor =
-        *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
-
-    // input buffers from XLA
-    void *qkv = buffers[0];
-    void *bias = buffers[1];
-    void *softmax_aux = buffers[2];
-    void *rng_state = buffers[3];
-    void *output = buffers[4];
-    void *doutput = buffers[5];
-    void *cu_seqlens = buffers[6];
-
-    // output buffers from XLA
-    void *dqkv = buffers[7];
-    void *dbias = buffers[8];
-    void *workspace = buffers[9];
-
-    // tensor sizes
-    auto input_batch = descriptor.input_batch;
-    auto bias_batch = descriptor.bias_batch;
-    auto max_seqlen = descriptor.q_max_seqlen;
-    auto attn_heads = descriptor.attn_heads;
-    auto bias_heads = descriptor.bias_heads;
-    auto head_dim = descriptor.head_dim;
-    auto scaling_factor = descriptor.scaling_factor;
-    auto dropout_probability = descriptor.dropout_probability;
-    auto bias_type = descriptor.bias_type;
-    auto mask_type = descriptor.mask_type;
-
-    auto dtype = descriptor.dtype;
-    auto qkv_shape = std::vector<size_t>{input_batch * max_seqlen, 3, attn_heads, head_dim};
-    auto output_shape = std::vector<size_t>{input_batch * max_seqlen, attn_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, max_seqlen, max_seqlen};
-
-    // input tensors
-    auto qkv_tensor = TensorWrapper(qkv, qkv_shape, dtype);
-    auto output_tensor = TensorWrapper(output, output_shape, dtype);
-    auto doutput_tensor = TensorWrapper(doutput, output_shape, dtype);
-
-    // output tensors
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in FP16/BF16
-    auto dqkv_tensor = TensorWrapper(dqkv, qkv_shape, dtype);
-    auto dbias_tensor = TensorWrapper(dbias, bias_shape, dtype);
-    auto cu_seqlens_tensor =
-        TensorWrapper(cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    // auxiliary tensors (propagated from the forward pass)
-    NVTETensorPack aux_input_tensors;
-    nvte_tensor_pack_create(&aux_input_tensors);
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BS3HD;
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, attn_heads, attn_heads, max_seqlen, max_seqlen, head_dim);
-    PrepareFusedAttnBackwardAuxTensors(&aux_input_tensors, &descriptor, backend, softmax_aux,
-                                       rng_state, bias);
-
-    // cuDNN workspace
-    auto wkspace_size = std::vector<size_t>{descriptor.wkspace_size};
-    auto wkspace_dtype = descriptor.wkspace_dtype;
-    auto workspace_tensor = TensorWrapper(workspace, wkspace_size, wkspace_dtype);
-
-    nvte_fused_attn_bwd_qkvpacked(qkv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
-                                  s_tensor.data(),  // not used for F16
-                                  s_tensor.data(),  // not used for F16
-                                  &aux_input_tensors, dqkv_tensor.data(), dbias_tensor.data(),
-                                  cu_seqlens_tensor.data(), max_seqlen, scaling_factor,
-                                  dropout_probability, qkv_layout, bias_type, mask_type,
-                                  workspace_tensor.data(), stream);
-
-    nvte_tensor_pack_destroy(&aux_input_tensors);
-}
-
-pybind11::tuple GetCrossFusedAttnForwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
-    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
-
-    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
-    auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
-    auto kv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
-
-    auto bias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
-
-    // FP16/BF16 doesn't use this tensor
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);
-    auto o_tensor = TensorWrapper(nullptr, q_shape, dtype);
-
-    auto q_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-    auto kv_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    auto dummy_rng_state_tensor = TensorWrapper(nullptr, std::vector<size_t>{2}, DType::kInt64);
-
-    NVTETensorPack aux_output_tensors;
-    nvte_tensor_pack_create(&aux_output_tensors);
-
-    TensorWrapper query_workspace_tensor;
-    nvte_fused_attn_fwd_kvpacked(q_tensor.data(), kv_tensor.data(), bias_tensor.data(),
-                                 s_tensor.data(), o_tensor.data(), &aux_output_tensors,
-                                 q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
-                                 dummy_rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen,
-                                 is_training, scaling_factor, dropout_probability, qkv_layout,
-                                 bias_type, mask_type, query_workspace_tensor.data(), nullptr);
-
-    auto work_shape = MakeShapeVector(query_workspace_tensor.shape());
-    return pybind11::make_tuple(work_shape, query_workspace_tensor.dtype());
-}
-
-void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
-                           size_t opaque_len) {
-    const CustomCallFusedAttnDescriptor &descriptor =
-        *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
-
-    // input buffers from XLA
-    void *q = buffers[0];
-    void *kv = buffers[1];
-    void *bias = buffers[2];
-    void *q_cu_seqlens = buffers[3];
-    void *kv_cu_seqlens = buffers[4];
-    void *seed = buffers[5];
-
-    // output buffers from XLA
-    void *output = buffers[6];
-    void *softmax_aux = buffers[7];
-    void *rng_state = buffers[8];
-    void *workspace = buffers[9];
-
-    // tensor sizes
-    auto input_batch = descriptor.input_batch;
-    auto bias_batch = descriptor.bias_batch;
-    auto q_max_seqlen = descriptor.q_max_seqlen;
-    auto kv_max_seqlen = descriptor.kv_max_seqlen;
-    auto attn_heads = descriptor.attn_heads;
-    auto num_gqa_groups = descriptor.num_gqa_groups;
-    auto bias_heads = descriptor.bias_heads;
-    auto head_dim = descriptor.head_dim;
-    auto scaling_factor = descriptor.scaling_factor;
-    auto dropout_probability = descriptor.dropout_probability;
-    auto bias_type = descriptor.bias_type;
-    auto mask_type = descriptor.mask_type;
-
-    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
-    // input tensors
-    auto dtype = descriptor.dtype;
-    auto q_tensor = TensorWrapper(q, q_shape, dtype);
-    auto kv_tensor = TensorWrapper(kv, kv_shape, dtype);
-    auto bias_tensor = TensorWrapper(bias, bias_shape, dtype);
-
-    // output tensors
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in FP16/BF16
-    auto o_tensor = TensorWrapper(output, q_shape, dtype);
-    auto q_cu_seqlens_tensor =
-        TensorWrapper(q_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-    auto kv_cu_seqlens_tensor =
-        TensorWrapper(kv_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    // prep RNG state
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
-    auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, attn_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
-        head_dim);
-    PopulateRngStateAsync(rng_state, seed, q_max_seqlen, kv_max_seqlen, backend, stream);
-
-    // auxiliary tensors (to be propagated to the backward pass later)
-    NVTETensorPack aux_output_tensors;
-    nvte_tensor_pack_create(&aux_output_tensors);
-    PrepareFusedAttnForwardAuxTensors(&aux_output_tensors, &descriptor, bias_type, backend,
-                                      softmax_aux);
-
-    // cuDNN workspace
-    auto workspace_tensor = TensorWrapper(workspace, std::vector<size_t>{descriptor.wkspace_size},
-                                          descriptor.wkspace_dtype);
-
-    nvte_fused_attn_fwd_kvpacked(q_tensor.data(), kv_tensor.data(), bias_tensor.data(),
-                                 s_tensor.data(), o_tensor.data(), &aux_output_tensors,
-                                 q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
-                                 rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen,
-                                 descriptor.is_training, scaling_factor, dropout_probability,
-                                 qkv_layout, bias_type, mask_type, workspace_tensor.data(), stream);
-
-    nvte_tensor_pack_destroy(&aux_output_tensors);
-}
-
-pybind11::tuple GetCrossFusedAttnBackwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
-    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
-
-    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto output_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
-    auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
-    auto kv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
-    auto doutput_tensor = TensorWrapper(nullptr, output_shape, dtype);
-    auto output_tensor = TensorWrapper(nullptr, output_shape, dtype);
-    // FP16/BF16 doesn't use this tensor
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);
-
-    auto dq_tensor = TensorWrapper(nullptr, q_shape, dtype);
-    auto dkv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
-    auto dbias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
-
-    auto q_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-    auto kv_cu_seqlens_tensor =
-        TensorWrapper(nullptr, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    NVTETensorPack aux_input_tensors;
-    nvte_tensor_pack_create(&aux_input_tensors);
-
-    TensorWrapper query_workspace_tensor;
-    nvte_fused_attn_bwd_kvpacked(
-        q_tensor.data(), kv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
-        s_tensor.data(),  // not used for FP16/BF16
-        s_tensor.data(),  // not used for FP16/BF16
-        &aux_input_tensors, dq_tensor.data(), dkv_tensor.data(), dbias_tensor.data(),
-        q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen,
-        scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
-        query_workspace_tensor.data(), nullptr);
-
-    auto work_shape = MakeShapeVector(query_workspace_tensor.shape());
-    return pybind11::make_tuple(work_shape, query_workspace_tensor.dtype());
-}
-
-void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
-                            size_t opaque_len) {
-    const CustomCallFusedAttnDescriptor &descriptor =
-        *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
-
-    // input buffers from XLA
-    void *q = buffers[0];
-    void *kv = buffers[1];
-    void *bias = buffers[2];
-    void *softmax_aux = buffers[3];
-    void *rng_state = buffers[4];
-    void *output = buffers[5];
-    void *doutput = buffers[6];
-    void *q_cu_seqlens = buffers[7];
-    void *kv_cu_seqlens = buffers[8];
-
-    // output buffers from XLA
-    void *dq = buffers[9];
-    void *dkv = buffers[10];
-    void *dbias = buffers[11];
-    void *workspace = buffers[12];
-
-    // tensor sizes
-    auto input_batch = descriptor.input_batch;
-    auto bias_batch = descriptor.bias_batch;
-    auto q_max_seqlen = descriptor.q_max_seqlen;
-    auto kv_max_seqlen = descriptor.kv_max_seqlen;
-    auto attn_heads = descriptor.attn_heads;
-    auto num_gqa_groups = descriptor.num_gqa_groups;
-    auto bias_heads = descriptor.bias_heads;
-    auto head_dim = descriptor.head_dim;
-    auto scaling_factor = descriptor.scaling_factor;
-    auto dropout_probability = descriptor.dropout_probability;
-    auto bias_type = descriptor.bias_type;
-    auto mask_type = descriptor.mask_type;
-
-    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
-    auto output_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
-    // input tensors
-    auto dtype = descriptor.dtype;
-    auto q_tensor = TensorWrapper(q, q_shape, dtype);
-    auto kv_tensor = TensorWrapper(kv, kv_shape, dtype);
-    auto output_tensor = TensorWrapper(output, output_shape, dtype);
-    auto doutput_tensor = TensorWrapper(doutput, output_shape, dtype);
-
-    // output tensors
-    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in FP16/BF16
-    auto dq_tensor = TensorWrapper(dq, q_shape, dtype);
-    auto dkv_tensor = TensorWrapper(dkv, kv_shape, dtype);
-    auto dbias_tensor = TensorWrapper(dbias, bias_shape, dtype);
-    auto q_cu_seqlens_tensor =
-        TensorWrapper(q_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-    auto kv_cu_seqlens_tensor =
-        TensorWrapper(kv_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
-
-    // auxiliary tensors (propagated from the forward pass)
-    NVTETensorPack aux_input_tensors;
-    nvte_tensor_pack_create(&aux_input_tensors);
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BS2HD;
-    auto backend = nvte_get_fused_attn_backend(
-        static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
-        mask_type, dropout_probability, attn_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
-        head_dim);
-    PrepareFusedAttnBackwardAuxTensors(&aux_input_tensors, &descriptor, backend, softmax_aux,
-                                       rng_state, bias);
-
-    // cuDNN workspace
-    auto wkspace_size = std::vector<size_t>{descriptor.wkspace_size};
-    auto wkspace_dtype = descriptor.wkspace_dtype;
-    auto workspace_tensor = TensorWrapper(workspace, wkspace_size, wkspace_dtype);
-
-    nvte_fused_attn_bwd_kvpacked(
-        q_tensor.data(), kv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
-        s_tensor.data(),  // not used for FP16/BF16
-        s_tensor.data(),  // not used for FP16/BF16
-        &aux_input_tensors, dq_tensor.data(), dkv_tensor.data(), dbias_tensor.data(),
-        q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen,
-        scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
-        workspace_tensor.data(), stream);
-
-    nvte_tensor_pack_destroy(&aux_input_tensors);
-}
-
 pybind11::tuple GetFusedAttnForwardWorkspaceSizes(
     size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD;
+    float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training) {
+    // For qkv_packed
+    auto qkv_shape = std::vector<size_t>{input_batch * q_max_seqlen, 3, attn_heads, head_dim};
+    auto qkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
 
+    // For kv_packed
     auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
-    auto v_shape = k_shape;
-    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
     auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
+    auto kv_shape = std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+    auto kv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
+
+    // For separate q, k, v
+    auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
     auto k_tensor = TensorWrapper(nullptr, k_shape, dtype);
+    auto v_shape = k_shape;
     auto v_tensor = TensorWrapper(nullptr, v_shape, dtype);
 
+    auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
     auto bias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
 
     // F16 doesn't use this tensor
@@ -1533,37 +1066,133 @@ pybind11::tuple GetFusedAttnForwardWorkspaceSizes(
     nvte_tensor_pack_create(&aux_output_tensors);
 
     TensorWrapper query_workspace_tensor;
-    nvte_fused_attn_fwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), bias_tensor.data(),
-                        s_tensor.data(), o_tensor.data(), &aux_output_tensors,
-                        q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
-                        dummy_rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen, is_training,
-                        scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
-                        query_workspace_tensor.data(), nullptr);
+    if (qkv_layout == NVTE_QKV_Layout::NVTE_BS3HD) {
+        assert(q_max_seqlen == kv_max_seqlen);
+        nvte_fused_attn_fwd_qkvpacked(
+            qkv_tensor.data(), bias_tensor.data(), s_tensor.data(), o_tensor.data(),
+            &aux_output_tensors, q_cu_seqlens_tensor.data(), dummy_rng_state_tensor.data(),
+            q_max_seqlen, is_training, scaling_factor, dropout_probability, qkv_layout, bias_type,
+            mask_type, query_workspace_tensor.data(), nullptr);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BS2HD) {
+        nvte_fused_attn_fwd_kvpacked(q_tensor.data(), kv_tensor.data(), bias_tensor.data(),
+                                     s_tensor.data(), o_tensor.data(), &aux_output_tensors,
+                                     q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
+                                     dummy_rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen,
+                                     is_training, scaling_factor, dropout_probability, qkv_layout,
+                                     bias_type, mask_type, query_workspace_tensor.data(), nullptr);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD) {
+        nvte_fused_attn_fwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), bias_tensor.data(),
+                            s_tensor.data(), o_tensor.data(), &aux_output_tensors,
+                            q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
+                            dummy_rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen, is_training,
+                            scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+                            query_workspace_tensor.data(), nullptr);
+    } else {
+        NVTE_ERROR("Unsupported QKVLayout.");
+    }
 
-    auto work_shape = MakeShapeVector(query_workspace_tensor.shape());
-    return pybind11::make_tuple(work_shape, query_workspace_tensor.dtype());
+    auto workspace_shape = MakeShapeVector(query_workspace_tensor.shape());
+    return pybind11::make_tuple(workspace_shape, query_workspace_tensor.dtype());
+}
+
+pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
+    size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen, size_t attn_heads,
+    size_t num_gqa_groups, size_t head_dim, float scaling_factor, float dropout_probability,
+    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype,
+    bool is_training) {
+    auto output_shape = std::vector<size_t>{batch_size * q_max_seqlen, attn_heads, head_dim};
+    auto output_tensor = TensorWrapper(nullptr, output_shape, dtype);
+    auto doutput_tensor = TensorWrapper(nullptr, output_shape, dtype);
+
+    auto bias_shape = std::vector<size_t>{1, attn_heads, q_max_seqlen, kv_max_seqlen};
+    auto dbias_tensor = TensorWrapper(nullptr, bias_shape, dtype);
+
+    // F16 doesn't use s_tensor
+    auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);
+
+    auto q_cu_seqlens_tensor =
+        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+    auto kv_cu_seqlens_tensor =
+        TensorWrapper(nullptr, std::vector<size_t>{batch_size + 1}, DType::kInt32);
+
+    NVTETensorPack aux_input_tensors;
+    nvte_tensor_pack_create(&aux_input_tensors);
+
+    TensorWrapper query_workspace_tensor;
+
+    if (qkv_layout == NVTE_QKV_Layout::NVTE_BS3HD) {
+        assert(q_max_seqlen == kv_max_seqlen);
+        auto qkv_shape = std::vector<size_t>{batch_size * q_max_seqlen, 3, attn_heads, head_dim};
+        auto qkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
+        auto dqkv_tensor = TensorWrapper(nullptr, qkv_shape, dtype);
+        nvte_fused_attn_bwd_qkvpacked(
+            qkv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
+            s_tensor.data(),  // not used for F16
+            s_tensor.data(),  // not used for F16
+            &aux_input_tensors, dqkv_tensor.data(), dbias_tensor.data(), q_cu_seqlens_tensor.data(),
+            q_max_seqlen, scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+            query_workspace_tensor.data(), nullptr);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BS2HD) {
+        auto q_shape = std::vector<size_t>{batch_size * q_max_seqlen, attn_heads, head_dim};
+        auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
+        auto dq_tensor = TensorWrapper(nullptr, q_shape, dtype);
+        auto kv_shape =
+            std::vector<size_t>{batch_size * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+        auto kv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
+        auto dkv_tensor = TensorWrapper(nullptr, kv_shape, dtype);
+        nvte_fused_attn_bwd_kvpacked(
+            q_tensor.data(), kv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
+            s_tensor.data(),  // not used for F16
+            s_tensor.data(),  // not used for F16
+            &aux_input_tensors, dq_tensor.data(), dkv_tensor.data(), dbias_tensor.data(),
+            q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen,
+            scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+            query_workspace_tensor.data(), nullptr);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD) {
+        auto q_shape = std::vector<size_t>{batch_size * q_max_seqlen, attn_heads, head_dim};
+        auto q_tensor = TensorWrapper(nullptr, q_shape, dtype);
+        auto dq_tensor = TensorWrapper(nullptr, q_shape, dtype);
+        auto k_shape = std::vector<size_t>{batch_size * kv_max_seqlen, num_gqa_groups, head_dim};
+        auto k_tensor = TensorWrapper(nullptr, k_shape, dtype);
+        auto dk_tensor = TensorWrapper(nullptr, k_shape, dtype);
+        auto v_shape = k_shape;
+        auto v_tensor = TensorWrapper(nullptr, v_shape, dtype);
+        auto dv_tensor = TensorWrapper(nullptr, v_shape, dtype);
+        nvte_fused_attn_bwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), output_tensor.data(),
+                            doutput_tensor.data(),
+                            s_tensor.data(),  // not used for F16
+                            s_tensor.data(),  // not used for F16
+                            &aux_input_tensors, dq_tensor.data(), dk_tensor.data(),
+                            dv_tensor.data(), dbias_tensor.data(), q_cu_seqlens_tensor.data(),
+                            kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen,
+                            scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+                            query_workspace_tensor.data(), nullptr);
+    } else {
+        NVTE_ERROR("Unsupported QKVLayout.");
+    }
+
+    auto workspace_shape = MakeShapeVector(query_workspace_tensor.shape());
+    return pybind11::make_tuple(workspace_shape, query_workspace_tensor.dtype());
 }
 
 void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len) {
     const CustomCallFusedAttnDescriptor &descriptor =
         *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
 
-    // input buffers from XLA
-    void *q = buffers[0];
-    void *k = buffers[1];
-    void *v = buffers[2];
+    /* Input buffers from XLA */
+    /* Buffers[0-2] are q, k, v, which are parsed later for different qkv_layout */
     void *bias = buffers[3];
     void *q_cu_seqlens = buffers[4];
     void *kv_cu_seqlens = buffers[5];
     void *seed = buffers[6];
 
-    // output buffers from XLA
+    /* Output buffer from XLA */
     void *output = buffers[7];
     void *softmax_aux = buffers[8];
     void *rng_state = buffers[9];
     void *workspace = buffers[10];
 
-    // tensor sizes
+    /* Descriptor */
     auto input_batch = descriptor.input_batch;
     auto bias_batch = descriptor.bias_batch;
     auto q_max_seqlen = descriptor.q_max_seqlen;
@@ -1576,29 +1205,26 @@ void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, s
     auto dropout_probability = descriptor.dropout_probability;
     auto bias_type = descriptor.bias_type;
     auto mask_type = descriptor.mask_type;
+    auto qkv_layout = descriptor.qkv_layout;
+    auto dtype = descriptor.dtype;
 
+    /* Input tensors */
     auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
     auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
     auto v_shape = k_shape;
     auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
-    // input tensors
-    auto dtype = descriptor.dtype;
-    auto q_tensor = TensorWrapper(q, q_shape, dtype);
-    auto k_tensor = TensorWrapper(k, k_shape, dtype);
-    auto v_tensor = TensorWrapper(v, v_shape, dtype);
     auto bias_tensor = TensorWrapper(bias, bias_shape, dtype);
 
-    // output tensors
+    /* Output tensors */
     auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in F16
-    auto o_tensor = TensorWrapper(output, q_shape, dtype);
+    auto o_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+    auto o_tensor = TensorWrapper(output, o_shape, dtype);
     auto q_cu_seqlens_tensor =
         TensorWrapper(q_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto kv_cu_seqlens_tensor =
         TensorWrapper(kv_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
-    // prep RNG state
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD;
+    /* Prepare RNG state */
     auto rng_state_tensor = TensorWrapper(rng_state, std::vector<size_t>{2}, DType::kInt64);
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
@@ -1606,22 +1232,59 @@ void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, s
         head_dim);
     PopulateRngStateAsync(rng_state, seed, q_max_seqlen, kv_max_seqlen, backend, stream);
 
-    // auxiliary tensors (to be propagated to the backward pass later)
+    /* Auxiliary tensors (to be propagated to the backward pass later) */
     NVTETensorPack aux_output_tensors;
     nvte_tensor_pack_create(&aux_output_tensors);
     PrepareFusedAttnForwardAuxTensors(&aux_output_tensors, &descriptor, bias_type, backend,
                                       softmax_aux);
 
-    // cuDNN workspace
+    /* cuDNN workspace */
     auto workspace_tensor = TensorWrapper(workspace, std::vector<size_t>{descriptor.wkspace_size},
                                           descriptor.wkspace_dtype);
 
-    nvte_fused_attn_fwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), bias_tensor.data(),
-                        s_tensor.data(), o_tensor.data(), &aux_output_tensors,
-                        q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
-                        rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen,
-                        descriptor.is_training, scaling_factor, dropout_probability, qkv_layout,
-                        bias_type, mask_type, workspace_tensor.data(), stream);
+    /* Call the underly NVTE API */
+    if (qkv_layout == NVTE_QKV_Layout::NVTE_BS3HD) {
+        auto qkv = buffers[0];
+        auto qkv_shape = std::vector<size_t>{input_batch * q_max_seqlen, 3, attn_heads, head_dim};
+        auto qkv_tensor = TensorWrapper(qkv, qkv_shape, dtype);
+        nvte_fused_attn_fwd_qkvpacked(
+            qkv_tensor.data(), bias_tensor.data(), s_tensor.data(), o_tensor.data(),
+            &aux_output_tensors, q_cu_seqlens_tensor.data(), rng_state_tensor.data(), q_max_seqlen,
+            descriptor.is_training, descriptor.scaling_factor, dropout_probability, qkv_layout,
+            bias_type, mask_type, workspace_tensor.data(), stream);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BS2HD) {
+        auto q = buffers[0];
+        auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+        auto q_tensor = TensorWrapper(q, q_shape, dtype);
+        auto kv = buffers[1];
+        auto kv_shape =
+            std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+        auto kv_tensor = TensorWrapper(kv, kv_shape, dtype);
+        nvte_fused_attn_fwd_kvpacked(
+            q_tensor.data(), kv_tensor.data(), bias_tensor.data(), s_tensor.data(), o_tensor.data(),
+            &aux_output_tensors, q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
+            rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen, descriptor.is_training,
+            scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+            workspace_tensor.data(), stream);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD) {
+        auto q = buffers[0];
+        auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+        auto q_tensor = TensorWrapper(q, q_shape, dtype);
+        auto k = buffers[1];
+        auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
+        auto k_tensor = TensorWrapper(k, k_shape, dtype);
+        auto v = buffers[2];
+        auto v_shape = k_shape;
+        auto v_tensor = TensorWrapper(v, v_shape, dtype);
+        nvte_fused_attn_fwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), bias_tensor.data(),
+                            s_tensor.data(), o_tensor.data(), &aux_output_tensors,
+                            q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(),
+                            rng_state_tensor.data(), q_max_seqlen, kv_max_seqlen,
+                            descriptor.is_training, scaling_factor, dropout_probability, qkv_layout,
+                            bias_type, mask_type, workspace_tensor.data(), stream);
+    } else {
+        NVTE_ERROR("Unsupported qkv_layout.");
+    }
 
     nvte_tensor_pack_destroy(&aux_output_tensors);
 }
@@ -1629,10 +1292,8 @@ void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, s
 pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
     size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training) {
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD;
-
+    float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training) {
     auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
     auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
     auto v_shape = k_shape;
@@ -1679,10 +1340,8 @@ void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, 
     const CustomCallFusedAttnDescriptor &descriptor =
         *UnpackOpaque<CustomCallFusedAttnDescriptor>(opaque, opaque_len);
 
-    // input buffers from XLA
-    void *q = buffers[0];
-    void *k = buffers[1];
-    void *v = buffers[2];
+    /* Input buffers from XLA */
+    /* Buffers[0-2] are q, k, v, which are parsed later for different qkv_layout */
     void *bias = buffers[3];
     void *softmax_aux = buffers[4];
     void *rng_state = buffers[5];
@@ -1691,14 +1350,12 @@ void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, 
     void *q_cu_seqlens = buffers[8];
     void *kv_cu_seqlens = buffers[9];
 
-    // output buffers from XLA
-    void *dq = buffers[10];
-    void *dk = buffers[11];
-    void *dv = buffers[12];
+    /* Output buffer from XLA */
+    /* Buffers[10-12] are dq, dk, dv, which are parsed later for different qkv_layout */
     void *dbias = buffers[13];
     void *workspace = buffers[14];
 
-    // tensor sizes
+    /* Descriptor */
     auto input_batch = descriptor.input_batch;
     auto bias_batch = descriptor.bias_batch;
     auto q_max_seqlen = descriptor.q_max_seqlen;
@@ -1711,36 +1368,26 @@ void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, 
     auto dropout_probability = descriptor.dropout_probability;
     auto bias_type = descriptor.bias_type;
     auto mask_type = descriptor.mask_type;
+    auto qkv_layout = descriptor.qkv_layout;
+    auto dtype = descriptor.dtype;
 
-    auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
-    auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
-    auto v_shape = k_shape;
+    /* Input tensors */
     auto output_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
     auto bias_shape = std::vector<size_t>{bias_batch, bias_heads, q_max_seqlen, kv_max_seqlen};
-
-    // input tensors
-    auto dtype = descriptor.dtype;
-    auto q_tensor = TensorWrapper(q, q_shape, dtype);
-    auto k_tensor = TensorWrapper(k, k_shape, dtype);
-    auto v_tensor = TensorWrapper(v, v_shape, dtype);
     auto output_tensor = TensorWrapper(output, output_shape, dtype);
     auto doutput_tensor = TensorWrapper(doutput, output_shape, dtype);
 
-    // output tensors
+    /* Output tensors */
     auto s_tensor = TensorWrapper(nullptr, std::vector<size_t>{1}, dtype);  // not used in F16
-    auto dq_tensor = TensorWrapper(dq, q_shape, dtype);
-    auto dk_tensor = TensorWrapper(dk, k_shape, dtype);
-    auto dv_tensor = TensorWrapper(dv, v_shape, dtype);
     auto dbias_tensor = TensorWrapper(dbias, bias_shape, dtype);
     auto q_cu_seqlens_tensor =
         TensorWrapper(q_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
     auto kv_cu_seqlens_tensor =
         TensorWrapper(kv_cu_seqlens, std::vector<size_t>{input_batch + 1}, DType::kInt32);
 
-    // auxiliary tensors (propagated from the forward pass)
+    /* Auxiliary tensors (propagated from the forward pass) */
     NVTETensorPack aux_input_tensors;
     nvte_tensor_pack_create(&aux_input_tensors);
-    constexpr auto qkv_layout = NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD;
     auto backend = nvte_get_fused_attn_backend(
         static_cast<NVTEDType>(dtype), static_cast<NVTEDType>(dtype), qkv_layout, bias_type,
         mask_type, dropout_probability, attn_heads, num_gqa_groups, q_max_seqlen, kv_max_seqlen,
@@ -1748,20 +1395,73 @@ void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, 
     PrepareFusedAttnBackwardAuxTensors(&aux_input_tensors, &descriptor, backend, softmax_aux,
                                        rng_state, bias);
 
-    // cuDNN workspace
+    /* cuDNN workspace */
     auto wkspace_size = std::vector<size_t>{descriptor.wkspace_size};
     auto wkspace_dtype = descriptor.wkspace_dtype;
     auto workspace_tensor = TensorWrapper(workspace, wkspace_size, wkspace_dtype);
 
-    nvte_fused_attn_bwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), output_tensor.data(),
-                        doutput_tensor.data(),
-                        s_tensor.data(),  // not used for F16
-                        s_tensor.data(),  // not used for F16
-                        &aux_input_tensors, dq_tensor.data(), dk_tensor.data(), dv_tensor.data(),
-                        dbias_tensor.data(), q_cu_seqlens_tensor.data(),
-                        kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen, scaling_factor,
-                        dropout_probability, qkv_layout, bias_type, mask_type,
-                        workspace_tensor.data(), stream);
+    /* Call the underly NVTE API */
+    if (qkv_layout == NVTE_QKV_Layout::NVTE_BS3HD) {
+        auto qkv = buffers[0];
+        auto qkv_shape = std::vector<size_t>{input_batch * q_max_seqlen, 3, attn_heads, head_dim};
+        auto qkv_tensor = TensorWrapper(qkv, qkv_shape, dtype);
+        auto dqkv = buffers[10];
+        auto dqkv_tensor = TensorWrapper(dqkv, qkv_shape, dtype);
+        nvte_fused_attn_bwd_qkvpacked(
+            qkv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
+            s_tensor.data(),  // not used for F16
+            s_tensor.data(),  // not used for F16
+            &aux_input_tensors, dqkv_tensor.data(), dbias_tensor.data(), q_cu_seqlens_tensor.data(),
+            q_max_seqlen, scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+            workspace_tensor.data(), stream);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BS2HD) {
+        auto q = buffers[0];
+        auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+        auto q_tensor = TensorWrapper(q, q_shape, dtype);
+        auto kv = buffers[1];
+        auto kv_shape =
+            std::vector<size_t>{input_batch * kv_max_seqlen, 2, num_gqa_groups, head_dim};
+        auto kv_tensor = TensorWrapper(kv, kv_shape, dtype);
+        auto dq = buffers[10];
+        auto dq_tensor = TensorWrapper(dq, q_shape, dtype);
+        auto dkv = buffers[11];
+        auto dkv_tensor = TensorWrapper(dkv, kv_shape, dtype);
+        nvte_fused_attn_bwd_kvpacked(
+            q_tensor.data(), kv_tensor.data(), output_tensor.data(), doutput_tensor.data(),
+            s_tensor.data(),  // not used for F16
+            s_tensor.data(),  // not used for F16
+            &aux_input_tensors, dq_tensor.data(), dkv_tensor.data(), dbias_tensor.data(),
+            q_cu_seqlens_tensor.data(), kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen,
+            scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+            workspace_tensor.data(), stream);
+    } else if (qkv_layout == NVTE_QKV_Layout::NVTE_BSHD_BSHD_BSHD) {
+        auto q = buffers[0];
+        auto q_shape = std::vector<size_t>{input_batch * q_max_seqlen, attn_heads, head_dim};
+        auto q_tensor = TensorWrapper(q, q_shape, dtype);
+        auto k = buffers[1];
+        auto k_shape = std::vector<size_t>{input_batch * kv_max_seqlen, num_gqa_groups, head_dim};
+        auto k_tensor = TensorWrapper(k, k_shape, dtype);
+        auto v = buffers[2];
+        auto v_shape = k_shape;
+        auto v_tensor = TensorWrapper(v, v_shape, dtype);
+        auto dq = buffers[10];
+        auto dq_tensor = TensorWrapper(dq, q_shape, dtype);
+        auto dk = buffers[11];
+        auto dk_tensor = TensorWrapper(dk, k_shape, dtype);
+        auto dv = buffers[12];
+        auto dv_tensor = TensorWrapper(dv, v_shape, dtype);
+        nvte_fused_attn_bwd(q_tensor.data(), k_tensor.data(), v_tensor.data(), output_tensor.data(),
+                            doutput_tensor.data(),
+                            s_tensor.data(),  // not used for F16
+                            s_tensor.data(),  // not used for F16
+                            &aux_input_tensors, dq_tensor.data(), dk_tensor.data(),
+                            dv_tensor.data(), dbias_tensor.data(), q_cu_seqlens_tensor.data(),
+                            kv_cu_seqlens_tensor.data(), q_max_seqlen, kv_max_seqlen,
+                            scaling_factor, dropout_probability, qkv_layout, bias_type, mask_type,
+                            workspace_tensor.data(), stream);
+    } else {
+        NVTE_ERROR("Unsupported qkv_layout.");
+    }
 
     nvte_tensor_pack_destroy(&aux_input_tensors);
 }

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -118,17 +118,18 @@ struct CustomCallFusedAttnDescriptor {
     float dropout_probability;
     NVTE_Bias_Type bias_type;
     NVTE_Mask_Type mask_type;
+    NVTE_QKV_Layout qkv_layout;
     DType dtype;
     DType wkspace_dtype;
     bool is_training;
 };
 
 pybind11::bytes PackCustomCallFusedAttnDescriptor(
-    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
+    size_t input_batch, size_t batch_size, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    size_t wkspace_size, float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
-    DType dtype, DType wkspace_dtype, bool is_training);
+    size_t wkspace_size, float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype,
+    bool is_training);
 
 NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
                                             NVTE_QKV_Layout qkv_layout, NVTE_Bias_Type bias_type,
@@ -207,55 +208,19 @@ void ScaledUpperTriangMaskedSoftmaxForward(cudaStream_t stream, void **buffers, 
 void ScaledUpperTriangMaskedSoftmaxBackward(cudaStream_t stream, void **buffers, const char *opaque,
                                             std::size_t opaque_len);
 
-pybind11::tuple GetSelfFusedAttnForwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t max_seqlen,
-    size_t attn_heads, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
-
-void SelfFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
-                          size_t opaque_len);
-
-pybind11::tuple GetSelfFusedAttnBackwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t max_seqlen,
-    size_t attn_heads, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
-
-void SelfFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
-                           size_t opaque_len);
-
-pybind11::tuple GetCrossFusedAttnForwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
-    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
-
-void CrossFusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque,
-                           size_t opaque_len);
-
-pybind11::tuple GetCrossFusedAttnBackwardWorkspaceSizes(
-    size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
-    size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
-
-void CrossFusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque,
-                            size_t opaque_len);
-
 pybind11::tuple GetFusedAttnForwardWorkspaceSizes(
     size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
+    float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training);
 
 void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 
 pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
     size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
-    float scaling_factor, float dropout_probability,
-    NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type, DType dtype, bool is_training);
+    float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
+    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training);
 
 void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 


### PR DESCRIPTION
This PR does a few refactorings on JAX fused attention

- The prefixes `self`/`cross` have been renamed to `_qkvpacked`/`_kvpacked` to more accurately reflect their meanings.
- The three separate custom calls for _qkvpacked, _kvpacked, and separate have been consolidated into a single custom call. This simplification is intended to ease the future development works.
- Add `no_mask` and `padding_causal` for mask generalization. 
  - For mask with `padding`(i.e. `padding_causal`, `padding`), users are required to supply a runtime mask indicating the positions of padding.
  - For mask without `padding` (i.e. `no_mask`, `causal_mask`), TE will generate masks automatically and can reduce the time needed to calculate padding offsets, thereby improving performance.
  - The documentation has been updated to reflect these changes in mask behavior.
- Reduce the number of skipped cases in `test_fused_attn.py`