### PR TITLE
[JAX] Expose sliding window attn to TE-JAX API

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -149,7 +149,7 @@ def make_mask(
     # The only difference is that for window size part [w, 0], cuDNN uses a mask that each
     # row has at most w elements that are NOT masked out, while get_swa_mask() generates
     # a mask that each row has at most w+1 elements that are not masked out. To compare
-    # cuDNN results with Python reference implementation with mask, we adjust the 
+    # cuDNN results with Python reference implementation with mask, we adjust the
     # arguments for the jnp.triu function by adding 1
     if window_size_left >= 0:
         max_seqlen_q = inv_mask.shape[-2]
@@ -341,7 +341,7 @@ class FusedAttnRunner:
             self.max_seqlen_kv,
             self.head_dim,
             self.window_size_left,
-            self.window_size_right
+            self.window_size_right,
         ).get_fused_attn_backend()
         if self.backend == NVTE_Fused_Attn_Backend.NVTE_No_Backend:
             pytest.skip("Unsupported inputs combination or device compute capability.")
@@ -776,7 +776,9 @@ class TestFusedAttn:
             window_size = check_set_window_size(attn_mask_type, (random.randint(0, s_kv // 10), 0))
             window_size_left, window_size_right = window_size
             if s_q > s_kv:
-                pytest.skip("seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN")
+                pytest.skip(
+                    "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
+                )
         runner = FusedAttnRunner(
             b,
             s_q,
@@ -810,7 +812,7 @@ class TestFusedAttn:
         dtype,
         qkv_layout,
         bias_shape,
-        swa
+        swa,
     ):
         """
         Test backward with parameterized configs
@@ -822,7 +824,9 @@ class TestFusedAttn:
             window_size = check_set_window_size(attn_mask_type, (random.randint(0, s_kv // 10), 0))
             window_size_left, window_size_right = window_size
             if s_q > s_kv:
-                pytest.skip("seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN")
+                pytest.skip(
+                    "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
+                )
         runner = FusedAttnRunner(
             b,
             s_q,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -312,6 +312,11 @@ class FusedAttnRunner:
             if self.max_seqlen_q != self.max_seqlen_kv:
                 pytest.skip("QKVPACKED layout requires max_seqlen_q and max_seqlen_kv to be equal.")
 
+        if self.max_seqlen_q > self.max_seqlen_kv and self.window_size[0] > 0:
+            pytest.skip(
+                "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
+            )
+
         self.backend = FusedAttnHelper(
             self.dtype,
             self.dtype,
@@ -752,10 +757,6 @@ class TestFusedAttn:
         window_size = (-1, -1)
         if swa:
             window_size = (s_kv // 10, 0)
-            if s_q > s_kv:
-                pytest.skip(
-                    "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
-                )
         runner = FusedAttnRunner(
             b,
             s_q,
@@ -796,10 +797,6 @@ class TestFusedAttn:
         window_size = (-1, -1)
         if swa:
             window_size = (s_kv // 10, 0)
-            if s_q > s_kv:
-                pytest.skip(
-                    "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
-                )
         runner = FusedAttnRunner(
             b,
             s_q,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -126,7 +126,7 @@ def make_mask(
     segment_pad_q: ArrayLike,
     segment_pad_kv: ArrayLike,
     attn_mask_type: AttnMaskType,
-    window_size: Tuple[int, int]
+    window_size: Tuple[int, int],
 ) -> Array:
     """
     Create attention mask based on mask type. A `True` value in the mask means

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -311,7 +311,7 @@ class FusedAttnRunner:
             if self.max_seqlen_q != self.max_seqlen_kv:
                 pytest.skip("QKVPACKED layout requires max_seqlen_q and max_seqlen_kv to be equal.")
 
-        if self.max_seqlen_q > self.max_seqlen_kv and self.window_size[0] > 0:
+        if self.max_seqlen_q > self.max_seqlen_kv and self.window_size is not None:
             pytest.skip(
                 "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
             )
@@ -328,7 +328,7 @@ class FusedAttnRunner:
             self.max_seqlen_q,
             self.max_seqlen_kv,
             self.head_dim,
-            self.window_size,
+            (-1, -1) if self.window_size is None else self.window_size,
         ).get_fused_attn_backend()
         if self.backend == NVTE_Fused_Attn_Backend.NVTE_No_Backend:
             pytest.skip("Unsupported inputs combination or device compute capability.")
@@ -753,7 +753,7 @@ class TestFusedAttn:
         This test is not intended to run automatically during CI as it is time-consuming
         It is kept for development and debugging
         """
-        window_size = (-1, -1)
+        window_size = None
         if swa:
             window_size = (s_kv // 10, 0)
         runner = FusedAttnRunner(
@@ -793,7 +793,7 @@ class TestFusedAttn:
         """
         Test backward with parameterized configs
         """
-        window_size = (-1, -1)
+        window_size = None
         if swa:
             window_size = (s_kv // 10, 0)
         runner = FusedAttnRunner(

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -772,6 +772,7 @@ class TestFusedAttn:
         window_size_left = -1
         window_size_right = -1
         if swa:
+            random.seed(42)
             # Use a small window size to avoid long running time
             window_size = check_set_window_size(attn_mask_type, (random.randint(0, s_kv // 10), 0))
             window_size_left, window_size_right = window_size
@@ -820,6 +821,7 @@ class TestFusedAttn:
         window_size_left = -1
         window_size_right = -1
         if swa:
+            random.seed(42)
             # Use a small window size to avoid long running time
             window_size = check_set_window_size(attn_mask_type, (random.randint(0, s_kv // 10), 0))
             window_size_left, window_size_right = window_size

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -4,7 +4,7 @@
 """Test transformer_engine.jax.flax.TransformerLayer"""
 import os
 from functools import partial
-from typing import Dict
+from typing import Dict, Tuple
 
 import flax
 import jax
@@ -61,8 +61,7 @@ _KEY_OF_SELF_ATTN_MASK_TYPE = "self_attn_mask_type"
 _KEY_OF_FLOAT32_ATTENTION_LOGITS = "float32_attention_logits"
 _KEY_OF_USE_BIAS = "use_bias"
 _KEY_OF_RELATIVE_EMBEDDING = "enable_relative_embedding"
-_KEY_OF_WINDOW_SIZE_LEFT = "window_size_left"
-_KEY_OF_WINDOW_SIZE_RIGHT = "window_size_right"
+_KEY_OF_WINDOW_SIZE = "window_size"
 
 BASE_ATTRS = {
     _KEY_OF_TRANSPOSE_BS: True,
@@ -72,8 +71,7 @@ BASE_ATTRS = {
     _KEY_OF_INTERMEDIATE_DROPOUT: 0,
     _KEY_OF_SELF_ATTN_MASK_TYPE: "padding_causal",
     _KEY_OF_LAYERNORM_TYPE: "layernorm",
-    _KEY_OF_WINDOW_SIZE_LEFT: -1,
-    _KEY_OF_WINDOW_SIZE_RIGHT: -1,
+    _KEY_OF_WINDOW_SIZE: (-1, -1),
 }
 
 ATTRS = [
@@ -199,8 +197,7 @@ ATTRS = [
     },
     {
         _KEY_OF_SELF_ATTN_MASK_TYPE: "causal",
-        _KEY_OF_WINDOW_SIZE_LEFT: 64,  # Must < seqlen in DATA_SHAPE
-        _KEY_OF_WINDOW_SIZE_RIGHT: 0,
+        _KEY_OF_WINDOW_SIZE: (64, 0),  # Left size must < DATA_SHAPE seqlen
     },
 ]
 

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -332,10 +332,14 @@ class EncoderRunner(BaseRunner):
 
         padded_mask = jnp.zeros((batch, 1, seqlen, seqlen), dtype=jnp.uint8)
         causal_mask = jnp.triu(jnp.ones((batch, 1, seqlen, seqlen), dtype=jnp.uint8), k=1)
-        if self.attrs[_KEY_OF_SELF_ATTN_MASK_TYPE] in ["casual", "padding_causal"]:
+        if self.attrs[_KEY_OF_SELF_ATTN_MASK_TYPE] in ["causal", "padding_causal"]:
             mask = causal_mask
         else:
             mask = padded_mask
+            if self.attrs[_KEY_OF_WINDOW_SIZE][0] > 0:
+                pytest.skip(
+                    "cuDNN only supports SWA with causal / padding_causal mask"
+                )
 
         ref_masks = (1 - mask,)
         test_masks = (None, mask)  # The second arg of Transformer is encoded tokens.
@@ -385,10 +389,14 @@ class DecoderRunner(BaseRunner):
 
         padded_mask = jnp.zeros((batch, 1, seqlen, seqlen), dtype=jnp.uint8)
         causal_mask = jnp.triu(jnp.ones((batch, 1, seqlen, seqlen), dtype=jnp.uint8), k=1)
-        if self.attrs[_KEY_OF_SELF_ATTN_MASK_TYPE] in ["casual", "padding_causal"]:
+        if self.attrs[_KEY_OF_SELF_ATTN_MASK_TYPE] in ["causal", "padding_causal"]:
             self_mask = causal_mask
         else:
             self_mask = padded_mask
+            if self.attrs[_KEY_OF_WINDOW_SIZE][0] > 0:
+                pytest.skip(
+                    "cuDNN only supports SWA with causal / padding_causal mask"
+                )
 
         ref_masks = (1 - self_mask, 1 - padded_mask)
         test_masks = (self_mask, padded_mask)

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -196,8 +196,16 @@ ATTRS = [
         _KEY_OF_MLP_ACTIVATIONS: (("relu", "relu")),
     },
     {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
         _KEY_OF_SELF_ATTN_MASK_TYPE: "causal",
         _KEY_OF_WINDOW_SIZE: (64, 0),  # Left size must < DATA_SHAPE seqlen
+    },
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "padding",
+        _KEY_OF_WINDOW_SIZE: (2, 2),
     },
 ]
 
@@ -336,8 +344,6 @@ class EncoderRunner(BaseRunner):
             mask = causal_mask
         else:
             mask = padded_mask
-            if self.attrs[_KEY_OF_WINDOW_SIZE][0] > 0:
-                pytest.skip("cuDNN only supports SWA with causal / padding_causal mask")
 
         ref_masks = (1 - mask,)
         test_masks = (None, mask)  # The second arg of Transformer is encoded tokens.
@@ -391,8 +397,6 @@ class DecoderRunner(BaseRunner):
             self_mask = causal_mask
         else:
             self_mask = padded_mask
-            if self.attrs[_KEY_OF_WINDOW_SIZE][0] > 0:
-                pytest.skip("cuDNN only supports SWA with causal / padding_causal mask")
 
         ref_masks = (1 - self_mask, 1 - padded_mask)
         test_masks = (self_mask, padded_mask)

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -200,6 +200,7 @@ ATTRS = [
         _KEY_OF_RELATIVE_EMBEDDING: False,
         _KEY_OF_SELF_ATTN_MASK_TYPE: "causal",
         _KEY_OF_WINDOW_SIZE: (64, 0),  # Left size must < DATA_SHAPE seqlen
+        _KEY_OF_FLOAT32_ATTENTION_LOGITS: True,
     },
     {
         _KEY_OF_TRANSPOSE_BS: False,

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -337,9 +337,7 @@ class EncoderRunner(BaseRunner):
         else:
             mask = padded_mask
             if self.attrs[_KEY_OF_WINDOW_SIZE][0] > 0:
-                pytest.skip(
-                    "cuDNN only supports SWA with causal / padding_causal mask"
-                )
+                pytest.skip("cuDNN only supports SWA with causal / padding_causal mask")
 
         ref_masks = (1 - mask,)
         test_masks = (None, mask)  # The second arg of Transformer is encoded tokens.
@@ -394,9 +392,7 @@ class DecoderRunner(BaseRunner):
         else:
             self_mask = padded_mask
             if self.attrs[_KEY_OF_WINDOW_SIZE][0] > 0:
-                pytest.skip(
-                    "cuDNN only supports SWA with causal / padding_causal mask"
-                )
+                pytest.skip("cuDNN only supports SWA with causal / padding_causal mask")
 
         ref_masks = (1 - self_mask, 1 - padded_mask)
         test_masks = (self_mask, padded_mask)

--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -61,6 +61,8 @@ _KEY_OF_SELF_ATTN_MASK_TYPE = "self_attn_mask_type"
 _KEY_OF_FLOAT32_ATTENTION_LOGITS = "float32_attention_logits"
 _KEY_OF_USE_BIAS = "use_bias"
 _KEY_OF_RELATIVE_EMBEDDING = "enable_relative_embedding"
+_KEY_OF_WINDOW_SIZE_LEFT = "window_size_left"
+_KEY_OF_WINDOW_SIZE_RIGHT = "window_size_right"
 
 BASE_ATTRS = {
     _KEY_OF_TRANSPOSE_BS: True,
@@ -70,6 +72,8 @@ BASE_ATTRS = {
     _KEY_OF_INTERMEDIATE_DROPOUT: 0,
     _KEY_OF_SELF_ATTN_MASK_TYPE: "padding_causal",
     _KEY_OF_LAYERNORM_TYPE: "layernorm",
+    _KEY_OF_WINDOW_SIZE_LEFT: -1,
+    _KEY_OF_WINDOW_SIZE_RIGHT: -1,
 }
 
 ATTRS = [
@@ -192,6 +196,11 @@ ATTRS = [
     },
     {
         _KEY_OF_MLP_ACTIVATIONS: (("relu", "relu")),
+    },
+    {
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "causal",
+        _KEY_OF_WINDOW_SIZE_LEFT: 64,  # Must < seqlen in DATA_SHAPE
+        _KEY_OF_WINDOW_SIZE_RIGHT: 0,
     },
 ]
 

--- a/tests/jax/test_praxis_layers.py
+++ b/tests/jax/test_praxis_layers.py
@@ -693,7 +693,7 @@ class DotProductAttnAttr:
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
-            WINDOW_SIZE: (64, 0), # Left size must <= S in DATA_SHAPE
+            WINDOW_SIZE: (64, 0),  # Left size must <= S in DATA_SHAPE
         },
     ]
 

--- a/tests/jax/test_praxis_layers.py
+++ b/tests/jax/test_praxis_layers.py
@@ -4,7 +4,7 @@
 
 import os
 from functools import partial
-from typing import Dict
+from typing import Dict, Tuple
 
 import flax
 import jax
@@ -645,64 +645,55 @@ class DotProductAttnAttr:
     NUM_GQA_GROUPS = "num_gqa_groups"
     TRANSPOSE_BS = "transpose_batch_sequence"
     SCALE_FACTOR = "scale_factor"
-    WINDOW_SIZE_LEFT = "window_size_left"
-    WINDOW_SIZE_RIGHT = "window_size_right"
+    WINDOW_SIZE = "window_size"
     ATTRS = [
         {
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "padding_causal",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "padding_causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 2.0,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "no_mask",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
-            WINDOW_SIZE_LEFT: 64,
-            WINDOW_SIZE_RIGHT: 0,
+            WINDOW_SIZE: (64, 0), # Left size must <= S in DATA_SHAPE
         },
     ]
 
@@ -730,8 +721,7 @@ class TestDotProductAttn(TestLayer):
         num_gqa_groups = num_attention_heads
         attn_mask_type = attrs[DotProductAttnAttr.ATTN_MASK_TYPE]
         transpose_batch_sequence = attrs[DotProductAttnAttr.TRANSPOSE_BS]
-        window_size_left = attrs[DotProductAttnAttr.WINDOW_SIZE_LEFT]
-        window_size_right = attrs[DotProductAttnAttr.WINDOW_SIZE_RIGHT]
+        window_size = attrs[DotProductAttnAttr.WINDOW_SIZE]
 
         praxis_p = pax_fiddle.Config(
             DotProductAttention,
@@ -742,8 +732,7 @@ class TestDotProductAttn(TestLayer):
             num_gqa_groups=num_gqa_groups,
             attn_mask_type=attn_mask_type,
             transpose_batch_sequence=transpose_batch_sequence,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+            window_size=window_size,
         )
         flax_cls = partial(
             flax_DotProductAttention,
@@ -753,8 +742,7 @@ class TestDotProductAttn(TestLayer):
             num_gqa_groups=num_gqa_groups,
             attn_mask_type=attn_mask_type,
             transpose_batch_sequence=transpose_batch_sequence,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+            window_size=window_size,
         )
 
         return praxis_p, flax_cls
@@ -779,8 +767,7 @@ class MultiHeadAttnAttr:
     ENABLE_ROPE = "enable_rotary_pos_emb"
     ROPE_GROUP_METHOD = "rotary_pos_emb_group_method"
     LORA_SCOPE = "low_rank_adaptation_scope"
-    WINDOW_SIZE_LEFT = "window_size_left"
-    WINDOW_SIZE_RIGHT = "window_size_right"
+    WINDOW_SIZE = "window_size"
     ATTRS = [
         {
             USE_BIAS: True,
@@ -790,8 +777,7 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -801,8 +787,7 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -812,8 +797,7 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -823,8 +807,7 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -834,8 +817,7 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -845,8 +827,7 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -858,8 +839,7 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -871,8 +851,7 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -884,8 +863,7 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -896,8 +874,7 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "padding",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -908,8 +885,7 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "causal",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -920,8 +896,7 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "causal",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: 64,
-            WINDOW_SIZE_RIGHT: 0,
+            WINDOW_SIZE: (64, 0),  # Left size must <= S in DATA_SHAPE
         },
     ]
 
@@ -964,8 +939,7 @@ class TestMultiHeadAttn(TestLayer):
         scale_attn_logits = False
         scaled_query_init = True
         float32_logits = False
-        window_size_left = attrs[MultiHeadAttnAttr.WINDOW_SIZE_LEFT]
-        window_size_right = attrs[MultiHeadAttnAttr.WINDOW_SIZE_RIGHT]
+        window_size = attrs[MultiHeadAttnAttr.WINDOW_SIZE]
 
         praxis_p = pax_fiddle.Config(
             MultiHeadAttention,
@@ -990,8 +964,7 @@ class TestMultiHeadAttn(TestLayer):
             scale_attn_logits=scale_attn_logits,
             scaled_query_init=scaled_query_init,
             float32_logits=float32_logits,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+            window_size=window_size,
         )
         flax_cls = partial(
             flax_MultiHeadAttention,
@@ -1015,8 +988,7 @@ class TestMultiHeadAttn(TestLayer):
             scale_attn_logits=scale_attn_logits,
             scaled_query_init=scaled_query_init,
             float32_logits=float32_logits,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+            window_size=window_size,
         )
 
         return praxis_p, flax_cls
@@ -1054,8 +1026,7 @@ class TransformerLayerAttr:
     ENABLE_ROPE = "enable_rotary_pos_emb"
     ROPE_GROUP_METHOD = "rotary_pos_emb_group_method"
     LORA_SCOPE = "low_rank_adaptation_scope"
-    WINDOW_SIZE_LEFT = "window_size_left"
-    WINDOW_SIZE_RIGHT = "window_size_right"
+    WINDOW_SIZE = "window_size"
     ATTRS = [
         {
             USE_BIAS: True,
@@ -1066,8 +1037,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1078,8 +1048,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1090,8 +1059,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1102,8 +1070,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1114,8 +1081,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1126,8 +1092,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1138,8 +1103,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1150,8 +1114,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1162,8 +1125,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1174,8 +1136,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1186,8 +1147,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1198,8 +1158,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1210,8 +1169,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1222,8 +1180,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1234,8 +1191,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1246,8 +1202,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1259,8 +1214,7 @@ class TransformerLayerAttr:
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
             LORA_SCOPE: "all",
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1271,8 +1225,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1283,8 +1236,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1295,8 +1247,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1307,8 +1258,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1319,8 +1269,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "alternate",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1331,8 +1280,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "alternate",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1343,8 +1291,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1355,8 +1302,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1368,8 +1314,7 @@ class TransformerLayerAttr:
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
             LORA_SCOPE: "all",
-            WINDOW_SIZE_LEFT: -1,
-            WINDOW_SIZE_RIGHT: -1,
+            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1380,8 +1325,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: 64,
-            WINDOW_SIZE_RIGHT: 0,
+            WINDOW_SIZE: (64, 0),  # Left size must <= S in DATA_SHAPE
         },
         {
             USE_BIAS: True,
@@ -1392,8 +1336,7 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE_LEFT: 64,
-            WINDOW_SIZE_RIGHT: 0,
+            WINDOW_SIZE: (64, 0),  # Left size must <= S in DATA_SHAPE
         },
     ]
 
@@ -1438,8 +1381,7 @@ class TestTransformer(TestLayer):
         )
         drop_path = 0.0
         transpose_batch_sequence = attrs[TransformerLayerAttr.TRANSPOSE_BS]
-        window_size_left = attrs[TransformerLayerAttr.WINDOW_SIZE_LEFT]
-        window_size_right = attrs[TransformerLayerAttr.WINDOW_SIZE_RIGHT]
+        window_size = attrs[TransformerLayerAttr.WINDOW_SIZE]
 
         rel_embedding_init = RelativePositionBiases.generate_embedding_init(
             relative_embedding.embedding_init,
@@ -1481,8 +1423,7 @@ class TestTransformer(TestLayer):
             relative_embedding=relative_embedding,
             drop_path=drop_path,
             transpose_batch_sequence=transpose_batch_sequence,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+            window_size=window_size,
         )
         flax_cls = partial(
             flax_TransformerLayer,
@@ -1511,8 +1452,7 @@ class TestTransformer(TestLayer):
             low_rank_adaptation_scope=low_rank_adaptation_scope,
             drop_path=drop_path,
             transpose_batch_sequence=transpose_batch_sequence,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+            window_size=window_size,
         )
 
         return praxis_p, flax_cls

--- a/tests/jax/test_praxis_layers.py
+++ b/tests/jax/test_praxis_layers.py
@@ -651,43 +651,36 @@ class DotProductAttnAttr:
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "padding_causal",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 0.125,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "padding_causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 2.0,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "no_mask",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             ATTN_MASK_TYPE: "causal",
@@ -721,7 +714,7 @@ class TestDotProductAttn(TestLayer):
         num_gqa_groups = num_attention_heads
         attn_mask_type = attrs[DotProductAttnAttr.ATTN_MASK_TYPE]
         transpose_batch_sequence = attrs[DotProductAttnAttr.TRANSPOSE_BS]
-        window_size = attrs[DotProductAttnAttr.WINDOW_SIZE]
+        window_size = attrs.get(DotProductAttnAttr.WINDOW_SIZE, None)
 
         praxis_p = pax_fiddle.Config(
             DotProductAttention,
@@ -777,7 +770,6 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -787,7 +779,6 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -797,7 +788,6 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -807,7 +797,6 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -817,7 +806,6 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -827,7 +815,6 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -839,7 +826,6 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -851,7 +837,6 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -863,7 +848,6 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -874,7 +858,6 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "padding",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -885,7 +868,6 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "causal",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -939,7 +921,7 @@ class TestMultiHeadAttn(TestLayer):
         scale_attn_logits = False
         scaled_query_init = True
         float32_logits = False
-        window_size = attrs[MultiHeadAttnAttr.WINDOW_SIZE]
+        window_size = attrs.get(MultiHeadAttnAttr.WINDOW_SIZE, None)
 
         praxis_p = pax_fiddle.Config(
             MultiHeadAttention,
@@ -1037,7 +1019,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1048,7 +1029,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1059,7 +1039,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1070,7 +1049,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1081,7 +1059,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1092,7 +1069,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1103,7 +1079,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1114,7 +1089,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1125,7 +1099,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1136,7 +1109,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1147,7 +1119,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1158,7 +1129,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1169,7 +1139,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1180,7 +1149,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1191,7 +1159,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1202,7 +1169,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1214,7 +1180,6 @@ class TransformerLayerAttr:
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
             LORA_SCOPE: "all",
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1225,7 +1190,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1236,7 +1200,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1247,7 +1210,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1258,7 +1220,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1269,7 +1230,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "alternate",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1280,7 +1240,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "alternate",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1291,7 +1250,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1302,7 +1260,6 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1314,7 +1271,6 @@ class TransformerLayerAttr:
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
             LORA_SCOPE: "all",
-            WINDOW_SIZE: (-1, -1),
         },
         {
             USE_BIAS: True,
@@ -1381,7 +1337,7 @@ class TestTransformer(TestLayer):
         )
         drop_path = 0.0
         transpose_batch_sequence = attrs[TransformerLayerAttr.TRANSPOSE_BS]
-        window_size = attrs[TransformerLayerAttr.WINDOW_SIZE]
+        window_size = attrs.get(TransformerLayerAttr.WINDOW_SIZE, None)
 
         rel_embedding_init = RelativePositionBiases.generate_embedding_init(
             relative_embedding.embedding_init,

--- a/tests/jax/test_praxis_layers.py
+++ b/tests/jax/test_praxis_layers.py
@@ -645,41 +645,64 @@ class DotProductAttnAttr:
     NUM_GQA_GROUPS = "num_gqa_groups"
     TRANSPOSE_BS = "transpose_batch_sequence"
     SCALE_FACTOR = "scale_factor"
+    WINDOW_SIZE_LEFT = "window_size_left"
+    WINDOW_SIZE_RIGHT = "window_size_right"
     ATTRS = [
         {
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             ATTN_MASK_TYPE: "padding_causal",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
             SCALE_FACTOR: 0.125,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 0.125,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             ATTN_MASK_TYPE: "padding_causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 2.0,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             ATTN_MASK_TYPE: "no_mask",
             TRANSPOSE_BS: False,
             SCALE_FACTOR: 1.0,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
+        },
+        {
+            ATTN_MASK_TYPE: "causal",
+            TRANSPOSE_BS: False,
+            SCALE_FACTOR: 1.0,
+            WINDOW_SIZE_LEFT: 64,
+            WINDOW_SIZE_RIGHT: 0,
         },
     ]
 
@@ -707,6 +730,8 @@ class TestDotProductAttn(TestLayer):
         num_gqa_groups = num_attention_heads
         attn_mask_type = attrs[DotProductAttnAttr.ATTN_MASK_TYPE]
         transpose_batch_sequence = attrs[DotProductAttnAttr.TRANSPOSE_BS]
+        window_size_left = attrs[DotProductAttnAttr.WINDOW_SIZE_LEFT]
+        window_size_right = attrs[DotProductAttnAttr.WINDOW_SIZE_RIGHT]
 
         praxis_p = pax_fiddle.Config(
             DotProductAttention,
@@ -717,6 +742,8 @@ class TestDotProductAttn(TestLayer):
             num_gqa_groups=num_gqa_groups,
             attn_mask_type=attn_mask_type,
             transpose_batch_sequence=transpose_batch_sequence,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
         flax_cls = partial(
             flax_DotProductAttention,
@@ -726,6 +753,8 @@ class TestDotProductAttn(TestLayer):
             num_gqa_groups=num_gqa_groups,
             attn_mask_type=attn_mask_type,
             transpose_batch_sequence=transpose_batch_sequence,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
 
         return praxis_p, flax_cls
@@ -750,6 +779,8 @@ class MultiHeadAttnAttr:
     ENABLE_ROPE = "enable_rotary_pos_emb"
     ROPE_GROUP_METHOD = "rotary_pos_emb_group_method"
     LORA_SCOPE = "low_rank_adaptation_scope"
+    WINDOW_SIZE_LEFT = "window_size_left"
+    WINDOW_SIZE_RIGHT = "window_size_right"
     ATTRS = [
         {
             USE_BIAS: True,
@@ -759,6 +790,8 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -768,6 +801,8 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -777,6 +812,8 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "padding",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -786,6 +823,8 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -795,6 +834,8 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -804,6 +845,8 @@ class MultiHeadAttnAttr:
             ROPE_GROUP_METHOD: "consecutive",
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -815,6 +858,8 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -826,6 +871,8 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -837,6 +884,8 @@ class MultiHeadAttnAttr:
             NUM_GQA_GROUPS: 4,
             ATTN_MASK_TYPE: "causal",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -847,6 +896,8 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "padding",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -857,6 +908,20 @@ class MultiHeadAttnAttr:
             ATTN_MASK_TYPE: "causal",
             LORA_SCOPE: "all",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
+        },
+        {
+            USE_BIAS: True,
+            LN_TYPE: "layernorm",
+            ZERO_CEN: False,
+            ENABLE_ROPE: False,
+            ROPE_GROUP_METHOD: "consecutive",
+            ATTN_MASK_TYPE: "causal",
+            LORA_SCOPE: "all",
+            TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: 64,
+            WINDOW_SIZE_RIGHT: 0,
         },
     ]
 
@@ -899,6 +964,8 @@ class TestMultiHeadAttn(TestLayer):
         scale_attn_logits = False
         scaled_query_init = True
         float32_logits = False
+        window_size_left = attrs[MultiHeadAttnAttr.WINDOW_SIZE_LEFT]
+        window_size_right = attrs[MultiHeadAttnAttr.WINDOW_SIZE_RIGHT]
 
         praxis_p = pax_fiddle.Config(
             MultiHeadAttention,
@@ -923,6 +990,8 @@ class TestMultiHeadAttn(TestLayer):
             scale_attn_logits=scale_attn_logits,
             scaled_query_init=scaled_query_init,
             float32_logits=float32_logits,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
         flax_cls = partial(
             flax_MultiHeadAttention,
@@ -946,6 +1015,8 @@ class TestMultiHeadAttn(TestLayer):
             scale_attn_logits=scale_attn_logits,
             scaled_query_init=scaled_query_init,
             float32_logits=float32_logits,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
 
         return praxis_p, flax_cls
@@ -983,6 +1054,8 @@ class TransformerLayerAttr:
     ENABLE_ROPE = "enable_rotary_pos_emb"
     ROPE_GROUP_METHOD = "rotary_pos_emb_group_method"
     LORA_SCOPE = "low_rank_adaptation_scope"
+    WINDOW_SIZE_LEFT = "window_size_left"
+    WINDOW_SIZE_RIGHT = "window_size_right"
     ATTRS = [
         {
             USE_BIAS: True,
@@ -993,6 +1066,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1003,6 +1078,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1013,6 +1090,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1023,6 +1102,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1033,6 +1114,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1043,6 +1126,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1053,6 +1138,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1063,6 +1150,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1073,6 +1162,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1083,6 +1174,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1093,6 +1186,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1103,6 +1198,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1113,6 +1210,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1123,6 +1222,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1133,6 +1234,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1143,6 +1246,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1154,6 +1259,8 @@ class TransformerLayerAttr:
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
             LORA_SCOPE: "all",
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1164,6 +1271,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1174,6 +1283,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1184,6 +1295,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: True,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1194,6 +1307,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: False,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1204,6 +1319,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "alternate",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1214,6 +1331,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "alternate",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1224,6 +1343,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1234,6 +1355,8 @@ class TransformerLayerAttr:
             ENABLE_ROPE: True,
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
         },
         {
             USE_BIAS: True,
@@ -1245,6 +1368,32 @@ class TransformerLayerAttr:
             ROPE_GROUP_METHOD: "consecutive",
             TRANSPOSE_BS: False,
             LORA_SCOPE: "all",
+            WINDOW_SIZE_LEFT: -1,
+            WINDOW_SIZE_RIGHT: -1,
+        },
+        {
+            USE_BIAS: True,
+            LN_TYPE: "layernorm",
+            ZERO_CEN: False,
+            ACTIVATION: ("relu",),
+            LYR_TYPE: TransformerLayerType.ENCODER,
+            ENABLE_ROPE: False,
+            ROPE_GROUP_METHOD: "consecutive",
+            TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: 64,
+            WINDOW_SIZE_RIGHT: 0,
+        },
+        {
+            USE_BIAS: True,
+            LN_TYPE: "layernorm",
+            ZERO_CEN: False,
+            ACTIVATION: ("relu",),
+            LYR_TYPE: TransformerLayerType.DECODER,
+            ENABLE_ROPE: False,
+            ROPE_GROUP_METHOD: "consecutive",
+            TRANSPOSE_BS: False,
+            WINDOW_SIZE_LEFT: 64,
+            WINDOW_SIZE_RIGHT: 0,
         },
     ]
 
@@ -1289,6 +1438,8 @@ class TestTransformer(TestLayer):
         )
         drop_path = 0.0
         transpose_batch_sequence = attrs[TransformerLayerAttr.TRANSPOSE_BS]
+        window_size_left = attrs[TransformerLayerAttr.WINDOW_SIZE_LEFT]
+        window_size_right = attrs[TransformerLayerAttr.WINDOW_SIZE_RIGHT]
 
         rel_embedding_init = RelativePositionBiases.generate_embedding_init(
             relative_embedding.embedding_init,
@@ -1330,6 +1481,8 @@ class TestTransformer(TestLayer):
             relative_embedding=relative_embedding,
             drop_path=drop_path,
             transpose_batch_sequence=transpose_batch_sequence,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
         flax_cls = partial(
             flax_TransformerLayer,
@@ -1358,6 +1511,8 @@ class TestTransformer(TestLayer):
             low_rank_adaptation_scope=low_rank_adaptation_scope,
             drop_path=drop_path,
             transpose_batch_sequence=transpose_batch_sequence,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
         )
 
         return praxis_p, flax_cls

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -915,7 +915,7 @@ def apply_swa_mask(
         "causal": AttnMaskType.CAUSAL_MASK,
         "padding_causal": AttnMaskType.PADDING_CAUSAL_MASK,
         "causal_bottom_right": AttnMaskType.CAUSAL_BOTTOM_RIGHT_MASK,
-        "padding_causal_bottom_right": AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK
+        "padding_causal_bottom_right": AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK,
     }
     _attn_mask_type = mask_map.get(attn_mask_type, None)
     assert _attn_mask_type is not None

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -920,6 +920,7 @@ def apply_swa_mask(
     new_mask = jnp.where(original_mask == 1, swa_mask_bcast, original_mask)
     return new_mask
 
+
 class EncoderLayer(nn.Module):
     """Transformer encoder layer."""
 
@@ -965,8 +966,12 @@ class EncoderLayer(nn.Module):
     def __call__(self, inputs, encoder_mask=None, deterministic=False):
         # Currently cuDNN backend only supports SWA for causal/padding_causal, follow this
         if self.self_attn_mask_type in ["causal", "padding_causal"] and self.window_size_left > 0:
-            encoder_mask = apply_swa_mask(self.self_attn_mask_type, encoder_mask,
-                                          self.window_size_left, self.window_size_right)
+            encoder_mask = apply_swa_mask(
+                self.self_attn_mask_type,
+                encoder_mask,
+                self.window_size_left,
+                self.window_size_right,
+            )
 
         # Relative position embedding as attention biases.
         sequence_dim = 0 if self.transpose_batch_sequence else 1
@@ -1133,8 +1138,12 @@ class DecoderLayer(nn.Module):
     ):
         # Currently cuDNN backend only supports SWA for causal/padding_causal, follow this
         if self.self_attn_mask_type in ["causal", "padding_causal"] and self.window_size_left > 0:
-            decoder_mask = apply_swa_mask(self.self_attn_mask_type, decoder_mask,
-                                          self.window_size_left, self.window_size_right)
+            decoder_mask = apply_swa_mask(
+                self.self_attn_mask_type,
+                decoder_mask,
+                self.window_size_left,
+                self.window_size_right,
+            )
 
         # Relative position embedding as attention biases.
         sequence_dim = 0 if self.transpose_batch_sequence else 1

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -18,7 +18,7 @@ from jax import lax, vmap
 from jax import nn as jax_nn
 from jax import random as jax_random
 
-from transformer_engine.jax.attention import AttnMaskType, get_swa_mask
+from transformer_engine.jax.attention import AttnMaskType, make_swa_mask
 from transformer_engine.jax.fp8 import DType as TEDType
 
 PRNGKey = Any
@@ -921,7 +921,7 @@ def apply_swa_mask(
     assert _attn_mask_type is not None
     max_seqlen_q = original_mask.shape[-2]
     max_seqlen_kv = original_mask.shape[-1]
-    swa_mask = get_swa_mask(window_size, max_seqlen_q, max_seqlen_kv, _attn_mask_type)
+    swa_mask = make_swa_mask(max_seqlen_q, max_seqlen_kv, window_size, _attn_mask_type)
     # In swa_mask and original_mask 0 is masked out
     swa_mask = swa_mask.astype(original_mask.dtype)
     swa_mask_bcast = jnp.broadcast_to(swa_mask, original_mask.shape)

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -119,11 +119,13 @@ def check_set_window_size(
         ):
             window_size = (orig_window_size[0], 0)
             warnings.warn(
-                "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type=" + attn_mask_type.name
+                "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type="
+                + attn_mask_type.name
             )
         elif orig_window_size != (-1, 0) and (orig_window_size[0] < 0 or orig_window_size[1] != 0):
             assert False, (
-                "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type=" + attn_mask_type.name
+                "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type="
+                + attn_mask_type.name
             )
     elif attn_mask_type in non_causal_mask_types:
         if orig_window_size is None:
@@ -131,15 +133,18 @@ def check_set_window_size(
         elif orig_window_size == (-1, 0):
             window_size = (-1, -1)
             warnings.warn(
-                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type.name
+                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type="
+                + attn_mask_type.name
             )
         elif orig_window_size != (-1, -1) and (orig_window_size[0] < 0 or orig_window_size[1] < 0):
             assert False, (
-                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type.name
+                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type="
+                + attn_mask_type.name
             )
     else:
         assert False, "Invalid attn_mask_type: " + attn_mask_type.name
     return window_size
+
 
 def canonicalize_attn_mask_type(attn_mask_type: str):
     """Convert string attn_mask_type to AttnMaskType
@@ -184,8 +189,8 @@ def is_fused_attn_kernel_available(
     q_max_seqlen,
     kv_max_seqlen,
     head_dim,
-    window_size_left = -1,
-    window_size_right = -1,
+    window_size_left=-1,
+    window_size_right=-1,
 ):
     """
     To check whether the fused attention kernel is supported

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -151,7 +151,7 @@ def make_swa_mask(
     max_seqlen_kv: int,
     window_size: Optional[Tuple[int, int]] = None,
     attn_mask_type: AttnMaskType = AttnMaskType.NO_MASK,
-    dtype: jax.typing.DTypeLike = jnp.float32
+    dtype: jax.typing.DTypeLike = jnp.float32,
 ):
     """
     Generate sliding window mask. `True` or `1` means keep the element.
@@ -185,7 +185,7 @@ def make_swa_mask(
         return swa_mask
     bottom_right_masks = [
         AttnMaskType.CAUSAL_BOTTOM_RIGHT_MASK,
-        AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK
+        AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK,
     ]
     left_window, right_window = window_size
     if attn_mask_type in bottom_right_masks:

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -244,8 +244,7 @@ def is_fused_attn_kernel_available(
     q_max_seqlen,
     kv_max_seqlen,
     head_dim,
-    window_size_left=-1,
-    window_size_right=-1,
+    window_size: Tuple[int, int] = (-1, -1),
 ):
     """
     To check whether the fused attention kernel is supported
@@ -262,8 +261,7 @@ def is_fused_attn_kernel_available(
         q_max_seqlen,
         kv_max_seqlen,
         head_dim,
-        window_size_left,
-        window_size_right,
+        window_size,
     ).is_fused_attn_kernel_available()
 
 
@@ -366,8 +364,7 @@ def fused_attn(
     scaling_factor: float,
     dropout_probability: float,
     is_training: bool,
-    window_size_left: int = -1,
-    window_size_right: int = -1,
+    window_size: Tuple[int, int] = (-1, -1),
     context_parallel_causal_load_balanced: bool = False,
     context_parallel_axis: str = "",
 ):
@@ -396,8 +393,7 @@ def fused_attn(
         scaling_factor (float): Scaling factor for the attention scores.
         dropout_probability (float): Dropout probability to apply during attention.
         is_training (bool): Flag indicating whether the model is in training mode.
-        window_size_left (int): Sliding window size (the left half).
-        window_size_right (int): Sliding window size (the right half).
+        window_size (Tuple[int, int]): Sliding window size.
         context_parallel_causal_load_balanced (bool):
             Indicates the sequences are ordered for causal mask load balancing when running context parallelism.
         context_parallel_axis (str): The name of the context parallel axis.
@@ -455,8 +451,7 @@ def fused_attn(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=1,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
+        window_size=window_size,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )
@@ -479,8 +474,7 @@ def fused_attn_thd(
     dropout_probability: float,
     is_training: bool,
     max_segments_per_seq: int = 1,
-    window_size_left: int = -1,
-    window_size_right: int = -1,
+    window_size: Tuple[int, int] = (-1, -1),
     context_parallel_causal_load_balanced: bool = False,
     context_parallel_axis: str = "",
 ):
@@ -521,6 +515,8 @@ def fused_attn_thd(
             Indicating the maximum number of segments inside a sequence. This parameter is to
             constrain the limit usage and need to be static during the e2e training. The XLA compile
             time and memory consumption is proportional to `max_segments_per_seq`.
+        window_size (Tuple[int, int]):
+            Sliding window size.
         context_parallel_causal_load_balanced (bool):
             Indicates the sequences are ordered for causal mask load balancing when running context parallelism.
         context_parallel_axis (str): The name of the context parallel axis.
@@ -578,8 +574,7 @@ def fused_attn_thd(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=max_segments_per_seq,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
+        window_size=window_size,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )
@@ -587,7 +582,7 @@ def fused_attn_thd(
     return output
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17))
+@partial(jax.custom_vjp, nondiff_argnums=(7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
 def _fused_attn(
     qkv: Tuple[jnp.ndarray, ...],
     bias: Optional[jnp.ndarray],
@@ -603,8 +598,7 @@ def _fused_attn(
     dropout_probability: float,
     is_training: bool,
     max_segments_per_seq: int,
-    window_size_left: int,
-    window_size_right: int,
+    window_size: Tuple[int, int],
     context_parallel_causal_load_balanced: bool,
     context_parallel_axis: str,
 ):
@@ -623,8 +617,7 @@ def _fused_attn(
         dropout_probability,
         is_training,
         max_segments_per_seq,
-        window_size_left,
-        window_size_right,
+        window_size,
         context_parallel_causal_load_balanced,
         context_parallel_axis,
     )
@@ -646,8 +639,7 @@ def _fused_attn_fwd_rule(
     dropout_probability,
     is_training,
     max_segments_per_seq,
-    window_size_left,
-    window_size_right,
+    window_size,
     context_parallel_causal_load_balanced,
     context_parallel_axis,
 ):
@@ -666,8 +658,7 @@ def _fused_attn_fwd_rule(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=max_segments_per_seq,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
+        window_size=window_size,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )
@@ -695,8 +686,7 @@ def _fused_attn_bwd_rule(
     dropout_probability,
     is_training,
     max_segments_per_seq,
-    window_size_left,
-    window_size_right,
+    window_size,
     context_parallel_causal_load_balanced,
     context_parallel_axis,
     ctx,
@@ -731,8 +721,7 @@ def _fused_attn_bwd_rule(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=max_segments_per_seq,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
+        window_size=window_size,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -145,6 +145,7 @@ def check_set_window_size(
         assert False, "Invalid attn_mask_type: " + attn_mask_type.name
     return window_size
 
+
 # Following get_swa_mask() in transformer_engine/pytorch/attention.py
 def get_swa_mask(
     window_size: Tuple[int, int],
@@ -198,6 +199,7 @@ def get_swa_mask(
             swa_mask = jnp.triu(swa_mask, k=max_seqlen_kv - max_seqlen_q - left)
             swa_mask = jnp.tril(swa_mask, k=max_seqlen_kv - max_seqlen_q + right)
     return swa_mask
+
 
 def canonicalize_attn_mask_type(attn_mask_type: str):
     """Convert string attn_mask_type to AttnMaskType

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -6,6 +6,7 @@
 from enum import Enum
 from functools import partial
 from typing import Optional, Tuple
+import warnings
 from jax.ad_checkpoint import checkpoint_name
 import jax
 import jax.numpy as jnp
@@ -86,6 +87,60 @@ def get_qkv_format(qkv_layout):
     return QKVFormat(nvte_get_qkv_format(qkv_layout.value))
 
 
+# Following check_set_window_size() in transformer_engine/pytorch/attention.py
+def check_set_window_size(
+    attn_mask_type: AttnMaskType,
+    window_size: Tuple[int, int] = None,
+):
+    """Check if sliding window size is compliant with attention mask type.
+    If not, set it to the appropriate size.
+
+         attn_mask_type                              |   window_size
+    -------------------------------------------------------------------------
+    NO_MASK, PADDING_MASK                            | (-1, -1) or (>=0, >=0)
+    CAUSAL_MASK                                      | (-1,  0) or (>=0, 0)
+    PADDING_CAUSAL_MASK                              | (-1,  0) or (>=0, 0)
+    CAUSAL_BOTTOM_RIGHT_MASK                         | (-1,  0) or (>=0, 0)
+    PADDING_CAUSAL_BOTTOM_RIGHT_MASK                 | (-1,  0) or (>=0, 0)
+    """
+    orig_window_size = window_size
+    non_causal_mask_types = {AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK}
+    causal_mask_types = {
+        AttnMaskType.CAUSAL_MASK,
+        AttnMaskType.PADDING_CAUSAL_MASK,
+        AttnMaskType.CAUSAL_BOTTOM_RIGHT_MASK,
+        AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK,
+    }
+    if attn_mask_type in causal_mask_types:
+        if orig_window_size is None:
+            window_size = (-1, 0)
+        elif orig_window_size == (-1, -1) or (
+            orig_window_size[0] >= 0 and orig_window_size[1] != 0
+        ):
+            window_size = (orig_window_size[0], 0)
+            warnings.warn(
+                "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type=" + attn_mask_type.name
+            )
+        elif orig_window_size != (-1, 0) and (orig_window_size[0] < 0 or orig_window_size[1] != 0):
+            assert False, (
+                "window_size should be (-1, 0) or (>=0, 0) for attn_mask_type=" + attn_mask_type.name
+            )
+    elif attn_mask_type in non_causal_mask_types:
+        if orig_window_size is None:
+            window_size = (-1, -1)
+        elif orig_window_size == (-1, 0):
+            window_size = (-1, -1)
+            warnings.warn(
+                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type.name
+            )
+        elif orig_window_size != (-1, -1) and (orig_window_size[0] < 0 or orig_window_size[1] < 0):
+            assert False, (
+                "window_size should be (-1, -1) or (>=0, >=0) for attn_mask_type=" + attn_mask_type.name
+            )
+    else:
+        assert False, "Invalid attn_mask_type: " + attn_mask_type.name
+    return window_size
+
 def canonicalize_attn_mask_type(attn_mask_type: str):
     """Convert string attn_mask_type to AttnMaskType
     TE-JAX currently fall back to the padding version kernels for the libraries integration.
@@ -129,6 +184,8 @@ def is_fused_attn_kernel_available(
     q_max_seqlen,
     kv_max_seqlen,
     head_dim,
+    window_size_left = -1,
+    window_size_right = -1,
 ):
     """
     To check whether the fused attention kernel is supported
@@ -145,6 +202,8 @@ def is_fused_attn_kernel_available(
         q_max_seqlen,
         kv_max_seqlen,
         head_dim,
+        window_size_left,
+        window_size_right,
     ).is_fused_attn_kernel_available()
 
 
@@ -247,6 +306,8 @@ def fused_attn(
     scaling_factor: float,
     dropout_probability: float,
     is_training: bool,
+    window_size_left: int = -1,
+    window_size_right: int = -1,
     context_parallel_causal_load_balanced: bool = False,
     context_parallel_axis: str = "",
 ):
@@ -275,6 +336,8 @@ def fused_attn(
         scaling_factor (float): Scaling factor for the attention scores.
         dropout_probability (float): Dropout probability to apply during attention.
         is_training (bool): Flag indicating whether the model is in training mode.
+        window_size_left (int): Sliding window size (the left half).
+        window_size_right (int): Sliding window size (the right half).
         context_parallel_causal_load_balanced (bool):
             Indicates the sequences are ordered for causal mask load balancing when running context parallelism.
         context_parallel_axis (str): The name of the context parallel axis.
@@ -332,6 +395,8 @@ def fused_attn(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=1,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )
@@ -354,6 +419,8 @@ def fused_attn_thd(
     dropout_probability: float,
     is_training: bool,
     max_segments_per_seq: int = 1,
+    window_size_left: int = -1,
+    window_size_right: int = -1,
     context_parallel_causal_load_balanced: bool = False,
     context_parallel_axis: str = "",
 ):
@@ -451,6 +518,8 @@ def fused_attn_thd(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=max_segments_per_seq,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )
@@ -458,7 +527,7 @@ def fused_attn_thd(
     return output
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(7, 8, 9, 10, 11, 12, 13, 14, 15))
+@partial(jax.custom_vjp, nondiff_argnums=(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17))
 def _fused_attn(
     qkv: Tuple[jnp.ndarray, ...],
     bias: Optional[jnp.ndarray],
@@ -474,6 +543,8 @@ def _fused_attn(
     dropout_probability: float,
     is_training: bool,
     max_segments_per_seq: int,
+    window_size_left: int,
+    window_size_right: int,
     context_parallel_causal_load_balanced: bool,
     context_parallel_axis: str,
 ):
@@ -492,6 +563,8 @@ def _fused_attn(
         dropout_probability,
         is_training,
         max_segments_per_seq,
+        window_size_left,
+        window_size_right,
         context_parallel_causal_load_balanced,
         context_parallel_axis,
     )
@@ -513,6 +586,8 @@ def _fused_attn_fwd_rule(
     dropout_probability,
     is_training,
     max_segments_per_seq,
+    window_size_left,
+    window_size_right,
     context_parallel_causal_load_balanced,
     context_parallel_axis,
 ):
@@ -531,6 +606,8 @@ def _fused_attn_fwd_rule(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=max_segments_per_seq,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )
@@ -558,6 +635,8 @@ def _fused_attn_bwd_rule(
     dropout_probability,
     is_training,
     max_segments_per_seq,
+    window_size_left,
+    window_size_right,
     context_parallel_causal_load_balanced,
     context_parallel_axis,
     ctx,
@@ -592,6 +671,8 @@ def _fused_attn_bwd_rule(
         dropout_probability=dropout_probability,
         is_training=is_training,
         max_segments_per_seq=max_segments_per_seq,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
         context_parallel_causal_load_balanced=context_parallel_causal_load_balanced,
         context_parallel_axis=context_parallel_axis,
     )

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -1060,6 +1060,10 @@ class FusedAttnCPWithAllGatherFwdPrimitive(FusedAttnFwdPrimitive):
     def partition(config, mesh, arg_infos, result_infos):
         # Call base implementation for non-context parallel mesh to avoid unecessary work.
         is_context_parallel = get_mesh_axis_size(config.cp_axis, mesh) > 1
+        if is_context_parallel and config.window_size_left > -1:
+            assert (
+                is_context_parallel and config.window_size_left == -1
+            ), "Sliding window attention is not supported when context parallelism is enabled"
         if not is_context_parallel:
             return FusedAttnFwdPrimitive.partition(config, mesh, arg_infos, result_infos)
 
@@ -1154,6 +1158,10 @@ class FusedAttnCPWithAllGatherBwdPrimitive(FusedAttnBwdPrimitive):
     def partition(config, mesh, arg_infos, result_infos):
         # Call base implementation for non-context parallel mesh to avoid unecessary work.
         is_context_parallel = get_mesh_axis_size(config.cp_axis, mesh) > 1
+        if is_context_parallel and config.window_size_left > -1:
+            assert (
+                is_context_parallel and config.window_size_left == -1
+            ), "Sliding window attention is not supported when context parallelism is enabled"
         if not is_context_parallel:
             return FusedAttnBwdPrimitive.partition(config, mesh, arg_infos, result_infos)
 

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -127,7 +127,7 @@ class FusedAttnHelper:
             self.kv_max_seqlen,
             self.head_dim,
             self.window_size_left,
-            self.window_size_right
+            self.window_size_right,
         )
 
     @staticmethod
@@ -272,7 +272,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
             kv_max_seqlen,
             head_dim,
             config.window_size_left,
-            config.window_size_right
+            config.window_size_right,
         ).get_fused_attn_backend()
 
         if backend == NVTE_Fused_Attn_Backend.NVTE_F16_max512_seqlen:
@@ -320,7 +320,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
             config.is_training,
             config.max_segments_per_seq,
             config.window_size_left,
-            config.window_size_right
+            config.window_size_right,
         )
         wkspace_aval = q_aval.update(
             shape=wkspace_info[0], dtype=te_dtype_to_jax_dtype(wkspace_info[1])
@@ -401,7 +401,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
             config.is_training,
             not FusedAttnHelper.is_non_deterministic_allowed(),
             config.window_size_left,
-            config.window_size_right
+            config.window_size_right,
         )
 
         out = custom_caller(FusedAttnFwdPrimitive.name, args, opaque, has_side_effect=False)
@@ -630,7 +630,7 @@ class FusedAttnBwdPrimitive(BasePrimitive):
             deterministic,
             config.max_segments_per_seq,
             config.window_size_left,
-            config.window_size_right
+            config.window_size_right,
         )
 
         dq_aval = q_aval.update(shape=q_aval.shape, dtype=q_dtype)
@@ -731,7 +731,7 @@ class FusedAttnBwdPrimitive(BasePrimitive):
             config.is_training,
             not FusedAttnHelper.is_non_deterministic_allowed(),
             config.window_size_left,
-            config.window_size_right
+            config.window_size_right,
         )
 
         out = custom_caller(FusedAttnBwdPrimitive.name, args, opaque, has_side_effect=False)
@@ -1261,7 +1261,7 @@ class FusedAttnCPWithAllGatherBwdPrimitive(FusedAttnBwdPrimitive):
                     output,
                     doutput,
                     q_seqlen,
-                    kv_seqlen
+                    kv_seqlen,
                 )
                 for idx in range(cp_size)
             ]

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -223,6 +223,7 @@ def generate_cu_seqlen(actual_seqlen):
 def _fix_window_size_left(window_size_left: int) -> int:
     return window_size_left + 1
 
