### PR TITLE
Flash attention support softcap.

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -657,7 +657,6 @@ def get_attention_backend(
         use_flash_attention
         and use_fused_attention
         and fused_attention_backend == FusedAttnBackend["F16_arbitrary_seqlen"]
-        and int(os.getenv("NVTE_FUSED_ATTN", "1"))!=0
     ):
         if device_compute_capability == (9, 0):
             logger.debug(

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -73,7 +73,7 @@ from transformer_engine.pytorch.graph import is_graph_capturing
 
 _flash_attn_version = PkgVersion(get_pkg_version("flash-attn"))
 _flash_attn_version_required = PkgVersion("2.0.6")
-_flash_attn_max_version = PkgVersion("2.5.8")
+_flash_attn_max_version = PkgVersion("2.6.1")
 _flash_attn_2_plus = _flash_attn_version >= PkgVersion("2")
 _flash_attn_2_1_plus = _flash_attn_version >= PkgVersion("2.1")
 _flash_attn_2_3_plus = _flash_attn_version >= PkgVersion("2.3")


### PR DESCRIPTION
# Description

Flash attention had support softcap in commit [8f873cc6](https://github.com/Dao-AILab/flash-attention/commit/8f873cc6acac2933d757b2ed6069518d619b341b), which is used in [gemma2](https://storage.googleapis.com/deepmind-media/gemma/gemma-2-report.pdf).

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## Changes

add `softcap` args in Flashattention, and update `_flash_attn_max_version` to 2.6.1

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
