### PR TITLE
[TE/JAX] Add default include path for XLA FFI

### DIFF
--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -9,8 +9,27 @@ from pathlib import Path
 import setuptools
 from glob import glob
 
-from .utils import cuda_path, xla_path, all_files_in_dir
+from .utils import cuda_path, all_files_in_dir
 from typing import List
+
+
+def xla_path() -> str:
+    """XLA root path lookup.
+    Throws FileNotFoundError if XLA source is not found."""
+
+    try:
+        from jax.extend import ffi
+    except ImportError:
+        if os.getenv("XLA_HOME"):
+            xla_home = Path(os.getenv("XLA_HOME"))
+        else:
+            xla_home = "/opt/xla"
+    else:
+        xla_home = ffi.include_dir()
+
+    if not os.path.isdir(xla_home):
+        raise FileNotFoundError("Could not find xla source.")
+    return xla_home
 
 
 def setup_jax_extension(

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -24,6 +24,7 @@ else:
 if not os.path.isdir(jax_ffi_include):
     raise Exception("Can not locate the XLA FFI include directory!")
 
+
 def setup_jax_extension(
     csrc_source_files,
     csrc_header_files,

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -9,20 +9,8 @@ from pathlib import Path
 import setuptools
 from glob import glob
 
-from .utils import cuda_path, all_files_in_dir
+from .utils import cuda_path, xla_path, all_files_in_dir
 from typing import List
-
-
-try:
-    from jax.extend import ffi
-except ImportError:
-    jax_ffi_include = "/opt/xla"
-    pass
-else:
-    jax_ffi_include = ffi.include_dir()
-
-if not os.path.isdir(jax_ffi_include):
-    raise Exception("Can not locate the XLA FFI include directory!")
 
 
 def setup_jax_extension(
@@ -40,13 +28,14 @@ def setup_jax_extension(
 
     # Header files
     cuda_home, _ = cuda_path()
+    xla_home = xla_path()
     include_dirs = [
         cuda_home / "include",
         common_header_files,
         common_header_files / "common",
         common_header_files / "common" / "include",
         csrc_header_files,
-        jax_ffi_include,
+        xla_home,
     ]
 
     # Compile flags

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -2,7 +2,8 @@
 #
 # See LICENSE for license information.
 
-"""Paddle-paddle related extensions."""
+"""JAX related extensions."""
+import os
 from pathlib import Path
 
 import setuptools
@@ -11,8 +12,17 @@ from glob import glob
 from .utils import cuda_path, all_files_in_dir
 from typing import List
 
-from jax.extend import ffi
 
+try:
+    from jax.extend import ffi
+except ImportError:
+    jax_ffi_include = "/opt/xla"
+    pass
+else:
+    jax_ffi_include = ffi.include_dir()
+
+if not os.path.isdir(jax_ffi_include):
+    raise Exception("Can not locate the XLA FFI include directory!")
 
 def setup_jax_extension(
     csrc_source_files,
@@ -29,7 +39,6 @@ def setup_jax_extension(
 
     # Header files
     cuda_home, _ = cuda_path()
-    jax_ffi_include = ffi.include_dir()
     include_dirs = [
         cuda_home / "include",
         common_header_files,

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -203,6 +203,26 @@ def cuda_version() -> Tuple[int, ...]:
     return tuple(int(v) for v in version)
 
 
+@functools.lru_cache(maxsize=None)
+def xla_path() -> str:
+    """XLA root path lookup.
+    Throws FileNotFoundError if XLA source is not found."""
+
+    try:
+        from jax.extend import ffi
+    except ImportError:
+        if os.getenv("XLA_HOME"):
+            xla_home = Path(os.getenv("XLA_HOME"))
+        else:
+            xla_home = "/opt/xla"
+    else:
+        xla_home = ffi.include_dir()
+
+    if not os.path.isdir(xla_home):
+        raise FileNotFoundError("Could not find xla source.")
+    return xla_home
+
+
 def get_frameworks() -> List[str]:
     """DL frameworks to build support for"""
     _frameworks: List[str] = []

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -203,26 +203,6 @@ def cuda_version() -> Tuple[int, ...]:
     return tuple(int(v) for v in version)
 
 
-@functools.lru_cache(maxsize=None)
-def xla_path() -> str:
-    """XLA root path lookup.
-    Throws FileNotFoundError if XLA source is not found."""
-
-    try:
-        from jax.extend import ffi
-    except ImportError:
-        if os.getenv("XLA_HOME"):
-            xla_home = Path(os.getenv("XLA_HOME"))
-        else:
-            xla_home = "/opt/xla"
-    else:
-        xla_home = ffi.include_dir()
-
-    if not os.path.isdir(xla_home):
-        raise FileNotFoundError("Could not find xla source.")
-    return xla_home
-
-
 def get_frameworks() -> List[str]:
     """DL frameworks to build support for"""
     _frameworks: List[str] = []


### PR DESCRIPTION
# Description

PR #946 added new custom calls with FFI, which requires XLA FFI path to be included for the cmake build. 
`jax.extend.ffi.include_dir()` was used to extract the path which caused an [issue in the NVIDIA/JAX-Toolbox](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/10385063935/job/28753692698#step:10:2073), as `jax` is not installed at the time TE wheel build, thus impossible to import.

This PR added an option to use a default path if `jax` is unavailable.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
