### PR TITLE
[PyTorch] Remove unnecessary Pylint overrides

### DIFF
--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -32,8 +32,9 @@ from .te_onnx_extensions import (
     onnx_rmsnorm_fwd,
     onnx_rmsnorm_fwd_fp8
 )
+
+import torch
 try:
-    import torch
     torch._dynamo.config.error_on_nested_jit_trace = False
-except: # pylint: disable=bare-except
-    pass
+except AttributeError:
+    pass  # error_on_nested_jit_trace was added in PyTorch 2.2.0

--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -3,6 +3,8 @@
 # See LICENSE for license information.
 
 """Transformer Engine bindings for pyTorch"""
+import torch
+
 from .module import LayerNormLinear
 from .module import Linear
 from .module import LayerNormMLP
@@ -33,7 +35,6 @@ from .te_onnx_extensions import (
     onnx_rmsnorm_fwd_fp8
 )
 
-import torch
 try:
     torch._dynamo.config.error_on_nested_jit_trace = False
 except AttributeError:

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -585,7 +585,7 @@ def checkpoint(
             "`get_rng_state_tracker` must be passed as keyword arguments to `checkpoint`.",
             DeprecationWarning, stacklevel=2,
         )
-        distribute_saved_activations, get_rng_state_tracker, tp_group = args[:3] # pylint: disable=unbalanced-tuple-unpacking
+        distribute_saved_activations, get_rng_state_tracker, tp_group = args[:3]
         args = args[3:]
 
     # Trigger the native PyTorch checkpoint if the function is not or does not contain a

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -585,7 +585,7 @@ def checkpoint(
             "`get_rng_state_tracker` must be passed as keyword arguments to `checkpoint`.",
             DeprecationWarning, stacklevel=2,
         )
-        distribute_saved_activations, get_rng_state_tracker, tp_group = args[:3]
+        distribute_saved_activations, get_rng_state_tracker, tp_group = args[:3] # pylint: disable=unbalanced-tuple-unpacking
         args = args[3:]
 
     # Trigger the native PyTorch checkpoint if the function is not or does not contain a

--- a/transformer_engine/pytorch/float8_tensor.py
+++ b/transformer_engine/pytorch/float8_tensor.py
@@ -730,8 +730,6 @@ class Float8Tensor(torch.Tensor):
             return None
 
         # Slice op
-        # TODO Consider additional bookkeeping so we invalidate caches # pylint: disable=fixme
-        # if these slices are modified in-place
         if func == aten.slice.Tensor:
             tensor = args[0]
             data = tensor._data

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -502,12 +502,12 @@ def fp8_model_init(enabled: bool = True) -> None:
 
              This functionality is *EXPERIMENTAL*.
     """
+    _fp8_parameters = FP8GlobalStateManager.FP8_PARAMETERS
+    FP8GlobalStateManager.FP8_PARAMETERS = enabled
     try:
-        _fp8_parameters = FP8GlobalStateManager.FP8_PARAMETERS
-        FP8GlobalStateManager.FP8_PARAMETERS = enabled
         yield
     finally:
-        FP8GlobalStateManager.FP8_PARAMETERS = _fp8_parameters # pylint: disable=used-before-assignment
+        FP8GlobalStateManager.FP8_PARAMETERS = _fp8_parameters
 
 
 @contextmanager
@@ -555,16 +555,16 @@ def fp8_autocast(
                distributed group over which amaxes for the fp8 tensors
                are reduced at the end of each training step.
     """
+    fp8_state = FP8GlobalStateManager.get_fp8_autocast_state()
+    FP8GlobalStateManager.fp8_autocast_enter(enabled=enabled,
+                                             calibrating=calibrating,
+                                             fp8_recipe=fp8_recipe,
+                                             fp8_group=fp8_group,
+                                             _graph=_graph)
     try:
-        fp8_state = FP8GlobalStateManager.get_fp8_autocast_state()
-        FP8GlobalStateManager.fp8_autocast_enter(enabled=enabled,
-                                                 calibrating=calibrating,
-                                                 fp8_recipe=fp8_recipe,
-                                                 fp8_group=fp8_group,
-                                                 _graph=_graph)
         yield
     finally:
-        FP8GlobalStateManager.set_fp8_autocast_state(fp8_state) # pylint: disable=used-before-assignment
+        FP8GlobalStateManager.set_fp8_autocast_state(fp8_state)
         FP8GlobalStateManager.fp8_autocast_exit(enabled, _graph=_graph)
 
 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -703,7 +703,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                     out=grad_output_c,
                 )
             else:
-                grad_output_c = grad_ouput_mat # pylint: disable=undefined-variable
+                grad_output_c = grad_output_mat
             if not ctx.ub_overlap_ag:
                 grad_output_c, _ = gather_along_first_dim(grad_output_c, ctx.tp_group)
                 if not isinstance(grad_output_c, Float8Tensor):

--- a/transformer_engine/pytorch/softmax.py
+++ b/transformer_engine/pytorch/softmax.py
@@ -336,7 +336,7 @@ class FusedScaleMaskSoftmax(nn.Module):
             return self.forward_fused_softmax(inp, mask, scale)
         return self.forward_torch_softmax(inp, mask, scale)
 
-    def is_kernel_available(self, mask: torch.Tensor, b: int, np: int, sq: int, sk: int) -> bool:
+    def is_kernel_available(self, mask: torch.Tensor, b: int, np: int, sq: int, sk: int) -> bool: # pylint: disable=too-many-return-statements
         """Check FusedScaleMaskSoftmax kernel availability based on size"""
         attn_batches = b * np
 
@@ -344,7 +344,7 @@ class FusedScaleMaskSoftmax(nn.Module):
             return False  # user doesn't want to fuse
         if not self.input_in_float16:
             return False  # input must be fp16
-        if not (16 < sk < 16384):
+        if not 16 < sk < 16384:
             return False  # sk must be 16 ~ 16384
         if sk % 8 != 0:
             return False  # sk must be divisor of 8

--- a/transformer_engine/pytorch/softmax.py
+++ b/transformer_engine/pytorch/softmax.py
@@ -340,15 +340,16 @@ class FusedScaleMaskSoftmax(nn.Module):
         """Check FusedScaleMaskSoftmax kernel availability based on size"""
         attn_batches = b * np
 
-        if ( # pylint: disable=too-many-boolean-expressions
-            not self.scaled_masked_softmax_fusion   # user doesn't want to fuse
-            or not self.input_in_float16            # input must be fp16
-            or sk < 16
-            or sk > 16384                           # sk must be 16 ~ 16384
-            or sk % 8 != 0                          # sk must be divisor of 8
-            or self.attn_mask_type == "arbitrary"   # Custom masks not supported
-        ):
-            return False
+        if not self.scaled_masked_softmax_fusion:
+            return False  # user doesn't want to fuse
+        if not self.input_in_float16:
+            return False  # input must be fp16
+        if not (16 < sk < 16384):
+            return False  # sk must be 16 ~ 16384
+        if sk % 8 != 0:
+            return False  # sk must be divisor of 8
+        if self.attn_mask_type == "arbitrary":
+            return False  # Custom masks not supported
 
         if self.attn_mask_type == "causal":         # unfused causal softmax kernel
             return True


### PR DESCRIPTION
https://github.com/NVIDIA/TransformerEngine/pull/768 introduced a typo that was covered up by a Pylint override. Going forward we should only rely on linter overrides when absolutely necessary. Even if there are cases where it makes code slightly messier, the style consistency and error checking are still worth it.

This PR removes all of the Pylint overrides that were easy to remove.