### PR TITLE
Don't save fp8 q/k/v/out tensors when using bf16 bprop

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -4727,6 +4727,7 @@ class FusedAttnFunc_qkvpacked(torch.autograd.Function):
 
         ctx.fp8 = fp8 and int(os.getenv("NVTE_FP8_DPA_BWD", "1"))
         qkvo_tensors = (qkv, out_save) if not ctx.fp8 else (None, None)
+        fp8_tensors = fp8_tensors if ctx.fp8 else (None, None, None, None)
         ctx.save_for_backward(
             *qkvo_tensors, cu_seqlens, cu_seqlens_padded, *fp8_tensors, *aux_ctx_tensors
         )
@@ -5115,6 +5116,7 @@ class FusedAttnFunc_kvpacked(torch.autograd.Function):
 
         ctx.fp8 = fp8 and int(os.getenv("NVTE_FP8_DPA_BWD", "1"))
         qkvo_tensors = (q, kv, out_save) if not ctx.fp8 else (None, None, None)
+        fp8_tensors = fp8_tensors if ctx.fp8 else (None, None, None, None, None)
         ctx.save_for_backward(
             *qkvo_tensors,
             cu_seqlens_q,
@@ -5627,6 +5629,7 @@ class FusedAttnFunc(torch.autograd.Function):
 
         ctx.fp8 = fp8 and int(os.getenv("NVTE_FP8_DPA_BWD", "1"))
         qkvo_tensors = (q, k, v, out_save) if not ctx.fp8 else (None, None, None, None)
+        fp8_tensors = fp8_tensors if ctx.fp8 else (None, None, None, None, None, None)
         ctx.save_for_backward(
             *qkvo_tensors,
             cu_seqlens_q,


### PR DESCRIPTION
# Description

**When using `FP8_DPA=1 NVTE_FP8_DPA_BWD=0`, the backprop uses BF16 q/k/v/out tensors and the fp8 q/k/v/o are not used. So we should avoid saving them for backprop, which reduces the peak memory footprint.** 

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
