### PR TITLE
Userbuffer: Remove unnecessary fence from producer

### DIFF
--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
@@ -48,7 +48,6 @@
 #define ATOMIC_PRODUCER(chunk)                                                                     \
   if (counters) {                                                                                  \
     ((unsigned int *)counters)[chunk] = 0;                                                         \
-    asm volatile("fence.sc.gpu;\n");                                                               \
   }
 
 // Return true if producer > consumer, otherwise false while preventing integer overflow


### PR DESCRIPTION
Remove the unnecessary fence from the producer API.
This is expected minor performance gain.