### PR TITLE
Use pyproject.toml to specify build requirements

### DIFF
--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -360,10 +360,3 @@ def copy_common_headers(
         new_path = dst_dir / path.relative_to(src_dir)
         new_path.parent.mkdir(exist_ok=True, parents=True)
         shutil.copy(path, new_path)
-
-
-def install_and_import(package):
-    """Install a package via pip (if not already installed) and import into globals."""
-    main_package = package.split("[")[0]
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
-    globals()[main_package] = importlib.import_module(main_package)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+[build-system]
+requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "ninja", "pip"]
+
+# Use legacy backend to import local packages in setup.py
+build-backend = "setuptools.build_meta:__legacy__"
+

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ from build_tools.utils import (
     found_ninja,
     found_pybind11,
     get_frameworks,
-    install_and_import,
     remove_dups,
     cuda_toolkit_include_path,
 )
@@ -36,7 +35,6 @@ os.environ["NVTE_PROJECT_BUILDING"] = "1"
 if "pytorch" in frameworks:
     from torch.utils.cpp_extension import BuildExtension
 elif "jax" in frameworks:
-    install_and_import("pybind11[global]")
     from pybind11.setup_helpers import build_ext as BuildExtension
 
 

--- a/transformer_engine/jax/pyproject.toml
+++ b/transformer_engine/jax/pyproject.toml
@@ -3,7 +3,7 @@
 # See LICENSE for license information.
 
 [build-system]
-requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "ninja", "pip"]
+requires = ["setuptools>=61.0", "pybind11[global]", "pip", "jax[cuda12]", "flax>=0.7.1"]
 
 # Use legacy backend to import local packages in setup.py
 build-backend = "setuptools.build_meta:__legacy__"

--- a/transformer_engine/jax/pyproject.toml
+++ b/transformer_engine/jax/pyproject.toml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+[build-system]
+requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "ninja", "pip"]
+
+# Use legacy backend to import local packages in setup.py
+build-backend = "setuptools.build_meta:__legacy__"
+

--- a/transformer_engine/jax/setup.py
+++ b/transformer_engine/jax/setup.py
@@ -100,7 +100,6 @@ if __name__ == "__main__":
         description="Transformer acceleration library - Jax Lib",
         ext_modules=ext_modules,
         cmdclass={"build_ext": CMakeBuildExtension},
-        setup_requires=setup_requires,
         install_requires=["jax", "flax>=0.7.1"],
         tests_require=["numpy"],
     )

--- a/transformer_engine/jax/setup.py
+++ b/transformer_engine/jax/setup.py
@@ -44,11 +44,10 @@ if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or os.path.isdir(build_tools_
 
 
 from build_tools.build_ext import get_build_ext
-from build_tools.utils import copy_common_headers, install_and_import, cuda_toolkit_include_path
+from build_tools.utils import copy_common_headers, cuda_toolkit_include_path
 from build_tools.te_version import te_version
 from build_tools.jax import setup_jax_extension
 
-install_and_import("pybind11")
 from pybind11.setup_helpers import build_ext as BuildExtension
 
 os.environ["NVTE_PROJECT_BUILDING"] = "1"

--- a/transformer_engine/jax/setup.py
+++ b/transformer_engine/jax/setup.py
@@ -44,7 +44,7 @@ if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or os.path.isdir(build_tools_
 
 
 from build_tools.build_ext import get_build_ext
-from build_tools.utils import copy_common_headers, cuda_toolkit_include_path
+from build_tools.utils import copy_common_headers
 from build_tools.te_version import te_version
 from build_tools.jax import setup_jax_extension
 
@@ -92,20 +92,6 @@ if __name__ == "__main__":
             "csrc", current_file_path / "csrc", current_file_path / common_headers_dir
         )
     ]
-
-    setup_requires = ["jax[cuda12]", "flax>=0.7.1"]
-    if cuda_toolkit_include_path() is None:
-        setup_requires.extend(
-            [
-                "nvidia-cuda-runtime-cu12",
-                "nvidia-cublas-cu12",
-                "nvidia-cudnn-cu12",
-                "nvidia-cuda-cccl-cu12",
-                "nvidia-cuda-nvcc-cu12",
-                "nvidia-nvtx-cu12",
-                "nvidia-cuda-nvrtc-cu12",
-            ]
-        )
 
     # Configure package
     setuptools.setup(

--- a/transformer_engine/pytorch/pyproject.toml
+++ b/transformer_engine/pytorch/pyproject.toml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+[build-system]
+requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "ninja", "pip"]
+
+# Use legacy backend to import local packages in setup.py
+build-backend = "setuptools.build_meta:__legacy__"
+

--- a/transformer_engine/pytorch/pyproject.toml
+++ b/transformer_engine/pytorch/pyproject.toml
@@ -3,7 +3,7 @@
 # See LICENSE for license information.
 
 [build-system]
-requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "ninja", "pip"]
+requires = ["setuptools>=61.0", "pip", "torch>=2.1"]
 
 # Use legacy backend to import local packages in setup.py
 build-backend = "setuptools.build_meta:__legacy__"

--- a/transformer_engine/pytorch/setup.py
+++ b/transformer_engine/pytorch/setup.py
@@ -29,7 +29,7 @@ if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or os.path.isdir(build_tools_
 
 
 from build_tools.build_ext import get_build_ext
-from build_tools.utils import copy_common_headers, cuda_toolkit_include_path
+from build_tools.utils import copy_common_headers
 from build_tools.te_version import te_version
 from build_tools.pytorch import setup_pytorch_extension
 
@@ -48,20 +48,6 @@ if __name__ == "__main__":
         )
     ]
 
-    setup_requires = ["torch>=2.1"]
-    if cuda_toolkit_include_path() is None:
-        setup_requires.extend(
-            [
-                "nvidia-cuda-runtime-cu12",
-                "nvidia-cublas-cu12",
-                "nvidia-cudnn-cu12",
-                "nvidia-cuda-cccl-cu12",
-                "nvidia-cuda-nvcc-cu12",
-                "nvidia-nvtx-cu12",
-                "nvidia-cuda-nvrtc-cu12",
-            ]
-        )
-
     # Configure package
     setuptools.setup(
         name="transformer_engine_torch",
@@ -69,7 +55,6 @@ if __name__ == "__main__":
         description="Transformer acceleration library - Torch Lib",
         ext_modules=ext_modules,
         cmdclass={"build_ext": CMakeBuildExtension},
-        setup_requires=setup_requires,
         install_requires=["torch>=2.1"],
         tests_require=["numpy", "torchvision"],
     )


### PR DESCRIPTION
# Description

`setup_requires` is deprecated ([pep ref](https://peps.python.org/pep-0517/)) and will be removed in `setuptools` v75.0.0. This PR uses the newer `pyproject.toml` to specify build time dependencies. We can consider gradually moving over other functionality to `pyproject.toml` as required.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
