### PR TITLE
Revert "[C/PyTorch] Removed MPI dependence in Userbuffers (#901)"

### DIFF
--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -17,6 +17,15 @@ from typing import List, Optional, Tuple
 
 
 @functools.lru_cache(maxsize=None)
+def userbuffers_enabled() -> bool:
+    """Check if userbuffers support is enabled"""
+    if int(os.getenv("NVTE_WITH_USERBUFFERS", "0")):
+        assert os.getenv("MPI_HOME"), "MPI_HOME must be set if NVTE_WITH_USERBUFFERS=1"
+        return True
+    return False
+
+
+@functools.lru_cache(maxsize=None)
 def debug_build_enabled() -> bool:
     """Whether to build with a debug configuration"""
     for arg in sys.argv:

--- a/examples/pytorch/comm_gemm_overlap/run_overlap.sh
+++ b/examples/pytorch/comm_gemm_overlap/run_overlap.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+NUM_GPU=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+
+env MPICC=$(which mpicc) python -m pip install mpi4py
+
+mpiexec \
+--oversubscribe \
+-np ${NUM_GPU} \
+-x CUDA_DEVICE_MAX_CONNECTIONS=1 \
+-x MASTER_ADDR=$(hostname) \
+-x MASTER_PORT=33558 \
+-x PATH \
+python ln_mlp_with_overlap.py --num-replicas 2

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ from build_tools.utils import (
     found_ninja,
     found_pybind11,
     remove_dups,
+    userbuffers_enabled,
     get_frameworks,
     install_and_import,
 )
@@ -41,13 +42,21 @@ CMakeBuildExtension = get_build_ext(BuildExtension)
 
 
 def setup_common_extension() -> CMakeExtension:
-    """Setup CMake extension for common library"""
+    """Setup CMake extension for common library
+
+    Also builds JAX or userbuffers support if needed.
+
+    """
+    cmake_flags = []
+    if userbuffers_enabled():
+        cmake_flags.append("-DNVTE_WITH_USERBUFFERS=ON")
+
     # Project directory root
     root_path = Path(__file__).resolve().parent
     return CMakeExtension(
         name="transformer_engine",
-        cmake_path=root_path / Path("transformer_engine/common"),
-        cmake_flags=[],
+        cmake_path=root_path / Path("transformer_engine"),
+        cmake_flags=cmake_flags,
     )
 
 

--- a/transformer_engine/CMakeLists.txt
+++ b/transformer_engine/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+cmake_minimum_required(VERSION 3.18)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES 70 80 89 90)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+project(transformer_engine LANGUAGES CUDA CXX)
+
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --threads 4")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
+endif()
+
+find_package(CUDAToolkit REQUIRED cublas nvToolsExt)
+
+# Check for cuDNN frontend API
+set(CUDNN_FRONTEND_INCLUDE_DIR
+    "${CMAKE_SOURCE_DIR}/../3rdparty/cudnn-frontend/include")
+if(NOT EXISTS "${CUDNN_FRONTEND_INCLUDE_DIR}")
+    message(FATAL_ERROR
+            "Could not find cuDNN frontend API. "
+            "Try running 'git submodule update --init --recursive' "
+            "within the Transformer Engine source.")
+endif()
+include(${CMAKE_SOURCE_DIR}/../3rdparty/cudnn-frontend/cmake/cuDNN.cmake)
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+include_directories(${PROJECT_SOURCE_DIR})
+
+add_subdirectory(common)
+if(NVTE_WITH_USERBUFFERS)
+    message(STATUS "userbuffers support enabled")
+    add_subdirectory(pytorch/csrc/userbuffers)
+endif()

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -2,39 +2,6 @@
 #
 # See LICENSE for license information.
 
