### PR TITLE
disable using nvfuser when pytorch version >= 2.2

### DIFF
--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -35,7 +35,9 @@ def set_jit_fusion_options() -> None:
     # flags required to enable jit fusion kernels
     TORCH_MAJOR = int(torch.__version__.split(".")[0])
     TORCH_MINOR = int(torch.__version__.split(".")[1])
-    if (TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR >= 10):
+    if (TORCH_MAJOR == 2 and TORCH_MINOR >= 2):
+        pass
+    elif (TORCH_MAJOR == 2) or (TORCH_MAJOR == 1 and TORCH_MINOR >= 10):
         # nvfuser
         torch._C._jit_set_profiling_executor(True)
         torch._C._jit_set_profiling_mode(True)


### PR DESCRIPTION
# Description

Nvfuser is depracated starting torch 2.2 so disabling that here

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

Please list the changes introduced in this PR:
Ignore nvfuser options when torch version >= 2.2

