### PR TITLE
[PyTorch] Custom kernel to compute reciprocal of a single float

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -356,11 +356,20 @@ void fused_amax_and_scale_update_after_reduction(const at::Tensor &amax_reductio
                                                  const std::string &amax_compute_algo,
                                                  transformer_engine::DType fp8_dtype, float margin);
 
-void scalar_reciprocal(const at::Tensor &src,
-                       std::optional<at::Tensor> dst = std::nullopt,
-                       int64_t src_offset = 0,
-                       int64_t dst_offset = 0,
-                       const std::optional<at::Tensor> &noop_flag = std::nullopt);
+/* Reciprocal of a single float32
+ *
+ * /param[in]  Input tensor.
+ * /param[out] Output tensor.
+ * /param[in]  Offset within input tensor.
+ * /param[in]  Offset within output tensor.
+ * /param[in]  float32 flag indicating whether to avoid updating
+ *             output.
+ */
+at::Tensor scalar_reciprocal(const at::Tensor &src,
+                             std::optional<at::Tensor> dst = std::nullopt,
+                             int64_t src_offset = 0,
+                             int64_t dst_offset = 0,
+                             const std::optional<at::Tensor> &noop_flag = std::nullopt);
 
 /***************************************************************************************************
  * Rotary positional embedding

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -357,7 +357,7 @@ void fused_amax_and_scale_update_after_reduction(const at::Tensor &amax_reductio
                                                  transformer_engine::DType fp8_dtype, float margin);
 
 void scalar_reciprocal(const at::Tensor &src,
-                       at::Tensor dst,
+                       std::optional<at::Tensor> dst = std::nullopt,
                        int64_t src_offset = 0,
                        int64_t dst_offset = 0,
                        const std::optional<at::Tensor> &noop_flag = std::nullopt);

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -365,10 +365,8 @@ void fused_amax_and_scale_update_after_reduction(const at::Tensor &amax_reductio
  * /param[in]  float32 flag indicating whether to avoid updating
  *             output.
  */
-at::Tensor scalar_reciprocal(const at::Tensor &src,
-                             std::optional<at::Tensor> dst = std::nullopt,
-                             int64_t src_offset = 0,
-                             int64_t dst_offset = 0,
+at::Tensor scalar_reciprocal(const at::Tensor &src, std::optional<at::Tensor> dst = std::nullopt,
+                             int64_t src_offset = 0, int64_t dst_offset = 0,
                              const std::optional<at::Tensor> &noop_flag = std::nullopt);
 
 /***************************************************************************************************

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -7,6 +7,10 @@
 #ifndef TRANSFORMER_ENGINE_PYTORCH_CSRC_EXTENSIONS_H_
 #define TRANSFORMER_ENGINE_PYTORCH_CSRC_EXTENSIONS_H_
 
+#include <cstdint>
+#include <optional>
+#include <vector>
+
 #include "common.h"
 #include "common/common.h"
 
@@ -351,6 +355,12 @@ void fused_amax_and_scale_update_after_reduction(const at::Tensor &amax_reductio
                                                  std::vector<at::Tensor> scale_invs,
                                                  const std::string &amax_compute_algo,
                                                  transformer_engine::DType fp8_dtype, float margin);
+
+void scalar_reciprocal(const at::Tensor &src,
+                       at::Tensor dst,
+                       int64_t src_offset = 0,
+                       int64_t dst_offset = 0,
+                       const std::optional<at::Tensor> &noop_flag = std::nullopt);
 
 /***************************************************************************************************
  * Rotary positional embedding

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -4,6 +4,8 @@
  * See LICENSE for license information.
  ************************************************************************/
 
+#include <optional>
+
 #include <pybind11/functional.h>
 
 #include "../comm_gemm_overlap.h"
@@ -137,6 +139,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fused_amax_and_scale_update_after_reduction", &fused_amax_and_scale_update_after_reduction,
         "Update amax history and FP8 scale/scale_inv after reduction",
         py::call_guard<py::gil_scoped_release>());
+  m.def("scalar_reciprocal", &scalar_reciprocal,
+        "Reciprocal of a single float",
+        py::call_guard<py::gil_scoped_release>(),
+        py::arg("src"), py::arg("dst"),
+        py::arg("src_offset") = 0, py::arg("dst_offset") = 0,
+        py::arg("noop_flag") = std::nullopt);
 
   // fused apply rope
   m.def("fused_rope_forward", &fused_rope_forward, "Fused Apply RoPE FWD",

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -4,9 +4,9 @@
  * See LICENSE for license information.
  ************************************************************************/
 
-#include <optional>
-
 #include <pybind11/functional.h>
+
+#include <optional>
 
 #include "../comm_gemm_overlap.h"
 #include "../extensions.h"
@@ -139,12 +139,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fused_amax_and_scale_update_after_reduction", &fused_amax_and_scale_update_after_reduction,
         "Update amax history and FP8 scale/scale_inv after reduction",
         py::call_guard<py::gil_scoped_release>());