+
 class FusedAttnFwdPrimitive(BasePrimitive):
     """
     Fused Attention Forward Primitive

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -221,7 +221,7 @@ def generate_cu_seqlen(actual_seqlen):
 # results. FusedAttn{Fwd, Bwd}Primitive classes are the entering points to C++ backends, so we
 # make the change here. This function needs to be removed if the cuDNN API is fixed.
 def _fix_window_size_left(window_size_left: int) -> int:
-    return window_size_left + 1
+    return window_size_left if window_size_left == -1 else window_size_left + 1
 
 
 class FusedAttnFwdPrimitive(BasePrimitive):

--- a/transformer_engine/jax/csrc/extensions.h
+++ b/transformer_engine/jax/csrc/extensions.h
@@ -135,6 +135,8 @@ struct CustomCallFusedAttnDescriptor {
   DType wkspace_dtype;
   bool is_training;
   bool deterministic;
+  int64_t window_size_left;
+  int64_t window_size_right;
 };
 
 pybind11::bytes PackCustomCallFusedAttnDescriptor(
@@ -143,7 +145,7 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
     size_t max_segments_per_seq, size_t wkspace_size, float scaling_factor,
     float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
     NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype, bool is_training,
-    bool deterministic);
+    bool deterministic, int64_t window_size_left, int64_t window_size_right);
 
 // Transpose
 
@@ -239,14 +241,15 @@ NVTE_Fused_Attn_Backend GetFusedAttnBackend(DType q_dtype, DType kv_dtype,
                                             NVTE_Mask_Type mask_type, float dropout_probability,
                                             size_t q_num_heads, size_t kv_num_heads,
                                             size_t q_max_seqlen, size_t kv_max_seqlen,
-                                            size_t head_dim);
+                                            size_t head_dim, int64_t window_size_left,
+                                            int64_t window_size_right);
 
 pybind11::tuple GetFusedAttnForwardWorkspaceSizes(
     size_t input_batch, size_t bias_batch, size_t q_max_seqlen, size_t kv_max_seqlen,
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
     float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
     NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training,
-    size_t max_segments_per_seq);
+    size_t max_segments_per_seq, int64_t window_size_left, int64_t window_size_right);
 
 void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 
@@ -255,7 +258,7 @@ pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
     float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
     NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training,
-    bool deterministic, size_t max_segments_per_seq);
+    bool deterministic, size_t max_segments_per_seq, int64_t window_size_left, int64_t window_size_right);
 
 void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 

--- a/transformer_engine/jax/csrc/extensions.h
+++ b/transformer_engine/jax/csrc/extensions.h
@@ -258,7 +258,8 @@ pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
     size_t attn_heads, size_t num_gqa_groups, size_t bias_heads, size_t head_dim,
     float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
     NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, bool is_training,
-    bool deterministic, size_t max_segments_per_seq, int64_t window_size_left, int64_t window_size_right);
+    bool deterministic, size_t max_segments_per_seq, int64_t window_size_left,
+    int64_t window_size_right);
 
 void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 

--- a/transformer_engine/jax/csrc/extensions/packing.cpp
+++ b/transformer_engine/jax/csrc/extensions/packing.cpp
@@ -70,11 +70,14 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
     float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
     NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype, bool is_training,
     bool deterministic, int64_t window_size_left, int64_t window_size_right) {
-  return PackOpaque(CustomCallFusedAttnDescriptor{
-      input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, bias_heads,
-      head_dim, max_segments_per_seq, wkspace_size, scaling_factor, dropout_probability, bias_type,
-      mask_type, qkv_layout, dtype, wkspace_dtype, is_training, deterministic, window_size_left,
-      window_size_right});
+  return PackOpaque(
+      CustomCallFusedAttnDescriptor{input_batch,   bias_batch,       q_max_seqlen,
+                                    kv_max_seqlen, attn_heads,       num_gqa_groups,
+                                    bias_heads,    head_dim,         max_segments_per_seq,
+                                    wkspace_size,  scaling_factor,   dropout_probability,
+                                    bias_type,     mask_type,        qkv_layout,
+                                    dtype,         wkspace_dtype,    is_training,
+                                    deterministic, window_size_left, window_size_right});
 }
 
 }  // namespace jax

--- a/transformer_engine/jax/csrc/extensions/packing.cpp
+++ b/transformer_engine/jax/csrc/extensions/packing.cpp
@@ -69,11 +69,12 @@ pybind11::bytes PackCustomCallFusedAttnDescriptor(
     size_t max_segments_per_seq, size_t wkspace_size, float scaling_factor,
     float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
     NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype, bool is_training,
-    bool deterministic) {
+    bool deterministic, int64_t window_size_left, int64_t window_size_right) {
   return PackOpaque(CustomCallFusedAttnDescriptor{
       input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, bias_heads,
       head_dim, max_segments_per_seq, wkspace_size, scaling_factor, dropout_probability, bias_type,
-      mask_type, qkv_layout, dtype, wkspace_dtype, is_training, deterministic});
+      mask_type, qkv_layout, dtype, wkspace_dtype, is_training, deterministic, window_size_left,
+      window_size_right});
 }
 
 }  // namespace jax

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -25,7 +25,7 @@ from jax.ad_checkpoint import checkpoint_name
 from .module import DenseGeneral, LayerNormDenseGeneral, LayerNormMLP
 from .module import LayerNorm, Softmax
 from ..attention import AttnBiasType, AttnMaskType, QKVLayout
-from ..attention import is_fused_attn_kernel_available, canonicalize_attn_mask_type
+from ..attention import is_fused_attn_kernel_available, get_swa_mask, canonicalize_attn_mask_type
 from ..attention import fused_attn
 from ..softmax import SoftmaxType
 from ..sharding import num_of_devices
@@ -118,6 +118,8 @@ class _UnfusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-
     float32_logits: bool = False
     scale_factor: Optional[float] = None
     transpose_batch_sequence: bool = True
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     @nn.compact
     def __call__(
@@ -193,13 +195,33 @@ class _UnfusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-
             if self.attn_bias_type == AttnBiasType.PRE_SCALE_BIAS:
                 attn_weights += bias
 
+        def apply_swa_mask(attn_mask_type: AttnMaskType, original_mask: Array) -> Array:
+            """Apply the sliding window mask to a given mask"""
+            window_size = (self.window_size_left, self.window_size_right)
+            max_seqlen_q = original_mask.shape[-2]
+            max_seqlen_kv = original_mask.shape[-1]
+            swa_mask = get_swa_mask(window_size, max_seqlen_q, max_seqlen_kv, attn_mask_type)
+            # In swa_mask 0 is masked out, in original_mask 1 is masked out
+            swa_mask = 1 - swa_mask.astype(original_mask.dtype)
+            swa_mask_bcast = jnp.broadcast_to(swa_mask, original_mask.shape)
+            new_mask = jnp.where(original_mask == 0, swa_mask_bcast, original_mask)
+            return new_mask
+
+
         def convert_to_softmax_type(attn_mask_type, mask):
             """Convert the attn_mask_type to SoftmaxType"""
-            # mask is ignored for no_mask and causal_mask
-            if attn_mask_type in [AttnMaskType.NO_MASK, AttnMaskType.CAUSAL_MASK]:
+            # mask is ignored for no_mask and causal_mask without sliding window
+            if attn_mask_type == AttnMaskType.NO_MASK:
                 mask = None
+            if attn_mask_type == AttnMaskType.CAUSAL_MASK and self.window_size_left < 0:
+                mask = None
+            # Currently cuDNN backend only supports SWA for causal/padding_causal, follow this
             if attn_mask_type in [AttnMaskType.CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_MASK]:
-                return SoftmaxType.SCALED_UPPER_TRIANG_MASKED, mask
+                if self.window_size_left < 0:
+                    return SoftmaxType.SCALED_UPPER_TRIANG_MASKED, mask
+                else:
+                    swa_mask = apply_swa_mask(attn_mask_type, mask)
+                    return SoftmaxType.SCALED_MASKED, swa_mask
             if attn_mask_type in [AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK]:
                 if mask is not None:
                     return SoftmaxType.SCALED_MASKED, mask
@@ -244,6 +266,8 @@ class _FusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-me
     qkv_layout: QKVLayout = QKVLayout.BSHD_BSHD_BSHD
     scale_factor: Optional[float] = None
     transpose_batch_sequence: bool = False
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     @nn.compact
     def __call__(
@@ -289,6 +313,8 @@ class _FusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-me
                 scaling_factor=scale_factor,
                 dropout_probability=self.attention_dropout,
                 is_training=not deterministic,
+                window_size_left=self.window_size_left,
+                window_size_right=self.window_size_right,
             )
         elif self.qkv_layout == QKVLayout.BSHD_BS2HD:
             """kvpacked format, treat
