### PR TITLE
Update required CMake version to 3.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
 
     # Requirements that may be installed outside of Python
     if not found_cmake():
-        setup_reqs.append("cmake>=3.18")
+        setup_reqs.append("cmake>=3.25")
     if not found_ninja():
         setup_reqs.append("ninja")
     if not found_pybind11():

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # See LICENSE for license information.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.25)
 
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   set(CMAKE_CUDA_ARCHITECTURES 70 80 89 90)
@@ -19,7 +19,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
 endif()
 
-find_package(CUDAToolkit REQUIRED cublas nvToolsExt)
+find_package(CUDAToolkit REQUIRED cublas nvtx3
 
 # Check for cuDNN frontend API
 set(CUDNN_FRONTEND_INCLUDE_DIR
@@ -80,7 +80,7 @@ target_link_libraries(transformer_engine PUBLIC
                       CUDA::cuda_driver
                       CUDA::cudart
                       CUDA::nvrtc
-                      CUDA::nvToolsExt
+                      CUDA::nvtx3
                       CUDNN::cudnn)
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -19,7 +19,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
 endif()
 
-find_package(CUDAToolkit REQUIRED cublas nvtx3
+find_package(CUDAToolkit REQUIRED cublas nvtx3)
 
 # Check for cuDNN frontend API
 set(CUDNN_FRONTEND_INCLUDE_DIR


### PR DESCRIPTION
# Description

CMake 3.25 changes NVTX support by deprecating the [`CUDA::nvToolsExt`](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html#nvtoolsext) target and adding a [`CUDA::nvtx3`](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html#nvtx3) target. I suspect this is related to the build error in https://github.com/NVIDIA/TransformerEngine/issues/879.

We also had another user run into strange build errors with CMake 3.20.4, which they fixed by upgrading to 3.24.3 (see https://github.com/NVIDIA/TransformerEngine/issues/803#issuecomment-2128275904). This makes me think our current requirement of 3.18 is inaccurate. CMake 3.25 was released in [November 2022](https://discourse.cmake.org/t/cmake-3-25-0-available-for-download/6885), so I don't think it's an unreasonable minimum.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Update required CMake version to 3.25

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
