### PR TITLE
Find CXX component for MPI, fortran and C are not needed

### DIFF
--- a/transformer_engine/pytorch/csrc/userbuffers/CMakeLists.txt
+++ b/transformer_engine/pytorch/csrc/userbuffers/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(transformer_engine_userbuffers PUBLIC
                            "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Configure dependencies
-find_package(MPI REQUIRED)
+find_package(MPI REQUIRED COMPONENTS CXX)
 target_link_libraries(transformer_engine_userbuffers PUBLIC
                       CUDA::cudart
                       CUDA::cuda_driver


### PR DESCRIPTION
# Description

The default `find_package` is searching for all components. From the CMakeLists.txt I modified, you are linking only against `MPI::MPI_CXX` target. It is unnecessary to find the other C and Fortran mpi components.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Cleanup
