### PR TITLE
Upgrade pytest version

### DIFF
--- a/qa/L0_jax_unittest/test.sh
+++ b/qa/L0_jax_unittest/test.sh
@@ -4,7 +4,7 @@
 
 set -xe
 
-pip install pytest==7.2
+pip install pytest==8.2.1
 : ${TE_PATH:=/opt/transformerengine}
 
 pytest -c $TE_PATH/tests/jax/pytest.ini -v $TE_PATH/tests/jax -k 'not distributed'

--- a/qa/L0_paddle_unittest/test.sh
+++ b/qa/L0_paddle_unittest/test.sh
@@ -4,7 +4,7 @@
 
 set -xe
 
-pip install pytest==7.2
+pip install pytest==8.2.1
 : ${TE_PATH:=/opt/transformerengine}
 pytest -Wignore -v $TE_PATH/tests/paddle
 pytest -Wignore -v $TE_PATH/examples/paddle/mnist

--- a/qa/L0_pytorch_unittest/test.sh
+++ b/qa/L0_pytorch_unittest/test.sh
@@ -6,7 +6,7 @@ set -e
 
 : ${TE_PATH:=/opt/transformerengine}
 
-pip install pytest==7.2 onnxruntime==1.13.1
+pip install pytest==8.2.1 onnxruntime==1.13.1
 pytest -v -s $TE_PATH/tests/pytorch/test_sanity.py
 pytest -v -s $TE_PATH/tests/pytorch/test_recipe.py
 pytest -v -s $TE_PATH/tests/pytorch/test_deferred_init.py

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
         "importlib-metadata>=1.0; python_version<'3.8'",
         "packaging",
     ]
-    test_reqs: List[str] = ["pytest"]
+    test_reqs: List[str] = ["pytest>=8.2.1"]
 
     # Requirements that may be installed outside of Python
     if not found_cmake():


### PR DESCRIPTION
# Description

#877 revealed an issue when using pytest.ini config with lower version of pytest that result in CI failures in JAX distributed testing.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Upgrade minimum `pytest` version to `8.2.1` for testing.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
