### PR TITLE
Ln force no weight sharding

### DIFF
--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -18,7 +18,7 @@ def generate_configs():
     if is_devices_enough(2):
         configs.append([2, (2,), ('dp'), MeshResource(dp_resource='dp')])
         configs.append([2, (2,), ('tp'), MeshResource(tp_resource='tp')])
-
+        
     if is_devices_enough(4):
         TP_size = 2
         DP_size = 2

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -18,6 +18,7 @@ def generate_configs():
     if is_devices_enough(2):
         configs.append([2, (2,), ('dp'), MeshResource(dp_resource='dp')])
         configs.append([2, (2,), ('tp'), MeshResource(tp_resource='tp')])
+        
 
     if is_devices_enough(4):
         TP_size = 2
@@ -105,6 +106,7 @@ def compare_ops(target_func,
                 metric_bwd_dtype=None,
                 in_shardings=_UNSPECIFIED,
                 out_shardings=_UNSPECIFIED,
+                check_collectives=False,
                 **kwargs):
     assert len(inputs) >= 1
 
@@ -130,4 +132,5 @@ def compare_ops(target_func,
     for i in range(len(target_grads)):
         assert_allclose(target_grads[i], ref_grads[i], dtype=metric_bwd_dtype)
 
-    assert_equal_collectives(target_hlo, coll_count_ref)
+    if check_collectives:
+        assert_equal_collectives(target_hlo, coll_count_ref)

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -106,7 +106,6 @@ def compare_ops(target_func,
                 metric_bwd_dtype=None,
                 in_shardings=_UNSPECIFIED,
                 out_shardings=_UNSPECIFIED,
-                check_collectives=False,
                 **kwargs):
     assert len(inputs) >= 1
 
@@ -132,5 +131,5 @@ def compare_ops(target_func,
     for i in range(len(target_grads)):
         assert_allclose(target_grads[i], ref_grads[i], dtype=metric_bwd_dtype)
 
-    if check_collectives:
-        assert_equal_collectives(target_hlo, coll_count_ref)
+
+    assert_equal_collectives(target_hlo, coll_count_ref)

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -18,7 +18,6 @@ def generate_configs():
     if is_devices_enough(2):
         configs.append([2, (2,), ('dp'), MeshResource(dp_resource='dp')])
         configs.append([2, (2,), ('tp'), MeshResource(tp_resource='tp')])
-        
 
     if is_devices_enough(4):
         TP_size = 2
@@ -130,6 +129,5 @@ def compare_ops(target_func,
 
     for i in range(len(target_grads)):
         assert_allclose(target_grads[i], ref_grads[i], dtype=metric_bwd_dtype)
-
 
     assert_equal_collectives(target_hlo, coll_count_ref)

--- a/tests/jax/test_distributed_layernorm.py
+++ b/tests/jax/test_distributed_layernorm.py
@@ -34,7 +34,7 @@ class TestDistributedLayernorm:
         else:
             raise NotImplementedError
 
-        g_pspec = b_pspec = PartitionSpec(mesh_resource.dp_resource)
+        g_pspec = b_pspec = PartitionSpec(None)
 
         return (x, gamma, beta), (x_pspec, g_pspec, b_pspec)
 
@@ -92,8 +92,8 @@ class TestDistributedLayernorm:
                         grad_args=(0, 1, 2),
                         metric_fwd_dtype=dtype,
                         metric_bwd_dtype=dtype,
-                        in_shardings=(x_pspec, g_spec_forced, b_spec_forced),
-                        out_shardings=(None, (x_pspec, g_spec_forced, b_spec_forced)))
+                        in_shardings=(x_pspec, g_pspec, b_pspec),
+                        out_shardings=(None, (x_pspec, g_pspec, b_pspec)))
 
     @pytest.mark.parametrize('device_count,mesh_shape,mesh_axes,mesh_resource', generate_configs())
     @pytest.mark.parametrize('data_shape', [[32, 128, 1024], [32, 1024]])
@@ -129,5 +129,5 @@ class TestDistributedLayernorm:
                         grad_args=(0, 1),
                         metric_fwd_dtype=dtype,
                         metric_bwd_dtype=dtype,
-                        in_shardings=(x_pspec, g_spec_forced),
-                        out_shardings=(None, (x_pspec, g_spec_forced)))
+                        in_shardings=(x_pspec, g_pspec),
+                        out_shardings=(None, (x_pspec, g_pspec)))

