### PR TITLE
[PyTorch] Check and set sliding window size based on attention mask type

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2385,12 +2385,15 @@ def check_set_window_size(
     """Check if sliding window size is compliant with mask type and if not,
     assert or set it to the appropriate size.
         no_mask, padding      : window_size = (-1, -1) or (>=0, >=0)
-        causal, padding_causal: window_size = (-1,  0)
+        causal, padding_causal: window_size = (-1,  0) or (>=0, 0)
         arbitrary             : window_size = (-1, -1)
     """
     if "causal" in attn_mask_type:
-        window_size = (-1, 0)
-    elif attn_mask_type in ["padding", "no_mask"]:
+        if window_size is None:
+            window_size = (-1, 0)
+        else:
+            window_size = (window_size[0], 0)
+    elif attn_mask_type in ["no_mask", "padding"]:
         if window_size is None or window_size in [(-1, -1), (-1, 0)]:
             window_size = (-1, -1)
             warnings.warn(

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2394,10 +2394,12 @@ def check_set_window_size(
         if window_size is None or window_size in [(-1, -1), (-1, 0)]:
             window_size = (-1, -1)
             warnings.warn(
-                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type="+attn_mask_type)
+                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type
+            )
         elif window_size[0] < 0 or window_size[0] < 0:
-            assert False, "window_size should be (-1, -1) or (>=0, >=0) " \
-                "for attn_mask_type="+attn_mask_type
+            assert False, (
+                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type
+            )
     elif attn_mask_type == "arbitrary":
         window_size = (-1, -1)
     return window_size

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2405,7 +2405,9 @@ def check_set_window_size(
                 "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type=" + attn_mask_type
             )
     elif attn_mask_type in ["no_mask", "padding", "arbitrary"]:
-        if orig_window_size is None or (orig_window_size[0] == -1 and orig_window_size[1] in [-1, 0]):
+        if orig_window_size is None or (
+            orig_window_size[0] == -1 and orig_window_size[1] in [-1, 0]
+        ):
             window_size = (-1, -1)
             warnings.warn(
                 "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type

--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -238,6 +238,8 @@ class TransformerLayer(torch.nn.Module):
         kv_channels: Optional[int] = None,
         self_attn_mask_type: str = "causal",
         window_size: Optional[Tuple[int, int]] = None,
+        enc_dec_attn_mask_type: str = "padding",
+        enc_dec_window_size: Optional[Tuple[int, int]] = None,
         tp_group: Optional[dist_group_type] = None,
         tp_size: int = 1,
         params_dtype: Optional[torch.dtype] = None,
@@ -271,6 +273,8 @@ class TransformerLayer(torch.nn.Module):
 
         self.self_attn_mask_type = self_attn_mask_type
         self.window_size = check_set_window_size(self_attn_mask_type, window_size)
+        self.enc_dec_attn_mask_type = enc_dec_attn_mask_type
+        self.enc_dec_window_size = check_set_window_size(enc_dec_attn_mask_type, enc_dec_window_size)
         params_dtype = torch.get_default_dtype() if params_dtype is None else params_dtype
         ub_bulk_wgrad = ub_tp_comm_overlap and ub_bulk_wgrad
         ub_bulk_dgrad = ub_tp_comm_overlap and ub_bulk_dgrad
@@ -367,7 +371,7 @@ class TransformerLayer(torch.nn.Module):
             self.inter_attention = MultiheadAttention(
                 *attention_args,
                 **common_attention_kwargs,
-                attn_mask_type="padding",
+                attn_mask_type=enc_dec_attn_mask_type,
                 input_layernorm=True,
                 attention_type="cross",
                 bias=bias,
@@ -501,6 +505,8 @@ class TransformerLayer(torch.nn.Module):
         window_size: Optional[Tuple[int, int]] = None,
         encoder_output: Optional[torch.Tensor] = None,
         enc_dec_attn_mask: Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]] = None,
+        enc_dec_attn_mask_type: Optional[str] = None,
+        enc_dec_window_size: Optional[Tuple[int, int]] = None,
         is_first_microbatch: Optional[bool] = None,
         checkpoint_core_attention: bool = False,
         inference_params: Optional[InferenceParams] = None,
@@ -531,9 +537,9 @@ class TransformerLayer(torch.nn.Module):
                         a `False` means that position is allowed to participate in attention.
         self_attn_mask_type: {'no_mask', 'causal', 'padding', 'padding_causal', 'arbitrary'},
                             default = `causal`
-                            Type of attention mask passed into softmax operation.
+                            Type of attention mask passed into softmax operation for encoder.
         window_size: Optional[Tuple[int, int]], default = `None`
-                    sliding window size for local attention.
+                    Sliding window size for local attention in encoder.
         encoder_output : Optional[torch.Tensor], default = `None`
              Output of the encoder block to be fed into the decoder block if using
              `layer_type="decoder"`.
@@ -545,6 +551,11 @@ class TransformerLayer(torch.nn.Module):
              for 'arbitrary' mask. It should be 'None' for 'causal' and 'no_mask'. A `True` value
              means the corresponding position is masked out and a `False` means that position is
              allowed to participate in attention.
+        enc_dec_attn_mask_type: {'no_mask', 'causal', 'padding', 'padding_causal', 'arbitrary'},
+                            default = `None`
+                            Type of attention mask passed into softmax operation for decoder.
+        enc_dec_window_size: Optional[Tuple[int, int]], default = `None`
+                    Sliding window size for local attention in decoder.
         is_first_microbatch : {True, False, None}, default = None
                              During training using either gradient accumulation or
                              pipeline parallelism a minibatch of data is further split
@@ -586,10 +597,18 @@ class TransformerLayer(torch.nn.Module):
         if window_size is None:
             window_size = self.window_size
         window_size = check_set_window_size(self_attn_mask_type, window_size)
+        if enc_dec_attn_mask_type is None:
+            enc_dec_attn_mask_type = self.enc_dec_attn_mask_type
+        if enc_dec_window_size is None:
+            enc_dec_window_size = self.enc_dec_window_size
+        enc_dec_window_size = check_set_window_size(enc_dec_attn_mask_type, enc_dec_window_size)
 
         assert (
             self_attn_mask_type in AttnMaskTypes
         ), f"self_attn_mask_type {self_attn_mask_type} not supported"
+        assert (
+            enc_dec_attn_mask_type in AttnMaskTypes
+        ), f"enc_dec_attn_mask_type {enc_dec_attn_mask_type} not supported"
 
         hidden_states = hidden_states.contiguous()
 
@@ -602,6 +621,13 @@ class TransformerLayer(torch.nn.Module):
             "padding" in self_attn_mask_type or self_attn_mask_type == "arbitrary"
         ) and attention_mask is not None:
             assert attention_mask.dtype == torch.bool, "Attention mask must be a boolean tensor"
+        if (
+            "padding" in enc_dec_attn_mask_type or enc_dec_attn_mask_type == "arbitrary"
+        ) and enc_dec_attn_mask is not None:
+            assert (
+                all(enc_dec_attn_mask[i].dtype == torch.bool
+                for i in range(len(enc_dec_attn_mask)))
+            ), "Encoder-decoder attention mask must be boolean tensor(s)"
 
         # For AMP
         if torch.is_autocast_enabled():
@@ -639,7 +665,7 @@ class TransformerLayer(torch.nn.Module):
             inter_attention_outputs = self.inter_attention(
                 hidden_states,
                 attention_mask=enc_dec_attn_mask,
-                window_size=window_size,
+                window_size=enc_dec_window_size,
                 encoder_output=encoder_output,
                 is_first_microbatch=is_first_microbatch,
                 checkpoint_core_attention=checkpoint_core_attention,

--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -270,8 +270,7 @@ class TransformerLayer(torch.nn.Module):
         super().__init__()
 
         self.self_attn_mask_type = self_attn_mask_type
-        self.window_size = window_size
-        self.window_size = check_set_window_size(self_attn_mask_type, self.window_size)
+        self.window_size = check_set_window_size(self_attn_mask_type, window_size)
         params_dtype = torch.get_default_dtype() if params_dtype is None else params_dtype
         ub_bulk_wgrad = ub_tp_comm_overlap and ub_bulk_wgrad
         ub_bulk_dgrad = ub_tp_comm_overlap and ub_bulk_dgrad
@@ -582,12 +581,11 @@ class TransformerLayer(torch.nn.Module):
                          to efficienly calculate and store the context during inference.
         """
 
-        if self_attn_mask_type is not None:
-            window_size = check_set_window_size(self_attn_mask_type, window_size)
         if self_attn_mask_type is None:
             self_attn_mask_type = self.self_attn_mask_type
         if window_size is None:
             window_size = self.window_size
+        window_size = check_set_window_size(self_attn_mask_type, window_size)
 
         assert (
             self_attn_mask_type in AttnMaskTypes
@@ -641,6 +639,7 @@ class TransformerLayer(torch.nn.Module):
             inter_attention_outputs = self.inter_attention(
                 hidden_states,
                 attention_mask=enc_dec_attn_mask,
+                window_size=window_size,
                 encoder_output=encoder_output,
                 is_first_microbatch=is_first_microbatch,
                 checkpoint_core_attention=checkpoint_core_attention,

--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -274,7 +274,9 @@ class TransformerLayer(torch.nn.Module):
         self.self_attn_mask_type = self_attn_mask_type
         self.window_size = check_set_window_size(self_attn_mask_type, window_size)
         self.enc_dec_attn_mask_type = enc_dec_attn_mask_type
-        self.enc_dec_window_size = check_set_window_size(enc_dec_attn_mask_type, enc_dec_window_size)
+        self.enc_dec_window_size = check_set_window_size(
+            enc_dec_attn_mask_type, enc_dec_window_size
+        )
         params_dtype = torch.get_default_dtype() if params_dtype is None else params_dtype
         ub_bulk_wgrad = ub_tp_comm_overlap and ub_bulk_wgrad
         ub_bulk_dgrad = ub_tp_comm_overlap and ub_bulk_dgrad
@@ -624,9 +626,8 @@ class TransformerLayer(torch.nn.Module):
         if (
             "padding" in enc_dec_attn_mask_type or enc_dec_attn_mask_type == "arbitrary"
         ) and enc_dec_attn_mask is not None:
-            assert (
-                all(enc_dec_attn_mask[i].dtype == torch.bool
-                for i in range(len(enc_dec_attn_mask)))
+            assert all(
+                enc_dec_attn_mask[i].dtype == torch.bool for i in range(len(enc_dec_attn_mask))
             ), "Encoder-decoder attention mask must be boolean tensor(s)"
 
         # For AMP


### PR DESCRIPTION
# Description

This PR improves the function `check_set_window_size` in PyTorch so that `window_size` is always appropriately set based on the mask type.
```
no_mask, padding      : window_size = (-1, -1) or (>=0, >=0)
causal, padding_causal: window_size = (-1,  0)
arbitrary             : window_size = (-1, -1)
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Please list the changes introduced in this PR:

- Added checks for different combinations of `window_size` and `attn_mask_type` to ensure they are consistent.

# Checklist:

- [ x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ x] The functionality is complete
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
