### PR TITLE
[Pytorch] Update context parallel softmax lse correction func

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -482,9 +482,10 @@ def flash_attn_fwd_out_correction(out, out_per_step, softmax_lse, softmax_lse_pe
 @jit_fuser
 def flash_attn_fwd_softmax_lse_correction(softmax_lse, softmax_lse_per_step):
     """Merge softmax stats of each step in Attention with context parallelism"""
-    softmax_lse.exp_()
-    softmax_lse.add_(softmax_lse_per_step.to(torch.double).exp())
-    softmax_lse.log_()
+    max_scale = torch.max(softmax_lse, softmax_lse_per_step)
+    min_scale = torch.min(softmax_lse, softmax_lse_per_step)
+    new_scale = max_scale + torch.log(1 + torch.exp(min_scale - max_scale))
+    softmax_lse.copy_(new_scale)
 
 
 class AttnFuncWithCP(torch.autograd.Function):


### PR DESCRIPTION
The original implementation would result in 'nan' when the value of lse.exp() exceeds the range of double, causing incorrect values and gradients at the corresponding positions.