### PR TITLE
[PyTorch] Remove unnecessary check for UB support

### DIFF
--- a/transformer_engine/pytorch/transformer.py
+++ b/transformer_engine/pytorch/transformer.py
@@ -10,7 +10,6 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import torch
 
-import transformer_engine_torch as tex
 from transformer_engine.pytorch.module import LayerNormMLP, LayerNorm, RMSNorm
 from transformer_engine.pytorch.attention import (
     InferenceParams,
@@ -269,9 +268,6 @@ class TransformerLayer(torch.nn.Module):
         attn_input_format: str = "sbhd",
     ) -> None:
         super().__init__()
-
-        if ub_tp_comm_overlap:
-            assert tex.userbuf_comm_available(), "Userbuffer communication backend not available."
 
         self.self_attn_mask_type = self_attn_mask_type
         self.window_size = window_size


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/901 modified the PyTorch build so we always build with Userbuffers support, so it removed `transformer_engine_torch.userbuf_comm_available`. This PR removes an instance where we call that function.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

-  Remove unnecessary check for UB support

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