-  m.def("scalar_reciprocal", &scalar_reciprocal,
-        "Reciprocal of a single float",
-        py::call_guard<py::gil_scoped_release>(),
-        py::arg("src"), py::arg("dst") = std::nullopt,
-        py::arg("src_offset") = 0, py::arg("dst_offset") = 0,
-        py::arg("noop_flag") = std::nullopt);
+  m.def("scalar_reciprocal", &scalar_reciprocal, "Reciprocal of a single float",
+        py::call_guard<py::gil_scoped_release>(), py::arg("src"), py::arg("dst") = std::nullopt,
+        py::arg("src_offset") = 0, py::arg("dst_offset") = 0, py::arg("noop_flag") = std::nullopt);
 
   // fused apply rope
   m.def("fused_rope_forward", &fused_rope_forward, "Fused Apply RoPE FWD",

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -142,7 +142,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("scalar_reciprocal", &scalar_reciprocal,
         "Reciprocal of a single float",
         py::call_guard<py::gil_scoped_release>(),
-        py::arg("src"), py::arg("dst"),
+        py::arg("src"), py::arg("dst") = std::nullopt,
         py::arg("src_offset") = 0, py::arg("dst_offset") = 0,
         py::arg("noop_flag") = std::nullopt);
 

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cu
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cu
@@ -70,6 +70,8 @@ at::Tensor scalar_reciprocal(const at::Tensor &src,
                              int64_t src_offset,
                              int64_t dst_offset,
                              const std::optional<at::Tensor> &noop_flag) {
+  using namespace transformer_engine;
+
   // Allocate output tensor if needed
   NVTE_CHECK(dst || dst_offset == 0,
              "Provided offset in output tensor without providing output tensor");

--- a/transformer_engine/pytorch/csrc/extensions/recipe.cu
+++ b/transformer_engine/pytorch/csrc/extensions/recipe.cu
@@ -12,9 +12,9 @@
 #include "extensions.h"
 
 void fused_amax_and_scale_update_after_reduction(
-    const at::Tensor &amax_reduction_buffer, std::vector<at::Tensor> amax_histories,
+    const at::Tensor& amax_reduction_buffer, std::vector<at::Tensor> amax_histories,
     std::vector<at::Tensor> scales, std::vector<at::Tensor> scale_invs,
-    const std::string &amax_compute_algo, transformer_engine::DType fp8_dtype, float margin) {
+    const std::string& amax_compute_algo, transformer_engine::DType fp8_dtype, float margin) {
   using namespace transformer_engine;
   size_t num_tensors = amax_histories.size();
   std::vector<Tensor> t_amax_histories(num_tensors);
@@ -54,9 +54,9 @@ void fused_amax_and_scale_update_after_reduction(
 
 namespace {
 
-__global__ void __launch_bounds__(1) scalar_reciprocal_kernel(const float* __restrict__ src,
-                                                              float* __restrict__ dst,
-                                                              const float* __restrict__ noop) {
+__global__ void __launch_bounds__(1)
+    scalar_reciprocal_kernel(const float* __restrict__ src, float* __restrict__ dst,
+                             const float* __restrict__ noop) {
   if (noop != nullptr && *noop == 1.f) {
     return;
   }
@@ -65,11 +65,9 @@ __global__ void __launch_bounds__(1) scalar_reciprocal_kernel(const float* __res
 
 }  // namespace
 
-at::Tensor scalar_reciprocal(const at::Tensor &src,
-                             std::optional<at::Tensor> dst,
-                             int64_t src_offset,
-                             int64_t dst_offset,
-                             const std::optional<at::Tensor> &noop_flag) {
+at::Tensor scalar_reciprocal(const at::Tensor& src, std::optional<at::Tensor> dst,
+                             int64_t src_offset, int64_t dst_offset,
+                             const std::optional<at::Tensor>& noop_flag) {
   using namespace transformer_engine;
 
   // Allocate output tensor if needed
@@ -86,7 +84,8 @@ at::Tensor scalar_reciprocal(const at::Tensor &src,
   }
 
   // Launch kernel
-  scalar_reciprocal_kernel<<<1,1,0,at::cuda::getCurrentCUDAStream()>>>(src_ptr, dst_ptr, noop_ptr);
+  scalar_reciprocal_kernel<<<1, 1, 0, at::cuda::getCurrentCUDAStream()>>>(src_ptr, dst_ptr,
+                                                                          noop_ptr);
 
   return dst_val;
 }

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -152,6 +152,7 @@ class _LayerNormLinear(torch.autograd.Function):
             zero_centered_gamma,
             is_grad_enabled,
         )
+        ln_out_fp8_scale_inv = None
 
         # Column Parallel Linear
         ln_out_gathered = False
@@ -212,6 +213,12 @@ class _LayerNormLinear(torch.autograd.Function):
 
             assert isinstance(weight_fp8, Float8Tensor)
 
+            # FP8 scale-inverse for GEMM input
+            ln_out_fp8_scale_inv = tex.scalar_reciprocal(
+                fp8_meta["scaling_fwd"].scale,
+                src_offset=tex.FP8FwdTensors.GEMM1_INPUT,
+            )
+
             if fp8_meta["recipe"].fp8_mha:
                 out_index, meta_tensor, output_te_dtype, output_dtype = (
                     tex.FP8FwdTensors.GEMM1_OUTPUT,
@@ -232,8 +239,8 @@ class _LayerNormLinear(torch.autograd.Function):
                 0,
                 weight_fp8._fp8_dtype,
                 ln_out_total,
-                fp8_meta["scaling_fwd"].scale_inv,
-                tex.FP8FwdTensors.GEMM1_INPUT,
+                ln_out_fp8_scale_inv,
+                0,
                 fp8_dtype_forward,
                 output_dtype,
                 get_workspace(),
@@ -323,7 +330,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 weight_fp8,
                 weight.main_grad if cpu_offloading and fuse_wgrad_accumulation else None,
                 ln_out if weight.requires_grad else None,
-                fp8_meta["scaling_fwd"].scale_inv.clone() if fp8 else None,
+                ln_out_fp8_scale_inv,
             )
 
             ctx.activation_dtype = activation_dtype
@@ -395,7 +402,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 weight_fp8,
                 main_grad,
                 ln_out,
-                fwd_scale_inverses,
+                ln_out_fp8_scale_inv,
             ) = ctx.saved_tensors
 
             # Gather intermediate/activation tensors if needed
@@ -592,8 +599,8 @@ class _LayerNormLinear(torch.autograd.Function):
                         ln_out_total_t = tex.fp8_transpose(ln_out_total, fp8_dtype_forward)
                         wgrad, _ = tex.fp8_gemm(
                             ln_out_total_t,
-                            fwd_scale_inverses,
-                            tex.FP8FwdTensors.GEMM1_INPUT,
+                            ln_out_fp8_scale_inv,
+                            0,
                             fp8_dtype_forward,
                             (
                                 grad_output_t._data
@@ -618,8 +625,8 @@ class _LayerNormLinear(torch.autograd.Function):
                     else:
                         ln_out_total_c = torch.ops.tex_ts.cast_from_fp8_ts(
                             ln_out_total,
-                            fwd_scale_inverses,
-                            tex.FP8FwdTensors.GEMM1_INPUT,
+                            ln_out_fp8_scale_inv,
+                            0,
                             fp8_dtype_forward,
                             TE_DType[ctx.activation_dtype],
                         )

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -216,7 +216,7 @@ class _LayerNormLinear(torch.autograd.Function):
             # FP8 scale-inverse for GEMM input
             ln_out_fp8_scale_inv = tex.scalar_reciprocal(
                 fp8_meta["scaling_fwd"].scale,
-                src_offset=tex.FP8FwdTensors.GEMM1_INPUT,
+                src_offset=int(tex.FP8FwdTensors.GEMM1_INPUT),
             )
 
             if fp8_meta["recipe"].fp8_mha:

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -157,7 +157,7 @@ class _Linear(torch.autograd.Function):
                 # FP8 scale-inverse
                 inputmat_fp8_scale_inv = tex.scalar_reciprocal(
                     fp8_meta["scaling_fwd"].scale,
-                    src_offset=tex.FP8FwdTensors.GEMM1_INPUT,
+                    src_offset=int(tex.FP8FwdTensors.GEMM1_INPUT),
                 )
 
         # Column Parallel Linear


### PR DESCRIPTION
# Description

FP8 training is frequently bottlenecked by CPU overheads and a non-trivial fraction of CPU overhead comes from small PyTorch operations. For example, when I benchmark the forward pass of  small `Linear` modules on an L40, I estimate ~20% of runtime is spent in handling the FP8 scaling factors (mainly in reciprocal and clone operations). This PR attempts to mitigate these overheads by adding a `scalar_reciprocal` kernel that operates on a single `float`, bringing the kernel launch cost down from ~20 us to ~10 us. In my benchmark of `Linear` forwards, I see a 8% reduction in runtime.

Alternative approaches:
- Modify the cast and cast-transpose kernels to perform the scale-inv update, similar to how they perform the amax update. Logically, the scale is part of the FP8 recipe and the scale-inv is part of the data.
- Use `torch.compile` to fuse FP8 scale operations. We would require significant refactoring to avoid incurring extra overhead from graph breaks, especially in how we deal with the  `FP8TensorMeta` class.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Custom kernel to compute reciprocal of a single float

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
