### PR TITLE
Do not attempt importing submodules if framework is not available

### DIFF
--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -20,26 +20,38 @@ def _lazy_import(name: str) -> ModuleType:
     loader.exec_module(module)
     return module
 
+# See which frameworks are available
+try:
+    import torch
+    _FOUND_PYTORCH = True
+except ImportError:
+    _FOUND_PYTORCH = False
+try:
+    import jax
+    _FOUND_JAX = True
+except ImportError:
+    _FOUND_JAX = False
+try:
+    import paddle
+    _FOUND_PADDLE = True
+except ImportError:
+    _FOUND_PADDLE = False
+
 # Import framework submodules
 # Note: Load module lazily if import fails. This way a useful import
 # error will be thrown if the user attempts to access the module.
-try:
-    from . import pytorch
-except ImportError:
-    pytorch = _lazy_import("transformer_engine.pytorch")
-try:
-    from . import jax
-except ImportError:
-    jax = _lazy_import("transformer_engine.jax")
-try:
-    from . import paddle
-except ImportError:
-    paddle = _lazy_import("transformer_engine.paddle")
-
-__all__ = [
-    "__version__",
-    "common",
-    "jax",
-    "paddle",
-    "pytorch",
-]
+if _FOUND_PYTORCH:
+    try:
+        from . import pytorch
+    except ImportError:
+        pytorch = _lazy_import("transformer_engine.pytorch")
+if _FOUND_JAX:
+    try:
+        from . import jax
+    except ImportError:
+        jax = _lazy_import("transformer_engine.jax")
+if _FOUND_PADDLE:
+    try:
+        from . import paddle
+    except ImportError:
+        paddle = _lazy_import("transformer_engine.paddle")


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/839 breaks Lightning Thunder's JIT infrastructure (see https://github.com/NVIDIA/TransformerEngine/pull/839#issuecomment-2108824717). Thunder calls [`inspect.stack`](https://docs.python.org/3/library/inspect.html#inspect.stack), which indiscriminately interacts with all of Transformer Engine's submodules, including lazily loaded submodules for JAX and PaddlePaddle that are intended to throw import errors.

This is a quick fix that only attempts to import submodules if the corresponding DL framework is available. The original bug may reemerge if a Thunder user incidentally has JAX or PaddlePaddle in their Python environment.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

- Do not attempt importing submodules if framework is not available

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