@@ -311,6 +337,8 @@ class _FusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-me
                 scaling_factor=scale_factor,
                 dropout_probability=self.attention_dropout,
                 is_training=not deterministic,
+                window_size_left=self.window_size_left,
+                window_size_right=self.window_size_right,
             )
         elif self.qkv_layout == QKVLayout.BSHD_BSHD_BSHD:
             if self.transpose_batch_sequence:
@@ -328,6 +356,8 @@ class _FusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-me
                 scaling_factor=scale_factor,
                 dropout_probability=self.attention_dropout,
                 is_training=not deterministic,
+                window_size_left=self.window_size_left,
+                window_size_right=self.window_size_right,
             )
         else:
             raise ValueError(f"Unsupported {self.qkv_layout=}.")
@@ -440,6 +470,10 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         Indicate whether the input tensors were switched axis of batch
         and sequence length dimension. if set to True, the input tensors
         should be in (seqlen, batch, ...), otherwise (batch, seqlen, ...).
+    window_size_left: int, default = -1
+        Sliding window size, the left half.
+    window_size_right: int, default = -1
+        Sliding window size, the right half.
 
     Optimization parameters
     -----------------------
@@ -459,6 +493,8 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
     qkv_layout: str = "bshd_bshd_bshd"
     scale_factor: Optional[float] = None
     transpose_batch_sequence: bool = True
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     @nn.compact
     def __call__(
@@ -532,6 +568,8 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
             seqlen_q,
             seqlen_kv,
             self.head_dim,
+            self.window_size_left,
+            self.window_size_right,
         )
 
         use_fused_attn = enable_fused_attn and has_fused_attn_kernel
