### PR TITLE
Make transformer_engine::getenv arguments independent of C++ ABI version

### DIFF
--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -98,7 +98,7 @@ const std::string &include_directory(bool required) {
       {"", "/usr/local/cuda"}};
     for (auto &[env, p] : search_paths) {
       if (p.empty()) {
-        p = getenv<Path>(env);
+        p = getenv<Path>(env.c_str());
       }
       if (!p.empty()) {
         if (file_exists(p / "cuda_runtime.h")) {

--- a/transformer_engine/common/util/system.cpp
+++ b/transformer_engine/common/util/system.cpp
@@ -20,9 +20,9 @@ namespace {
 
 template <typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type
-getenv_helper(const std::string &variable, const T &default_value) {
+getenv_helper(const char *variable, const T &default_value) {
   // Implementation for numeric types
-  const char *env = std::getenv(variable.c_str());
+  const char *env = std::getenv(variable);
   if (env == nullptr || env[0] == '\0') {
     return default_value;
   }
@@ -35,9 +35,9 @@ getenv_helper(const std::string &variable, const T &default_value) {
 
 template <typename T>
 inline typename std::enable_if<!std::is_arithmetic<T>::value, T>::type
-getenv_helper(const std::string &variable, const T &default_value) {
+getenv_helper(const char *variable, const T &default_value) {
   // Implementation for string-like types
-  const char *env = std::getenv(variable.c_str());
+  const char *env = std::getenv(variable);
   if (env == nullptr || env[0] == '\0') {
     return default_value;
   } else {
@@ -47,13 +47,13 @@ getenv_helper(const std::string &variable, const T &default_value) {
 
 }  // namespace
 
-#define NVTE_INSTANTIATE_GETENV(T, default_value)               \
-  template <> T getenv<T>(const std::string &variable,          \
-                          const T &default_value_) {            \
-    return getenv_helper<T>(variable, default_value_);          \
-  }                                                             \
-  template <> T getenv<T>(const std::string &variable) {        \
-    return getenv_helper<T>(variable, default_value);           \
+#define NVTE_INSTANTIATE_GETENV(T, default_value)          \
+  template <> T getenv<T>(const char *variable,            \
+                          const T &default_value_) {       \
+    return getenv_helper<T>(variable, default_value_);     \
+  }                                                        \
+  template <> T getenv<T>(const char *variable) {          \
+    return getenv_helper<T>(variable, default_value);      \
   }
 NVTE_INSTANTIATE_GETENV(bool, false);
 NVTE_INSTANTIATE_GETENV(float, 0.f);

--- a/transformer_engine/common/util/system.h
+++ b/transformer_engine/common/util/system.h
@@ -19,11 +19,11 @@ namespace transformer_engine {
  * returned.
  */
 template <typename T = std::string>
-T getenv(const std::string &variable);
+T getenv(const char *variable);
 
 /*! \brief Get environment variable and convert to type */
 template <typename T = std::string>
-T getenv(const std::string &variable, const T &default_value);
+T getenv(const char *variable, const T &default_value);
 
 /*! \brief Check if a file exists and can be read */
 bool file_exists(const std::string &path);


### PR DESCRIPTION
# Description

This is a cleaner workaround for undefined symbol errors for `transformer_engine::getenv` in the PyTorch `CUDAExtension` for which previously `system.cpp` from the common lib was being included as a source file in the framework build. We still need to be mindful when using `getenv` in the framework extensions henceforth with T as `string` or `filesystem::path` since this would also be the return type and would lead to the same errors.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Changes `transformer_engine::getenv` to use `const char*` arg instead of `std::string` argument.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes