### PR TITLE
[PyTorch] Fix typo from #768

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -703,7 +703,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                     out=grad_output_c,
                 )
             else:
-                grad_output_c = grad_ouput_mat # pylint: disable=undefined-variable
+                grad_output_c = grad_output_mat
             if not ctx.ub_overlap_ag:
                 grad_output_c, _ = gather_along_first_dim(grad_output_c, ctx.tp_group)
                 if not isinstance(grad_output_c, Float8Tensor):


### PR DESCRIPTION
This is a quick PR that fixes a typo from #768 and can be cherry-picked into the 1.6 release. See https://github.com/NVIDIA/TransformerEngine/pull/794 for a full description.