### PR TITLE
Fixes for pip wheels

### DIFF
--- a/build_tools/wheel_utils/build_wheels.sh
+++ b/build_tools/wheel_utils/build_wheels.sh
@@ -11,9 +11,8 @@ BUILD_PYTORCH=${4:-true}
 BUILD_PADDLE=${5:-true}
 
 export NVTE_RELEASE_BUILD=1
-export TARGET_BRANCH=${TARGET_BRANCH:-wheels}
-mkdir /wheelhouse
-mkdir /wheelhouse/logs
+export TARGET_BRANCH=${TARGET_BRANCH:-}
+mkdir -p /wheelhouse/logs
 
 # Generate wheels for common library.
 git config --global --add safe.directory /TransformerEngine

--- a/qa/L0_paddle_wheel/test.sh
+++ b/qa/L0_paddle_wheel/test.sh
@@ -15,7 +15,6 @@ cd transformer_engine/paddle
 python setup.py bdist_wheel
 
 export NVTE_RELEASE_BUILD=0
-cd $TE_PATH
 pip install dist/*
 
 python $TE_PATH/tests/paddle/test_sanity_import.py

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(${PROJECT_SOURCE_DIR}/..)
 # Configure Transformer Engine library
 set(transformer_engine_SOURCES)
 list(APPEND transformer_engine_SOURCES
+     pycudnn.cpp
      transformer_engine.cpp
      transpose/cast_transpose.cu
      transpose/transpose.cu
@@ -71,6 +72,8 @@ list(APPEND transformer_engine_SOURCES
 add_library(transformer_engine SHARED ${transformer_engine_SOURCES})
 target_include_directories(transformer_engine PUBLIC
                            "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_compile_definitions(transformer_engine PUBLIC NV_CUDNN_FRONTEND_USE_DYNAMIC_LOADING)
 
 # Configure dependencies
 target_link_libraries(transformer_engine PUBLIC

--- a/transformer_engine/common/pycudnn.cpp
+++ b/transformer_engine/common/pycudnn.cpp
@@ -1,0 +1,14 @@
+/*************************************************************************
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+namespace cudnn_frontend {
+
+// This is needed to define the symbol `cudnn_dlhandle`
+// When using the flag NV_CUDNN_FRONTEND_USE_DYNAMIC_LOADING
+// to enable dynamic loading.
+void *cudnn_dlhandle = nullptr;
+
+}  // namespace cudnn_frontend


### PR DESCRIPTION
# Description

A follow-up PR to #1036 mainly enabling dynamic loading of a different cudnn lib version at runtime.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Use dynamic loading for cudnn-frontend using CMake flag.
- Add the symbol for cudnn_dlhandle to debug linker issue.
- Minor fix in paddle wheel CI test.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
