### PR TITLE
[PyTorch] Relax the contiguous check for flash attention

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -4881,11 +4881,19 @@ class FlashAttention(torch.nn.Module):
                     query_layer, key_layer, value_layer = [
                         x.transpose(0, 1) for x in (query_layer, key_layer, value_layer)
                     ]
+            if context_parallel:
+                query_layer, key_layer, value_layer = [
+                    x.contiguous() for x in (query_layer, key_layer, value_layer)
+                ]
         else:
             if qkv_format == "sbhd":
                 query_layer._data, key_layer._data, value_layer._data = [
                     x.transpose(0, 1)
                     for x in (query_layer._data, key_layer._data, value_layer._data)
+                ]
+            if context_parallel:
+                query_layer._data, key_layer._data, value_layer._data = [
+                    x.contiguous() for x in (query_layer._data, key_layer._data, value_layer._data)
                 ]
 
         batch_size = query_layer.shape[0]

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -4879,22 +4879,13 @@ class FlashAttention(torch.nn.Module):
                     )
                 else:
                     query_layer, key_layer, value_layer = [
-                        x.transpose(0, 1).contiguous()
-                        for x in (query_layer, key_layer, value_layer)
+                        x.transpose(0, 1) for x in (query_layer, key_layer, value_layer)
                     ]
-            elif qkv_format in ["bshd", "thd"]:
-                query_layer, key_layer, value_layer = [
-                    x.contiguous() for x in (query_layer, key_layer, value_layer)
-                ]
         else:
             if qkv_format == "sbhd":
                 query_layer._data, key_layer._data, value_layer._data = [
-                    x.transpose(0, 1).contiguous()
+                    x.transpose(0, 1)
                     for x in (query_layer._data, key_layer._data, value_layer._data)
-                ]
-            elif qkv_format in ["bshd", "thd"]:
-                query_layer._data, key_layer._data, value_layer._data = [
-                    x.contiguous() for x in (query_layer._data, key_layer._data, value_layer._data)
                 ]
 
         batch_size = query_layer.shape[0]
@@ -5090,11 +5081,7 @@ class FlashAttention(torch.nn.Module):
                 output.reshape(batch_size * max_seqlen_q // cp_size, -1).transpose_2d()
                 output = output.reshape(batch_size, max_seqlen_q // cp_size, -1)
             else:
-                output = (
-                    output.view(batch_size, max_seqlen_q // cp_size, -1)
-                    .transpose(0, 1)
-                    .contiguous()
-                )
+                output = output.view(batch_size, max_seqlen_q // cp_size, -1).transpose(0, 1)
         elif qkv_format == "bshd":
             # (bs)hd -> bs(hd)
             output = output.reshape(batch_size, max_seqlen_q // cp_size, -1)
@@ -5102,7 +5089,7 @@ class FlashAttention(torch.nn.Module):
             # thd -> t(hd)
             output = output.reshape(output.shape[0], -1)
 
-        return output
+        return output.contiguous()
 
 
 def _combine_tensors(


### PR DESCRIPTION
# Description

The continuity requirements and behavior of FlashAttention are:
- q/k/v are contiguous **at the last dimension**. [[ref 1](https://github.com/Dao-AILab/flash-attention/blob/bdf733be55f0b323a8cf7cc6745a81c3f43cd7f0/flash_attn/flash_attn_interface.py#L15)][[ref 2](https://github.com/Dao-AILab/flash-attention/blob/bdf733be55f0b323a8cf7cc6745a81c3f43cd7f0/csrc/flash_attn/flash_api.cpp#L379-L381)]
- out has the same layout (stride) as q. [[ref](https://github.com/Dao-AILab/flash-attention/blob/bdf733be55f0b323a8cf7cc6745a81c3f43cd7f0/csrc/flash_attn/flash_api.cpp#L441)]

So we can just remove the `.contiguous()` calls on q/k/v and rely on FlashAttention doing the minimum continuity check. For `sbhd` formats, all the four `.contiguous()` calls on q/k/v/out are removed.

For context parallel, we still force q/k/v to be contiguous.

Closes https://github.com/NVIDIA/TransformerEngine/pull/359.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
