### PR TITLE
[PyTorch] make GroupedLinear inp support collection of torch.Tensor

### DIFF
--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -717,7 +717,6 @@ class GroupedLinear(TransformerEngineBaseModule):
         self,
         inp: Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]],
         m_splits: List[int],
-        split_inp: Optional[bool] = True,
         is_first_microbatch: Optional[bool] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, ...]]:
         """
@@ -725,8 +724,11 @@ class GroupedLinear(TransformerEngineBaseModule):
 
         Parameters
         ----------
-        inp : torch.Tensor
-             Input tensor.
+        inp : {torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]}
+             Input tensor or collection of input tensor.
+
+             * `inp` will be split base `m_splits` if type of `inp` is torch.tensor.
+             * assume `inp` is split base `m_splits` if `inp` is collection of torch.Tensor.
         m_splits : List[int]
                  List of integers representing the split of the input tensor.
         is_first_microbatch : {True, False, None}, default = None
@@ -744,13 +746,11 @@ class GroupedLinear(TransformerEngineBaseModule):
                                produced)
         """
         if isinstance(inp, torch.Tensor):
-            assert split_inp == True, "split_inp must be set True when inp is torch.Tensor"
+            split_inp = True
             inputmats = [inp]
         else:
             # inp is a list or tuple
-            assert (
-                split_inp == False
-            ), "split_inp must be set False when inp is collection of torch.Tensor"
+            split_inp = False
             inputmats = inp
 
         for inp in inputmats:

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -717,6 +717,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         self,
         inp: Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]],
         m_splits: List[int],
+        split_inp: Optional[bool] = True,
         is_first_microbatch: Optional[bool] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, ...]]:
         """
@@ -742,12 +743,14 @@ class GroupedLinear(TransformerEngineBaseModule):
                                first microbatch (since it is the first gradient being
                                produced)
         """
-        split_inp = False
         if isinstance(inp, torch.Tensor):
-            split_inp = True
+            assert split_inp == True, "split_inp must be set True when inp is torch.Tensor"
             inputmats = [inp]
         else:
             # inp is a list or tuple
+            assert (
+                split_inp == False
+            ), "split_inp must be set False when inp is collection of torch.Tensor"
             inputmats = inp
 
         for inp in inputmats:


### PR DESCRIPTION
# Description

For FP8 GroupedMLP linear_fc1, to make sure Tensor shape is aligned by 16 we will split activation and pad each tensor then concat list of Tensor as GroupedLinear `inp` args.

**e.g.**
```python
class TEGroupedMLP(MegatronModule):
...
    forward(self, permuted_local_hidden_states: torch.Tensor, tokens_per_expert: torch.Tensor):
        def _pad_tensor(inp: torch.Tensor):
            if inp.shape[0] % 16 == 0:
                return inp
            pad_len = (inp.shape[0] + 15) // 16 * 16 - inp.shape[0]
            pad_tensor = torch.zeros(pad_len, inp.shape[1], dtype=inp.dtype, device=inp.device)
            return torch.cat((inp, pad_tensor), dim=0)

        tokens_per_expert = tokens_per_expert.tolist()
        if self.config.fp8:
            splited_permuted_local_hidden_states = torch.split(
                permuted_local_hidden_states.view(-1, permuted_local_hidden_states.shape[-1]), tokens_per_expert)
            splited_pad_permuted_local_hidden_states = [_pad_tensor(hidden_states) for hidden_states in splited_permuted_local_hidden_states]
            orig_tokens_per_expert = tokens_per_expert
            tokens_per_expert = [hidden_states.shape[0] for hidden_states in splited_pad_permuted_local_hidden_states]
            permuted_local_hidden_states = torch.cat(splited_pad_permuted_local_hidden_states, dim=0)

        intermediate_parallel, bias_parallel = self.linear_fc1(
            permuted_local_hidden_states, tokens_per_expert
        )
...
```

In _GroupedLinear it will split `inp` base `m_splits`. Actually the cat and split is duplicated in this place. We hope _GroupedLinear can accept `inp` as a collection of Tensor (e.g List[torch.Tensor] or Tuple[torch.Tensor]) to **reduce 2 * cat kernel call (1 * forward + 1 * backward)**.

**profiling:**
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/6cfe59b5-7bbd-4faa-880b-233ab827776c">



Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Make GroupedLinear `inp` support collection of torch.Tensor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
