### PR TITLE
[PyTorch] Drop FA as an installation requirement

### DIFF
--- a/qa/L1_pytorch_FA_versions_test/test.sh
+++ b/qa/L1_pytorch_FA_versions_test/test.sh
@@ -1,0 +1,15 @@
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+set -e
+
+: ${TE_PATH:=/opt/transformerengine}
+
+pip install pytest==8.2.1 onnxruntime==1.13.1
+FA_versions=(2.0.6 2.0.6.post2 2.0.7 2.0.8 2.1.1 2.1.2.post3 2.2.0 2.2.1 2.2.2 2.2.3.post2 2.2.4 2.2.4.post1 2.2.5 2.3.0 2.3.1.post1 2.3.2 2.3.3 2.3.4 2.3.5 2.3.6 2.4.0.post1 2.4.1 2.4.2 2.4.3.post1 2.5.0 2.5.1.post1 2.5.2 2.5.3 2.5.4 2.5.5 2.5.6 2.5.7 2.5.8 2.5.9.post1 2.6.0.post1 2.6.1 2.6.2 2.6.3)
+for fa_version in "${FA_versions[@]}"
+do
+pip install flash-attn==${fa_version}
+NVTE_TORCH_COMPILE=0 pytest -v -s $TE_PATH/tests/pytorch/fused_attn/test_fused_attn.py
+done

--- a/qa/L1_pytorch_FA_versions_test/test.sh
+++ b/qa/L1_pytorch_FA_versions_test/test.sh
@@ -6,7 +6,7 @@ set -e
 
 : ${TE_PATH:=/opt/transformerengine}
 
-pip install pytest==8.2.1 onnxruntime==1.13.1
+pip install pytest==8.2.1 onnxruntime==1.19.2
 FA_versions=(2.1.1 2.3.0 2.4.0.post1 2.4.1 2.5.7 2.6.3 3.0.0b1)
 for fa_version in "${FA_versions[@]}"
 do

--- a/qa/L1_pytorch_FA_versions_test/test.sh
+++ b/qa/L1_pytorch_FA_versions_test/test.sh
@@ -6,7 +6,7 @@ set -e
 
 : ${TE_PATH:=/opt/transformerengine}
 
-pip install pytest==8.2.1 onnxruntime==1.19.2
+pip install pytest==8.2.1
 FA_versions=(2.1.1 2.3.0 2.4.0.post1 2.4.1 2.5.7 2.6.3 3.0.0b1)
 for fa_version in "${FA_versions[@]}"
 do

--- a/qa/L1_pytorch_FA_versions_test/test.sh
+++ b/qa/L1_pytorch_FA_versions_test/test.sh
@@ -7,9 +7,17 @@ set -e
 : ${TE_PATH:=/opt/transformerengine}
 
 pip install pytest==8.2.1 onnxruntime==1.13.1
-FA_versions=(2.0.6 2.0.6.post2 2.0.7 2.0.8 2.1.1 2.1.2.post3 2.2.0 2.2.1 2.2.2 2.2.3.post2 2.2.4 2.2.4.post1 2.2.5 2.3.0 2.3.1.post1 2.3.2 2.3.3 2.3.4 2.3.5 2.3.6 2.4.0.post1 2.4.1 2.4.2 2.4.3.post1 2.5.0 2.5.1.post1 2.5.2 2.5.3 2.5.4 2.5.5 2.5.6 2.5.7 2.5.8 2.5.9.post1 2.6.0.post1 2.6.1 2.6.2 2.6.3)
+FA_versions=(2.1.1 2.3.0 2.4.0.post1 2.4.1 2.5.7 2.6.3 3.0.0b1)
 for fa_version in "${FA_versions[@]}"
 do
-pip install flash-attn==${fa_version}
-NVTE_TORCH_COMPILE=0 pytest -v -s $TE_PATH/tests/pytorch/fused_attn/test_fused_attn.py
+  if [ "${fa_version}" \< "3.0.0" ]
+  then
+    pip install flash-attn==${fa_version}
+  else
+    pip install "git+https://github.com/Dao-AILab/flash-attention.git#egg=flashattn-hopper&subdirectory=hopper"
+    python_path=`python -c "import site; print(site.getsitepackages()[0])"`
+    mkdir -p $python_path/flashattn_hopper
+    wget -P $python_path/flashattn_hopper https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/hopper/flash_attn_interface.py
+  fi
+  NVTE_TORCH_COMPILE=0 pytest -v -s $TE_PATH/tests/pytorch/fused_attn/test_fused_attn.py
 done

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ def setup_requirements() -> Tuple[List[str], List[str], List[str]]:
     # Framework-specific requirements
     if not bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))):
         if "pytorch" in frameworks:
