### PR TITLE
[MoE][Pytorch]Fix size mismatch error in fp8 transpose.

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/transpose.cu
+++ b/transformer_engine/pytorch/csrc/extensions/transpose.cu
@@ -285,9 +285,9 @@ at::Tensor fp8_transpose(at::Tensor input, transformer_engine::DType otype) {
 
   size_t M = static_cast<size_t>(input.size(0));
   size_t N = static_cast<size_t>(input.size(1));
-  if (M == 0 || N == 0) return input;
 
   auto output = allocateTorchTensor(input.size(1), input.size(0), DType::kByte);
+  if (M == 0 || N == 0) return output;
 
   auto input_cu = makeTransformerEngineTensor(input.data_ptr(), {M, N}, otype);
   auto output_cu = makeTransformerEngineTensor(output.data_ptr(), {N, M}, otype);


### PR DESCRIPTION
# Description

Replace the return value from input with output in `fp8_cast`.

When training MoE models and disable gradient accumulation fusion, if an linear expert receive zero number of tokens, this bug will cause tensor shape mismatch between wgrad and weight.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