--- a/tests/jax/test_distributed_layernorm.py
+++ b/tests/jax/test_distributed_layernorm.py
@@ -34,7 +34,7 @@ class TestDistributedLayernorm:
         else:
             raise NotImplementedError
 
-        g_pspec = b_pspec = PartitionSpec(None)
+        g_pspec = b_pspec = PartitionSpec(mesh_resource.dp_resource)
 
         return (x, gamma, beta), (x_pspec, g_pspec, b_pspec)
 
@@ -91,7 +91,8 @@ class TestDistributedLayernorm:
                         metric_fwd_dtype=dtype,
                         metric_bwd_dtype=dtype,
                         in_shardings=(x_pspec, g_pspec, b_pspec),
-                        out_shardings=(None, (x_pspec, g_pspec, b_pspec)))
+                        out_shardings=(None, (x_pspec, g_pspec, b_pspec)),
+                        check_collectives=False)
 
     @pytest.mark.parametrize('device_count,mesh_shape,mesh_axes,mesh_resource', generate_configs())
     @pytest.mark.parametrize('data_shape', [[32, 128, 1024], [32, 1024]])
@@ -127,4 +128,5 @@ class TestDistributedLayernorm:
                         metric_fwd_dtype=dtype,
                         metric_bwd_dtype=dtype,
                         in_shardings=(x_pspec, g_pspec),
-                        out_shardings=(None, (x_pspec, g_pspec)))
+                        out_shardings=(None, (x_pspec, g_pspec)),
+                        check_collectives=False)

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -466,8 +466,8 @@ class LayerNormFwdPrimitive(BasePrimitive):
 
 
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
-        b_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(b_spec)))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
+        b_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         mu_sharding = rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
 
@@ -647,7 +647,7 @@ class LayerNormBwdPrimitive(BasePrimitive):
             )
 
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_b_spec)))
+        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
         return dx_sharding, dgamma_sharding, dbeta_sharding
 
     @staticmethod
@@ -668,11 +668,11 @@ class LayerNormBwdPrimitive(BasePrimitive):
             )
         
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_b_spec)))
+        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_shardings = dx_sharding, dgamma_sharding, dbeta_sharding
         x_shardings = (dx_sharding,) * 2    # dz and x should have the same sharding.
         mu_shardings = (NamedSharding(mesh, PartitionSpec(*x_spec[:-1])),) * 2
-        arg_shardings = (*x_shardings, *mu_shardings, NamedSharding(mesh, PartitionSpec(*(None,) * len(g_b_spec))))
+        arg_shardings = (*x_shardings, *mu_shardings, NamedSharding(mesh, PartitionSpec(None)))
 
         def sharded_impl(dz, x, mu, rsigma, gamma):
             local_dx, local_dgamma, local_dbeta = \
@@ -859,7 +859,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
             )
         
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
         arg_shardings = (x_sharding, g_sharding)
@@ -1018,7 +1018,7 @@ class RmsNormBwdPrimitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
+        dgamma_sharding = NamedSharding(mesh, PartitionSpec(None))
         return dx_sharding, dgamma_sharding
 
     @staticmethod
@@ -1038,11 +1038,11 @@ class RmsNormBwdPrimitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
+        dgamma_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_shardings = dx_sharding, dgamma_sharding
         x_shardings = (dx_sharding,) * 2    # dz and x should have the same sharding.
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
-        arg_shardings = (*x_shardings, rsigma_sharding, NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec))))
+        arg_shardings = (*x_shardings, rsigma_sharding, NamedSharding(mesh, PartitionSpec(None)))
 
         def sharded_impl(dz, x, rsigma, gamma):
             local_dx, local_dgamma = \
