### PR TITLE
[PyTorch] FP8 AllToAll

### DIFF
--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -10,6 +10,7 @@ from .module import Linear
 from .module import LayerNormMLP
 from .module import LayerNorm
 from .module import RMSNorm
+from .module import FP8AllToAll
 from .attention import DotProductAttention
 from .attention import InferenceParams
 from .attention import MultiheadAttention

--- a/transformer_engine/pytorch/module/__init__.py
+++ b/transformer_engine/pytorch/module/__init__.py
@@ -8,3 +8,4 @@ from .linear import Linear
 from .layernorm_mlp import LayerNormMLP
 from .layernorm import LayerNorm
 from .rmsnorm import RMSNorm
+from .all_to_all import FP8AllToAll

--- a/transformer_engine/pytorch/module/all_to_all.py
+++ b/transformer_engine/pytorch/module/all_to_all.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""FP8 AlltoAll API"""
+from typing import Union, Optional, Tuple, List, Dict, Any
+
+import torch
+
+from .. import cpp_extensions as tex
+
+from .base import TransformerEngineBaseModule
+
+from ..cpp_extensions import cast_to_fp8, cast_from_fp8
+from ..constants import dist_group_type, TE_DType
+from ..fp8 import get_fp8_te_dtype, FP8GlobalStateManager
+from ..graph import is_graph_capturing
+from ..jit import no_torch_dynamo
+from ..utils import requires_grad
+
+__all__ = ["FP8AllToAll"]
+
+
+class _FP8AllToAll(torch.autograd.Function):
+    """Functional FP8AllToAll
+    Calls custom cuda extensions.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        group: dist_group_type,
+        inp: torch.Tensor,
+        output_split_sizes: Union[List, None],
+        input_split_sizes: Union[List, None],
+        is_grad_enabled: bool,
+        activation_dtype: torch.dtype,
+        fp8_meta: Dict[str, Any],
+    ) -> torch.Tensor:
+
+        world_size = torch.distributed.get_world_size(group=group)
+        # Bypass the function if we are using only 1 GPU.
+        if world_size == 1:
+            return inp
+
+        inp = inp.contiguous()
+        fp8_dtype_forward = get_fp8_te_dtype(fp8_meta["recipe"], fprop_tensor=True)
+        inp_fp8 = cast_to_fp8(
+            inp,
+            fp8_meta["scaling_fwd"],
+            tex.FP8FwdTensors.GEMM1_INPUT,
+            fp8_dtype_forward,
+        )
+  
+        if output_split_sizes is None:
+            # Equal split (all2all)
+            output_fp8 = torch.empty_like(inp_fp8)
+        else:
+            # Unequal split (all2all-v)
+            output_fp8 = torch.empty(
+                size=[sum(output_split_sizes)] + list(inp_fp8.size()[1:]),
+                dtype=inp_fp8.dtype,
+                device=inp_fp8.device,
+            )
+        torch.distributed.all_to_all_single(
+            output_fp8,
+            inp_fp8,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=group,
+        )
+
+        if output_fp8.nelement() == 0:
+            output = torch.empty_like(output_fp8, dtype=activation_dtype)
+        else:
+            output = cast_from_fp8(
+                output_fp8,
+                fp8_meta["scaling_fwd"],
+                tex.FP8FwdTensors.GEMM1_INPUT,
+                fp8_dtype_forward,
+                TE_DType[activation_dtype],
+            )
+
+        if is_grad_enabled:
+            ctx.group = group
+            ctx.output_split_sizes = output_split_sizes
+            ctx.input_split_sizes = input_split_sizes
+            ctx.activation_dtype = activation_dtype
+            ctx.fp8_meta = fp8_meta
+            ctx.reduce_and_update_bwd_fp8_tensors = False
+            if requires_grad(inp,):
+                ctx.reduce_and_update_bwd_fp8_tensors = (
+                    ctx.reduce_and_update_bwd_fp8_tensors
+                    or FP8GlobalStateManager.is_first_fp8_module()
+                )
+
+        return output
+
+    @staticmethod
+    def backward(
+        ctx, grad_output: torch.Tensor
+    ) -> Tuple[Union[torch.Tensor, None], ...]:
+
+        with torch.cuda.nvtx.range("_FP8AllToAll"):
+            world_size = torch.distributed.get_world_size(group=ctx.group)
+            # Bypass the function if we are using only 1 GPU.
+            if world_size == 1:
+                return grad_output
+
+            grad_output = grad_output.contiguous()
+            fp8_dtype_backward = get_fp8_te_dtype(
+                ctx.fp8_meta["recipe"], fprop_tensor=False
+            )
+            grad_output_fp8 = cast_to_fp8(
+                grad_output,
+                ctx.fp8_meta["scaling_bwd"],
+                tex.FP8BwdTensors.GRAD_OUTPUT1,
+                fp8_dtype_backward,
+            )
+
+            if ctx.input_split_sizes is None:
+                # Equal split (all2all)
+                dgrad_fp8 = torch.empty_like(grad_output_fp8)
+            else:
+                # Unequal split (all2all-v)
+                dgrad_fp8 = torch.empty(
+                    size=[sum(ctx.input_split_sizes)] + list(grad_output_fp8.size()[1:]),
+                    dtype=grad_output_fp8.dtype,
+                    device=grad_output_fp8.device,
+                )
+            torch.distributed.all_to_all_single(
+                dgrad_fp8,
+                grad_output_fp8,
+                output_split_sizes=ctx.input_split_sizes,
+                input_split_sizes=ctx.output_split_sizes,
+                group=ctx.group,
+            )
+
+            if dgrad_fp8.nelement() == 0:
+                dgrad = torch.empty_like(dgrad_fp8, dtype=ctx.activation_dtype)
+            else:
+                dgrad = cast_from_fp8(
+                    dgrad_fp8,
+                    ctx.fp8_meta["scaling_bwd"],
+                    tex.FP8BwdTensors.GRAD_OUTPUT1,
+                    fp8_dtype_backward,
+                    TE_DType[ctx.activation_dtype],
+                )
+
+        if ctx.reduce_and_update_bwd_fp8_tensors and not is_graph_capturing():
+            FP8GlobalStateManager.reduce_and_update_fp8_tensors(forward=False)
+
+        return (
+            None,
+            dgrad,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+class FP8AllToAll(TransformerEngineBaseModule):
+    r"""
+    Cast_to_fp8 -> FP8 AllToAll -> Cast_from_fp8.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_fp8_weights_scratchpad(
+        self,
+        is_first_microbatch: Union[bool, None],
+    ) -> List[torch.Tensor]:
+        return [None, None]
+
+    @no_torch_dynamo()
+    def forward(
+        self,
+        group: dist_group_type,
+        inp: torch.Tensor,
+        output_split_sizes: Union[List, None],
+        input_split_sizes: Union[List, None],
+    ) -> torch.Tensor:
+        """
+        FP8AllToAll FWD.
+
+        Parameters
+        ----------
+        inp : torch.Tensor
+             Input tensor.
+        """
+        with self.prepare_forward(inp, None) as inp:
+            assert self.fp8, "Need to run inside fp8_autocast region."
+            self.set_activation_dtype(inp)
+
+            if torch.is_grad_enabled():
+                fwd_fn = _FP8AllToAll.apply
+                args = []
+            else:
+                fwd_fn = _FP8AllToAll.forward
+                args = [None]
+
+            args += (
+                group,
+                inp,
+                output_split_sizes,
+                input_split_sizes,
+                torch.is_grad_enabled(),
+                self.activation_dtype,
+                self.fp8_meta,
+            )
+
+            return fwd_fn(*args)


### PR DESCRIPTION
# Description

Add a FP8AllToAll layer, which conducts `cast_to_fp8` -> `all_to_all in fp8` -> `cast_from_fp8`. 
We're getting about 5% end to end performance gain in Mixtral 8x7B and 8x22B training with the parallelism configs where alltoall happens on inter-node connections such as IB/RoCE.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Please list the changes introduced in this PR:

- Add a FP8AllToAll layer

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
