### PR TITLE
Fix autocast deprecation warning.

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -575,7 +575,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         """Get activation data type for AMP."""
         # Native AMP (`torch.autocast`) gets highest priority
         if torch.is_autocast_enabled():
-            self.activation_dtype = torch.get_autocast_gpu_dtype()
+            self.activation_dtype = torch.get_autocast_dtype('cuda')
             return
 
         # All checks after this have already been performed once, thus skip

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -575,7 +575,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         """Get activation data type for AMP."""
         # Native AMP (`torch.autocast`) gets highest priority
         if torch.is_autocast_enabled():
-            self.activation_dtype = torch.get_autocast_dtype('cuda')
+            self.activation_dtype = torch.get_autocast_dtype("cuda")
             return
 
         # All checks after this have already been performed once, thus skip


### PR DESCRIPTION
Fixes warning about deprecation of `torch.get_autocast_gpu_dtype`