@@ -4394,8 +4394,8 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
-        b_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(b_spec)))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
+        b_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         mu_sharding = rsigma_sharding = NamedSharding(
             mesh, PartitionSpec(*get_padded_spec(arg_infos[0])[:-1]))
@@ -4632,7 +4632,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[0])[:-1]))
         amax_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[2])))

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -453,9 +453,21 @@ class LayerNormFwdPrimitive(BasePrimitive):
                 f"Force to not shard the hidden dim, which might introduce extra collective ops, " \
                 f"and hurt performance."
             )
+        if g_spec[-1] is not None:
+            warnings.warn(
+                f"{LayerNormFwdPrimitive.name} does not support sharding of parameter gamma " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
+        if b_spec[-1] is not None:
+            warnings.warn(
+                f"{LayerNormFwdPrimitive.name} does not support sharding of parameter beta " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
+
+
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*g_spec))
-        b_sharding = NamedSharding(mesh, PartitionSpec(*b_spec))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
+        b_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         mu_sharding = rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
 
@@ -628,8 +640,14 @@ class LayerNormBwdPrimitive(BasePrimitive):
                 f"and hurt performance."
             )
         g_b_spec = get_padded_spec(arg_infos[4])
+        if g_b_spec[-1] is not None:
+            warnings.warn(
+                f"{LayerNormBwdPrimitive.name} does not support sharding of gradients of gamma and beta of Layernorm" \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
+
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(*g_b_spec))
+        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
         return dx_sharding, dgamma_sharding, dbeta_sharding
 
     @staticmethod
@@ -643,12 +661,18 @@ class LayerNormBwdPrimitive(BasePrimitive):
                 f"and hurt performance."
             )
         g_b_spec = get_padded_spec(arg_infos[4])
+        if g_b_spec[-1] is not None:
+            warnings.warn(
+                f"{LayerNormBwdPrimitive.name} does not support sharding of gradients of gamma and beta of Layernorm" \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
+        
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(*g_b_spec))
+        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_shardings = dx_sharding, dgamma_sharding, dbeta_sharding
         x_shardings = (dx_sharding,) * 2    # dz and x should have the same sharding.
         mu_shardings = (NamedSharding(mesh, PartitionSpec(*x_spec[:-1])),) * 2
-        arg_shardings = (*x_shardings, *mu_shardings, NamedSharding(mesh, PartitionSpec(*g_b_spec)))
+        arg_shardings = (*x_shardings, *mu_shardings, NamedSharding(mesh, PartitionSpec(None)))
 
         def sharded_impl(dz, x, mu, rsigma, gamma):
             local_dx, local_dgamma, local_dbeta = \
@@ -828,8 +852,14 @@ class RmsNormFwdPrimitive(BasePrimitive):
                 f"Force to not shard the hidden dim, which might introduce extra collective ops, " \
                 f"and hurt performance."
             )
+        if g_spec[-1] is not None:
+            warnings.warn(
+                f"{RmsNormFwdPrimitive.name} does not support sharding of parameter gamma " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
+        
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*g_spec))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
         arg_shardings = (x_sharding, g_sharding)
@@ -982,8 +1012,13 @@ class RmsNormBwdPrimitive(BasePrimitive):
                 f"and hurt performance."
             )
         g_spec = get_padded_spec(arg_infos[3])
+        if g_spec[-1] is not None:
+            warnings.warn(
+                f"{RmsNormBwdPrimitive.name} does not support sharding of parameter gamma " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = NamedSharding(mesh, PartitionSpec(*g_spec))
+        dgamma_sharding = NamedSharding(mesh, PartitionSpec(None))
         return dx_sharding, dgamma_sharding
 
     @staticmethod
@@ -997,12 +1032,17 @@ class RmsNormBwdPrimitive(BasePrimitive):
                 f"and hurt performance."
             )
         g_spec = get_padded_spec(arg_infos[3])
