### PR TITLE
Fused Attention Support 64-bit Ragged Offsets for Large THD Tensors

### DIFF
--- a/transformer_engine/common/common.h
+++ b/transformer_engine/common/common.h
@@ -56,6 +56,7 @@ constexpr T DIVUP(const T &x, const T &y) {
 
 using byte = uint8_t;
 using int32 = int32_t;
+using int64 = int64_t;
 using fp32 = float;
 using fp16 = half;
 using bf16 = nv_bfloat16;
@@ -73,6 +74,7 @@ constexpr inline const char *type_name() noexcept;
   }
 TRANSFORMER_ENGINE_TYPE_NAME(uint8_t)
 TRANSFORMER_ENGINE_TYPE_NAME(int32_t)
+TRANSFORMER_ENGINE_TYPE_NAME(int64_t)
 TRANSFORMER_ENGINE_TYPE_NAME(float)
 TRANSFORMER_ENGINE_TYPE_NAME(half)
 TRANSFORMER_ENGINE_TYPE_NAME(nv_bfloat16)
@@ -84,7 +86,7 @@ TRANSFORMER_ENGINE_TYPE_NAME(__nv_fp8_e5m2)
 
 template <typename T>
 struct TypeInfo {
-  using types = std::tuple<byte, int32, fp32, fp16, bf16, fp8e4m3, fp8e5m2>;
+  using types = std::tuple<byte, int32, int64, fp32, fp16, bf16, fp8e4m3, fp8e5m2>;
 
   template <typename U, DType current>
   struct Helper {
@@ -121,7 +123,11 @@ struct TypeInfo {
       { __VA_ARGS__ }                                        \
     } break;                                                 \
     case DType::kInt32: {                                    \
-      using type = float;                                    \
+      using type = int32_t;                                  \
+      { __VA_ARGS__ }                                        \
+    } break;                                                 \
+    case DType::kInt64: {                                    \
+      using type = int64_t;                                  \
       { __VA_ARGS__ }                                        \
     } break;                                                 \
     case DType::kFloat32: {                                  \
@@ -244,6 +250,14 @@ inline int log2_ceil(int value) {
   int log2_value = 0;
   while ((1 << log2_value) < value) ++log2_value;
   return log2_value;
+}
+
+template <size_t B>
+inline size_t alignTo(size_t x) {
+  size_t r = x % B;
+  if (r == 0) return x;
+
+  return x + B - r;
 }
 
 template <typename T>

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -80,7 +80,18 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
   const int sm_arch_ = cuda::sm_arch(device_id);
   NVTE_CHECK(q_dtype == kv_dtype, "Q and KV must have the same data type.");
   NVTE_QKV_Format qkv_format = nvte_get_qkv_format(qkv_layout);
+  NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
   auto cudnn_runtime_version = cudnnGetVersion();
+
+  // For ragged offsets we only support 32-bit prior to cuDNN 9.5
+  // Only used when THD format is requested.
+  const bool requires_64bit_ragged_offset =
+      (qkv_format == NVTE_THD && fused_attn::get_ragged_offset_dtype(
+                                     layout_group, num_attn_heads, num_gqa_groups, max_seqlen_q,
+                                     max_seqlen_kv, head_dim_qk, head_dim_v) == DType::kInt64);
+  const bool supported_ragged_offset_size =
+      (!requires_64bit_ragged_offset || cudnn_runtime_version >= 90500);
+
   if (((q_dtype == NVTEDType::kNVTEFloat8E4M3) || (q_dtype == NVTEDType::kNVTEFloat8E5M2)) &&
       (sm_arch_ >= 90) && (bias_type == NVTE_Bias_Type::NVTE_NO_BIAS) &&
       (((cudnn_runtime_version >= 8900) && (qkv_layout == NVTE_QKV_Layout::NVTE_T3HD) &&
@@ -91,7 +102,8 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
         ((qkv_format == NVTE_QKV_Format::NVTE_BSHD) ||
          (qkv_format == NVTE_QKV_Format::NVTE_SBHD)) &&
         ((attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK) ||
-         (attn_mask_type == NVTE_Mask_Type::NVTE_NO_MASK))))) {
+         (attn_mask_type == NVTE_Mask_Type::NVTE_NO_MASK)))) &&
+      !requires_64bit_ragged_offset) {
     if (cudnn_runtime_version >= 8900) {
       backend = NVTE_Fused_Attn_Backend::NVTE_FP8;
     } else {
@@ -203,6 +215,9 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
            flag_arb)) {
         backend = static_cast<NVTE_Fused_Attn_Backend>(env_backend);
       }
