### PR TITLE
Cache CUDA Driver API functions

### DIFF
--- a/transformer_engine/common/util/cuda_driver.cpp
+++ b/transformer_engine/common/util/cuda_driver.cpp
@@ -18,12 +18,13 @@ namespace transformer_engine {
 namespace cuda_driver {
 
 void *get_symbol(const char *symbol) {
-  static thread_local std::unordered_list<std::string_view, void*> cache;
+  static thread_local std::unordered_list<std::string_view, void *> cache;
   const std::string_view key(symbol);
   if (cache.count(symbol) == 0) {
     void *entry_point;
     cudaDriverEntryPointQueryResult driver_result;
-    NVTE_CHECK_CUDA(cudaGetDriverEntryPoint(symbol, &entry_point, cudaEnableDefault, &driver_result));
+    NVTE_CHECK_CUDA(
+        cudaGetDriverEntryPoint(symbol, &entry_point, cudaEnableDefault, &driver_result));
     NVTE_CHECK(driver_result == cudaDriverEntryPointSuccess,
                "Could not find CUDA driver entry point for ", symbol);
     cache[key] = entry_point;

--- a/transformer_engine/common/util/cuda_driver.cpp
+++ b/transformer_engine/common/util/cuda_driver.cpp
@@ -7,99 +7,28 @@
 #include <dlfcn.h>
 
 #include <filesystem>
+#include <string_view>
+#include <unordered_map
 
 #include "../common.h"
 #include "../util/cuda_runtime.h"
 
 namespace transformer_engine {
 
-namespace {
-
-/*! \brief Wrapper class for a shared library
- *
- * \todo Windows support
- */
-class Library {
- public:
-  explicit Library(const char *filename) {
-#if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
-    // TODO Windows support
-    NVTE_ERROR("Shared library initialization is not supported with Windows");
-#else
-    handle_ = dlopen(filename, RTLD_LAZY | RTLD_LOCAL);
-    NVTE_CHECK(handle_ != nullptr, "Lazy library initialization failed");
-#endif  // _WIN32 or _WIN64 or __WINDOW__
-  }
-
-  ~Library() {
-#if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
-    // TODO Windows support
-#else
-    if (handle_ != nullptr) {
-      dlclose(handle_);
-    }
-#endif  // _WIN32 or _WIN64 or __WINDOW__
-  }
-
-  Library(const Library &) = delete;  // move-only
-
-  Library(Library &&other) noexcept { swap(*this, other); }
-
-  Library &operator=(Library other) noexcept {
-    // Copy-and-swap idiom
-    swap(*this, other);
-    return *this;
-  }
-
-  friend void swap(Library &first, Library &second) noexcept;
-
-  void *get() noexcept { return handle_; }
-
-  const void *get() const noexcept { return handle_; }
-
-  /*! \brief Get pointer corresponding to symbol in shared library */
-  void *get_symbol(const char *symbol) {
-#if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
-    // TODO Windows support
-    NVTE_ERROR("Shared library initialization is not supported with Windows");
-#else
-    void *ptr = dlsym(handle_, symbol);
-    NVTE_CHECK(ptr != nullptr, "Could not find symbol in lazily-initialized library");
-    return ptr;
-#endif  // _WIN32 or _WIN64 or __WINDOW__
-  }
-
- private:
-  void *handle_ = nullptr;
-};
-
-void swap(Library &first, Library &second) noexcept {
-  using std::swap;
-  swap(first.handle_, second.handle_);
-}
-
-/*! \brief Lazily-initialized shared library for CUDA driver */
-Library &cuda_driver_lib() {
-#if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
-  constexpr char lib_name[] = "nvcuda.dll";
-#else
-  constexpr char lib_name[] = "libcuda.so.1";
-#endif
-  static Library lib(lib_name);
-  return lib;
-}
-
-}  // namespace
-
 namespace cuda_driver {
 
 void *get_symbol(const char *symbol) {
-  void *entry_point;
-  cudaDriverEntryPointQueryResult driver_result;
-  NVTE_CHECK_CUDA(cudaGetDriverEntryPoint(symbol, &entry_point, cudaEnableDefault, &driver_result));
-  NVTE_CHECK(driver_result == cudaDriverEntryPointSuccess,
-             "Could not find CUDA driver entry point for ", symbol);
-  return entry_point;
+  static thread_local std::unordered_list<std::string_view, void*> cache;
+  const std::string_view key(symbol);
+  if (cache.count(symbol) == 0) {
+    void *entry_point;
+    cudaDriverEntryPointQueryResult driver_result;
+    NVTE_CHECK_CUDA(cudaGetDriverEntryPoint(symbol, &entry_point, cudaEnableDefault, &driver_result));
+    NVTE_CHECK(driver_result == cudaDriverEntryPointSuccess,
+               "Could not find CUDA driver entry point for ", symbol);
+    cache[key] = entry_point;
+  }
+  return cache.at(key);
 }
 
 }  // namespace cuda_driver

--- a/transformer_engine/common/util/cuda_driver.h
+++ b/transformer_engine/common/util/cuda_driver.h
@@ -18,7 +18,10 @@ namespace transformer_engine {
 
 namespace cuda_driver {
 
-/*! \brief Get pointer corresponding to symbol in CUDA driver library */
+/*! \brief Get pointer corresponding to symbol in CUDA driver library
+ *
+ * Pointers are cached the first time they are accessed.
+ */
 void *get_symbol(const char *symbol);
 
 /*! \brief Call function in CUDA driver library


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/970 uses [`cudaGetDriverEntryPoint`](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DRIVER__ENTRY__POINT.html#group__CUDART__DRIVER__ENTRY__POINT) to access the CUDA Driver API. This adds some non-trivial CPU overhead to NVRTC kernels like for FP8 cast-transpose. This PR caches the function pointers from `cudaGetDriverEntryPoint` to minimize this overhead.

We may also want to consider further improvements to our wrappers to the CUDA Driver API, e.g. https://github.com/NVIDIA/TransformerEngine/pull/970#issuecomment-2194932909.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Cache CUDA Driver API functions

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
