### PR TITLE
Fix compilation bug with CUDA 12.1

### DIFF
--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
@@ -5,8 +5,8 @@
  ************************************************************************/
 
 #include <cuda.h>
-#include <cuda_runtime.h>
 #include <cuda_fp8.h>
+#include <cuda_runtime.h>
 
 #if __CUDA_ARCH__ >= 800
 #include <cuda_bf16.h>

--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers.cu
@@ -6,6 +6,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <cuda_fp8.h>
 
 #if __CUDA_ARCH__ >= 800
 #include <cuda_bf16.h>
@@ -15,7 +16,6 @@
 #endif
 
 #include <assert.h>
-#include <cuda_fp8.h>
 #include <stdio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes
This has been mentioned in #560 but somehow someone just changed it back... Importing <cuda_fp8.h>, which imports <cuda_bf16.h>, after defining nv_bfloat16 triggers re-declaration error.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
