### PR TITLE
Fixed convergence issues with CPU offloading

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -409,7 +409,7 @@ class _LayerNormLinear(torch.autograd.Function):
             )
 
             if ctx.cpu_offloading and ctx.fuse_wgrad_accumulation:
-                weight = torch.nn.Parameter(weight)
+                weight = torch.nn.Parameter(weight.requires_grad)
                 weight.main_grad = main_grad
 
             if ctx.ub_overlap_rs_dgrad:

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -289,8 +289,6 @@ class _LayerNormLinear(torch.autograd.Function):
 
         if is_grad_enabled:
             if cpu_offloading:
-                if fuse_wgrad_accumulation:
-                    weight.main_grad.weight_offloading = True
                 if fp8 and weight_fp8 is not None:
                     weight_fp8.weight_offloading = True
                 ln_weight.weight_offloading = True
@@ -411,7 +409,7 @@ class _LayerNormLinear(torch.autograd.Function):
             )
 
             if ctx.cpu_offloading and ctx.fuse_wgrad_accumulation:
-                weight = torch.nn.Parameter(weight, False)
+                weight = torch.nn.Parameter(weight)
                 weight.main_grad = main_grad
 
             if ctx.ub_overlap_rs_dgrad:

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -567,8 +567,8 @@ class _LayerNormMLP(torch.autograd.Function):
             )
 
             if ctx.cpu_offloading and ctx.fuse_wgrad_accumulation:
-                fc1_weight = Parameter(fc1_weight)
-                fc2_weight = Parameter(fc2_weight)
+                fc1_weight = Parameter(fc1_weight.requires_grad)
+                fc2_weight = Parameter(fc2_weight.requires_grad)
 
                 fc1_weight.main_grad = fc1_weight_main_grad
                 fc2_weight.main_grad = fc2_weight_main_grad

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -425,9 +425,6 @@ class _LayerNormMLP(torch.autograd.Function):
 
         if is_grad_enabled:
             if cpu_offloading:
-                if fuse_wgrad_accumulation:
-                    fc1_weight.main_grad.weight_offloading = True
-                    fc2_weight.main_grad.weight_offloading = True
                 if fp8 and fc1_weight_fp8 is not None:
                     fc1_weight_fp8.weight_offloading = True
                 if fp8 and fc2_weight_fp8 is not None:
@@ -570,8 +567,8 @@ class _LayerNormMLP(torch.autograd.Function):
             )
 
             if ctx.cpu_offloading and ctx.fuse_wgrad_accumulation:
-                fc1_weight = Parameter(fc1_weight, False)
-                fc2_weight = Parameter(fc2_weight, False)
+                fc1_weight = Parameter(fc1_weight)
+                fc2_weight = Parameter(fc2_weight)
 
                 fc1_weight.main_grad = fc1_weight_main_grad
                 fc2_weight.main_grad = fc2_weight_main_grad

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -310,8 +310,6 @@ class _Linear(torch.autograd.Function):
                     saved_inputmat = inputmat_no_fp8
 
                 if cpu_offloading:
-                    if fuse_wgrad_accumulation:
-                        weight.main_grad.weight_offloading = True
                     if fp8 and weight_fp8 is not None:
                         weight_fp8.weight_offloading = True
                     weight.weight_offloading = True
@@ -403,7 +401,7 @@ class _Linear(torch.autograd.Function):
             )
 
             if ctx.cpu_offloading and ctx.fuse_wgrad_accumulation:
-                weight = torch.nn.Parameter(weight, False)
+                weight = torch.nn.Parameter(weight)
                 weight.main_grad = main_grad
 
             tp_world_size = get_distributed_world_size(ctx.tp_group)

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -401,7 +401,7 @@ class _Linear(torch.autograd.Function):
             )
 
             if ctx.cpu_offloading and ctx.fuse_wgrad_accumulation:
-                weight = torch.nn.Parameter(weight)
+                weight = torch.nn.Parameter(weight.requires_grad)
                 weight.main_grad = main_grad
 
             tp_world_size = get_distributed_world_size(ctx.tp_group)


### PR DESCRIPTION
Fixed convergence issues when CPU offloading is enabled.

1) When activation offloading was enabled, the reloaded weights during backprop was re-constructed into a torch.nn.Parameter with the `requires_grad` switch as false. This switch should be try to compute weight gradients. Fixed this.

2) When weights are offloaded we try to offload the gradient accumulation buffer, by doing a deep copy of this buffer and recreating this which confuses the Distributed Optimizer about this buffer location. This makes the DistOpt using a stale location to look for fresh gradients from recent micro-batches. This has been fixed by not offloading the gradient accumulation buffer. Offloading gradient accumulation buffer was considered a free lunch but this subtle issues made me go back with my decision.