### PR TITLE
[PyTorch] Fix for type checking failure on custom callables

### DIFF
--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -521,8 +521,11 @@ def has_te_modules(network):
         for module in network.modules():
             if any(isinstance(module, te_class) for te_class in te_classes_list):
                 return True
+        return False
 
-    return False
+    # Cannot check for TE modules inside a custom class/callable that's not a torch.nn.Module,
+    # so just assume that it has TE modules just to be safe.
+    return True
 
 
 def checkpoint(


### PR DESCRIPTION
Fix for TE checkpoint incorrectly passing custom classes/callables to the native PyTorch checkpoint.