### PR TITLE
Remove Total Time Measurement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,6 @@ elif "jax" in frameworks:
     install_and_import("pybind11[global]")
     from pybind11.setup_helpers import build_ext as BuildExtension
 
-# Start timing
-start_time = time.perf_counter()
-
 
 CMakeBuildExtension = get_build_ext(BuildExtension)
 
@@ -55,7 +52,7 @@ class TimedBdist(bdist_wheel):
         start_time = time.perf_counter()
         super().run()
         total_time = time.perf_counter() - start_time
-        print(f"Time for bdist_wheel: {total_time:.2f} seconds")
+        print(f"Total time for bdist_wheel: {total_time:.2f} seconds")
 
 
 def setup_common_extension() -> CMakeExtension:
@@ -171,8 +168,3 @@ if __name__ == "__main__":
         include_package_data=True,
         package_data={"": ["VERSION.txt"]},
     )
-
-    # End timing
-    end_time = time.perf_counter()
-    total_time = end_time - start_time
-    print(f"Total build time: {total_time:.2f} seconds")


### PR DESCRIPTION
# Description

Remove total time measurement as having bdist time is already a good indicator. 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