-            install_reqs.extend(["torch", "flash-attn>=2.0.6,<=2.6.3,!=2.0.9,!=2.1.0"])
+            install_reqs.extend(["torch"])
             test_reqs.extend(["numpy", "onnxruntime", "torchvision", "prettytable"])
         if "jax" in frameworks:
             install_reqs.extend(["jax", "flax>=0.7.1"])

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -22,7 +22,7 @@ from transformer_engine.pytorch.attention import (
     get_attention_backend,
     _flash_attn_2_plus,
     _flash_attn_2_3_plus,
-    _flash_attn_3_plus,
+    _flash_attn_3_is_installed,
     check_set_window_size,
     AttentionParams,
     _attention_backends,
@@ -1351,7 +1351,7 @@ def test_mha_fp8_vs_f16(dtype, model, qkv_format, input_layernorm, fp8_dpa_bwd, 
     os.environ["NVTE_FP8_DPA_BWD"] = "1" if fp8_dpa_bwd else "0"
     config = model_configs_fp8_vs_f16[model]
 
-    if _flash_attn_3_plus and not is_training:
+    if _flash_attn_3_is_installed and not is_training:
         if RoPE:
             pytest.skip("Flash Attention doesn't support FP8 MHA with RoPE.")
         os.environ["NVTE_FLASH_ATTN"] = "1"
@@ -1379,7 +1379,7 @@ def test_mha_fp8_vs_f16(dtype, model, qkv_format, input_layernorm, fp8_dpa_bwd, 
     rtol = 5e-1
     rmse_tol = 0.15
     logging.debug("========== {:^25s} ==========".format("forward output"))
-    if _flash_attn_3_plus and not is_training:
+    if _flash_attn_3_is_installed and not is_training:
         _error(
             flash_attn_fwd_fp8,
             fused_attn_fwd_f16,
@@ -1532,7 +1532,7 @@ def test_dpa_fp8_vs_f16(dtype, model, qkv_layout, fp8_dpa_bwd, is_training):
     os.environ["NVTE_FP8_DPA_BWD"] = "1" if fp8_dpa_bwd else "0"
     os.environ["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] = "1"
 
-    if _flash_attn_3_plus and not is_training:
+    if _flash_attn_3_is_installed and not is_training:
         os.environ["NVTE_FLASH_ATTN"] = "1"
         os.environ["NVTE_FUSED_ATTN"] = "0"
         _attention_backends["backend_selection_requires_update"] = True
@@ -1559,7 +1559,7 @@ def test_dpa_fp8_vs_f16(dtype, model, qkv_layout, fp8_dpa_bwd, is_training):
     rmse_tol = 0.1
     bwd_names = ["dq", "dk", "dv"]
     logging.debug("========== {:^25s} ==========".format("forward output"))
-    if _flash_attn_3_plus and not is_training:
+    if _flash_attn_3_is_installed and not is_training:
         _error(
             flash_attn_fwd_fp8,
             fused_attn_fwd_f16,

--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -20,7 +20,6 @@ from transformer_engine.pytorch.attention import (
     MultiheadAttention,
     RotaryPositionEmbedding,
     get_attention_backend,
-    _flash_attn_2_plus,
     _flash_attn_2_3_plus,
     _flash_attn_3_is_installed,
     check_set_window_size,

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -145,8 +145,7 @@ except PackageNotFoundError:
         )
 else:
     if (
-        _flash_attn_version >= _flash_attn_version_required
-        and _flash_attn_version <= _flash_attn_max_version
+        _flash_attn_version_required <= _flash_attn_version <= _flash_attn_max_version
         and all(_flash_attn_version != x for x in _flash_attn_version_not_supported)
     ):
         from flash_attn.flash_attn_interface import flash_attn_func, flash_attn_varlen_func
@@ -204,9 +203,7 @@ else:
     )
 
     _flash_attn_3_is_installed = True
-    _flash_attn_3_0_0_beta = _flash_attn_3_version > PkgVersion(
-        "3.0.0b"
-    ) and _flash_attn_3_version < PkgVersion("3.0.0")
+    _flash_attn_3_0_0_beta = PkgVersion("3.0.0b") < _flash_attn_3_version < PkgVersion("3.0.0")
     _use_flash_attn_3 = True
 
 _attention_backends = {

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -367,7 +367,9 @@ def get_attention_backend(
         + str(
             (lambda x, y: x * 10 + y)(device_compute_capability[0], device_compute_capability[1])
         ),
-        "flash_attn_version": str(_flash_attn_version) if _flash_attn_is_installed else "not installed",
+        "flash_attn_version": (
+            str(_flash_attn_version) if _flash_attn_is_installed else "not installed"
+        ),
         "flash_attn_3_version": (
             str(_flash_attn_3_version) if _flash_attn_3_is_installed else "not installed"
         ),

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -385,8 +385,8 @@ def get_attention_backend(
 
     # The following sections check if `FlashAttention` supports the provided attention params,
     # regardless of whether FA2 or FA3 is installed. If FA2 or FA3 is not installed but is
-    # determined to be necessary for performance/functionality, we issue a warning at the end
-    # to prompt users to install appropriate FA versions.
+    # necessary for performance/functionality, a warning will be issued to prompt users to
+    # install an appropriate FA version.
     global _flash_attn_version_required, _flash_attn_max_version, _use_flash_attn_3
 
     # Filter: Environment variables

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -144,9 +144,8 @@ except PackageNotFoundError:
             ),
         )
 else:
-    if (
-        _flash_attn_version_required <= _flash_attn_version <= _flash_attn_max_version
-        and all(_flash_attn_version != x for x in _flash_attn_version_not_supported)
+    if _flash_attn_version_required <= _flash_attn_version <= _flash_attn_max_version and all(
+        _flash_attn_version != x for x in _flash_attn_version_not_supported
     ):
         from flash_attn.flash_attn_interface import flash_attn_func, flash_attn_varlen_func
         from flash_attn.flash_attn_interface import (

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -104,13 +104,7 @@ if not fa_logger.hasHandlers():
 
 @functools.lru_cache(maxsize=None)
 def _get_supported_versions(version_min, version_max):
-    return (
-        ">= "
-        + str(version_min)
-        + ", "
-        + "<= "
-        + str(version_max)
-    )
+    return ">= " + str(version_min) + ", " + "<= " + str(version_max)
 
 
 _NVTE_FLASH_ATTN = int(os.getenv("NVTE_FLASH_ATTN", "1"))

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -101,9 +101,18 @@ fa_logger.setLevel(_log_level)
 if not fa_logger.hasHandlers():
     fa_logger.addHandler(_stream_handler)
 
+
 @functools.lru_cache(maxsize=None)
 def _get_supported_versions(version_min, version_not_supported, version_max):
-    return ">= " + str(version_min) + ", " + "".join(["!= " + str(x) + ", " for x in version_not_supported]) + "<= " + str(version_max)
+    return (
+        ">= "
+        + str(version_min)
+        + ", "
+        + "".join(["!= " + str(x) + ", " for x in version_not_supported])
+        + "<= "
+        + str(version_max)
+    )
+
 
 _NVTE_FLASH_ATTN = int(os.getenv("NVTE_FLASH_ATTN", "1"))
 _NVTE_FUSED_ATTN = int(os.getenv("NVTE_FUSED_ATTN", "1"))
@@ -128,7 +137,11 @@ except PackageNotFoundError:
         fa_logger.debug(
             "flash-attn v2 is not installed. To use, please install a version in [%s] by \n"
             "pip install flash-attn==<version>",
-            _get_supported_versions(_flash_attn_version_required, _flash_attn_version_not_supported, _flash_attn_max_version),
+            _get_supported_versions(
+                _flash_attn_version_required,
+                _flash_attn_version_not_supported,
+                _flash_attn_max_version,
+            ),
         )
 else:
     if (
@@ -155,7 +168,11 @@ else:
     elif get_device_compute_capability() >= (8, 0) and _NVTE_FLASH_ATTN:
         fa_logger.warning(
             "Transformer Engine currently supports flash-attn %s. Found %s.",
-            _get_supported_versions(_flash_attn_version_required, _flash_attn_version_not_supported, _flash_attn_max_version),
+            _get_supported_versions(
+                _flash_attn_version_required,
+                _flash_attn_version_not_supported,
+                _flash_attn_max_version,
+            ),
             _flash_attn_version,
         )
 
@@ -187,7 +204,9 @@ else:
     )
 
     _flash_attn_3_is_installed = True
-    _flash_attn_3_0_0_beta = _flash_attn_3_version > PkgVersion("3.0.0b") and _flash_attn_3_version < PkgVersion("3.0.0")
+    _flash_attn_3_0_0_beta = _flash_attn_3_version > PkgVersion(
+        "3.0.0b"
+    ) and _flash_attn_3_version < PkgVersion("3.0.0")
     _use_flash_attn_3 = True
 
 _attention_backends = {
@@ -880,9 +899,13 @@ def get_attention_backend(
     # users to install flash-attn with the appropriate versions.
     if not use_fused_attention and use_flash_attention and not _flash_attn_is_installed:
         logger.warning(
-            "flash-attn may add important feature support or provide significant performance boost. "
-            "Please install flash-attn %s.",
-            _get_supported_versions(_flash_attn_version_required, _flash_attn_version_not_supported, _flash_attn_max_version),
+            "flash-attn may add important feature support or provide significant performance boost."
+            " Please install flash-attn %s.",
+            _get_supported_versions(
+                _flash_attn_version_required,
+                _flash_attn_version_not_supported,
+                _flash_attn_max_version,
+            ),
         )
     if use_flash_attention and not _flash_attn_is_installed:
         use_flash_attention = False

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -103,12 +103,11 @@ if not fa_logger.hasHandlers():
 
 
 @functools.lru_cache(maxsize=None)
-def _get_supported_versions(version_min, version_not_supported, version_max):
+def _get_supported_versions(version_min, version_max):
     return (
         ">= "
         + str(version_min)
         + ", "
-        + "".join(["!= " + str(x) + ", " if x > version_min else "" for x in version_not_supported])
         + "<= "
         + str(version_max)
     )
@@ -121,8 +120,7 @@ _NVTE_UNFUSED_ATTN = int(os.getenv("NVTE_UNFUSED_ATTN", "1"))
 # Detect flash-attn v2 in the environment
 _flash_attn_is_installed = False
 _flash_attn_version = PkgVersion("0")
-_flash_attn_version_required = PkgVersion("2.0.6")
-_flash_attn_version_not_supported = (PkgVersion("2.0.9"), PkgVersion("2.1.0"))
+_flash_attn_version_required = PkgVersion("2.1.1")
 _flash_attn_max_version = PkgVersion("2.6.3")
 _flash_attn_2_plus = False
 _flash_attn_2_1_plus = False
@@ -139,9 +137,7 @@ except PackageNotFoundError:
             """ "pip install flash-attn".""",
         )
 else:
-    if _flash_attn_version_required <= _flash_attn_version <= _flash_attn_max_version and all(
-        _flash_attn_version != x for x in _flash_attn_version_not_supported
-    ):
+    if _flash_attn_version_required <= _flash_attn_version <= _flash_attn_max_version:
         from flash_attn.flash_attn_interface import flash_attn_func, flash_attn_varlen_func
         from flash_attn.flash_attn_interface import (
             _flash_attn_varlen_forward as _flash_attn_forward,
@@ -163,7 +159,6 @@ else:
             "Supported flash-attn versions are %s. Found flash-attn %s.",
             _get_supported_versions(
                 _flash_attn_version_required,
-                _flash_attn_version_not_supported,
                 _flash_attn_max_version,
             ),
             _flash_attn_version,
@@ -895,7 +890,6 @@ def get_attention_backend(
             " Please install flash-attn %s.",
             _get_supported_versions(
                 _flash_attn_version_required,
-                _flash_attn_version_not_supported,
                 _flash_attn_max_version,
             ),
         )

--- a/transformer_engine/pytorch/setup.py
+++ b/transformer_engine/pytorch/setup.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         description="Transformer acceleration library - Torch Lib",
         ext_modules=ext_modules,
         cmdclass={"build_ext": CMakeBuildExtension},
-        install_requires=["torch", "flash-attn>=2.0.6,<=2.6.3,!=2.0.9,!=2.1.0"],
+        install_requires=["torch"],
         tests_require=["numpy", "onnxruntime", "torchvision"],
     )
     if any(x in sys.argv for x in (".", "sdist", "bdist_wheel")):


### PR DESCRIPTION
# Description

This PR removes [flash-attention](https://github.com/Dao-AILab/flash-attention) as a required dependency for Transformer Engine. Users can choose to install FA2 via:
```
# supported versions: >= 2.1.1, <=2.6.3
pip install flash-attn==2.6.3
```
or FA3 via:
```
# supported versions: >= 3.0.0b1
1) pip install "git+https://github.com/Dao-AILab/flash-attention.git#egg=flashattn-hopper&subdirectory=hopper"
2) python_path=`python -c "import site; print(site.getsitepackages()[0])"`
3) mkdir -p $python_path/flashattn_hopper
4) wget -P $python_path/flashattn_hopper https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/hopper/flash_attn_interface.py
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Remove flash-attention as a build dependency
- Change logic around backend selection/recommendation in attention

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
