### PR TITLE
[PyTorch] Remove some direct calls to PyTorch extensions in `Float8Tensor`

### DIFF
--- a/transformer_engine/pytorch/cpp_extensions/_common.py
+++ b/transformer_engine/pytorch/cpp_extensions/_common.py
@@ -68,13 +68,13 @@ def canonicalize_fp8_scales(
     # Force offsets to be the same if needed
     if not allow_multiple_offsets and not scale_offset == amax_offset == scale_inv_offset:
         if scale_offset != 0:
-            scale = scale[scale_offset]
+            scale = scale[scale_offset:]
             scale_offset = 0
         if amax_offset != 0:
-            amax = amax[0][amax_offset]
+            amax = amax[:, amax_offset:]
             amax_offset = 0
         if scale_inv_offset != 0:
-            scale_inv = scale_inv[scale_inv_offset]
+            scale_inv = scale_inv[scale_inv_offset:]
             scale_inv_offset = 0
 
     # Pack tensors and offsets into dicts

--- a/transformer_engine/pytorch/cpp_extensions/cast.py
+++ b/transformer_engine/pytorch/cpp_extensions/cast.py
@@ -81,8 +81,7 @@ def cast_from_fp8(
 
     # Construct empty tensors if needed
     if scale_inv is None:
-        scale_inv = empty_tensor()
-        scale_inv_offset = 0
+        raise ValueError("Did not provide either `scale_inv` or `fp8_meta_tensor`")
 
     # Launch FP8 cast kernel
     return torch.ops.tex_ts.cast_from_fp8_ts(

--- a/transformer_engine/pytorch/float8_tensor.py
+++ b/transformer_engine/pytorch/float8_tensor.py
@@ -146,7 +146,9 @@ class _ToFloat8Func(torch.autograd.Function):
             if isinstance(scale, torch.Tensor):
                 scale = scale.to(device=tensor.device, dtype=torch.float32)
                 if scale.numel() != 1:
-                    raise ValueError("Attempted to initialize Float8Tensor with invalid scale tensor")
+                    raise ValueError(
+                        "Attempted to initialize Float8Tensor with invalid scale tensor"
+                    )
             else:
                 if scale is None:
                     scale = 1


### PR DESCRIPTION
# Description

When `Float8Tensor` launches TE kernels, it directly calls the PyTorch extensions rather than using the Python wrapper functions in `te.pytorch.cpp_extensions`. This is because the Python wrapper functions required passing in `FP8TensorMeta` objects. https://github.com/NVIDIA/TransformerEngine/pull/1083 changed the APIs so the `FP8TensorMeta`s are optional. This PR takes advantage of these new APIs, which also has the effect of registering FP8 casts with TorchScript.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refractor

## Changes

- Replace `tex.cast_to_fp8` and `tex.cast_from_fp8` calls in `Float8Tensor` with `cpp_extensions` wrappers

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
