### PR TITLE
Avoid framework specific import from top level

### DIFF
--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -6,12 +6,3 @@
 from ._version import __version__
 from . import common
 
-try:
-    from . import pytorch
-except ImportError as e:
-    pass
-
-try:
-    from . import jax
-except ImportError as e:
-    pass


### PR DESCRIPTION
# Description

When the user calls import `transformer_engine`, we check for available frameworks in the top level `__init__.py` file. However, this is unnecessary. The user side code from, e.g. `transformer_engine.pytorch import ...` remains unchanged.
See #839 for details.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Removes framework specific imports from top level init file.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
