### PR TITLE
Change condition for ub tp overlap.

### DIFF
--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -111,7 +111,7 @@ class _Linear(torch.autograd.Function):
             assert_dim_for_fp8_exec(weight)
 
         tp_world_size = get_distributed_world_size(tp_group)
-        ub_overlap_rs = False if tp_world_size == 1 else ub_overlap_rs
+        ub_overlap_rs = False if tp_world_size == 1 or parallel_mode != "row" else ub_overlap_rs
 
         # Cast input to expected dtype
         inputmat = cast_if_needed(inputmat, activation_dtype)
@@ -405,7 +405,7 @@ class _Linear(torch.autograd.Function):
                 weight.main_grad = main_grad
 
             tp_world_size = get_distributed_world_size(ctx.tp_group)
-            ctx.ub_overlap_ag = False if tp_world_size == 1 else ctx.ub_overlap_ag
+            ctx.ub_overlap_ag = False if tp_world_size == 1 or ctx.parallel_mode != "row" else ctx.ub_overlap_ag
             if ctx.ub_overlap_ag:
                 dim_size = list(grad_output.size())
                 dim_size[0] = dim_size[0] * tp_world_size

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -405,7 +405,9 @@ class _Linear(torch.autograd.Function):
                 weight.main_grad = main_grad
 
             tp_world_size = get_distributed_world_size(ctx.tp_group)
-            ctx.ub_overlap_ag = False if tp_world_size == 1 or ctx.parallel_mode != "row" else ctx.ub_overlap_ag
+            ctx.ub_overlap_ag = (
+                False if tp_world_size == 1 or ctx.parallel_mode != "row" else ctx.ub_overlap_ag
+            )
             if ctx.ub_overlap_ag:
                 dim_size = list(grad_output.size())
                 dim_size[0] = dim_size[0] * tp_world_size


### PR DESCRIPTION
# Description

For MoELayer in MCore, we set `parallel_mode=None` to explicitly handle communications between TPxEP group. When using `--tp-comm-overlap`, the `ub_overlap_rs` will be enabled even when `parallel_mode=None`, which caused wrong results.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
