### PR TITLE
Improve JAX build tool

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -70,7 +70,7 @@ class CMakeExtension(setuptools.Extension):
         configure_command.append(f"-Dpybind11_DIR={pybind11_dir}")
 
         # CMake build and install commands
-        build_command = [_cmake_bin, "--build", build_dir]
+        build_command = [_cmake_bin, "--build", build_dir, "-j"]
         install_command = [_cmake_bin, "--install", build_dir]
 
         # Run CMake commands
@@ -94,7 +94,7 @@ def get_build_ext(extension_cls: Type[setuptools.Extension]):
                 if isinstance(ext, CMakeExtension):
                     print(f"Building CMake extension {ext.name}")
                     # Set up incremental builds for CMake extensions
-                    setup_dir = Path(__file__).resolve().parent
+                    setup_dir = Path(__file__).resolve().parent.parent
                     build_dir = setup_dir / "build" / "cmake"
 
                     # Ensure the directory exists

--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -70,7 +70,7 @@ class CMakeExtension(setuptools.Extension):
         configure_command.append(f"-Dpybind11_DIR={pybind11_dir}")
 
         # CMake build and install commands
-        build_command = [_cmake_bin, "--build", build_dir, "-j"]
+        build_command = [_cmake_bin, "--build", build_dir]
         install_command = [_cmake_bin, "--install", build_dir]
 
         # Run CMake commands

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -23,7 +23,7 @@ def setup_jax_extension(
     extensions_dir = csrc_source_files / "extensions"
     sources = [
         csrc_source_files / "utils.cu",
-    ] + all_files_in_dir(extensions_dir)
+    ] + all_files_in_dir(extensions_dir, ".cpp")
 
     # Header files
     cuda_home, _ = cuda_path()

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -32,7 +32,7 @@ def all_files_in_dir(path, name_extension=None):
     all_files = []
     for dirname, _, names in os.walk(path):
         for name in names:
-            if not (name_extension is None) and not (name_extension in name):
+            if name_extension is not None and name_extension not in name:
                 continue
             all_files.append(Path(dirname, name))
     return all_files

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -32,7 +32,7 @@ def all_files_in_dir(path, name_extension = None):
     all_files = []
     for dirname, _, names in os.walk(path):
         for name in names:
-            if not (name_extension is None) and name_extension not in name:
+            if not (name_extension is None) and not (name_extension in name):
                 continue
             all_files.append(Path(dirname, name))
     return all_files

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -28,7 +28,7 @@ def debug_build_enabled() -> bool:
     return False
 
 
-def all_files_in_dir(path, name_extension = None):
+def all_files_in_dir(path, name_extension=None):
     all_files = []
     for dirname, _, names in os.walk(path):
         for name in names:

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -28,10 +28,12 @@ def debug_build_enabled() -> bool:
     return False
 
 
-def all_files_in_dir(path):
+def all_files_in_dir(path, name_extension = None):
     all_files = []
     for dirname, _, names in os.walk(path):
         for name in names:
+            if not (name_extension is None) and name_extension not in name:
+                continue
             all_files.append(Path(dirname, name))
     return all_files
 


### PR DESCRIPTION
# Description

- ~~Enabling parallel build with `cmake` via `-j`.~~
- The current configs create two build directories, one is `TE_PATH/build_tools/build/cmake`, the other is `TE_PATH/build`. So I introduced a change in which `cmake` directory is created under `TE_PATH/build`, thus no `build` directory under `TE_PATH/build_tools` is created.
- Adding an option to select particular files with the same file extensions (for example *.cpp) in `all_files_in_dir`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
