### PR TITLE
Import framework submodules lazily

### DIFF
--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -3,15 +3,32 @@
 # See LICENSE for license information.
 
 """Top level package"""
+import importlib.util
+import sys
+from types import ModuleType
+
 from ._version import __version__
 from . import common
 
-try:
-    from . import pytorch
-except ImportError as e:
-    pass
+def _lazy_import(name: str) -> ModuleType:
+    """Construct a module that is imported the first time it is used"""
+    spec = importlib.util.find_spec(name)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
 
-try:
-    from . import jax
-except ImportError as e:
-    pass
+# Lazily import frameworks
+pytorch: ModuleType = _lazy_import("transformer_engine.pytorch")
+jax: ModuleType = _lazy_import("transformer_engine.jax")
+paddle: ModuleType = _lazy_import("transformer_engine.paddle")
+
+__all__ = [
+    "__version__",
+    "common",
+    "jax",
+    "paddle",
+    "pytorch",
+]

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -20,10 +20,21 @@ def _lazy_import(name: str) -> ModuleType:
     loader.exec_module(module)
     return module
 
-# Lazily import frameworks
-pytorch: ModuleType = _lazy_import("transformer_engine.pytorch")
-jax: ModuleType = _lazy_import("transformer_engine.jax")
-paddle: ModuleType = _lazy_import("transformer_engine.paddle")
+# Import framework submodules
+# Note: Load module lazily if import fails. This way a useful import
+# error will be thrown if the user attempts to access the module.
+try:
+    from . import pytorch
+except ImportError:
+    pytorch = _lazy_import("transformer_engine.pytorch")
+try:
+    from . import jax
+except ImportError:
+    jax = _lazy_import("transformer_engine.jax")
+try:
+    from . import paddle
+except ImportError:
+    paddle = _lazy_import("transformer_engine.paddle")
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
# Description

Whenever a user calls `import transformer_engine`, we attempt to import all framework submodules (`transformer_engine.pytorch`, etc) within try-catch statements. However, this can suppress important errors and make debugging tricky. A more sophisticated approach is to [import the submodules lazily](https://docs.python.org/3/library/importlib.html#implementing-lazy-imports), i.e. only import a module the first time it is used. For example, if running with a PyTorch build of TE:

```python
import transformer_engine as te
te.pytorch.__file__  # Imports transformer_engine.pytorch
te.jax.__file__      # Imports transformer_engine.jax, fails, and throws import error
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Please list the changes introduced in this PR:

- Load framework modules lazily

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
