### PR TITLE
Remove the commit hash from the release documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,10 @@ if not git_sha:
 
 git_sha = git_sha[:7] if len(git_sha) > 7 else git_sha
 
-version = str(te_version + "-" + git_sha)
+if "dev" in te_version:
+    version = str(te_version + "-" + git_sha)
+else:
+    version = str(te_version)
 release = te_version
 
 # hack: version is used for html creation, so put the version picker


### PR DESCRIPTION
# Description

This PR removes the commit hash from the release version of the documentation. This is because we changed the branching model of the repo and the commit hashes in the `stable` branch no longer correspond to the hashes we use to build the documentation (which are tips of the `release_vX.X` branches), even though the content is the same. In order to avoid confusion it is better to just not include the hash.

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Removed the commit hash from the version string visible in the documentation

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
