### PR TITLE
[PyTorch/C] Exposed Userbuffers configuration option to control comm and compute stream priorities

### DIFF
--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -145,6 +145,31 @@ const std::string &include_directory(bool required) {
   return path;
 }
 
+std::pair<int, int> stream_priority_range(int device_id) {
+  int ori_dev;
+  if (device_id >= 0) {
+    ori_dev = current_device();
+    NVTE_CHECK_CUDA(cudaSetDevice(device_id));
+  }
+  int min_priority, max_priority;
+  NVTE_CHECK_CUDA(cudaDeviceGetStreamPriorityRange(&min_priority, &max_priority));
+  if (device_id >= 0)
+    NVTE_CHECK_CUDA(cudaSetDevice(ori_dev));
+  return std::make_pair(min_priority, max_priority);
+}
+
+bool supports_multicast(int device_id) {
+  int result;
+  CUdevice cudev;
+  if (device_id < 0)
+    NVTE_CHECK_CUDA(cudaGetDevice(&device_id));
+  NVTE_CALL_CHECK_CUDA_DRIVER(cuDeviceGet, &cudev, device_id);
+  NVTE_CALL_CHECK_CUDA_DRIVER(cuDeviceGetAttribute, &result,
+                              CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cudev);
+
+  return static_cast<bool>(result);
+}
+
 }  // namespace cuda
 
 }  // namespace transformer_engine

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -102,8 +102,7 @@ void stream_priority_range(int *lowest_priority, int *highest_priority, int devi
 bool supports_multicast(int device_id) {
   static std::vector<bool> cache(num_devices());
   static std::vector<std::once_flag> flags(num_devices());
-  if (device_id < 0)
-    device_id = current_device();
+  if (device_id < 0) device_id = current_device();
 
   NVTE_CHECK(0 <= device_id && device_id < num_devices(), "invalid CUDA device ID");
   auto init = [&]() {

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -153,16 +153,14 @@ std::pair<int, int> stream_priority_range(int device_id) {
   }
   int min_priority, max_priority;
   NVTE_CHECK_CUDA(cudaDeviceGetStreamPriorityRange(&min_priority, &max_priority));
-  if (device_id >= 0)
-    NVTE_CHECK_CUDA(cudaSetDevice(ori_dev));
+  if (device_id >= 0) NVTE_CHECK_CUDA(cudaSetDevice(ori_dev));
   return std::make_pair(min_priority, max_priority);
 }
 
 bool supports_multicast(int device_id) {
   int result;
   CUdevice cudev;
-  if (device_id < 0)
-    NVTE_CHECK_CUDA(cudaGetDevice(&device_id));
+  if (device_id < 0) NVTE_CHECK_CUDA(cudaGetDevice(&device_id));
   NVTE_CALL_CHECK_CUDA_DRIVER(cuDeviceGet, &cudev, device_id);
   NVTE_CALL_CHECK_CUDA_DRIVER(cuDeviceGetAttribute, &result,
                               CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cudev);

--- a/transformer_engine/common/util/cuda_runtime.h
+++ b/transformer_engine/common/util/cuda_runtime.h
@@ -38,6 +38,22 @@ int sm_arch(int device_id = -1);
  */
 int sm_count(int device_id = -1);
 
+/* \brief Minimum and maximum stream priorities supported on device
+ *
+ * \param[in] device_id CUDA device (default is current device)
+ *
+ * \return Minimum and maximum stream priorities (zero if device does not support priorities)
+ */
+std::pair<int, int> stream_priority_range(int device_id = -1);
+
+/* \brief Check if device supports CUDA Multicast features
+ *
+ * \param[in] device_id CUDA device (default is current device)
+ *
+ * \return Support status for CUDA Multicast for given device ID
+ */
+bool supports_multicast(int device_id = -1);
+
 /* \brief Path to CUDA Toolkit headers
  *
  * The path can be configured by setting NVTE_CUDA_INCLUDE_DIR in the

--- a/transformer_engine/common/util/cuda_runtime.h
+++ b/transformer_engine/common/util/cuda_runtime.h
@@ -42,9 +42,11 @@ int sm_count(int device_id = -1);
  *
  * \param[in] device_id CUDA device (default is current device)
  *
- * \return Minimum and maximum stream priorities (zero if device does not support priorities)
+ * \param[out] lowest_priority Lowest stream priority value supported by the device.
+ *
+ * \param[out] highest_priority Highest stream priority value supported by the device.
  */
-std::pair<int, int> stream_priority_range(int device_id = -1);
+void stream_priority_range(int *lowest_priority, int *highest_priority, int device_id = -1);
 
 /* \brief Check if device supports CUDA Multicast features
  *

--- a/transformer_engine/pytorch/csrc/comm_gemm_overlap.h
+++ b/transformer_engine/pytorch/csrc/comm_gemm_overlap.h
@@ -38,8 +38,8 @@ namespace ubuf {
 void _set_stream_priority(at::cuda::CUDAStream *torch_stream, int priority) {
   cudaLaunchAttributeValue value;
   value.priority = priority;
-  NVTE_CHECK_CUDA(cudaStreamSetAttribute(torch_stream->stream(), cudaStreamAttributePriority,
-                                         &value));
+  NVTE_CHECK_CUDA(
+      cudaStreamSetAttribute(torch_stream->stream(), cudaStreamAttributePriority, &value));
 }
 
 int _get_stream_priority(const at::cuda::CUDAStream &torch_stream) {
@@ -206,8 +206,8 @@ struct UbufCommOverlap : torch::CustomClassHolder, UbufBase {
           at::cuda::getStreamFromExternal(stream_tmp, stream_main.device_index()));
     }
     if (transformer_engine::getenv<bool>("NVTE_UBDEBUG") && _ub_comm->myrank) {
-      printf("!!! [UB] Comm priority: %d | GEMM priority: %d\n",
-             _get_stream_priority(_stream_comm), _get_stream_priority(_stream_compute[0]));
+      printf("!!! [UB] Comm priority: %d | GEMM priority: %d\n", _get_stream_priority(_stream_comm),
+             _get_stream_priority(_stream_compute[0]));
     }
 
     _num_splits = num_splits;
@@ -756,8 +756,8 @@ struct UbufP2PCommOverlap : torch::CustomClassHolder, UbufBase {
     }
     if (transformer_engine::getenv<bool>("NVTE_UBDEBUG") && _ub_comm->myrank) {
       printf("!!! [UBP2P] Send priority: %d | Recv priority: %d | GEMM priority: %d\n",
-            _get_stream_priority(_stream_send), _get_stream_priority(_stream_recv),
-            _get_stream_priority(_stream_compute[0]));
+             _get_stream_priority(_stream_send), _get_stream_priority(_stream_recv),
+             _get_stream_priority(_stream_compute[0]));
     }
 
     // Set the number of SMs for GEMM with margin

--- a/transformer_engine/pytorch/csrc/comm_gemm_overlap.h
+++ b/transformer_engine/pytorch/csrc/comm_gemm_overlap.h
@@ -197,8 +197,8 @@ struct UbufCommOverlap : torch::CustomClassHolder, UbufBase {
     at::cuda::CUDAStream stream_main = at::cuda::getCurrentCUDAStream();
     for (int i = 0; i < std::min(num_max_streams, num_splits); i++) {
       cudaStream_t stream_tmp;
-      NVTE_CHECK_CUDA(cudaStreamCreateWithPriority(&stream_tmp, cudaStreamNonBlocking,
-                                                   gemm_priority));
+      NVTE_CHECK_CUDA(
+          cudaStreamCreateWithPriority(&stream_tmp, cudaStreamNonBlocking, gemm_priority));
       _stream_compute.push_back(
           at::cuda::getStreamFromExternal(stream_tmp, stream_main.device_index()));
     }
@@ -247,26 +247,20 @@ struct UbufCommOverlap : torch::CustomClassHolder, UbufBase {
   }
 
   void _set_stream_priority(at::cuda::CUDAStream stream, int priority) {
-    cudaLaunchAttributeValue attributes = { .priority = priority };
-    NVTE_CHECK_CUDA(cudaStreamSetAttribute((cudaStream_t)stream, cudaStreamAttributePriority,
-                                           &attributes));
+    cudaLaunchAttributeValue attributes = {.priority = priority};
+    NVTE_CHECK_CUDA(
+        cudaStreamSetAttribute((cudaStream_t)stream, cudaStreamAttributePriority, &attributes));
   }
 
-  void set_comm_priority(int priority) {
-    _set_stream_priority(_stream_comm, priority);
-  }
+  void set_comm_priority(int priority) { _set_stream_priority(_stream_comm, priority); }
 
   void set_gemm_priority(int priority) {
-    for (auto stream: _stream_compute) _set_stream_priority(stream, priority);
+    for (auto stream : _stream_compute) _set_stream_priority(stream, priority);
   }
 
-  int get_comm_priority() {
-    return _stream_comm.priority();
-  }
+  int get_comm_priority() { return _stream_comm.priority(); }
 
-  int get_gemm_priority() {
-    return _stream_compute[0].priority();
-  }
+  int get_gemm_priority() { return _stream_compute[0].priority(); }
 
   /*
   ** Bulk GEMM + COMM
@@ -752,8 +746,8 @@ struct UbufP2PCommOverlap : torch::CustomClassHolder, UbufBase {
     at::cuda::CUDAStream stream_main = at::cuda::getCurrentCUDAStream();
     for (int i = 0; i < std::min(num_max_streams, tp_size); i++) {
       cudaStream_t stream_tmp;
-      NVTE_CHECK_CUDA(cudaStreamCreateWithPriority(&stream_tmp, cudaStreamNonBlocking,
-                                                   gemm_priority));
+      NVTE_CHECK_CUDA(
+          cudaStreamCreateWithPriority(&stream_tmp, cudaStreamNonBlocking, gemm_priority));
       _stream_compute.push_back(
           at::cuda::getStreamFromExternal(stream_tmp, stream_main.device_index()));
     }
@@ -821,9 +815,9 @@ struct UbufP2PCommOverlap : torch::CustomClassHolder, UbufBase {
   }
 
   void _set_stream_priority(at::cuda::CUDAStream stream, int priority) {
-    cudaLaunchAttributeValue attributes = { .priority = priority };
-    NVTE_CHECK_CUDA(cudaStreamSetAttribute((cudaStream_t)stream, cudaStreamAttributePriority,
-                                           &attributes));
+    cudaLaunchAttributeValue attributes = {.priority = priority};
+    NVTE_CHECK_CUDA(
+        cudaStreamSetAttribute((cudaStream_t)stream, cudaStreamAttributePriority, &attributes));
   }
 
   void set_comm_priority(int priority) {
@@ -832,16 +826,12 @@ struct UbufP2PCommOverlap : torch::CustomClassHolder, UbufBase {
   }
 
   void set_gemm_priority(int priority) {
-    for (auto stream: _stream_compute) _set_stream_priority(stream, priority);
+    for (auto stream : _stream_compute) _set_stream_priority(stream, priority);
   }
 
-  int get_comm_priority() {
-    return _stream_send.priority();
-  }
+  int get_comm_priority() { return _stream_send.priority(); }
 
-  int get_gemm_priority() {
-    return _stream_compute[0].priority();
-  }
+  int get_gemm_priority() { return _stream_compute[0].priority(); }
 
   /*
   ** Split AllGather + AtomicGEMM using P2P communication

--- a/transformer_engine/pytorch/csrc/comm_gemm_overlap.h
+++ b/transformer_engine/pytorch/csrc/comm_gemm_overlap.h
@@ -7,8 +7,6 @@
 #ifndef TRANSFORMER_ENGINE_PYTORCH_CSRC_COMM_GEMM_OVERLAP_H_
 #define TRANSFORMER_ENGINE_PYTORCH_CSRC_COMM_GEMM_OVERLAP_H_
 
-#include <utility>
-
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -22,6 +20,7 @@
 #include <torch/types.h>
 
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <utility>
 
 #include "common/common.h"
 #include "common/util/system.h"
@@ -158,8 +157,7 @@ struct UbufCommOverlap : torch::CustomClassHolder, UbufBase {
   UbufCommOverlap(torch::Tensor sample, int myrank, int numranks, int mylocal, int numlocal,
                   int mynode, int numnodes, int tp_size, int num_comm_sm, int comm_cga_size,
                   int num_splits, bool set_sm_margin, int num_max_streams, bool atomic_gemm,
-                  UbufBootstrapCallbacks &callbacks, int comm_priority = 0,
-                  int gemm_priority = 0) {
+                  UbufBootstrapCallbacks &callbacks, int comm_priority = 0, int gemm_priority = 0) {
     // Initialize userbuf communicator
     if (!comm_created) {
       if (myrank == 0) {

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -46,6 +46,7 @@
 #include <vector>
 
 #include "common/util/logging.h"
+#include "common/util/cuda_runtime.h"
 
 namespace transformer_engine {
 

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -45,8 +45,8 @@
 #include <stdexcept>
 #include <vector>
 
-#include "common/util/logging.h"
 #include "common/util/cuda_runtime.h"
+#include "common/util/logging.h"
 
 namespace transformer_engine {
 

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -226,11 +226,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def_readwrite("scale_inv", &transformer_engine::FP8TensorMeta::scale_inv)
       .def_readwrite("amax_history", &transformer_engine::FP8TensorMeta::amax_history);
 
-  m.def("get_stream_priority_range", [](int device_id = -1) {
-            int low_pri, high_pri;
-            transformer_engine::cuda::stream_priority_range(&low_pri, &high_pri, device_id);
-            return std::make_pair(low_pri, high_pri);
-        }, py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);
+  m.def(
+      "get_stream_priority_range",
+      [](int device_id = -1) {
+        int low_pri, high_pri;
+        transformer_engine::cuda::stream_priority_range(&low_pri, &high_pri, device_id);
+        return std::make_pair(low_pri, high_pri);
+      },
+      py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);
 
   m.def("device_supports_multicast", &transformer_engine::cuda::supports_multicast,
         py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -226,8 +226,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def_readwrite("scale_inv", &transformer_engine::FP8TensorMeta::scale_inv)
       .def_readwrite("amax_history", &transformer_engine::FP8TensorMeta::amax_history);
 
-  m.def("get_stream_priority_range", &transformer_engine::cuda::stream_priority_range,
-        py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);
+  m.def("get_stream_priority_range", [](int device_id = -1) {
+            int low_pri, high_pri;
+            transformer_engine::cuda::stream_priority_range(&low_pri, &high_pri, device_id);
+            return std::make_pair(low_pri, high_pri);
+        }, py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);
 
   m.def("device_supports_multicast", &transformer_engine::cuda::supports_multicast,
         py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -252,7 +252,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // communication)
   py::class_<ubuf::UbufCommOverlap>(m, "UbufCommOverlap")
       .def(py::init<torch::Tensor &, int, int, int, int, int, int, int, int, int, int, bool, int,
-                    bool, ubuf::UbufBootstrapCallbacks &>(),
+                    bool, ubuf::UbufBootstrapCallbacks &, int, int>(),
+           py::call_guard<py::gil_scoped_release>(), py::arg("sample_tensor"), py::arg("myrank"),
+           py::arg("numranks"), py::arg("mylocal"), py::arg("numlocal"), py::arg("mynode"),
+           py::arg("numnodes"), py::arg("tp_size"), py::arg("num_comm_sm"), py::arg("num_cga_size"),
+           py::arg("num_splits"), py::arg("set_sm_margin"), py::arg("num_max_streams"),
+           py::arg("atomic_gemm"), py::arg("callbacks"), py::arg("comm_priority") = -1,
+           py::arg("gemm_priority") = -1)
+      .def("set_comm_priority", &ubuf::UbufCommOverlap::set_comm_priority,
+           py::call_guard<py::gil_scoped_release>())
+      .def("set_gemm_priority", &ubuf::UbufCommOverlap::set_gemm_priority,
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_comm_priority", &ubuf::UbufCommOverlap::get_comm_priority,
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_gemm_priority", &ubuf::UbufCommOverlap::get_gemm_priority,
            py::call_guard<py::gil_scoped_release>())
       .def("bulk_overlap", &ubuf::UbufCommOverlap::bulk_overlap,
            py::call_guard<py::gil_scoped_release>())
@@ -278,7 +291,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // communication)
   py::class_<ubuf::UbufP2PCommOverlap>(m, "UbufP2PCommOverlap")
       .def(py::init<torch::Tensor &, int, int, int, int, int, int, int, int, int, bool, bool, int,
-                    bool, bool, bool, ubuf::UbufBootstrapCallbacks &>(),
+                    bool, bool, bool, ubuf::UbufBootstrapCallbacks &, int, int>(),
+           py::call_guard<py::gil_scoped_release>(), py::arg("sample_tensor"), py::arg("myrank"),
+           py::arg("numranks"), py::arg("mylocal"), py::arg("numlocal"), py::arg("mynode"),
+           py::arg("numnodes"), py::arg("tp_size"), py::arg("num_comm_sm"), py::arg("num_cga_size"),
+           py::arg("set_sm_margin"), py::arg("aggregate"), py::arg("num_max_streams"),
+           py::arg("is_reduce_scatter"), py::arg("atomic_gemm"), py::arg("use_ce"),
+           py::arg("callbacks"), py::arg("comm_priority") = -1, py::arg("gemm_priority") = -1)
+      .def("set_comm_priority", &ubuf::UbufP2PCommOverlap::set_comm_priority,
+           py::call_guard<py::gil_scoped_release>())
+      .def("set_gemm_priority", &ubuf::UbufP2PCommOverlap::set_gemm_priority,
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_comm_priority", &ubuf::UbufP2PCommOverlap::get_comm_priority,
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_gemm_priority", &ubuf::UbufP2PCommOverlap::get_gemm_priority,
            py::call_guard<py::gil_scoped_release>())
       .def("split_overlap_ag_p2p", &ubuf::UbufP2PCommOverlap::split_overlap_ag,
            py::call_guard<py::gil_scoped_release>())

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -226,8 +226,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def_readwrite("scale_inv", &transformer_engine::FP8TensorMeta::scale_inv)
       .def_readwrite("amax_history", &transformer_engine::FP8TensorMeta::amax_history);
 
-  m.def("device_supports_multicast", &ubuf::device_supports_multicast,
-        py::call_guard<py::gil_scoped_release>());
+  m.def("get_stream_priority_range", &transformer_engine::cuda::stream_priority_range,
+        py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);
+
+  m.def("device_supports_multicast", &transformer_engine::cuda::supports_multicast,
+        py::call_guard<py::gil_scoped_release>(), py::arg("device_id") = -1);
 
   m.def("ubuf_built_with_mpi", &ubuf::ubuf_built_with_mpi,
         py::call_guard<py::gil_scoped_release>());
@@ -257,8 +260,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("numranks"), py::arg("mylocal"), py::arg("numlocal"), py::arg("mynode"),
            py::arg("numnodes"), py::arg("tp_size"), py::arg("num_comm_sm"), py::arg("num_cga_size"),
            py::arg("num_splits"), py::arg("set_sm_margin"), py::arg("num_max_streams"),
-           py::arg("atomic_gemm"), py::arg("callbacks"), py::arg("comm_priority") = -1,
-           py::arg("gemm_priority") = -1)
+           py::arg("atomic_gemm"), py::arg("callbacks"), py::arg("comm_priority") = 0,
+           py::arg("gemm_priority") = 0)
       .def("set_comm_priority", &ubuf::UbufCommOverlap::set_comm_priority,
            py::call_guard<py::gil_scoped_release>())
       .def("set_gemm_priority", &ubuf::UbufCommOverlap::set_gemm_priority,
@@ -297,7 +300,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("numnodes"), py::arg("tp_size"), py::arg("num_comm_sm"), py::arg("num_cga_size"),
            py::arg("set_sm_margin"), py::arg("aggregate"), py::arg("num_max_streams"),
            py::arg("is_reduce_scatter"), py::arg("atomic_gemm"), py::arg("use_ce"),
-           py::arg("callbacks"), py::arg("comm_priority") = -1, py::arg("gemm_priority") = -1)
+           py::arg("callbacks"), py::arg("comm_priority") = 0, py::arg("gemm_priority") = 0)
       .def("set_comm_priority", &ubuf::UbufP2PCommOverlap::set_comm_priority,
            py::call_guard<py::gil_scoped_release>())
       .def("set_gemm_priority", &ubuf::UbufP2PCommOverlap::set_gemm_priority,

--- a/transformer_engine/pytorch/csrc/userbuffers/userbuffers-host.cpp
+++ b/transformer_engine/pytorch/csrc/userbuffers/userbuffers-host.cpp
@@ -442,7 +442,7 @@ void destroy_communicator(communicator *comm) {
         if (rank != comm->nvrank) {
           cudaIpcCloseMemHandle(comm->peer_ptr[hndl][rank]);
         } else if (comm->mem_dealloc[hndl]) {
-          NVTE_CHECK_CUDA(cudaFree(comm->peer_ptr[hndl][rank]));
+          cudaFree(comm->peer_ptr[hndl][rank]);
         } else {
           comm->peer_ptr[hndl][rank] = nullptr;  // remove reference to external buffer
         }

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -48,6 +48,7 @@ _multi_stream_cublas_workspace = []
 _cublas_workspace = None
 _ub_communicators = None
 _NUM_MAX_UB_STREAMS = 3
+_MIN_STREAM_PRIORITY, _MAX_STREAM_PRIORITY = tex.get_stream_priority_range()
 layers_atomic_ring_exchange = []
 
 
@@ -253,8 +254,8 @@ def initialize_ub(
             "atomic_gemm": False,
             "use_ce": True,
             "fp8_buf": name in layers_all_gather_overlap,
-            "comm_priority": -1,
-            "gemm_priority": -1,
+            "comm_priority": _MAX_STREAM_PRIORITY,
+            "gemm_priority": _MIN_STREAM_PRIORITY,
         }
         return default_cfg
 
@@ -270,8 +271,8 @@ def initialize_ub(
         atomic_gemm: int = 0,
         use_ce: bool = True,
         fp8_buf: bool = False,
-        comm_priority: int = -1,
-        gemm_priority: int = -1,
+        comm_priority: int = 0,
+        gemm_priority: int = 0,
     ) -> None:
         if atomic_gemm:
             warnings.warn(

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -253,6 +253,8 @@ def initialize_ub(
             "atomic_gemm": False,
             "use_ce": True,
             "fp8_buf": name in layers_all_gather_overlap,
+            "comm_priority": -1,
+            "gemm_priority": -1,
         }
         return default_cfg
 
@@ -268,6 +270,8 @@ def initialize_ub(
         atomic_gemm: int = 0,
         use_ce: bool = True,
         fp8_buf: bool = False,
+        comm_priority: int = -1,
+        gemm_priority: int = -1,
     ) -> None:
         if atomic_gemm:
             warnings.warn(
@@ -325,6 +329,8 @@ def initialize_ub(
                 atomic_gemm,  # Use a single GEMM with atomic-counters
                 use_ce,  # Use copy engine for P2P communications
                 ub_callbacks,
+                comm_priority,
+                gemm_priority,
             )
         else:
             ub_obj = tex.UbufCommOverlap(
@@ -343,6 +349,8 @@ def initialize_ub(
                 _NUM_MAX_UB_STREAMS,  # Max concurrent GEMM streams
                 atomic_gemm,  # Use a single GEMM with atomic-counters
                 ub_callbacks,
+                comm_priority,
+                gemm_priority,
             )
         _ub_communicators[name] = ub_obj
 


### PR DESCRIPTION
# Description

Userbuffers configuration dictionary now has new `"comm_priority": -1` and `"gemm_priority: -1` options with default values of -1 for both.

Attn. @rachitgarg91 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Updated `tex.UbufCommOverlap` and `tex.UbufP2PCommOverlap` constructors with optional arguments for comm and GEMM stream priorities.
- Updated `te.module.base.initialize_ub()` to read `"comm_priority"` and `"gemm_priority"` options in the config dictionary.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
