### PR TITLE
[JAX] Allow multi-dims for dgamma and dbeta in LN descriptor.

### DIFF
--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -55,7 +55,7 @@ class Net(nn.Module):
         return x
 
 
-@partial(jax.jit, static_argnums=(0, 1, 2, 3, 4, 5))
+@partial(jax.jit)
 def train_step(state, inputs, masks, labels, var_collect, rngs):
     """Computes gradients, loss and accuracy for a single batch."""
 

--- a/examples/jax/mnist/test_single_gpu_mnist.py
+++ b/examples/jax/mnist/test_single_gpu_mnist.py
@@ -74,7 +74,7 @@ def apply_model(state, images, labels, var_collect, rngs=None):
     return grads, loss, accuracy
 
 
-@partial(jax.jit, static_argnums=(0, 1))
+@partial(jax.jit)
 def update_model(state, grads):
     """Update model params and FP8 meta."""
     state = state.apply_gradients(grads=grads[PARAMS_KEY])

--- a/transformer_engine/jax/cpp_extensions.py
+++ b/transformer_engine/jax/cpp_extensions.py
@@ -385,8 +385,8 @@ class LayerNormFwdPrimitive(BasePrimitive):
             hidden_size,
             wkspace_aval.size,
             barrier_aval.size,
-            0,    # no dgamma_part in FWD pass
-            0,    # no dbeta_part in BWD pass
+            (0,),    # no dgamma_part in FWD pass
+            (0,),    # no dbeta_part in BWD pass
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
             jax_dtype_to_te_dtype(wkspace_aval.dtype),
@@ -463,7 +463,6 @@ class LayerNormFwdPrimitive(BasePrimitive):
                 f"{LayerNormFwdPrimitive.name} does not support sharding of parameter beta " \
                 f"Enforcing no sharding of parameters hidden dim! " \
             )
-
 
         x_sharding = NamedSharding(mesh, PartitionSpec(*x_spec[:-1], None))
         g_sharding = NamedSharding(mesh, PartitionSpec(None))
@@ -589,8 +588,8 @@ class LayerNormBwdPrimitive(BasePrimitive):
             hidden_size,
             wkspace_aval.size,
             barrier_aval.size,
-            dgamma_part_aval.size,
-            dbeta_part_aval.size,
+            dgamma_part_aval.shape,
+            dbeta_part_aval.shape,
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
             jax_dtype_to_te_dtype(wkspace_aval.dtype),
@@ -791,8 +790,8 @@ class RmsNormFwdPrimitive(BasePrimitive):
             hidden_size,
             wkspace_aval.size,
             barrier_aval.size,
-            0,    # no dgamma_part in FWD pass
-            0,    # no dbeta_part in BWD pass
+            (0,),    # no dgamma_part in FWD pass
+            (0,),    # no dbeta_part in BWD pass
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
             jax_dtype_to_te_dtype(wkspace_aval.dtype),
@@ -968,8 +967,8 @@ class RmsNormBwdPrimitive(BasePrimitive):
             hidden_size,
             wkspace_aval.size,
             barrier_aval.size,
-            dgamma_part_aval.size,
-            0,    # no dbeta_part for RMSnorm
+            dgamma_part_aval.shape,
+            (0,),    # no dbeta_part for RMSnorm
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
             jax_dtype_to_te_dtype(wkspace_aval.dtype),
@@ -3588,8 +3587,8 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
             hidden_size,
             wkspace_aval.size,
             barrier_aval.size,
-            0,    # no dgamma_part in FWD pass
-            0,    # no dbeta_part in BWD pass
+            (0,),    # no dgamma_part in FWD pass
+            (0,),    # no dbeta_part in BWD pass
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
             jax_dtype_to_te_dtype(wkspace_aval.dtype),
@@ -3840,8 +3839,8 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
             hidden_size,
             wkspace_aval.size,
             barrier_aval.size,
-            0,    # no dgamma_part in FWD pass
-            0,    # no dbeta_part in BWD pass
+            (0,),    # no dgamma_part in FWD pass
+            (0,),    # no dbeta_part in BWD pass
             jax_dtype_to_te_dtype(x_aval.dtype),
             jax_dtype_to_te_dtype(gamma_aval.dtype),
             jax_dtype_to_te_dtype(wkspace_aval.dtype),

--- a/transformer_engine/jax/csrc/modules.h
+++ b/transformer_engine/jax/csrc/modules.h
@@ -69,8 +69,8 @@ struct CustomCallNormDescriptor {
     size_t hidden_size;
     size_t wkspace_size;
     size_t barrier_size;
-    size_t *dgamma_part_sizes;  // 2D tensor
-    size_t *dbeta_part_sizes;   // 2D tensor
+    Shape dgamma_part_shape;
+    Shape dbeta_part_shape;
     DType x_dtype;
     DType w_dtype;
     DType wkspace_dtype;
@@ -82,13 +82,11 @@ struct CustomCallNormDescriptor {
     int sm_margin;
 };
 
-pybind11::bytes PackCustomCallNormDescriptor(size_t batch_size, size_t hidden_size,
-                                             size_t wkspace_size, size_t barrier_size,
-                                             size_t *dgamma_part_sizes, size_t *dbeta_part_sizes,
-                                             DType x_dtype, DType w_dtype, DType wkspace_dtype,
-                                             DType barrier_dtype, DType dgamma_part_dtype,
-                                             DType dbeta_part_dtype, bool zero_centered_gamma,
-                                             float eps, int sm_margin);
+pybind11::bytes PackCustomCallNormDescriptor(
+    size_t batch_size, size_t hidden_size, size_t wkspace_size, size_t barrier_size,
+    const std::vector<size_t> &dgamma_part_shape, const std::vector<size_t> &dbeta_part_shape,
+    DType x_dtype, DType w_dtype, DType wkspace_dtype, DType barrier_dtype, DType dgamma_part_dtype,
+    DType dbeta_part_dtype, bool zero_centered_gamma, float eps, int sm_margin);
 
 struct SoftmaxDescriptor {
     size_t batch_size;


### PR DESCRIPTION
- Pass the uncompressed shape of `dgamma` and `dbeta` to `CustomCallNormDescriptor` for the shape checking in `layernorm_bwd`, which was introduced recently.