### PR TITLE
[JAX] Adapt latest JAX/PAX image

### DIFF
--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -315,8 +315,7 @@ def train_and_evaluate(args):
 
     jax.distributed.initialize(coordinator_address=args.coordinator_address,
                                num_processes=args.num_process,
-                               process_id=args.process_id,
-                               local_device_ids=args.process_id)
+                               process_id=args.process_id)
     assert jax.local_device_count() == 1, "1 GPU per process"
 
     num_gpu_tp = 2

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -315,7 +315,8 @@ def train_and_evaluate(args):
 
     jax.distributed.initialize(coordinator_address=args.coordinator_address,
                                num_processes=args.num_process,
-                               process_id=args.process_id)
+                               process_id=args.process_id,
+                               local_device_ids=args.process_id)
     assert jax.local_device_count() == 1, "1 GPU per process"
 
     num_gpu_tp = 2

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -485,7 +485,8 @@ class TestGeLuFP8(TestGeLu):
         primitive.defvjp(primitive_fwd, primitive_bwd)
         func = value_and_grad(lambda x, y, z, w: jnp.mean(primitive(x, y, z, w)), (0, 1, 2, 3))
 
-        return func(inputs, no_use, no_use, no_use)
+        return func(inputs, jnp.transpose(inputs, (2, 0, 1)),
+                    jnp.zeros(inputs.shape[-1], dtype=inputs.dtype), no_use)
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)
     @pytest.mark.parametrize('shape', [(32, 2, 64), (64, 2, 256)])
@@ -582,7 +583,7 @@ class TestGatedGeLuFP8(TestGatedGeLu):
         primitive.defvjp(primitive_fwd, primitive_bwd)
         func = value_and_grad(lambda x, y, z: jnp.mean(primitive(x, y, z)), (0, 1, 2))
 
-        return func(inputs, no_use, no_use)
+        return func(inputs, jnp.transpose(inputs, (1, 2, 0)), no_use)
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)
     @pytest.mark.parametrize('shape', [(32, 2, 64), (64, 2, 256)])

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -731,19 +731,18 @@ class LayerNorm(nn.Module):
                                                    axes=('embed',))
             bias = jnp.asarray(bias, self.dtype)
 
-            y = jnp.asarray(y, self.dtype)
             if not self.zero_centered_gamma:
                 z = y * scale + bias
             else:
-                z = y * (scale + 1) + bias
+                z = y * (scale + 1.) + bias
         else:
             assert self.layernorm_type == 'rmsnorm'
             assert not self.zero_centered_gamma
             mean2 = jnp.mean(lax.square(x), axis=-1, keepdims=True)
-            y = jnp.asarray(x * lax.rsqrt(mean2 + self.epsilon), self.dtype)
+            y = x * lax.rsqrt(mean2 + self.epsilon)
             z = y * scale
 
-        return z
+        return jnp.asarray(z, self.dtype)
 
 
 class RelativePositionBiases(nn.Module):


### PR DESCRIPTION
1. custom primitives requires the same shape for fwd input and bwd corresponding gradients. We used shape = [1] for dummy inputs in the past. This PR changed the input shape to be match as the bwd return output.
2. Latest JAX changed their layernorm fusion kernel, so the original ref code computed the `scale * y + bias` in bfloat16 which leads higher difference with TE's layernorm after 03-14 image. This PR makes the reference code computes `scale * y + bias` in higher precision and then cast back to the bfloat16, which aligns [TE's implementations](https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/common/layer_norm/ln_fwd_kernels.cuh#L120-L125) (fp32 register computation and cast to F16 before saving to global memory).
3. WAR `jax.distributed.init` issue by not providing `local_device_ids`, which forces JAX to query devices and call `cuinit`.