### PR TITLE
[PyTorch] Add documentation for FP8 attention checkpointing

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,47 @@
+..
+    Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+    See LICENSE for license information.
+
+Frequently Asked Questions (FAQ)
+================================
+
+FP8 checkpoint compatibility 
+----------------------------
+
+Transformer Engine starts to support FP8 attention in 1.6. When checkpointing, it stores the FP8 metadata, including the scaling factors and amax history, under a `._extra_state` key. As our FP8 attention support expands from one backend to multiple backends, the location of the `._extra_state` key has also shifted. We take the `MultiheadAttention` module as an example and show the checkpoint structure in different Transformer Engine versions.
+
+.. list-table::
+   :widths: 15 25 50
+   :header-rows: 1
+
+   * - Version
+     - FP8 metadata
+     - Checkpoint compatibility (checkpoint version: loading behavior)
+   * - <= 1.5
+     - None
+     -
+       - <= 1.5: no FP8 metadata loaded (as expected)
+       - > 1.5: "unexpected key" error
+   * - 1.6, 1.7
+     - `core_attention.fused_attention._extra_state`
+     -
+       - <= 1.5: initialize FP8 metadata to default, i.e. 1s for scaling factors and 0s for amaxes
+       - 1.6, 1.7: load FP8 metadata from checkpoint
+       - >= 1.8: "unexpected key" error
+   * - >=1.8, <= 1.11
+     - `core_attention._extra_state`
+     -
+       - <= 1.5: initialize FP8 metadata to default, i.e. 1s for scaling factors and 0s for amaxes
+       - 1.6, 1.7: this checkpoint save/load version pair relies on users to map the 1.6/1.7 key to the 1.8-1.11 key; otherwise, initialize FP8 metadata to default, i.e. 1s for scaling factors and 0s for amaxes. Mapping in this example can be done by:
+         .. code-block:: python
+
+             >>> state_dict["core_attention._extra_state"] = \
+                     state_dict["core_attention.fused_attention._extra_state"]
+             >>> del state_dict["core_attention.fused_attention._extra_state"]
+       - >= 1.8: load FP8 metadata from checkpoint
+   * - >=1.12
+     - `core_attention._extra_state`
+     -
+       - <= 1.5: initialize FP8 metadata to default, i.e. 1s for scaling factors and 0s for amaxes
+       - >= 1.6: load FP8 metadata from checkpoint 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Transformer Engine documentation
 
    installation
    examples/quickstart.ipynb
+   faq
 
 .. toctree::
    :hidden:

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -1006,7 +1006,7 @@ def test_sanity_fp8_gemm_with_unalignment(N, datatype):
 
 
 @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
-@pytest.mark.skipif(get_device_compute_capability() != (9, 0), reason="FP8 tests require Hopper.")
+@pytest.mark.skipif(get_device_compute_capability() < (9, 0), reason="FP8 tests require Hopper.")
 @pytest.mark.skipif(get_cudnn_version() < (9, 3, 0), reason="cuDNN 9.3.0+ is required.")
 @pytest.mark.parametrize("model", ["large"])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -48,6 +48,7 @@ from test_numerics import reset_rng_states, dtype_tols
 # Only run FP8 tests on H100.
 fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()
 
+
 def custom_amax_to_scale(
     amax: torch.Tensor,
     scale: torch.Tensor,
@@ -1013,7 +1014,9 @@ def test_sanity_attention_extra_state(model, dtype):
     config = model_configs[model]
     outputs = _run_attention_extra_state(dtype, config, checkpoint=False)
     outputs_checkpoint = _run_attention_extra_state(dtype, config, checkpoint=True)
-    outputs_checkpoint_v1_6 = _run_attention_extra_state(dtype, config, mimic_v1_6=True, checkpoint=True)
+    outputs_checkpoint_v1_6 = _run_attention_extra_state(
+        dtype, config, mimic_v1_6=True, checkpoint=True
+    )
 
     # Check that results match
     tols = dtype_tols(dtype)
@@ -1032,9 +1035,10 @@ def test_sanity_attention_extra_state(model, dtype):
             **tols,
         )
 
+
 def _run_attention_extra_state(dtype, config, checkpoint=False, mimic_v1_6=False):
     steps = 10