-cmake_minimum_required(VERSION 3.18)
-
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES 70 80 89 90)
-endif()
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-
-project(transformer_engine LANGUAGES CUDA CXX)
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
-endif()
-
-find_package(CUDAToolkit REQUIRED cublas nvToolsExt)
-
-# Check for cuDNN frontend API
-set(CUDNN_FRONTEND_INCLUDE_DIR
-    "${CMAKE_SOURCE_DIR}/../../3rdparty/cudnn-frontend/include")
-if(NOT EXISTS "${CUDNN_FRONTEND_INCLUDE_DIR}")
-    message(FATAL_ERROR
-            "Could not find cuDNN frontend API. "
-            "Try running 'git submodule update --init --recursive' "
-            "within the Transformer Engine source.")
-endif()
-include(${CMAKE_SOURCE_DIR}/../../3rdparty/cudnn-frontend/cmake/cuDNN.cmake)
-
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
-
-include_directories(${PROJECT_SOURCE_DIR}/..)
-
 # Configure Transformer Engine library
 set(transformer_engine_SOURCES)
 list(APPEND transformer_engine_SOURCES

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -42,5 +42,19 @@ def _load_library():
     return ctypes.CDLL(so_path, mode=ctypes.RTLD_GLOBAL)
 
 
+def _load_userbuffers():
+    """Load shared library with userbuffers"""
+
+    so_name = f"libtransformer_engine_userbuffers.{_get_sys_extension()}"
+    so_path = get_te_path() / "transformer_engine" / so_name
+    if not so_path.exists():
+        so_path = get_te_path() / so_name
+
+    if so_path.exists():
+        return ctypes.CDLL(so_path, mode=ctypes.RTLD_GLOBAL)
+    return None
+
+
 if "NVTE_PROJECT_BUILDING" not in os.environ:
     _TE_LIB_CTYPES = _load_library()
+    _UB_LIB_CTYPES = _load_userbuffers()

--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -38,8 +38,6 @@ from transformer_engine.pytorch.module import LayerNormMLP
 from transformer_engine.pytorch.module import LayerNorm
 from transformer_engine.pytorch.module import RMSNorm
 from transformer_engine.pytorch.module import GroupedLinear
-from transformer_engine.pytorch.module import initialize_ub
-from transformer_engine.pytorch.module import destroy_ub
 from transformer_engine.pytorch.attention import DotProductAttention
 from transformer_engine.pytorch.attention import InferenceParams
 from transformer_engine.pytorch.attention import MultiheadAttention

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -4,9 +4,6 @@
  * See LICENSE for license information.
  ************************************************************************/
 
-#ifndef TRANSFORMER_ENGINE_PYTORCH_CSRC_EXTENSIONS_H_
-#define TRANSFORMER_ENGINE_PYTORCH_CSRC_EXTENSIONS_H_
-
 #include "common.h"
 #include "common/common.h"
 
@@ -376,6 +373,10 @@ size_t get_cublasLt_version();
 
 size_t get_cudnn_version();
 
+bool userbuf_comm_available();
+
+void placeholder();
+
 /***************************************************************************************************
  * Support THD format for Context Parallel
  **************************************************************************************************/
@@ -439,5 +440,3 @@ void multi_tensor_sgd_cuda(int chunk_size, at::Tensor noop_flag,
                            std::vector<std::vector<at::Tensor>> tensor_lists, float wd,
                            float momentum, float dampening, float lr, bool nesterov, bool first_run,
                            bool wd_after_momentum, float scale);
-
-#endif  // TRANSFORMER_ENGINE_PYTORCH_CSRC_EXTENSIONS_H_

--- a/transformer_engine/pytorch/csrc/extensions/misc.cu
+++ b/transformer_engine/pytorch/csrc/extensions/misc.cu
@@ -9,3 +9,13 @@
 size_t get_cublasLt_version() { return cublasLtGetVersion(); }
 
 size_t get_cudnn_version() { return cudnnGetVersion(); }
+
+bool userbuf_comm_available() {  // TODO(ksivamani) check on python side
+#ifdef NVTE_WITH_USERBUFFERS
+  return true;
+#else
+  return false;
+#endif
+}
+
+void placeholder() {}  // TODO(ksivamani) clean this up

--- a/transformer_engine/pytorch/csrc/userbuffers/CMakeLists.txt
+++ b/transformer_engine/pytorch/csrc/userbuffers/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+# Configure userbuffers library
+add_library(transformer_engine_userbuffers SHARED
+            userbuffers.cu
+            userbuffers-host.cpp
+            ipcsocket.cc)
+target_include_directories(transformer_engine_userbuffers PUBLIC
+                           "${CMAKE_CURRENT_SOURCE_DIR}"
+                           "${PROJECT_SOURCE_DIR}/common/include")
+
+# Configure dependencies
+find_package(MPI REQUIRED)
+target_link_libraries(transformer_engine_userbuffers PUBLIC
+                      CUDA::cudart
+                      CUDA::cuda_driver
+                      MPI::MPI_CXX
+                      )
+target_include_directories(transformer_engine_userbuffers PRIVATE
+                           ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+# Compiler options
+set_source_files_properties(userbuffers.cu
+                            userbuffers-host.cpp
+                            ipcsocket.cc
+                            PROPERTIES
+                            COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:-maxrregcount=64>")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")
+
+# Install library
+install(TARGETS transformer_engine_userbuffers DESTINATION .)

--- a/transformer_engine/pytorch/csrc/userbuffers/ipcsocket.cc
+++ b/transformer_engine/pytorch/csrc/userbuffers/ipcsocket.cc
@@ -75,8 +75,9 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash,
   handle->abortFlag = abortFlag;
   // Mark socket as non-blocking
   if (handle->abortFlag) {
-    int flags = fcntl(fd, F_GETFL);
-    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    int flags;
+    EQCHECK(flags = fcntl(fd, F_GETFL), -1);
+    SYSCHECK(fcntl(fd, F_SETFL, flags | O_NONBLOCK), "fcntl");
   }
 
   return ncclSuccess;

--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers-host.cpp
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers-host.cpp
@@ -9,32 +9,34 @@
 #include <cuda_runtime_api.h>
 #include <inttypes.h>
 #include <math.h>
+#include <mpi.h>
 #include <sched.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
-#include <chrono>
-#include <iostream>
-#include <map>
-#include <utility>
-
-#include "../util/cuda_driver.h"
+#include "common/util/cuda_driver.h"
 #include "ipcsocket.h"
 #include "userbuffers.h"
 
-#ifdef UB_MPI_BOOTSTRAP
-#include <mpi.h>
-static MPI_Comm EXT_COMM_WORLD = MPI_COMM_WORLD;
-static MPI_Comm EXT_COMM_INTRA;
-static MPI_Comm EXT_COMM_INTER;
-#else
-static char EXT_COMM_WORLD[] = "world";
-static char EXT_COMM_INTRA[] = "intra";
-static char EXT_COMM_INTER[] = "inter";
-#endif
-
 #define MULTICAST_GB_TOTAL 512
+
+static int oob_bcast(void *comm_context, void *buf, int size, int root) {
+  MPI_Bcast(buf, size, MPI_BYTE, root,
+            (reinterpret_cast<communicator *>(comm_context))->comm_inter);
+  return 0;
+}
+
+static int oob_barrier(void *comm_context) {
+  MPI_Barrier((reinterpret_cast<communicator *>(comm_context))->comm_inter);
+  return 0;
+}
+
+static int oob_gather(void *comm_context, int root, void *sbuf, void *rbuf, int len) {
+  MPI_Gather(sbuf, len, MPI_BYTE, rbuf, len, MPI_BYTE, root,
+             (reinterpret_cast<communicator *>(comm_context))->comm_inter);
+  return 0;
+}
 
 int stringCmp(const void *a, const void *b) { return strcmp((const char *)a, (const char *)b); }
 
@@ -83,23 +85,18 @@ int pipe_rank(communicator *comm, int step) {
   return newnode * numlocal + newlocal;
 }
 
-int create_communicator_grouped2(
-    communicator **comm, int myrank, int numranks, int mylocal, int numlocal, int mynode,
-    int numnodes, std::function<void(void **, void *, size_t, ExtComm)> ext_alloc_copy_allgather,
-    std::function<void(ExtComm)> ext_barrier, std::function<void(void *)> ext_free, int pipegpus,
-    int pipenodes, int tensorgpus, int tensornodes) {
-  *comm = new communicator();
+int create_communicator_grouped2(communicator **comm, int pipegpus, int pipenodes, int tensorgpus,
+                                 int tensornodes) {
+  *comm = reinterpret_cast<communicator *>(malloc(sizeof(communicator)));
 
-  (*comm)->comm_world = EXT_COMM_WORLD;
-  (*comm)->_alloc_copy_allgather = ext_alloc_copy_allgather;
-  (*comm)->_barrier = ext_barrier;
-  (*comm)->_free = ext_free;
-  (*comm)->nranks = numranks;
+  int myrank, nranks, cur_dev, ndev;
+  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+  (*comm)->nranks = nranks;
   (*comm)->myrank = myrank;
   (*comm)->free_region = 0;
   (*comm)->launch_mode = NVTE_LAUNCH_GPU | NVTE_LAUNCH_CPU;
 
-  int cur_dev, ndev;
   cudaDeviceProp device_prop;
   CUDACHECK(cudaGetDevice(&cur_dev));
   CUDACHECK(cudaGetDeviceCount(&ndev));
@@ -126,7 +123,32 @@ int create_communicator_grouped2(
            (*comm)->ub_timeout, device_clock);
   }
 
-  (*comm)->comm_intra = EXT_COMM_INTRA;
+  int ret = 0;
+  // split communicator
+  char host_name[MPI_MAX_PROCESSOR_NAME];
+  char(*host_names)[MPI_MAX_PROCESSOR_NAME];
+  int namelen, bytes, color, my_node, mylocal, numlocal, num_nodes;
+  int rank = (*comm)->myrank, size = (*comm)->nranks;
+  MPI_Get_processor_name(host_name, &namelen);
+  bytes = size * sizeof(char[MPI_MAX_PROCESSOR_NAME]);
+  host_names = (char(*)[MPI_MAX_PROCESSOR_NAME])malloc(bytes);
+  strcpy(host_names[rank], host_name);  // NOLINT(*)
+  for (int n = 0; n < size; n++)
+    MPI_Bcast(&(host_names[n]), MPI_MAX_PROCESSOR_NAME, MPI_CHAR, n, MPI_COMM_WORLD);
+  qsort(host_names, size, sizeof(char[MPI_MAX_PROCESSOR_NAME]), stringCmp);
+
+  color = 0;
+  for (int n = 0; n < size; n++) {
+    if (n > 0 && strcmp(host_names[n - 1], host_names[n])) color++;
+    if (strcmp(host_name, host_names[n]) == 0) break;
+  }
+  free(host_names);
+
+  MPI_Comm_split(MPI_COMM_WORLD, color, rank, &(*comm)->comm_intra);
+  // find intranode numbers and make internode communicator
+  // figure out mylocal
+  MPI_Comm_rank((*comm)->comm_intra, &mylocal);
+  MPI_Comm_size((*comm)->comm_intra, &numlocal);
   (*comm)->nvrank = mylocal;
   (*comm)->nvsize = numlocal;
 
@@ -153,7 +175,7 @@ int create_communicator_grouped2(
 
   if (ndev == numlocal) {  // all visible devices
     if (cur_dev != mylocal)
-      printf("%d: device used %d[%d] ,resetting device to %d\n", myrank, cur_dev, ndev, mylocal);
+      printf("%d: device used %d[%d] ,resetting device to %d\n", rank, cur_dev, ndev, mylocal);
     CUDACHECK(cudaSetDevice(mylocal));
   }
   (*comm)->mydev = cur_dev;
@@ -169,22 +191,31 @@ int create_communicator_grouped2(
   (*comm)->ar2_firstgpu = mylocal - mylocal % tensorgpus;
   (*comm)->ar2_nvrank = mylocal - (*comm)->ar2_firstgpu;
   // ar2 has step equal to ar_nvsize
-  int allnodes = numranks / numlocal;
-  int nodeid = myrank / numlocal;
+  int allnodes = nranks / numlocal;
+  int mynode = myrank / numlocal;
   int datanodes = allnodes / pipenodes / tensornodes;
   int pipenodegroup_id = myrank / numlocal / (datanodes * tensornodes);
 
   (*comm)->pipe_id = pipegpus * pipenodegroup_id + mylocal / (datagpus * tensorgpus);
 
-  (*comm)->comm_inter = EXT_COMM_INTER;
-  (*comm)->first_node = nodeid - mynode;
-  (*comm)->num_nodes = numnodes;
-  (*comm)->my_node = mynode;
+  CUDACHECK(cudaFree(0));
+  int datanodegroup_id =
+      myrank / numlocal / datanodes;  // data reduction group node belongs, equals 0 for all if both
+                                      // pipenodes=1 and tensornodes=1
+  // mpi communicator only needed for SHARP which is always
+  // allreduce1/data-parallel
+  MPI_Comm_split(MPI_COMM_WORLD, mylocal + numlocal * datanodegroup_id, rank, &(*comm)->comm_inter);
+  // different rails from same group are in different subcommunicators
+
+  MPI_Comm_size((*comm)->comm_inter, &num_nodes);
+  MPI_Comm_rank((*comm)->comm_inter, &my_node);
+  (*comm)->first_node = mynode - my_node;
+  (*comm)->num_nodes = num_nodes;
+  (*comm)->my_node = my_node;
 
   (*comm)->num2_nodes = tensornodes;
   (*comm)->my2_node = (mynode / datanodes) % tensornodes;
   (*comm)->first2_node = mynode - (*comm)->my2_node * datanodes;
-
   (*comm)->fifo = reinterpret_cast<ub_request *>(malloc(sizeof(ub_request) * NVTE_MAX_REQUESTS));
   (*comm)->nblocks = 8;
   (*comm)->alignblock = 1024 * 512;
@@ -210,18 +241,13 @@ int create_communicator_grouped2(
     mcProp.size = mc_maxsize;
     (*comm)->mc_maxsize = mc_maxsize;
 
-    // Broadcast the a POSIX file descriptor from the local root rank to other local ranks.
-    // NOTE: This cannot be done via MPI_Bcast or other external comm libraries. They mangle the
-    //       file descriptor and prevent cuMemImportFromShareableHandle() from correctly
-    //       interpreting the file. Instead, we use system socket to send/recv the file handle
-    //       without mangling.
     int fd;
     volatile uint32_t abortFlag = 0;
     struct ncclIpcSocket ipcSock = {0};
     uint64_t opId = 0xdeadcafeb000 + (*comm)->ar2_firstgpu;
     ncclResult_t ret = ncclSuccess;
     NCCLCHECK(ncclIpcSocketInit(&ipcSock, (*comm)->ar2_nvrank, (uint64_t)opId, &abortFlag));
-    (*comm)->_barrier((*comm)->comm_world);
+    MPI_Barrier(MPI_COMM_WORLD);
 
     if ((*comm)->ar2_nvrank == 0) {
       NVTE_CALL_CHECK_CUDA_DRIVER(cuMulticastCreate, &(*comm)->mc_handle, &mcProp);
@@ -231,17 +257,17 @@ int create_communicator_grouped2(
           (uint64_t)0);
 
       for (int p = 1; p < (*comm)->ar2_nvsize; p++) {
-        (*comm)->_barrier((*comm)->comm_intra);
+        MPI_Barrier((*comm)->comm_intra);
         NCCLCHECKGOTO(ncclIpcSocketSendFd(&ipcSock, fd, p, (uint64_t)opId), ret, error);
       }
     } else {
-      for (int i = 0; i < (*comm)->ar2_nvrank; i++) (*comm)->_barrier((*comm)->comm_intra);
+      for (int i = 0; i < (*comm)->ar2_nvrank; i++) MPI_Barrier((*comm)->comm_intra);
       NCCLCHECKGOTO(ncclIpcSocketRecvFd(&ipcSock, &fd), ret, error);
       for (int i = 0; i < (*comm)->ar2_nvsize - (*comm)->ar2_nvrank - 1; i++)
-        (*comm)->_barrier((*comm)->comm_intra);
-      NVTE_CALL_CHECK_CUDA_DRIVER(
-          cuMemImportFromShareableHandle, &(*comm)->mc_handle, reinterpret_cast<void *>(fd),
-          static_cast<CUmemAllocationHandleType>(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+        MPI_Barrier((*comm)->comm_intra);
+      NVTE_CALL_CHECK_CUDA_DRIVER(cuMemImportFromShareableHandle, &(*comm)->mc_handle,
+                                  reinterpret_cast<void *>(fd),
+                                  CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
     }
   error:
     NCCLCHECK(ncclIpcSocketClose(&ipcSock));
@@ -263,7 +289,7 @@ int create_communicator_grouped2(
                                 const_cast<CUmemAccessDesc *>(&accessDesc), (size_t)1);
 
     (*comm)->mc_baseptr = reinterpret_cast<void *>(mc_va);
-    (*comm)->_barrier((*comm)->comm_world);
+    MPI_Barrier(MPI_COMM_WORLD);
     if (!(*comm)->myrank) printf("MC initialized succesfully, window size = %ld\n", mc_maxsize);
   } else {
     if (!(*comm)->myrank) printf("MC NOT initialized and used\n");
@@ -275,10 +301,12 @@ int create_communicator_grouped2(
 #define LOCALSIZE 4 * (NVTE_REG0_OFFSET(*comm) + NVTE_REG0_FLAGS + NVTE_REG0_COMMBUFFER * NBUF)
   // peer pointers + op flags + comm buffer
 
-  CUDACHECK(cudaMalloc(&(*comm)->gpu_ptrs, LOCALSIZE));  // flags and pointers, no block data yet
+  CUDACHECK(cudaMalloc(&(*comm)->gpu_ptrs,
+                       LOCALSIZE));  // flags and pointers, no block data yet
   CUDACHECK(cudaMemset((*comm)->gpu_ptrs, 0, LOCALSIZE));
   CUDACHECK(cudaDeviceSynchronize());
-  register_user_buffer_collective(&((*comm)->gpu_ptrs), LOCALSIZE, *comm, false);
+  register_user_buffer_collective(&((*comm)->gpu_ptrs), LOCALSIZE,
+                                  *comm);  // will use handler 0
   CUDACHECK(cudaMalloc(&(*comm)->send_id, (*comm)->nranks * sizeof(int)));
   CUDACHECK(cudaMalloc(&(*comm)->recv_id, NVTE_MAX_REGIONS * (*comm)->nranks * sizeof(int)));
   CUDACHECK(cudaMemset((*comm)->send_id, 0, (*comm)->nranks * sizeof(int)));
@@ -292,12 +320,12 @@ int create_communicator_grouped2(
 #define GPU_PAGE_MASK (~GPU_PAGE_OFFSET)
 
   CUDACHECK(cudaMalloc(&(*comm)->flags, 2 * GPU_PAGE_SIZE));
+  unsigned int flag = 1;
   CUDACHECK(cudaMemset((*comm)->flags, 0, 2 * GPU_PAGE_SIZE));
   (*comm)->flags =
       reinterpret_cast<int *>(((CUdeviceptr)(*comm)->flags + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK);
 
   using namespace std;
-
   sched_param param;
   pthread_attr_t attr;
   pthread_attr_init(&attr);
@@ -310,144 +338,23 @@ int create_communicator_grouped2(
     printf(
         "%d/%d:(%d x %d): DP %d x %d TP %d x %d, DPGROUP %dx%d TPGROUP "
         "%dx%d PIPE_ID %d/%d\n",
-        myrank, numranks, myrank / numlocal, myrank % numlocal, (*comm)->my_node,
-        (*comm)->ar_nvrank, (*comm)->my2_node, (*comm)->ar2_nvrank, (*comm)->num_nodes,
-        (*comm)->ar_nvsize, (*comm)->num2_nodes, (*comm)->ar2_nvsize, (*comm)->pipe_id,
-        pipegpus * pipenodes);
+        myrank, nranks, myrank / numlocal, myrank % numlocal, (*comm)->my_node, (*comm)->ar_nvrank,
+        (*comm)->my2_node, (*comm)->ar2_nvrank, (*comm)->num_nodes, (*comm)->ar_nvsize,
+        (*comm)->num2_nodes, (*comm)->ar2_nvsize, (*comm)->pipe_id, pipegpus * pipenodes);
   fflush(NULL);
 
   return 0;
 }
 
-int create_communicator_grouped(
-    communicator **comm, int myrank, int numranks, int mylocal, int numlocal, int mynode,
-    int numnodes, std::function<void(void **, void *, size_t, ExtComm)> ext_alloc_copy_allgather,
-    std::function<void(ExtComm)> ext_barrier, std::function<void(void *)> ext_free, int pipegpus,
-    int pipenodes) {
-  return create_communicator_grouped2(comm, myrank, numranks, mylocal, numlocal, mynode, numnodes,
-                                      ext_alloc_copy_allgather, ext_barrier, ext_free, pipegpus,
-                                      pipenodes, 1, 1);
+int create_communicator_grouped(communicator **comm, int pipegpus, int pipenodes) {
+  return create_communicator_grouped2(comm, pipegpus, pipenodes, 1, 1);
 }
 
-int create_communicator(
-    communicator **comm, int myrank, int numranks, int mylocal, int numlocal, int mynode,
-    int numnodes, std::function<void(void **, void *, size_t, ExtComm)> ext_alloc_copy_allgather,
-    std::function<void(ExtComm)> ext_barrier, std::function<void(void *)> ext_free) {
-  return create_communicator_grouped2(comm, myrank, numranks, mylocal, numlocal, mynode, numnodes,
-                                      ext_alloc_copy_allgather, ext_barrier, ext_free, 1, 1, 1, 1);
+int create_communicator(communicator **comm) {
+  return create_communicator_grouped2(comm, 1, 1, 1, 1);
 }
 
-int create_communicator_grouped2_mpi(communicator **comm, int pipegpus, int pipenodes,
-                                     int tensorgpus, int tensornodes) {
-#ifdef UB_MPI_BOOTSTRAP
-  // get global numbers
-  int myrank, numranks;
-  MPI_Comm_rank(EXT_COMM_WORLD, &myrank);
-  MPI_Comm_size(EXT_COMM_WORLD, &numranks);
-
-  // find intranode numbers and make internode communicator
-  char host_name[MPI_MAX_PROCESSOR_NAME];
-  char(*host_names)[MPI_MAX_PROCESSOR_NAME];
-  int namelen, bytes, color;
-  int rank = (*comm)->myrank, size = (*comm)->nranks;
-  MPI_Get_processor_name(host_name, &namelen);
-  bytes = size * sizeof(char[MPI_MAX_PROCESSOR_NAME]);
-  host_names = (char(*)[MPI_MAX_PROCESSOR_NAME])malloc(bytes);
-  strcpy(host_names[rank], host_name);  // NOLINT(*)
-  for (int n = 0; n < size; n++)
-    MPI_Bcast(&(host_names[n]), MPI_MAX_PROCESSOR_NAME, MPI_CHAR, n, EXT_COMM_WORLD);
-  qsort(host_names, size, sizeof(char[MPI_MAX_PROCESSOR_NAME]), stringCmp);
-
-  color = 0;
-  for (int n = 0; n < size; n++) {
-    if (n > 0 && strcmp(host_names[n - 1], host_names[n])) color++;
-    if (strcmp(host_name, host_names[n]) == 0) break;
-  }
-  free(host_names);
-
-  int mylocal, numlocal;
-  MPI_Comm_split(EXT_COMM_WORLD, color, rank, &EXT_COMM_INTRA);
-  MPI_Comm_rank(EXT_COMM_INTRA, &mylocal);
-  MPI_Comm_size(EXT_COMM_INTRA, &numlocal);
-
-  // find internode numbers and make internode communicator
-  CUDACHECK(cudaFree(0));
-  int allnodes = numranks / numlocal;
-  int datanodes = allnodes / pipenodes / tensornodes;
-  // data reduction group node belongs, equals 0 for all if both pipenodes=1 and tensornodes=1
-  int datanodegroup_id = myrank / numlocal / datanodes;
-  // mpi communicator only needed for SHARP which is always allreduce1/data-parallel
-  MPI_Comm_split(EXT_COMM_WORLD, mylocal + numlocal * datanodegroup_id, rank, &EXT_COMM_INTER);
-  // different rails from same group are in different subcommunicators
-  int mynode, numnodes;
-  MPI_Comm_size(EXT_COMM_INTER, &numnodes);
-  MPI_Comm_rank(EXT_COMM_INTER, &mynode);
-
-  // finally call the abstracted constructor with MPI info
-  return create_communicator_grouped2(comm, myrank, numranks, mylocal, numlocal, mynode, numnodes,
-                                      &ub_alloc_copy_allgather, &ub_barrier, &ub_free, pipegpus,
-                                      pipenodes, tensorgpus, tensornodes);
-#else
-  NVTE_UB_ERROR(std::string("Bootstrapping Userbuffers with MPI requires ") +
-                std::string("building Transformer Engine with UB_MPI_BOOTSTRAP=1"));
-#endif
-}
-
-int create_communicator_grouped_mpi(communicator **comm, int pipegpus, int pipenodes) {
-  return create_communicator_grouped2_mpi(comm, pipegpus, pipenodes, 1, 1);
-}
-
-int create_communicator_mpi(communicator **comm) {
-  return create_communicator_grouped2_mpi(comm, 1, 1, 1, 1);
-}
-
-void destroy_communicator(communicator *comm) {
-  for (int hndl = 0; hndl < comm->free_region; hndl++) {
-    if (comm->mem_dealloc[hndl]) {
-      NVTE_CALL_CHECK_CUDA_DRIVER(cuMemAddressFree,
-                                  reinterpret_cast<CUdeviceptr>(comm->ucbase_ptr[hndl]),
-                                  comm->mem_size[hndl] * comm->nvsize);
-      for (int rank = 0; rank < comm->nvsize; rank++) {
-        NVTE_CALL_CHECK_CUDA_DRIVER(cuMemRelease, comm->uchandles[hndl][rank]);
-      }
-      free(reinterpret_cast<void *>(comm->uchandles[hndl]));
-    } else {
-      for (int rank = 0; rank < comm->nvsize; rank++) {
-        if (rank != comm->nvrank) {
-          cudaIpcCloseMemHandle(comm->peer_ptr[hndl][rank]);
-        } else {
-          comm->peer_ptr[hndl][rank] = nullptr;  // remove reference to external buffer
-        }
-      }
-      free(comm->peer_ptr[hndl]);
-    }
-    comm->mem_ptr[hndl] = nullptr;
-  }
-  cudaFree(reinterpret_cast<void *>(comm->flags));
-  cudaFree(reinterpret_cast<void *>(comm->recv_id));
-  cudaFree(reinterpret_cast<void *>(comm->send_id));
-  if (comm->use_mc) {
-    NVTE_CALL_CHECK_CUDA_DRIVER(cuMemAddressFree, reinterpret_cast<CUdeviceptr>(comm->mc_baseptr),
-                                comm->mc_maxsize);
-    NVTE_CALL_CHECK_CUDA_DRIVER(cuMemRelease, comm->mc_handle);
-  }
-  if (comm->mem_dealloc[0]) {
-    cudaFree(comm->gpu_ptrs);
-  }
-  free(comm->fifo);
-  delete comm;
-}
-
-void destroy_communicator_mpi(communicator *comm) {
-#ifdef UB_MPI_BOOTSTRAP
-  MPI_Comm_free(comm->comm_inter);
-  MPI_Comm_free(comm->comm_intra);
-  destroy_communicator(comm);
-#else
-  NVTE_UB_ERROR(std::string("Communicator is not bootstrapped with MPI and ") +
-                std::string("can only be deallocated with destroy_communicator()."));
-#endif
-}
+void destroy_communicator(communicator *comm) {}
 
 int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *comm, bool alloc) {
   if (comm->free_region > NVTE_MAX_REGIONS) return -1;
@@ -455,7 +362,6 @@ int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *
   comm->peer_ptr[hndl] = reinterpret_cast<void **>(malloc(sizeof(void *) * (comm->nvsize)));
   size_t aligned_size = bytes;
   comm->memflags[hndl] = 0;
-  comm->mem_dealloc[hndl] = alloc;
 
   if (alloc) {
     int nranks = comm->nvsize;  // total GPUs in NVLINK domain
@@ -505,14 +411,9 @@ int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *
     uint64_t opId = 0xdeadcafebeef;
     ncclResult_t ret = ncclSuccess;
 
-    // All-gather POSIX file descriptors across local ranks.
-    // NOTE: This cannot be done via MPI_Allgather or other external comm libraries. They mangle
-    //       the file descriptor and prevent cuMemImportFromShareableHandle() from correctly
-    //       interpreting the file. Instead, we use system socket to send/recv the file handle
-    //       without mangling.
     NCCLCHECK(ncclIpcSocketInit(&ipcSock, myrank, (uint64_t)opId, &abortFlag));
     for (int p = 1; p < nranks; p++) {
-      comm->_barrier(comm->comm_intra);
+      MPI_Barrier(comm->comm_intra);
       NCCLCHECKGOTO(
           ncclIpcSocketSendFd(&ipcSock, peerfd[myrank], (myrank + p) % nranks, (uint64_t)opId), ret,
           error);
@@ -576,19 +477,18 @@ int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *
 
   } else {
     assert(comm->nvsize <= 8);
-    cudaIpcMemHandle_t memhndl;
-    CUDACHECK(cudaIpcGetMemHandle(&memhndl, *gpubuff));
+    cudaIpcMemHandle_t *memhndl =
+        reinterpret_cast<cudaIpcMemHandle_t *>(malloc(sizeof(cudaIpcMemHandle_t) * (comm->nvsize)));
 
-    cudaIpcMemHandle_t *tmp;
-    comm->_alloc_copy_allgather(reinterpret_cast<void **>(&tmp), reinterpret_cast<void *>(&memhndl),
-                                sizeof(cudaIpcMemHandle_t), comm->comm_intra);
+    CUDACHECK(cudaIpcGetMemHandle(&memhndl[comm->nvrank], *gpubuff));
 
-    for (int i = 0; i < comm->nvsize; i++) {
-      if (i != comm->nvrank) {
-        CUDACHECK(cudaIpcOpenMemHandle(&(comm->peer_ptr[hndl][i]), tmp[i],  // NOLINT(*)
-                                       cudaIpcMemLazyEnablePeerAccess));
-      }
-    }
+    MPI_Allgather(&memhndl[comm->nvrank], sizeof(cudaIpcMemHandle_t), MPI_BYTE, memhndl,
+                  sizeof(cudaIpcMemHandle_t), MPI_BYTE, comm->comm_intra);
+
+    for (int i = 0; i < comm->nvsize; i++)
+      if (i != comm->nvrank)
+        CUDACHECK(cudaIpcOpenMemHandle((void **)&(comm->peer_ptr[hndl][i]),  // NOLINT(*)
+                                       memhndl[i], cudaIpcMemLazyEnablePeerAccess));
     comm->peer_ptr[hndl][comm->nvrank] = *gpubuff;
     CUDACHECK(cudaDeviceSynchronize());
 
@@ -597,7 +497,7 @@ int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *
         comm->peer_ptr[hndl], comm->nvsize * sizeof(void *), cudaMemcpyHostToDevice));
 
     CUDACHECK(cudaDeviceSynchronize());
-    comm->_free(tmp);
+    free(memhndl);
   }
   comm->mem_size[hndl] = aligned_size;
 

--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers.h
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers.h
@@ -8,49 +8,13 @@
 #define TRANSFORMER_ENGINE_USERBUFFERS_H_
 
 #include <cuda.h>
-#include <cuda_runtime.h>
+#include <mpi.h>  // TODO (tym): Removing will remove PyT extension dependence on MPI
 #include <pthread.h>
 
 #include <chrono>
-#include <functional>
 #include <stdexcept>
 
-#ifdef UB_MPI_BOOTSTRAP
-#include <mpi.h>
-
-#include <stdexcept>
-
-#define UB_MPI_CHECK(expr)                                                                   \
-  do {                                                                                       \
-    const int mpicode = (expr);                                                              \
-    if (mpicode != MPI_SUCCESS) {                                                            \
-      char mpimsg[MPI_MAX_ERROR_STRING];                                                     \
-      int mpilen;                                                                            \
-      MPI_Error_string(mpicode, mpimsg, &mpilen);                                            \
-      std::vector<char> errmsg(1024);                                                        \
-      snprintf(errmsg.data(), errmsg.size(), "%s:%s in function %s: %s", __FILE__, __LINE__, \
-               __func__, mpimsg);                                                            \
-      throw std::runtime_error(errmsg.data());                                               \
-    }                                                                                        \
-  } while (false)
-
-typedef MPI_Comm ExtComm;
-
-void ub_alloc_copy_allgather(void **globaldata, void *localdata, size_t localbytes, ExtComm comm) {
-  int myrank, nranks;
-  UB_MPI_CHECK(MPI_Comm_rank(comm, &myrank));
-  UB_MPI_CHECK(MPI_Comm_size(comm, &nranks));
-  *globaldata = malloc(nranks * localbytes);
-  UB_MPI_CHECK(MPI_Allgather(localdata, localbytes, MPI_BYTE, *globaldata, nranks * localbytes,
-                             MPI_BYTE, comm));
-}
-
-void ub_barrier(ExtComm comm) { UB_MPI_CHECK(MPI_Barrier(comm)); }
-
-void ub_free(void *ptr) { free(ptr); }
-#else
-typedef char *ExtComm;
-#endif
+#include "cuda_runtime.h"
 
 #define NVTE_MAX_REGIONS 16
 #define NVTE_MAX_SMS 32
@@ -137,7 +101,6 @@ struct communicator {
   CUmemGenericAllocationHandle *uchandles[NVTE_MAX_REGIONS];
   void *ucbase_ptr[NVTE_MAX_REGIONS];  // only for cuMem allocated memory
   size_t mem_size[NVTE_MAX_REGIONS];
-  bool mem_dealloc[NVTE_MAX_REGIONS];
 
   void *mc_ptr[NVTE_MAX_REGIONS];
   void *mc_baseptr;
@@ -169,18 +132,9 @@ struct communicator {
   int padding2[15];
   volatile int tail;
 
-  // Abstract communication callbacks to support external bootstrapping (e.g. DL frameworks)
-  std::function<void(void **, void *, size_t, ExtComm)> _alloc_copy_allgather;
-  std::function<void(ExtComm)> _barrier;
-  std::function<void(void *)> _free;
-
-  ExtComm comm_world,
-      comm_inter,  // reduction group communicator (subset of the nodes) along GPU rail
-      comm_intra;  // full intranode (all ndev GPUS)
-#ifdef UB_MPI_BOOTSTRAP
   MPI_Request mpihndl[NVTE_MAX_SHARP];
-#endif
-
+  MPI_Comm comm_inter,  // reduction group communicator (subset of the nodes) along GPU rail
+      comm_intra;       // full intranode (all ndev GPUS)
   int *send_id, *recv_id;
   int mydev;
   uint64_t ub_timeout;
@@ -190,35 +144,18 @@ typedef struct communicator communicator;
 void producer(void *atomic_ptr, int chunk_i, cudaStream_t stream);
 void consumer(void *atomic_ptr, int chunk_i, cudaStream_t stream);
 void consumer_batch(void *atomic_ptr, int first_chunk_i, int num_chunks, cudaStream_t stream);
-
+int create_communicator(communicator **comm);
 /*  creates communicator, allocates all internal buffers if necessary */
-int create_communicator_grouped2(
-    communicator **comm, int myrank, int numranks, int mylocal, int numlocal, int mynode,
-    int numnodes, std::function<void(void **, void *, size_t, ExtComm)> ext_alloc_copy_allgather,
-    std::function<void(ExtComm)> ext_barrier, std::function<void(void *)> ext_free, int pipegpus,
-    int pipenodes, int tensorgpus, int tensornodes);
 
-int create_communicator_grouped(
-    communicator **comm, int myrank, int numranks, int mylocal, int numlocal, int mynode,
-    int numnodes, std::function<void(void **, void *, size_t, ExtComm)> ext_alloc_copy_allgather,
-    std::function<void(ExtComm)> ext_barrier, std::function<void(void *)> ext_free, int pipegpus,
-    int pipenodes);
-
-int create_communicator(
-    communicator **comm, int myrank, int numranks, int mylocal, int numlocal, int mynode,
-    int numnodes, std::function<void(void **, void *, size_t, ExtComm)> ext_alloc_copy_allgather,
-    std::function<void(ExtComm)> ext_barrier, std::function<void(void *)> ext_free);
-
-int create_communicator_grouped2_mpi(communicator **comm, int pipegpus, int pipenodes,
-                                     int tensorgpus, int tensornodes);
-
-int create_communicator_grouped_mpi(communicator **comm, int pipegpus, int pipenodes);
-
-int create_communicator_mpi(communicator **comm);
-
-void destroy_communicator(communicator *comm);
-
-void destroy_communicator_mpi(communicator *comm);
+int create_communicator_grouped(communicator **comm, int pipegpus, int pipenodes);
+int create_communicator_grouped2(communicator **comm, int pipegpus, int pipenodes, int tensorgpus,
+                                 int tensornodes);
+/*  creates communicator with
+    allreduce1 to happen in datagpus x datanodes groups,
+    allreduce2 to happen in tensorgpus x tensor nodes,
+        where num_nodes = pipenodes x tensornodes x datanodes
+            nvlink_size = pipegpus x tensorgpus x datagpus
+ */
 
 // int check_user_buffer_registration(void* gpubuff, int bytes, communicator* comm, size_t* offset);
 /*
@@ -232,7 +169,8 @@ int pipe_rank(communicator *comm,
                           // data-parallel and tensor-parallel position within data and tensor
                           // groups would be preserved
 
-int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *comm, bool alloc);
+int register_user_buffer_collective(void **gpubuff, size_t bytes, communicator *comm,
+                                    bool alloc = false);
 /*  returns handler and registers buffers. assumed to be collective i.e. you use same groups and
    dont mix buffers for different operations returns -1 if cant register (too many preregistered
    regions already) if alloc==true will allocate memory and fill the pointers (required for NVL

--- a/transformer_engine/pytorch/module/__init__.py
+++ b/transformer_engine/pytorch/module/__init__.py
@@ -9,4 +9,3 @@ from .grouped_linear import GroupedLinear
 from .layernorm_mlp import LayerNormMLP
 from .layernorm import LayerNorm
 from .rmsnorm import RMSNorm
-from .base import initialize_ub, destroy_ub

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -905,6 +905,9 @@ class LayerNormLinear(TransformerEngineBaseModule):
             assert ub_name is not None, "Userbuffer name [string] is not set."
         self.ub_name = ub_name
 
+        if any([ub_bulk_wgrad, ub_bulk_dgrad, ub_overlap_ag]):
+            assert tex.userbuf_comm_available(), "Userbuffer communication backend not available."
+
         if tp_group is None:
             self.tp_size = tp_size
             if tp_size == 1:

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -1301,6 +1301,9 @@ class LayerNormMLP(TransformerEngineBaseModule):
             and not get_ub("fc1_fprop").is_atomic_gemm()
         )
 
+        if any([ub_bulk_wgrad, ub_bulk_dgrad, ub_overlap_rs, ub_overlap_ag, ub_overlap_rs_dgrad]):
+            assert tex.userbuf_comm_available(), "Userbuffer communication backend not available."
+
         if tp_group is None:
             self.tp_size = tp_size
             if tp_size == 1:

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -755,6 +755,7 @@ class Linear(TransformerEngineBaseModule):
         self.ub_overlap_ag = ub_overlap_ag
         if ub_overlap_rs or ub_overlap_ag:
             assert ub_name is not None, "Userbuffer name [string] is not set."
+            assert tex.userbuf_comm_available(), "Userbuffer communication backend not available."
         self.ub_name = ub_name
         self.get_rng_state_tracker = get_rng_state_tracker
         self.rng_tracker_name = rng_tracker_name


### PR DESCRIPTION
# Description

This reverts commit e706e5faac64aa7c7564bbee495f814c63c2c319.

NeMo/Mcore reported issues initializing Userbuffers in multi-node configurations after PR #901.

PR #986 fixes this issue, but also exhibits a ~2% regression in performance. 

This PR reverts PR #901. MPI-dependence removal will be brought back with PR #986 once the cause of the perf regression is identified and resolved.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Reverts PR #901.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
