### PR TITLE
[TE/JAX] Remove tuple wrapper of singleton in HLO lowering return

### DIFF
--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -98,7 +98,7 @@ class ActLuPrimitive(BasePrimitive):
 
         out = custom_caller(ActLuPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
     @staticmethod
     def impl(x, act_enum):
@@ -226,7 +226,7 @@ class DActLuPrimitive(BasePrimitive):
 
         out = custom_caller(DActLuPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
     @staticmethod
     def impl(dz, x, act_enum):

--- a/transformer_engine/jax/cpp_extensions/softmax.py
+++ b/transformer_engine/jax/cpp_extensions/softmax.py
@@ -135,7 +135,7 @@ class SoftmaxPrimitive(BasePrimitive):
 
         out = custom_caller(name, args, opaque, False)
 
-        return [out]
+        return out
 
     @staticmethod
     def forward_impl(primitive, logits, scale_factor):
@@ -247,7 +247,7 @@ class SoftmaxPrimitive(BasePrimitive):
 
         out = custom_caller(name, args, opaque, False)
 
-        return [out]
+        return out
 
     @staticmethod
     def backward_impl(primitive, dz, softmax_out, scale_factor):
@@ -577,7 +577,7 @@ class ScaledMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
 
         out = custom_caller(ScaledMaskedSoftmaxFwdPrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
     @staticmethod
     def impl(logits, mask, scale_factor):

--- a/transformer_engine/jax/cpp_extensions/transpose.py
+++ b/transformer_engine/jax/cpp_extensions/transpose.py
@@ -103,7 +103,7 @@ class TransposePrimitive(BasePrimitive):
 
         out = custom_caller(TransposePrimitive.name, args, opaque, False)
 
-        return [out]
+        return out
 
     @staticmethod
     def impl(x, static_axis_boundary, transpose_axis_boundary):


### PR DESCRIPTION
# Description

JAX introduced a new PR (google/jax#22211) which restrictes the output format of HLO lowering with an additional assertion. The assertion fails when the lowering function returns a single value wrapped in a tuple or a list which we have in a few custom calls in TE. This restriction is then relaxed temporarily in google/jax#22314 by replacing the assertion with a warning.

This PR removed all the singleton wrappers in our TE custom call so no warnings or issues arise. 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