@@ -577,6 +615,8 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
                 float32_logits=self.float32_logits,
                 scale_factor=scale_factor,
                 transpose_batch_sequence=self.transpose_batch_sequence,
+                window_size_left=self.window_size_left,
+                window_size_right=self.window_size_right,
             )(query, key, value, mask, bias, dropout_rng=dropout_rng, deterministic=deterministic)
         else:
             x = _FusedDotProductAttention(
@@ -587,6 +627,8 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
                 scale_factor=scale_factor,
                 transpose_batch_sequence=self.transpose_batch_sequence,
                 qkv_layout=qkv_layout,
+                window_size_left=self.window_size_left,
+                window_size_right=self.window_size_right,
             )(query, key, value, mask, bias, dropout_rng=dropout_rng, deterministic=deterministic)
 
         return x
@@ -856,6 +898,10 @@ class MultiHeadAttention(nn.Module):  # pylint: disable=too-few-public-methods
         For fused attention backend, the accumulation is always float32 without the perf overhead.
     fuse_qkv: bool, default = None
         Deprecated. Please refer `fuse_qkv_params`
+    window_size_left: int, default = -1
+        Sliding window size (the left half).
+    window_size_right: int, default = -1
+        Sliding window size (the right half).
     """
 
     head_dim: int
@@ -886,6 +932,8 @@ class MultiHeadAttention(nn.Module):  # pylint: disable=too-few-public-methods
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
     float32_logits: bool = False
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     # Deprecated parameters
     num_heads: Optional[int] = None
@@ -1280,6 +1328,8 @@ class MultiHeadAttention(nn.Module):  # pylint: disable=too-few-public-methods
             qkv_layout=qkv_layout.name,
             scale_factor=scale_factor,
             transpose_batch_sequence=self.transpose_batch_sequence,
+            window_size_left=self.window_size_left,
+            window_size_right=self.window_size_right,
         )(*dpa_args, mask, bias, deterministic=deterministic)
         x = x.reshape((x.shape[0], x.shape[1], x.shape[2] * x.shape[3]))
 
@@ -1555,6 +1605,10 @@ class TransformerLayer(nn.Module):  # pylint: disable=too-few-public-methods
         :math:`\frac{alpha}{rank} * lora\_output`. None means no scaling.
     enable_sequence_parallel: bool, default = False
         Whether to enable sequence parallelism to operations except dot.
+    window_size_left: int, default = -1
+        Sliding window size, the left half.
+    window_size_right: int, default = -1
+        Sliding window size, the right half.
 
     Optimization parameters
     -----------------------
@@ -1618,6 +1672,8 @@ class TransformerLayer(nn.Module):  # pylint: disable=too-few-public-methods
     enable_sequence_parallel: bool = False
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     def __post_init__(self):
         if self.mha_kernel_init is None:
@@ -1771,6 +1827,8 @@ class TransformerLayer(nn.Module):  # pylint: disable=too-few-public-methods
             use_bias=self.use_bias,
             bias_init=self.bias_init,
             name=mha_name,
+            window_size_left=self.window_size_left,
+            window_size_right=self.window_size_right,
         )(inputs, inputs, attention_mask, attn_bias, deterministic=deterministic, decode=decode)
 
         def hidden_dropout(x, deterministic):
@@ -1848,6 +1906,8 @@ class TransformerLayer(nn.Module):  # pylint: disable=too-few-public-methods
                 use_bias=self.use_bias,
                 bias_init=self.bias_init,
                 name="encoder_decoder_attention",
+                window_size_left=self.window_size_left,
+                window_size_right=self.window_size_right,
             )(x, encoded, encoder_decoder_mask, deterministic=deterministic)
 
             y = with_sharding_constraint_by_logical_axes(

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -212,12 +212,11 @@ class _UnfusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-
                 mask = None
             if attn_mask_type == AttnMaskType.CAUSAL_MASK and self.window_size is None:
                 mask = None
+            if mask is not None:
+                mask = apply_swa_mask(attn_mask_type, mask)
             # Currently cuDNN backend only supports SWA for causal/padding_causal, follow this
             if attn_mask_type in [AttnMaskType.CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_MASK]:
-                if self.window_size[0] < 0:
-                    return SoftmaxType.SCALED_UPPER_TRIANG_MASKED, mask
-                swa_mask = apply_swa_mask(attn_mask_type, mask)
-                return SoftmaxType.SCALED_MASKED, swa_mask
+                return SoftmaxType.SCALED_UPPER_TRIANG_MASKED, mask
             if attn_mask_type in [AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK]:
                 if mask is not None:
                     return SoftmaxType.SCALED_MASKED, mask

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -207,7 +207,6 @@ class _UnfusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-
             new_mask = jnp.where(original_mask == 0, swa_mask_bcast, original_mask)
             return new_mask
 
-
         def convert_to_softmax_type(attn_mask_type, mask):
             """Convert the attn_mask_type to SoftmaxType"""
             # mask is ignored for no_mask and causal_mask without sliding window

--- a/transformer_engine/jax/praxis/transformer.py
+++ b/transformer_engine/jax/praxis/transformer.py
@@ -80,7 +80,7 @@ class DotProductAttention(TransformerEngineBaseLayer):
     qkv_layout: str = "bshd_bshd_bshd"
     scale_factor: Optional[float] = None
     transpose_batch_sequence: bool = True
-    window_size: Tuple[int, int] = (-1, -1)
+    window_size: Optional[Tuple[int, int]] = None
 
     def setup(self) -> None:
         """setup"""
@@ -153,7 +153,7 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
     float32_logits: bool = False
-    window_size: Tuple[int, int] = (-1, -1)
+    window_size: Optional[Tuple[int, int]] = None
 
     # Deprecated parameters
     num_heads: Optional[int] = None
@@ -296,7 +296,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
     enable_sequence_parallel: bool = False
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
-    window_size: Tuple[int, int] = (-1, -1)
+    window_size: Optional[Tuple[int, int]] = None
 
     def __post_init__(self):
         if self.num_gqa_groups is None:

--- a/transformer_engine/jax/praxis/transformer.py
+++ b/transformer_engine/jax/praxis/transformer.py
@@ -382,7 +382,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
             scale_attn_logits=self.scale_attn_logits,
             scaled_query_init=self.scaled_query_init,
             window_size_left=self.window_size_left,
-            window_size_right=self.window_size_right
+            window_size_right=self.window_size_right,
         )
 
         self.create_layer("transformerlayer", transformerlayer_cls)

--- a/transformer_engine/jax/praxis/transformer.py
+++ b/transformer_engine/jax/praxis/transformer.py
@@ -80,6 +80,8 @@ class DotProductAttention(TransformerEngineBaseLayer):
     qkv_layout: str = "bshd_bshd_bshd"
     scale_factor: Optional[float] = None
     transpose_batch_sequence: bool = True
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     def setup(self) -> None:
         """setup"""
@@ -102,6 +104,8 @@ class DotProductAttention(TransformerEngineBaseLayer):
             qkv_layout=self.qkv_layout,
             scale_factor=self.scale_factor,
             transpose_batch_sequence=self.transpose_batch_sequence,
+            window_size_left=self.window_size_left,
+            window_size_right=self.window_size_right,
         )
 
         self.create_layer("dot_product_attention", dpa_cls)
@@ -151,6 +155,8 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
     float32_logits: bool = False
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     # Deprecated parameters
     num_heads: Optional[int] = None
@@ -233,6 +239,8 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
             scale_attn_logits=self.scale_attn_logits,
             scaled_query_init=self.scaled_query_init,
             float32_logits=self.float32_logits,
+            window_size_left=self.window_size_left,
+            window_size_right=self.window_size_right,
         )
 
         self.create_layer("multi_head_attn", mha_cls)
@@ -292,6 +300,8 @@ class TransformerLayer(TransformerEngineBaseLayer):
     enable_sequence_parallel: bool = False
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
+    window_size_left: int = -1
+    window_size_right: int = -1
 
     def __post_init__(self):
         if self.num_gqa_groups is None:
@@ -371,6 +381,8 @@ class TransformerLayer(TransformerEngineBaseLayer):
             enable_sequence_parallel=self.enable_sequence_parallel,
             scale_attn_logits=self.scale_attn_logits,
             scaled_query_init=self.scaled_query_init,
+            window_size_left=self.window_size_left,
+            window_size_right=self.window_size_right
         )
 
         self.create_layer("transformerlayer", transformerlayer_cls)

--- a/transformer_engine/jax/praxis/transformer.py
+++ b/transformer_engine/jax/praxis/transformer.py
@@ -80,8 +80,7 @@ class DotProductAttention(TransformerEngineBaseLayer):
     qkv_layout: str = "bshd_bshd_bshd"
     scale_factor: Optional[float] = None
     transpose_batch_sequence: bool = True
-    window_size_left: int = -1
-    window_size_right: int = -1
+    window_size: Tuple[int, int] = (-1, -1)
 
     def setup(self) -> None:
         """setup"""
@@ -104,8 +103,7 @@ class DotProductAttention(TransformerEngineBaseLayer):
             qkv_layout=self.qkv_layout,
             scale_factor=self.scale_factor,
             transpose_batch_sequence=self.transpose_batch_sequence,
-            window_size_left=self.window_size_left,
-            window_size_right=self.window_size_right,
+            window_size=self.window_size,
         )
 
         self.create_layer("dot_product_attention", dpa_cls)
@@ -155,8 +153,7 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
     float32_logits: bool = False
-    window_size_left: int = -1
-    window_size_right: int = -1
+    window_size: Tuple[int, int] = (-1, -1)
 
     # Deprecated parameters
     num_heads: Optional[int] = None
@@ -239,8 +236,7 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
             scale_attn_logits=self.scale_attn_logits,
             scaled_query_init=self.scaled_query_init,
             float32_logits=self.float32_logits,
-            window_size_left=self.window_size_left,
-            window_size_right=self.window_size_right,
+            window_size=self.window_size,
         )
 
         self.create_layer("multi_head_attn", mha_cls)
@@ -300,8 +296,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
     enable_sequence_parallel: bool = False
     scale_attn_logits: bool = False
     scaled_query_init: bool = True
-    window_size_left: int = -1
-    window_size_right: int = -1
+    window_size: Tuple[int, int] = (-1, -1)
 
     def __post_init__(self):
         if self.num_gqa_groups is None:
@@ -381,8 +376,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
             enable_sequence_parallel=self.enable_sequence_parallel,
             scale_attn_logits=self.scale_attn_logits,
             scaled_query_init=self.scaled_query_init,
-            window_size_left=self.window_size_left,
-            window_size_right=self.window_size_right,
+            window_size=self.window_size,
         )
 
         self.create_layer("transformerlayer", transformerlayer_cls)


### PR DESCRIPTION
# Description

Recent models employ sliding window attention (SWA). Some frameworks use cuDNN fused attention through the TE-JAX Flash Attention API. The SWA support has not been exposed to this API yet. However, on the backend TE does have support for the SWA. This PR expose the SWA support to the Flash Attention API.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

Expose sliding window attention to the TE-JAX API

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
