### PR TITLE
[PyTorch] Expose `multi_tensor_*` kernels

### DIFF
--- a/transformer_engine/pytorch/optimizers/__init__.py
+++ b/transformer_engine/pytorch/optimizers/__init__.py
@@ -3,9 +3,6 @@
 # See LICENSE for license information.
 
 """Fused optimizers and multi-tensor kernels."""
-from .fused_adam import FusedAdam
-from .fused_sgd import FusedSGD
-from .multi_tensor_apply import MultiTensorApply, multi_tensor_applier
 from transformer_engine_torch import (
     multi_tensor_scale,
     multi_tensor_l2norm,
@@ -15,3 +12,6 @@ from transformer_engine_torch import (
     multi_tensor_adam_capturable_master,
     multi_tensor_sgd,
 )
+from .fused_adam import FusedAdam
+from .fused_sgd import FusedSGD
+from .multi_tensor_apply import MultiTensorApply, multi_tensor_applier

--- a/transformer_engine/pytorch/optimizers/__init__.py
+++ b/transformer_engine/pytorch/optimizers/__init__.py
@@ -6,3 +6,12 @@
 from .fused_adam import FusedAdam
 from .fused_sgd import FusedSGD
 from .multi_tensor_apply import MultiTensorApply, multi_tensor_applier
+from transformer_engine_torch import (
+    multi_tensor_scale,
+    multi_tensor_l2norm,
+    multi_tensor_unscale_l2norm,
+    multi_tensor_adam,
+    multi_tensor_adam_capturable,
+    multi_tensor_adam_capturable_master,
+    multi_tensor_sgd,
+)


### PR DESCRIPTION
# Description

Expose `multi_tensor_*` kernels under `transformer_engine.pytorch.optimizers` to avoid importing `transformer_engine_torch` outside of TE.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
