### PR TITLE
[Core] Fix bug when selecting tuned RMSNorm kernels

### DIFF
--- a/transformer_engine/common/rmsnorm/rmsnorm_api.cpp
+++ b/transformer_engine/common/rmsnorm/rmsnorm_api.cpp
@@ -89,7 +89,7 @@ BwdFunction &get_bwd_launcher(DType wtype, DType itype, DType otype, DType ctype
   if (params.rows % 4 == 0 && is_aligned(params.x) && is_aligned(params.rs) &&
       is_aligned(params.gamma) && is_aligned(params.dz) && is_aligned(params.dx) &&
       is_aligned(params.dgamma) && is_aligned(params.dgamma_part) &&
-      layer_norm::BWD_TUNED_FUNCS.count(tuned_key) > 0) {
+      BWD_TUNED_FUNCS.count(tuned_key) > 0) {
     return BWD_TUNED_FUNCS.at(tuned_key);
   }
 


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/886 introduced a bug by checking the wrong `unordered_map` when deciding whether to use a tuned RMSNorm kernel. See https://github.com/NVIDIA/TransformerEngine/issues/941#issuecomment-2202068692.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Fix bug from checking wrong `unordered_map` when deciding to whether to use tuned RMSNorm kernel

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
