### PR TITLE
Fix undefined symbol issue for transformer_engine::getenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -445,6 +445,12 @@ def setup_pytorch_extension() -> setuptools.Extension:
     sources = [
         src_dir / "common.cu",
         src_dir / "ts_fp8_op.cpp",
+        # We need to compile system.cpp because the pytorch extension uses
+        # transformer_engine::getenv. This is a workaround to avoid direct
+        # linking with libtransformer_engine.so, as the pre-built PyTorch
+        # wheel from conda or PyPI was not built with CXX11_ABI, and will
+        # cause undefined symbol issues.
+        root_path / "transformer_engine" / "common" / "util" / "system.cpp",
     ] + \
     _all_files_in_dir(extensions_dir)
 


### PR DESCRIPTION
Fix https://github.com/NVIDIA/TransformerEngine/issues/756. The issue happens because we recently included `common/util/system.h` into PyTorch source CPP files at https://github.com/NVIDIA/TransformerEngine/pull/713/files to utilize the `transformer_engine::getenv` method. As a result, the PyTorch `transformer_engine_extensions` will now search for symbols within the `libtransformer_engine.so` library.

However, if the user builds TransformerEngine in a local environment (conda or PyPI), because the pre-built PyTorch, either from conda or PyPI, has the CXX11_ABI set as False, whereas the common library is using the new CXX11_ABI. As a result, there will be an undefined symbol problem when importing `transformer_engine_extensions`. NGC PyTorch container is using `CXX11_ABI=1`, so there is no problem.