+    }
+    if (!supported_ragged_offset_size) {
+      backend = NVTE_Fused_Attn_Backend::NVTE_No_Backend;
     }
     if (cudnn_runtime_version < 8901 &&
         backend == NVTE_Fused_Attn_Backend::NVTE_F16_max512_seqlen) {

--- a/transformer_engine/common/fused_attn/fused_attn_fp8.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_fp8.cu
@@ -1087,14 +1087,10 @@ void fused_attn_fp8_fwd_impl(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, in
 
     auto plan = get_plan(fa_fprop_cache, descriptor);
     size_t wkspace_size = static_cast<size_t>(plan.getWorkspaceSize());
-    const size_t num_bytes_per_ragged_offset = (b + 1) * sizeof(int32_t);
-    const size_t seqlen_offsets_workspace_size = 2 * num_bytes_per_ragged_offset;
-    const size_t actual_seqlens_workspace_size = b * sizeof(int32_t);
 
     // Exit to request upper level API to allocate memory if needed
     if (workspace_ptr == nullptr) {
-      *workspace_size =
-          wkspace_size + seqlen_offsets_workspace_size + actual_seqlens_workspace_size;
+      *workspace_size = wkspace_size + ((b + 1) * 2 + b) * sizeof(int32_t);
       return;
     }
 
@@ -1102,12 +1098,12 @@ void fused_attn_fp8_fwd_impl(int64_t b, int64_t h, int64_t s_q, int64_t s_kv, in
     // null streams for sizing the cuDNN workspace.
     NVTE_CHECK_CUDNN(cudnnSetStream(handle_, stream));
 
-    int8_t* base_workspace_ptr = reinterpret_cast<int8_t*>(workspace_ptr) + wkspace_size;
-    int32_t* qkv_ragged_offset = reinterpret_cast<int32_t*>(base_workspace_ptr);
-    int32_t* o_ragged_offset =
-        reinterpret_cast<int32_t*>(base_workspace_ptr + num_bytes_per_ragged_offset);
-    int32_t* actual_seqlens_q =
-        reinterpret_cast<int32_t*>(base_workspace_ptr + seqlen_offsets_workspace_size);
+    int32_t* qkv_ragged_offset =
+        reinterpret_cast<int32_t*>(reinterpret_cast<int8_t*>(workspace_ptr) + wkspace_size);
+    int32_t* o_ragged_offset = reinterpret_cast<int32_t*>(reinterpret_cast<int8_t*>(workspace_ptr) +
+                                                          wkspace_size + (b + 1) * sizeof(int32_t));
+    int32_t* actual_seqlens_q = reinterpret_cast<int32_t*>(
+        reinterpret_cast<int8_t*>(workspace_ptr) + wkspace_size + (b + 1) * 2 * sizeof(int32_t));
     // FP8 currently only supports self-attention, so doesn't use devPtrcuSeqlensKV
     dim3 blockDims(128);
     dim3 gridDims((b + blockDims.x) / blockDims.x);
@@ -1557,14 +1553,10 @@ void fused_attn_fp8_bwd_impl(
 
     auto plan = get_plan(fa_bprop_cache, descriptor);
     size_t wkspace_size = static_cast<size_t>(plan.getWorkspaceSize());
-    const size_t num_bytes_per_ragged_offset = (b + 1) * sizeof(int32_t);
-    const size_t seqlen_offsets_workspace_size = 2 * num_bytes_per_ragged_offset;
-    const size_t actual_seqlens_workspace_size = b * sizeof(int32_t);
 
     // Exit to request upper level API to allocate memory if needed
     if (workspace_ptr == nullptr) {
-      *workspace_size =
-          wkspace_size + seqlen_offsets_workspace_size + actual_seqlens_workspace_size;
+      *workspace_size = wkspace_size + ((b + 1) * 2 + b) * sizeof(int32_t);
       return;
     }
 
@@ -1572,12 +1564,12 @@ void fused_attn_fp8_bwd_impl(
     // null streams for sizing the cuDNN workspace.
     NVTE_CHECK_CUDNN(cudnnSetStream(handle_, stream));
 
-    int8_t* base_workspace_ptr = reinterpret_cast<int8_t*>(workspace_ptr) + wkspace_size;
-    int32_t* qkv_ragged_offset = reinterpret_cast<int32_t*>(base_workspace_ptr);
-    int32_t* o_ragged_offset =
-        reinterpret_cast<int32_t*>(base_workspace_ptr + num_bytes_per_ragged_offset);
-    int32_t* actual_seqlens_q =
-        reinterpret_cast<int32_t*>(base_workspace_ptr + seqlen_offsets_workspace_size);
+    int32_t* qkv_ragged_offset =
+        reinterpret_cast<int32_t*>(reinterpret_cast<int8_t*>(workspace_ptr) + wkspace_size);
+    int32_t* o_ragged_offset = reinterpret_cast<int32_t*>(reinterpret_cast<int8_t*>(workspace_ptr) +
+                                                          wkspace_size + (b + 1) * sizeof(int32_t));
+    int32_t* actual_seqlens_q = reinterpret_cast<int32_t*>(
+        reinterpret_cast<int8_t*>(workspace_ptr) + wkspace_size + (b + 1) * 2 * sizeof(int32_t));
     // FP8 currently only supports self-attention, so doesn't use devPtrcuSeqlensKV
     dim3 blockDims(128);
     dim3 gridDims((b + blockDims.x) / blockDims.x);

--- a/transformer_engine/common/fused_attn/utils.h
+++ b/transformer_engine/common/fused_attn/utils.h
@@ -118,7 +118,7 @@ struct FADescriptor_v1 {
   }
 };
 
-__global__ void cu_seqlens_to_offsets(size_t b, size_t h, size_t d, int32_t *cu_seqlens_q,
+__global__ void cu_seqlens_to_offsets(int64_t b, int64_t h, int64_t d, int32_t *cu_seqlens_q,
                                       int32_t *actual_seqlens_q, int32_t *qkv_ragged_offset,
                                       int32_t *o_ragged_offset);
 
@@ -126,12 +126,17 @@ __global__ void cu_seqlens_to_actual_seqlens(size_t b, int32_t const *const q_cu
                                              int32_t const *const kv_cu_seqlens, int32_t *q_seqlens,
                                              int32_t *kv_seqlens);
 
-__global__ void cu_seqlens_padded_to_offsets(NVTE_QKV_Layout_Group layout_group, size_t b, size_t h,
-                                             size_t hg, size_t d_qk, size_t d_v,
-                                             int32_t *cu_seqlens_q_padded,
-                                             int32_t *cu_seqlens_kv_padded, int32_t *offsets_q,
-                                             int32_t *offsets_k, int32_t *offsets_v,
-                                             int32_t *offsets_o);
+__global__ void cu_seqlens_padded_to_offsets(NVTE_QKV_Layout_Group layout_group, int64_t b,
+                                             int64_t h, int64_t hg, int64_t d_qk, int64_t d_v,
+                                             const int32_t *cu_seqlens_q_padded,
+                                             const int32_t *cu_seqlens_kv_padded,
+                                             DType offset_dtype, void *offsets_q, void *offsets_k,
+                                             void *offsets_v, void *offsets_o);
+
+DType get_ragged_offset_dtype(NVTE_QKV_Layout_Group layout_group, int64_t num_attn_heads,
+                              int64_t num_gqa_groups, int64_t max_seqlen_q, int64_t max_seqlen_kv,
+                              int64_t head_dim_qk, int64_t head_dim_v);
+
 }  // namespace fused_attn
 
 cudnnDataType_t get_cudnn_dtype(const transformer_engine::DType t);

--- a/transformer_engine/common/include/transformer_engine/transformer_engine.h
+++ b/transformer_engine/common/include/transformer_engine/transformer_engine.h
@@ -24,7 +24,7 @@ extern "C" {
 enum NVTEDType {
   kNVTEByte = 0,       /*!< Byte */
   kNVTEInt32 = 1,      /*!< 32-bit integer */
-  kNVTEInt64 = 2,      /*!< 32-bit integer */
+  kNVTEInt64 = 2,      /*!< 64-bit integer */
   kNVTEFloat32 = 3,    /*!< 32-bit float */
   kNVTEFloat16 = 4,    /*!< 16-bit float (E5M10) */
   kNVTEBFloat16 = 5,   /*!< 16-bit bfloat (E8M7) */


### PR DESCRIPTION
# Description

This PR updates the data type of the ragged offset tensors, e.g. [offset_q](https://github.com/NVIDIA/TransformerEngine/blob/3b89c36f0e7427199e4e87076b8a5e1545d70346/transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu#L144), in the THD path of cuDNN attention. For long sequences, these offset tensors could have `int32` overflow. This PR updates them to `int64` for cuDNN 9.5+.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Add logic to determine if cuDNN 9.5+ is available to support 64-bit offset.

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
