### PR TITLE
[JAX] Fixed the shape miss-matching issue in MLP.

### DIFF
--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -177,6 +177,8 @@ ATTRS = [{}, {
     _KEY_OF_SELF_ATTN_BIAS_TYPE: "no_bias",
 }, {
     _KEY_OF_ATTENTION_DROPOUT: 0.3,
+}, {
+    _KEY_OF_MLP_ACTIVATIONS: (('relu', 'relu')),
 }]
 
 ATTRS = [{**BASE_ATTRS, **attr} for attr in ATTRS]

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -1148,8 +1148,8 @@ class LayerNormMLP(TransformerEngineBase):
                     x_i = _convert_to_activation_function(act_fn)(x[idx])
                     activations.append(x_i)
                 z = functools.reduce(operator.mul, activations)
-                if num_activations == 1:
-                    z = jnp.reshape(z, (*z.shape[:-2], -1))
+                # Remove act axis
+                z = jnp.reshape(z, (*z.shape[:-2], -1))
 
             z = nn.Dropout(rate=self.intermediate_dropout_rate,
                            broadcast_dims=self.intermediate_hidden_dropout_dims,


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.
This PR is to fix shaping miss-matching issues inbetween activations and its corresponding sharding contraints in MLP/FF1 when using unfused activation functions.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Please list the changes introduced in this PR:

- Squeeze output tensors of intermediate acitivations.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
