### PR TITLE
Fix cuDNN sliding window size

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -249,7 +249,7 @@ def test_dot_product_attention(
     # Test backend availability
     window_size = (-1, -1)
     if swa:
-        window_size = tuple(torch.randint(0, config.max_seqlen_kv, [2], dtype=torch.int32).tolist())
+        window_size = [min(config.max_seqlen_q, config.max_seqlen_kv)] * 2
     config.window_size = check_set_window_size(config.attn_mask_type, window_size)
     available_backends, fused_attn_backends = _get_attention_backends(
         config,

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -249,7 +249,7 @@ def test_dot_product_attention(
     # Test backend availability
     window_size = (-1, -1)
     if swa:
-        window_size = [min(config.max_seqlen_q, config.max_seqlen_kv)] * 2
+        window_size = [2, 2]
     config.window_size = check_set_window_size(config.attn_mask_type, window_size)
     available_backends, fused_attn_backends = _get_attention_backends(
         config,


### PR DESCRIPTION
# Description

This PR adjusts the sliding window size in `FusedAttention` (cuDNN attention) so it's consistent with our support in `FlashAttention` and `UnfusedDotProductAttention`. 

cuDNN supports sliding window `(i - window_size_left, i]`, exclusive of the `i -window_size_left` element. By passing `window_size_left + 1` to cuDNN, we achieve the same effect as the `[i - window_size_left, i]` support.

This PR also reduces the window size in our unit tests so any numerical differences between backends will be easier to notice.

Fixes #1197 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Adjust the `window_size` passed to cuDNN
- Test smaller window sizes in unit tests

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