-    path = 'checkpoint.pt'
+    path = "checkpoint.pt"
     fp8_enabled = True
     fp8_recipe = recipe.DelayedScaling(
         margin=0,
@@ -1081,7 +1085,9 @@ def _run_attention_extra_state(dtype, config, checkpoint=False, mimic_v1_6=False
     if checkpoint:
         sd = block.state_dict()
         if mimic_v1_6:
-            sd["self_attention.core_attention.fused_attention._extra_state"] = sd["self_attention.core_attention._extra_state"]
+            sd["self_attention.core_attention.fused_attention._extra_state"] = sd[
+                "self_attention.core_attention._extra_state"
+            ]
             del sd["self_attention.core_attention._extra_state"]
         torch.save(sd, path)
 
@@ -1105,7 +1111,7 @@ def _run_attention_extra_state(dtype, config, checkpoint=False, mimic_v1_6=False
 
         assert not param_grads, "Oops!"
 
-    for i in range((steps+1) // 2):
+    for i in range((steps + 1) // 2):
         with fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe):
             output = block(hidden_states, None)
             loss = output.sum()

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -6614,10 +6614,10 @@ class FusedAttention(torch.nn.Module):
         def remove_extra_states_check(self, incompatible_keys):  # pylint: disable=unused-argument
             """
             Temporarily remove fused_attention._extra_state as a missing key
-            or an unexpected key when loading TransformerEngine checkpoints.
+            or an unexpected key when loading Transformer Engine checkpoints.
             Please store FP8 metadata as DotProductAttention's _extra_state,
             rather than FusedAttention's _extra_state. This hook will be
-            phased out in TransformerEngine 2.0.
+            phased out in Transformer Engine 2.0.
             """
             for key in incompatible_keys.missing_keys:
                 if "fused_attention._extra_state" in key:
@@ -6878,7 +6878,7 @@ class DotProductAttention(TransformerEngineBaseModule):
                    e.g. a different mask for training and inference.
                    1. For "`no_mask`", no attention mask is applied.
                    2. For "`causal`", "`causal_bottom_right`", or the causal mask in
-                   "`padding_causal`" and "`padding_causal_bottom_right`", TransformerEngine
+                   "`padding_causal`" and "`padding_causal_bottom_right`", Transformer Engine
                    calculates and applies an upper triangular mask to the softmax input.
                    No user input is needed. Causal masks without the "`bottom_right`" appendix align
                    the diagonal line to the top left corner of the softmax matrix. With
@@ -7085,14 +7085,36 @@ class DotProductAttention(TransformerEngineBaseModule):
         def remove_extra_states_check(self, incompatible_keys):  # pylint: disable=unused-argument
             """
             Temporarily remove core_attention._extra_state as a missing key
-            when loading older TransformerEngine checkpoints. Will phase out
-            this hook in TransformerEngine 2.0.
+            when loading older Transformer Engine checkpoints. Will phase out
+            this hook in Transformer Engine 2.0.
             """
             for key in incompatible_keys.missing_keys:
                 if "core_attention._extra_state" in key:
                     incompatible_keys.missing_keys.remove(key)
 
         self.register_load_state_dict_post_hook(remove_extra_states_check)
+
+    def _load_from_state_dict(
+        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+    ):
+        """
+        This function helps to load Transformer Engine 1.6 and 1.7 checkpoints, where FP8 metadata
+        is stored under the `core_attention.fused_attention._extra_state` key and not the
+        `core_attention._extra_state` key. For more information, please see
+        `FP8 checkpoint compatibility <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/faq.html#fp8-checkpoint-compatibility>`_.
+        """
+        fused_attn_key = False
+        dot_product_attn_key = False
+        for k in state_dict.keys():
+            if 'core_attention.fused_attention._extra_state' in k:
+                fused_attn_key = True
+            if 'core_attention._extra_state' in k:
+                dot_product_attn_key = True
+        if fused_attn_key and not dot_product_attn_key:
+            prefix = prefix + 'fused_attention.'
+        super()._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+        )
 
     def _checkpointed_attention_forward(
         self,
@@ -7197,14 +7219,14 @@ class DotProductAttention(TransformerEngineBaseModule):
 
             Users can use environment variables :attr:`NVTE_FLASH_ATTN`, :attr:`NVTE_FUSED_ATTN`,
             and :attr:`NVTE_FUSED_ATTN_BACKEND` to control which DotProductAttention backend,
-            and FusedAttention backend if applicable, to use. TransformerEngine prioritizes
+            and FusedAttention backend if applicable, to use. Transformer Engine prioritizes
             FlashAttention over FusedAttention and over UnfusedDotProductAttention.
             If FusedAttention is being used, users can also choose to switch to flash-attn's
             implementation for backward by setting :attr:`NVTE_FUSED_ATTN_USE_FAv2_BWD=1`
             (default: 0), because of the performance differences between various versions of
             flash-attn and FusedAttention. Further, :attr:`NVTE_FUSED_ATTN_FORCE_WORKSPACE_OPT`
             can be used to enable (:attr:`1`) or disable (:attr:`0`) the workspace related
-            optimizations in FusedAttention. When unset, TransformerEngine determines the code path
+            optimizations in FusedAttention. When unset, Transformer Engine determines the code path
             based on its internal logic. These optimizations trade memory for performance
             and should be used with care.
 

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -7106,12 +7106,12 @@ class DotProductAttention(TransformerEngineBaseModule):
         fused_attn_key = False
         dot_product_attn_key = False
         for k in state_dict.keys():
-            if 'core_attention.fused_attention._extra_state' in k:
+            if "core_attention.fused_attention._extra_state" in k:
                 fused_attn_key = True
-            if 'core_attention._extra_state' in k:
+            if "core_attention._extra_state" in k:
                 dot_product_attn_key = True
         if fused_attn_key and not dot_product_attn_key:
-            prefix = prefix + 'fused_attention.'
+            prefix = prefix + "fused_attention."
         super()._load_from_state_dict(
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -6844,31 +6844,11 @@ class DotProductAttention(TransformerEngineBaseModule):
 
     .. note::
 
-        Transformer Engine starts to support FP8 attention from v1.6. It stores the FP8 metadata
-        under a `._extra_state` key in the checkpoint. As the FP8 support expands from FusedAttention
-        alone to both FusedAttention and FlashAttention, the location of the `._extra_state` key
-        has also changed.
+        Transformer Engine starts to support FP8 attention in 1.6. It stores the FP8 metadata
+        under a `._extra_state` key in the checkpoint. As the FP8 attention support expands
+        from one backend to multiple backends, the location of the key has also shifted in
+        different Transformer Engine versions. Please see `FP8 checkpoint compatibility <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/faq.html#fp8-checkpoint-compatibility>`_ for more information.
 
-        (1) <= v1.5:    No `._extra_state` key in the checkpoint as no FP8 support is available.
-                        When loading checkpoints created by > v1.5, it emits "unexpected key" errors.
-        (2) v1.6, v1.7: Stores FP8 metadata at `core_attention.fused_attention._extra_state`.
-                        When loading checkpoints created by < v1.6, it does not emit "missing key"
-                        errors and initializes FP8 metadata to default values, i.e. 1s for scaling
-                        factors and 0s for amaxes.
-                        When loading checkpoints created by > v1.7, it emits "unexpected key" errors
-                        as it does not expect the `core_attention._extra_state` key.
-        (3) >= v1.8:    Stores FP8 metadata at `core_attention._extra_state`.
-                        When loading checkpoints created by < v1.6, it does not emit "missing key"
-                        errors and initializes FP8 metadata to default values, i.e. 1s for scaling
-                        factors and 0s for amaxes.
-                        When loading checkpoints created by v1.6 or v1.7, it does not emit "missing
-                        key" or "unexpected key" errors, but does emit a warning that users should
-                        map the v1.6/v1.7 key to the v1.8 key. Without that mapping, it ignores the
-                        v1.6/v1.7 key and initializes FP8 metadata to default values. The mapping
-                        can be done via:
-                        >>> state_dict["self_attention.core_attention._extra_state"] = \
-                            state_dict["self_attention.core_attention.fused_attention._extra_state"]
-                        >>> del state_dict["self_attention.core_attention.fused_attention._extra_state"]
 
     Parameters
     ----------

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -6989,10 +6989,9 @@ class DotProductAttention(TransformerEngineBaseModule):
 
     .. note::
 
-        Transformer Engine starts to support FP8 attention in 1.6. It stores the FP8 metadata
-        under a `._extra_state` key in the checkpoint. As the FP8 attention support expands
-        from one backend to multiple backends, the location of the key has also shifted in
-        different Transformer Engine versions. Please see `FP8 checkpoint compatibility <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/faq.html#fp8-checkpoint-compatibility>`_ for more information.
+        Transformer Engine stores the FP8 metadata under a `._extra_state` key when checkpointing.
+        As the FP8 attention support expands from one backend to multiple backends, the location
+        of that key has also shifted (see `FP8 checkpoint compatibility <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/faq.html#fp8-checkpoint-compatibility>`_).
 
 
     Parameters
@@ -7249,10 +7248,10 @@ class DotProductAttention(TransformerEngineBaseModule):
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
     ):
         """
-        This function helps to load Transformer Engine 1.6 and 1.7 checkpoints, where FP8 metadata
-        is stored under the `core_attention.fused_attention._extra_state` key and not the
-        `core_attention._extra_state` key. For more information, please see
-        `FP8 checkpoint compatibility <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/faq.html#fp8-checkpoint-compatibility>`_.
+        This function helps to load Transformer Engine 1.6 and 1.7 checkpoints, where FP8 attention
+        metadata is stored under the `core_attention.fused_attention._extra_state` key and not the
+        `core_attention._extra_state` key. Please see `FP8 checkpoint compatibility
+        <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/faq.html#fp8-checkpoint-compatibility>`_ for more details.
         """
         fused_attn_key = False
         dot_product_attn_key = False


### PR DESCRIPTION
# Description

This PR adds an FAQ page to the documentation, and adds a section to the FAQ about FP8 checkpoint compatibility. It also adds a sanity unit test for checkpointing with 1.11(save)/1.11(load), and 1.6(save)/1.11(load).

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Adds documentation and tests for FP8 checkpointing

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
