### PR TITLE
Fix memory fence for ARM

### DIFF
--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers-host.cpp
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers-host.cpp
@@ -284,6 +284,9 @@ int create_communicator_grouped2(communicator **comm, int pipegpus, int pipenode
     (*comm)->hostflags[i] = 0;
 #if (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
   __asm__ __volatile__("dmb sy" : : : "memory");
+#elif defined(_MSC_VER) && _MSC_VER >= 1310
+  extern "C" void _ReadWriteBarrier();
+#  pragma intrinsic(_ReadWriteBarrier)
 #else
   _mm_mfence();
 #endif


### PR DESCRIPTION
TransformerEngine doesn't compile for aarch64, this PR:
- Conditionally use data memory barrier for ARM architecture.
- Fix a redefinition error coming from gdrapi.h defining the `GPU_PAGE_*` macros and already included in userbuffers.h. This adds an explicit include (which is guarded and prevent redefinition) since the `GPU_PAGE_*` variables are used in this .cpp file.