### PR TITLE
[C] Suppress 128-D warning from cudnn-frontend

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -134,6 +134,7 @@ set_source_files_properties(fused_softmax/scaled_masked_softmax.cu
                             COMPILE_OPTIONS "--use_fast_math")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -diag-suppress 128")
 
 # Number of parallel build jobs
 if(ENV{MAX_JOBS})


### PR DESCRIPTION
# Description

This PR suppresses the 128-D warning from cudnn-frontend 1.6.1.
```
    /code/pr-tols/TransformerEngine/transformer_engine/common/../../3rdparty/cudnn-frontend/include/cudnn_frontend_Errata.h(187): warning #128-D: loop is not reachable
                  do { if (isLoggingEnabled()) { getLogger() << message << std::endl; } } while (0);;
                  ^

    Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
```


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Suppress 128-D warning

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
