### PR TITLE
[PyTorch] reverting autocast API back to PyTorch v2.3.1 and below

### DIFF
--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -239,13 +239,13 @@ def _get_active_autocast_contexts():
     """
     autocast_cached = torch.is_autocast_cache_enabled()
 
-    gpu_autocast_enabled = torch.is_autocast_enabled('cuda')
-    gpu_autocast_dtype = torch.get_autocast_dtype('cuda')
+    gpu_autocast_enabled = torch.is_autocast_enabled()
+    gpu_autocast_dtype = torch.get_autocast_gpu_dtype()
     gpu_autocast_ctx = torch.cuda.amp.autocast(
         gpu_autocast_enabled, gpu_autocast_dtype, autocast_cached)
 
-    cpu_autocast_enabled = torch.is_autocast_enabled('cpu')
-    cpu_autocast_dtype = torch.get_autocast_dtype('cpu')
+    cpu_autocast_enabled = torch.is_autocast_cpu_enabled()
+    cpu_autocast_dtype = torch.get_autocast_cpu_dtype()
     cpu_autocast_ctx = torch.cpu.amp.autocast(
         cpu_autocast_enabled, cpu_autocast_dtype, autocast_cached)
 


### PR DESCRIPTION
# Description

PR #916 prematurely updated PyTorch autocast API to v 2.4.0-RC. This PR reverts it back to the API in v2.3.1 and older.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes

- Revert autocast API changes in PR #916.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