+        if g_spec[-1] is not None:
+            warnings.warn(
+                f"{RmsNormBwdPrimitive.name} does not support sharding of parameter gamma " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = NamedSharding(mesh, PartitionSpec(*g_spec))
+        dgamma_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_shardings = dx_sharding, dgamma_sharding
         x_shardings = (dx_sharding,) * 2    # dz and x should have the same sharding.
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
-        arg_shardings = (*x_shardings, rsigma_sharding, NamedSharding(mesh, PartitionSpec(*g_spec)))
+        arg_shardings = (*x_shardings, rsigma_sharding, NamedSharding(mesh, PartitionSpec(None)))
 
         def sharded_impl(dz, x, rsigma, gamma):
             local_dx, local_dgamma = \
@@ -4335,15 +4375,27 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
     def partition(out_dtype, zero_centered_gamma, epsilon, mesh, arg_infos, result_infos):
         del result_infos
         x_spec = get_padded_spec(arg_infos[0])
+        g_spec = get_padded_spec(arg_infos[1])
+        b_spec = get_padded_spec(arg_infos[2])
         if x_spec[-1] is not None:
             warnings.warn(
-                f"Does not support to shard hidden dim in {LayerNormFwdPrimitive.name}! " \
+                f"Does not support to shard hidden dim in {LayerNormFwdFp8Primitive.name}! " \
                 f"Force to not shard the hidden dim, which might introduce extra collective ops, " \
                 f"and hurt performance."
             )
+        if g_spec[-1] is not None:
+            warnings.warn(
+                f"{LayerNormFwdFp8Primitive.name} does not support sharding of parameter gamma " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
+        if b_spec[-1] is not None:
+            warnings.warn(
+                f"{LayerNormFwdFp8Primitive.name} does not support sharding of parameter beta " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[1])))
-        b_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[2])))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
+        b_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         mu_sharding = rsigma_sharding = NamedSharding(
             mesh, PartitionSpec(*get_padded_spec(arg_infos[0])[:-1]))
@@ -4567,14 +4619,20 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
     def partition(out_dtype, epsilon, mesh, arg_infos, result_infos):
         del result_infos
         x_spec = get_padded_spec(arg_infos[0])
+        g_spec = get_padded_spec(arg_infos[1])
         if x_spec[-1] is not None:
             warnings.warn(
                 f"Does not support to shard hidden dim in {RmsNormFwdFp8Primitive.name}! " \
                 f"Force to not shard the hidden dim, which might introduce extra collective ops, " \
                 f"and hurt performance."
             )
+        if g_spec[-1] is not None:
+            warnings.warn(
+                f"{RmsNormFwdFp8Primitive.name} does not support sharding of parameter gamma " \
+                f"Enforcing no sharding of parameters hidden dim! " \
+            )
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[1])))
+        g_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[0])[:-1]))
         amax_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[2])))

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -466,8 +466,8 @@ class LayerNormFwdPrimitive(BasePrimitive):
 
 
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(None))
-        b_sharding = NamedSharding(mesh, PartitionSpec(None))
+        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
+        b_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(b_spec)))
         out_sharding = x_sharding
         mu_sharding = rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
 
@@ -647,7 +647,7 @@ class LayerNormBwdPrimitive(BasePrimitive):
             )
 
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
+        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_b_spec)))
         return dx_sharding, dgamma_sharding, dbeta_sharding
 
     @staticmethod
@@ -668,11 +668,11 @@ class LayerNormBwdPrimitive(BasePrimitive):
             )
         
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
+        dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_b_spec)))
         out_shardings = dx_sharding, dgamma_sharding, dbeta_sharding
         x_shardings = (dx_sharding,) * 2    # dz and x should have the same sharding.
         mu_shardings = (NamedSharding(mesh, PartitionSpec(*x_spec[:-1])),) * 2
