### PR TITLE
[PyTorch] Update Sequential container to handle changes in module base class

### DIFF
--- a/transformer_engine/pytorch/ops/sequential.py
+++ b/transformer_engine/pytorch/ops/sequential.py
@@ -5,7 +5,6 @@
 """Sequential container for fusible operations."""
 
 from __future__ import annotations
-from collections import OrderedDict
 from collections.abc import Iterable, Iterator
 from typing import Optional
 
@@ -82,8 +81,9 @@ class Sequential(torch.nn.Module):
     ) -> Sequential | torch.nn.Module:
         keys = self._get_keys_by_idx(idx)
         if isinstance(idx, slice):
-            modules = OrderedDict((str(i), self._modules[key]) for i, key in enumerate(keys))
-            return self.__class__(modules)
+            out = Sequential()
+            out.extend(self._modules[key] for key in keys)
+            return out
         return self._modules[keys[0]]
 
     def __setitem__(self, idx: int, module: torch.nn.Module) -> None:

--- a/transformer_engine/pytorch/ops/sequential.py
+++ b/transformer_engine/pytorch/ops/sequential.py
@@ -39,7 +39,7 @@ class Sequential(torch.nn.Module):
         self._module_groups = None
 
         # Add modules
-        if len(args) == 1 and isinstance(args[0], OrderedDict):
+        if len(args) == 1 and isinstance(args[0], dict):
             for key, module in args[0].items():
                 self.add_module(key, module)
         else:
@@ -129,11 +129,12 @@ class Sequential(torch.nn.Module):
         del self[idx]
         return out
 
-    def __iadd__(self, other: Sequential) -> Sequential:
-        return self.extend(other)
+    def __iadd__(self, modules: Iterable[torch.nn.Modules]) -> Sequential:
+        return self.extend(modules)
 
     def __add__(self, modules: Iterable[torch.nn.Modules]) -> Sequential:
-        out = self.__class__(self._modules)
+        out = Sequential()
+        out.extend(self)
         out.extend(modules)
         return out
 


### PR DESCRIPTION
# Description

https://github.com/pytorch/pytorch/pull/130199 changed `torch.nn.Module` so it stores internal modules in a `dict` instead of a `collections.OrderedDict`. This PR fixes some resulting test failures with `te.Sequential`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Update sequential container to handle storing modules in plain dicts

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
