### PR TITLE
Update minimum CMake version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Dependencies'
         run: |
           apt-get update
-          apt-get install -y git python3.8 pip ninja-build cudnn9-cuda-12
+          apt-get install -y git python3.9 pip ninja-build cudnn9-cuda-12
           pip install cmake==3.21.0
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'Dependencies'
         run: |
           apt-get update
-          apt-get install -y git python3.7 pip ninja-build cudnn9-cuda-12
+          apt-get install -y git python3.8 pip ninja-build cudnn9-cuda-12
           pip install cmake==3.21.0
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
       - name: 'Dependencies'
         run: |
           apt-get update
-          apt-get install -y git python3.9 pip cmake ninja-build cudnn9-cuda-12
+          apt-get install -y git python3.7 pip ninja-build cudnn9-cuda-12
+          pip install cmake==3.21.0
       - name: 'Checkout'
         uses: actions/checkout@v3
         with:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
 
     # Requirements that may be installed outside of Python
     if not found_cmake():
-        setup_reqs.append("cmake>=3.18")
+        setup_reqs.append("cmake>=3.21")
     if not found_ninja():
         setup_reqs.append("ninja")
     if not found_pybind11():

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # See LICENSE for license information.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.21)
 
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   set(CMAKE_CUDA_ARCHITECTURES 70 80 89 90)
@@ -18,7 +18,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
 endif()
 
-find_package(CUDAToolkit REQUIRED cublas nvToolsExt)
+find_package(CUDAToolkit REQUIRED)
 
 # Check for cuDNN frontend API
 set(CUDNN_FRONTEND_INCLUDE_DIR
@@ -79,7 +79,6 @@ target_link_libraries(transformer_engine PUBLIC
                       CUDA::cuda_driver
                       CUDA::cudart
                       CUDA::nvrtc
-                      CUDA::nvToolsExt
                       CUDNN::cudnn)
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})


### PR DESCRIPTION
# Description

We have had users run into build errors using CMake 3.20 (see https://github.com/NVIDIA/TransformerEngine/issues/803#issuecomment-2128275904), so this PR bumps the minimum version to 3.21 and uses it in the core-only build test. I may bump the version again if the build test fails.

I've also removed logic that links NVTX. https://github.com/NVIDIA/TransformerEngine/pull/1025 upgraded to NVTX 3, which is header-only.

Closes https://github.com/NVIDIA/TransformerEngine/issues/803. Also see https://github.com/NVIDIA/TransformerEngine/pull/943.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

- Increase minimum CMake version
- No longer link to NVTX

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
