### PR TITLE
Enable fuse_wgrad_accumulation flag if using cudagraphs

### DIFF
--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -391,7 +391,7 @@ def _make_graphed_callables(
                 # Update FP8 scale factors if needed
                 if ctx.is_first_module:
                     FP8GlobalStateManager.reduce_and_update_fp8_tensors(forward=False)
-                    
+
                 # Handle MCore wgrad accumulate fusion if needed
                 if ctx.fuse_wgrad_accumulation:
                     for param in module_params:
@@ -417,7 +417,7 @@ def _make_graphed_callables(
 
             # Handle custom DDP from mcore
             fuse_wgrad_accumulation = None
-            if 'fuse_wgrad_accumulation' in user_kwargs:
+            if "fuse_wgrad_accumulation" in user_kwargs:
                 fuse_wgrad_accumulation = user_kwargs["fuse_wgrad_accumulation"]
 
             # Check that required kwargs are provided


### PR DESCRIPTION
# Description

With `fuse_wgrad_accumuation` we toggle `weight.grad_added_to_main_grad = True`, which tells Mcore DDP to use `main_grad` and not `grad`.  [For instance here](https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/pytorch/module/linear.py#L582)
However with cudagraphs this does not occur; this PR adds the feature to toggle these flags after the cudagraph bwd replay.


Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
