### PR TITLE
Revert "[C] Suppress 128-D warning from cudnn-frontend"

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -135,7 +135,6 @@ set_source_files_properties(fused_softmax/scaled_masked_softmax.cu
                             COMPILE_OPTIONS "--use_fast_math")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -diag-suppress 128")
 
 # Number of parallel build jobs
 if(ENV{MAX_JOBS})


### PR DESCRIPTION
Reverts NVIDIA/TransformerEngine#1158

Fix: https://github.com/NVIDIA/cudnn-frontend/pull/105