### PR TITLE
Allow specifying cmake setup directory

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -106,8 +106,12 @@ def get_build_ext(extension_cls: Type[setuptools.Extension]):
                 if isinstance(ext, CMakeExtension):
                     print(f"Building CMake extension {ext.name}")
                     # Set up incremental builds for CMake extensions
-                    setup_dir = Path(__file__).resolve().parent.parent
-                    build_dir = setup_dir / "build" / "cmake"
+                    build_dir = os.getenv("NVTE_CMAKE_BUILD_DIR")
+                    if build_dir:
+                        build_dir = Path(build_dir).resolve()
+                    else:
+                        root_dir = Path(__file__).resolve().parent.parent
+                        build_dir = root_dir / "build" / "cmake"
 
                     # Ensure the directory exists
                     build_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.

Allow specifying which directory to store cmake build cache, which makes user defined docker buildx workflows more flexible.


Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x ] The functionality is complete
- [na] I have commented my code, particularly in hard-to-understand areas
- [na ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [na] New and existing unit tests pass locally with my changes
