### PR TITLE
Add dtensor support for TE optimizers

### DIFF
--- a/transformer_engine/pytorch/optimizers/multi_tensor_apply.py
+++ b/transformer_engine/pytorch/optimizers/multi_tensor_apply.py
@@ -3,6 +3,7 @@
 # See LICENSE for license information.
 
 """Multi-tensor apply entry."""
+from torch.distributed._tensor import DTensor
 
 
 class MultiTensorApply:  # pylint: disable=too-few-public-methods
@@ -12,6 +13,11 @@ class MultiTensorApply:  # pylint: disable=too-few-public-methods
         self.chunk_size = chunk_size
 
     def __call__(self, op, noop_flag_buffer, tensor_lists, *args):
+        for i, ts in enumerate(tensor_lists):
+            for j, t in enumerate(ts):
+                if isinstance(t, DTensor):
+                    tensor_lists[i][j] = t._local_tensor
+
         return op(self.chunk_size, noop_flag_buffer, tensor_lists, *args)
 
 


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.
multi_tensor_apply needs to work directly on the local shards of the DTensors in the optimizer states.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- If tensor is DTensor, replace it with its local shard.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
