### PR TITLE
[PyTorch] Disable THD tests on architectures lower than sm90

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
+++ b/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
@@ -66,6 +66,8 @@ model_configs_fused_attn = {
 @pytest.mark.parametrize("model", model_configs_fused_attn.keys())
 @pytest.mark.parametrize("qkv_format", ["bshd", "sbhd", "thd"])
 def test_cp_with_fused_attention(dtype, model, qkv_format):
+    if qkv_format == 'thd' and get_device_compute_capability() < (9, 0):
+        pytest.skip("THD format is only supported on sm90+.")
     subprocess.run(
         get_bash_arguments(
             dtype=dtype, model=model, qkv_format=qkv_format, kernel_backend="FusedAttention"

--- a/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
+++ b/tests/pytorch/fused_attn/test_fused_attn_with_cp.py
@@ -66,7 +66,7 @@ model_configs_fused_attn = {
 @pytest.mark.parametrize("model", model_configs_fused_attn.keys())
 @pytest.mark.parametrize("qkv_format", ["bshd", "sbhd", "thd"])
 def test_cp_with_fused_attention(dtype, model, qkv_format):
-    if qkv_format == 'thd' and get_device_compute_capability() < (9, 0):
+    if qkv_format == "thd" and get_device_compute_capability() < (9, 0):
         pytest.skip("THD format is only supported on sm90+.")
     subprocess.run(
         get_bash_arguments(


### PR DESCRIPTION
# Description

This PR disables CP tests for THD format for architectures lower than sm90. In the future, we will add a utility function so users can check this before running any tests.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Skipped tests for fused attention with THD and CP on <sm90.

# Checklist:

- [x ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x ] The functionality is complete
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
