### PR TITLE
Fix build error with Paddle >2.6.1

### DIFF
--- a/transformer_engine/paddle/csrc/custom_ops.cu
+++ b/transformer_engine/paddle/csrc/custom_ops.cu
@@ -1379,7 +1379,8 @@ void amax_and_scale_update_inplace_legacy(
   auto amax_numel = amax.numel();
   size_t num_blocks = (amax_history_numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
-  const int *current_step_id_ptr = reinterpret_cast<const int*>(GetOptionalDataPtr(current_step_id_tensor));
+  const int *current_step_id_ptr =
+      reinterpret_cast<const int *>(GetOptionalDataPtr(current_step_id_tensor));
   auto parameterSetter = [current_step_id_ptr,
                           fwd_update](phi::backends::gpu::CUDAKernelParams &params) {
     if (fwd_update) {

--- a/transformer_engine/paddle/csrc/custom_ops.cu
+++ b/transformer_engine/paddle/csrc/custom_ops.cu
@@ -1379,7 +1379,7 @@ void amax_and_scale_update_inplace_legacy(
   auto amax_numel = amax.numel();
   size_t num_blocks = (amax_history_numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
-  const int *current_step_id_ptr = GetOptionalDataPtr<int>(current_step_id_tensor);
+  const int *current_step_id_ptr = reinterpret_cast<const int*>(GetOptionalDataPtr(current_step_id_tensor));
   auto parameterSetter = [current_step_id_ptr,
                           fwd_update](phi::backends::gpu::CUDAKernelParams &params) {
     if (fwd_update) {


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1029 introduced a compilation error when cherry-picked into the `release_v1.9` branch. I would expect a similar error to show up when building with Paddle 2.7+.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Fix compilation error in Paddle extension

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