-        arg_shardings = (*x_shardings, *mu_shardings, NamedSharding(mesh, PartitionSpec(None)))
+        arg_shardings = (*x_shardings, *mu_shardings, NamedSharding(mesh, PartitionSpec(*(None,) * len(g_b_spec))))
 
         def sharded_impl(dz, x, mu, rsigma, gamma):
             local_dx, local_dgamma, local_dbeta = \
@@ -859,7 +859,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
             )
         
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(None))
+        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
         out_sharding = x_sharding
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
         arg_shardings = (x_sharding, g_sharding)
@@ -1018,7 +1018,7 @@ class RmsNormBwdPrimitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = NamedSharding(mesh, PartitionSpec(None))
+        dgamma_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
         return dx_sharding, dgamma_sharding
 
     @staticmethod
@@ -1038,11 +1038,11 @@ class RmsNormBwdPrimitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        dgamma_sharding = NamedSharding(mesh, PartitionSpec(None))
+        dgamma_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
         out_shardings = dx_sharding, dgamma_sharding
         x_shardings = (dx_sharding,) * 2    # dz and x should have the same sharding.
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1]))
-        arg_shardings = (*x_shardings, rsigma_sharding, NamedSharding(mesh, PartitionSpec(None)))
+        arg_shardings = (*x_shardings, rsigma_sharding, NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec))))
 
         def sharded_impl(dz, x, rsigma, gamma):
             local_dx, local_dgamma = \
@@ -4394,8 +4394,8 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(None))
-        b_sharding = NamedSharding(mesh, PartitionSpec(None))
+        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
+        b_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(b_spec)))
         out_sharding = x_sharding
         mu_sharding = rsigma_sharding = NamedSharding(
             mesh, PartitionSpec(*get_padded_spec(arg_infos[0])[:-1]))
@@ -4632,7 +4632,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
-        g_sharding = NamedSharding(mesh, PartitionSpec(None))
+        g_sharding = NamedSharding(mesh, PartitionSpec(*(None,) * len(g_spec)))
         out_sharding = x_sharding
         rsigma_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[0])[:-1]))
         amax_sharding = NamedSharding(mesh, PartitionSpec(*get_padded_spec(arg_infos[2])))

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -642,7 +642,8 @@ class LayerNormBwdPrimitive(BasePrimitive):
         g_b_spec = get_padded_spec(arg_infos[4])
         if g_b_spec[-1] is not None:
             warnings.warn(
-                f"{LayerNormBwdPrimitive.name} does not support sharding of gradients of gamma and beta of Layernorm" \
+                f"{LayerNormBwdPrimitive.name} does not support sharding of gradients " \
+                f"of gamma and beta of Layernorm " \
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
 
@@ -663,10 +664,11 @@ class LayerNormBwdPrimitive(BasePrimitive):
         g_b_spec = get_padded_spec(arg_infos[4])
         if g_b_spec[-1] is not None:
             warnings.warn(
-                f"{LayerNormBwdPrimitive.name} does not support sharding of gradients of gamma and beta of Layernorm" \
+                f"{LayerNormBwdPrimitive.name} does not support sharding of gradients " \
+                f"of gamma and beta of Layernorm " \
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
-        
+
         dx_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
         dgamma_sharding = dbeta_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_shardings = dx_sharding, dgamma_sharding, dbeta_sharding
@@ -857,7 +859,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
                 f"{RmsNormFwdPrimitive.name} does not support sharding of parameter gamma " \
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
-        
+
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
         g_sharding = NamedSharding(mesh, PartitionSpec(None))
         out_sharding = x_sharding


### PR DESCRIPTION
Sharding affine transformation weights in TE is currently unsupported. This PR forces replication of gamma/beta in the case of LayerNorm and gamma in the case of RMSNorm even if they are sharded as inputs. 