### PR TITLE
Pin NLTK version to fix JAX ci

### DIFF
--- a/qa/L0_jax_unittest/test.sh
+++ b/qa/L0_jax_unittest/test.sh
@@ -4,6 +4,7 @@
 
 set -xe
 
+pip install nltk==3.8.1
 pip install pytest==8.2.1
 : ${TE_PATH:=/opt/transformerengine}
 


### PR DESCRIPTION
# Description

NLTK's latest versions have introduced a [bug](https://github.com/Unstructured-IO/unstructured/issues/3511) resulting in JAX ci failures.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Pin NLTK version to 3.8.1 for CI tests.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
