### PR TITLE
Get CMake bin dir from CMake module if possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,12 +74,11 @@ def cmake_bin() -> Path:
     # Search in CMake Python package
     _cmake_bin: Optional[Path] = None
     try:
-        import cmake
+        from cmake import CMAKE_BIN_DIR
     except ImportError:
         pass
     else:
-        cmake_dir = Path(cmake.__file__).resolve().parent
-        _cmake_bin = cmake_dir / "data" / "bin" / "cmake"
+        _cmake_bin = Path(CMAKE_BIN_DIR).resolve() / "cmake"
         if not _cmake_bin.is_file():
             _cmake_bin = None
 


### PR DESCRIPTION
# Description

The build system attempts to get the CMake executable from the [`cmake` module](https://pypi.org/project/cmake/). However, there is a subtle edge case when the user does not have the module installed but does have a directory called `cmake` in their path. In this case, Python loads the wrong thing during `import cmake` and our detection logic throws an error (https://github.com/NVIDIA/TransformerEngine/issues/887). This PR fixes this issue by attempting to load the [`CMAKE_BIN_DIR`](https://github.com/scikit-build/cmake-python-distributions/blob/f18454b9040c749e86c40f6dd6b4e9e2a5d47ac7/cmake/__init__.py#L36) variable from `cmake`, which will only succeed if the correct `cmake` is imported.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

- Get CMake bin dir from CMake module if possible

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
