### PR TITLE
[PyTorch] Check network interface name when initializing Userbuffers

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -139,7 +139,7 @@ def initialize_ub(
 
         if ifname is not None:
             # Make sure the ifname found in the environment is a valid network interface
-            if ifname in [ name for _, name in socket.if_nameindex() ]:
+            if ifname in [name for _, name in socket.if_nameindex()]:
                 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                 try:
                     hostname = socket.inet_ntoa(

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -153,7 +153,8 @@ def initialize_ub(
                     s.close()
             else:
                 ifname_warning = (
-                    f"'{ifname}' is not a valid network interface! `te.initialize_ub()` will attempt to "
+                    f"'{ifname}' is not a valid network interface! `te.initialize_ub()` will"
+                    " attempt to "
                     + "detect ranks on the same node by matching 'socket.gethostname()', which is "
                     + "known to fail on virtual clusters like Kubernetes. If Userbuffers "
                     + "initialization fails, please set the 'NVTE_UB_SOCKET_IFNAME' variable in "

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -153,7 +153,7 @@ def initialize_ub(
                     s.close()
             else:
                 ifname_warning = (
-                    "'%s' is not a valid network interface! `te.initialize_ub()` will attempt to "
+                    f"'{ifname}' is not a valid network interface! `te.initialize_ub()` will attempt to "
                     + "detect ranks on the same node by matching 'socket.gethostname()', which is "
                     + "known to fail on virtual clusters like Kubernetes. If Userbuffers "
                     + "initialization fails, please set the 'NVTE_UB_SOCKET_IFNAME' variable in "


### PR DESCRIPTION
# Description

`te.initialize_ub()` constructs a list of ranks on the same physical node by comparing hostnames from network interfaces defined by `NVTE_UB_SOCKET_IFNAME`, `NCCL_SOCKET_IFNAME` or `GLOO_SOCKET_IFNAME` environment variables, in that order of priority. If none are defined, it falls back on using `os.gethostname()` instead.

This approach fails when `NCCL_SOCKET_IFNAME` is set to a base name like `eth` while the actual network interfaces are named `eth0`, `eth1`, and so on.

This PR avoids the error by checking the detected interface name against interfaces found in `socket.if_nameindex()` and falling back onto `os.gethostname()` with a useful warning message when the detected name is not valid.

Fixes #1170 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
