### PR TITLE
don't put master_param to state if None

### DIFF
--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -219,10 +219,8 @@ class FusedAdam(torch.optim.Optimizer):
                         assert (
                             state["master_param"].shape == p.shape
                         ), "Master weights shape must match model weights shape"
-                    else:
-                        state["master_param"] = None
 
-                p_master = state["master_param"]
+                p_master = state.get("master_param", None)
                 p_grad = p.grad
 
                 if self.master_weights and p_master is not None and p_master.grad is not None:


### PR DESCRIPTION
# Description

Avoid adding master_param to state dict if value is None.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
