### PR TITLE
Support CUDA Graph for MoE models

### DIFF
--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -720,22 +720,16 @@ class CudaRNGStatesTracker:
     """
 
     def __init__(self):
-        self.reset()
-
-    def is_initialized(self):
-        """Checks if the internal RNG state has been set wirth set_states()."""
-        return self._is_initialized
-
-    def reset(self):
-        """Set to the initial state (no tracker)."""
-
-        # Track if initialized.
-        self._is_initialized = False
-
         # Map from a string name to the cuda rng state.
         self.states_ = {}
-
         # Seeds are just for book keeping and ensure no seed is set twice.
+        self.seeds_ = set()
+
+    def reset(self):
+        """
+        Set to the initial state (no tracker).
+        """
+        self.states_ = {}
         self.seeds_ = set()
 
     def get_states(self) -> Dict[str, torch.Tensor]:
@@ -756,7 +750,6 @@ class CudaRNGStatesTracker:
         states: Dict[str, torch.Tensor]
                A mapping from string names to RNG states.
         """
-        self._is_initialized = True
         self.states_ = states
 
     def add(self, name: str, seed: int) -> None:
@@ -768,7 +761,6 @@ class CudaRNGStatesTracker:
         seed: int
              PyTorch seed for the RNG state.
         """
-        self._is_initialized = True
         # Check seed is not already used.
         if seed in self.seeds_:
             raise RuntimeError(f"seed {seed} already exists")

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -720,16 +720,22 @@ class CudaRNGStatesTracker:
     """
 
     def __init__(self):
-        # Map from a string name to the cuda rng state.
-        self.states_ = {}
-        # Seeds are just for book keeping and ensure no seed is set twice.
-        self.seeds_ = set()
+        self.reset()
+
+    def is_initialized(self):
+        """Checks if the internal RNG state has been set wirth set_states()."""
+        return self._is_initialized
 
     def reset(self):
-        """
-        Set to the initial state (no tracker).
-        """
+        """Set to the initial state (no tracker)."""
+
+        # Track if initialized.
+        self._is_initialized = False
+
+        # Map from a string name to the cuda rng state.
         self.states_ = {}
+
+        # Seeds are just for book keeping and ensure no seed is set twice.
         self.seeds_ = set()
 
     def get_states(self) -> Dict[str, torch.Tensor]:
@@ -750,6 +756,7 @@ class CudaRNGStatesTracker:
         states: Dict[str, torch.Tensor]
                A mapping from string names to RNG states.
         """
+        self._is_initialized = True
         self.states_ = states
 
     def add(self, name: str, seed: int) -> None:
@@ -761,6 +768,7 @@ class CudaRNGStatesTracker:
         seed: int
              PyTorch seed for the RNG state.
         """
+        self._is_initialized = True
         # Check seed is not already used.
         if seed in self.seeds_:
             raise RuntimeError(f"seed {seed} already exists")

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -442,16 +442,16 @@ class FP8GlobalStateManager:
         stashed_fp8_meta = cls.fp8_tensors_recompute_buffer[fp8_meta[buffer_position_key]].popleft()
 
         # Replace amaxes and scales with stashed values for phase 2 forward
-        fp8_meta["scaling_fwd"].amax_history = stashed_fp8_meta[0]
-        fp8_meta["scaling_fwd"].scale = stashed_fp8_meta[1]
-        fp8_meta["scaling_fwd"].scale_inv = stashed_fp8_meta[2]
+        fp8_meta["scaling_fwd"].amax_history.copy_(stashed_fp8_meta[0])
+        fp8_meta["scaling_fwd"].scale.copy_(stashed_fp8_meta[1])
+        fp8_meta["scaling_fwd"].scale_inv.copy_(stashed_fp8_meta[2])
 
     @staticmethod
     def restore_fp8_meta_tensors(fp8_meta: Dict[str, Any]) -> None:
         """Restore latest scaling factors and amaxes after recompute forward run."""
-        fp8_meta["scaling_fwd"].amax_history = fp8_meta["updated_amax_history_fwd"]
-        fp8_meta["scaling_fwd"].scale = fp8_meta["updated_scale_fwd"]
-        fp8_meta["scaling_fwd"].scale_inv = fp8_meta["updated_scale_inv_fwd"]
+        fp8_meta["scaling_fwd"].amax_history.copy_(fp8_meta["updated_amax_history_fwd"])
+        fp8_meta["scaling_fwd"].scale.copy_(fp8_meta["updated_scale_fwd"])
+        fp8_meta["scaling_fwd"].scale_inv.copy_(fp8_meta["updated_scale_inv_fwd"])
 
 
 @contextmanager

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -233,16 +233,27 @@ def _make_graphed_callables(
         set(warmup_func_idx)
     ), f"Warmup runs {len(warmup_func)} but only {len(set(warmup_func_idx))} are unique."
 
-    # Filter the TE modules and parameters that cudagraph can access.
+    # Filter the TE modules that cudagraph can access.
     visited_te_modules = set()
-    visited_params = set()
 
     def hook_fn(module, inputs, outputs):  # pylint: disable=unused-argument
         if isinstance(module, TransformerEngineBaseModule):
             visited_te_modules.add(module)
-        visited_params.update(module.parameters(recurse=False))
 
-    # Run warmup and do the above filtering.
+    # Filter the weights without gradients in backward. These weights are not in the computation graph so can be removed from cudagraph inputs.
+    no_grad_weights = None
+
+    def get_no_grads(static_input_surface, grad_inputs, func_idx):
+        grad_index = 0
+        none_grads = []
+        for i in range(len(static_input_surface)):
+            if static_input_surface[i].requires_grad:
+                if grad_inputs[grad_index] is None and i >= len(flatten_sample_args[func_idx]):
+                    none_grads.append(i)
+                grad_index += 1
+        return set(none_grads)
+
+    # Run warmup and do the above two filtering.
     with torch.cuda.stream(torch.cuda.Stream()):
         for func_idx, func in zip(warmup_func_idx, warmup_func):
             args = sample_args[func_idx]
@@ -263,22 +274,26 @@ def _make_graphed_callables(
                     only_inputs=True,
                     allow_unused=allow_unused_input,
                 )
+                if no_grad_weights is None:
+                    no_grad_weights = get_no_grads(static_input_surface, grad_inputs, func_idx)
                 del outputs, grad_inputs
             # The following code is added specifically for MCore's special requirements,
             # aimed at preventing warmup from altering the control flow.
             for module in func.modules():
                 if hasattr(module, "is_first_microbatch"):
                     module.is_first_microbatch = True
-
-    # Remove cudagraph input params that are not accessed.
-    for idx, _ in enumerate(flatten_sample_args):
-        per_callable_module_params[idx] = tuple(
-            param for param in per_callable_module_params[idx] if param in visited_params
-        )
-        per_callable_static_input_surfaces[idx] = (
-            flatten_sample_args[idx] + per_callable_module_params[idx]
-        )
-
+            if len(no_grad_weights) > 0:
+                per_callable_static_input_surfaces[func_idx] = tuple(
+                    inp
+                    for i, inp in enumerate(per_callable_static_input_surfaces[func_idx])
+                    if i not in no_grad_weights
+                )
+                per_callable_module_params[func_idx] = tuple(
+                    param
+                    for i, param in enumerate(per_callable_module_params[func_idx])
+                    if i + len(flatten_sample_args[func_idx]) not in no_grad_weights
+                )
+            no_grad_weights = None
     torch.cuda.synchronize()
 
     # All captures here share a mempool. To avoid replays corrupting each other's memory,

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -215,7 +215,7 @@ def _make_graphed_callables(
             warmup_func.append(func)
     else:
         fwd_idx = [0] * num_model_chunks
-        for idx, c_id in enumerate(_order):
+        for c_id in _order:
             if c_id > 0:
                 m_chunk = c_id - 1
                 for l_no in range(num_layers):
@@ -237,7 +237,7 @@ def _make_graphed_callables(
     visited_te_modules = set()
     visited_params = set()
 
-    def hook_fn(module, input, output):
+    def hook_fn(module, inputs, outputs): # pylint: disable=unused-argument
         if isinstance(module, TransformerEngineBaseModule):
             visited_te_modules.add(module)
         visited_params.update(module.parameters(recurse=False))

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -269,7 +269,7 @@ def _make_graphed_callables(
                     module.is_first_microbatch = True
 
     # Remove cudagraph input params that are not accessed.
-    for idx in range(len(flatten_sample_args)):
+    for idx, _ in enumerate(flatten_sample_args):
         per_callable_module_params[idx] = tuple(
             param for param in per_callable_module_params[idx] if param in visited_params
         )

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -237,7 +237,7 @@ def _make_graphed_callables(
     visited_te_modules = set()
     visited_params = set()
 
-    def hook_fn(module, inputs, outputs): # pylint: disable=unused-argument
+    def hook_fn(module, inputs, outputs):  # pylint: disable=unused-argument
         if isinstance(module, TransformerEngineBaseModule):
             visited_te_modules.add(module)
         visited_params.update(module.parameters(recurse=False))

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -238,10 +238,7 @@ def _make_graphed_callables(
     visited_params = set()
 
     def hook_fn(module, input, output):
-        if (
-            isinstance(module, TransformerEngineBaseModule)
-            and FP8GlobalStateManager.is_fp8_enabled()
-        ):
+        if isinstance(module, TransformerEngineBaseModule):
             visited_te_modules.add(module)
         visited_params.update(module.parameters(recurse=False))
 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1152,7 +1152,10 @@ class LayerNormLinear(TransformerEngineBaseModule):
                                produced)
         """
 
-        skip_fp8_weight_update = FP8GlobalStateManager.get_skip_fp8_weight_update_tensor()
+        if FP8GlobalStateManager.fp8_graph_capturing():
+            skip_fp8_weight_update = FP8GlobalStateManager.get_skip_fp8_weight_update_tensor()
+        else:
+            skip_fp8_weight_update = None
         if skip_fp8_weight_update is not None:
             is_first_microbatch = False
 
@@ -1214,7 +1217,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.apply_bias and not self.gemm_bias_unfused_add,
                 self.eps,
                 is_first_microbatch,
-                self.fp8,
+                False if self.fp8 is None else self.fp8,
                 self.fp8_calibration,
                 self.fp8_meta,
                 self.fuse_wgrad_accumulation,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1217,7 +1217,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.apply_bias and not self.gemm_bias_unfused_add,
                 self.eps,
                 is_first_microbatch,
-                False if self.fp8 is None else self.fp8,
+                self.fp8,
                 self.fp8_calibration,
                 self.fp8_meta,
                 self.fuse_wgrad_accumulation,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -1484,7 +1484,10 @@ class LayerNormMLP(TransformerEngineBaseModule):
                                produced)
         """
 
-        skip_fp8_weight_update = FP8GlobalStateManager.get_skip_fp8_weight_update_tensor()
+        if FP8GlobalStateManager.fp8_graph_capturing():
+            skip_fp8_weight_update = FP8GlobalStateManager.get_skip_fp8_weight_update_tensor()
+        else:
+            skip_fp8_weight_update = None
         if skip_fp8_weight_update is not None:
             is_first_microbatch = False
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -938,8 +938,10 @@ class Linear(TransformerEngineBaseModule):
                                first microbatch (since it is the first gradient being
                                produced)
         """
-
-        skip_fp8_weight_update = FP8GlobalStateManager.get_skip_fp8_weight_update_tensor()
+        if FP8GlobalStateManager.fp8_graph_capturing():
+            skip_fp8_weight_update = FP8GlobalStateManager.get_skip_fp8_weight_update_tensor()
+        else:
+            skip_fp8_weight_update = None
         if skip_fp8_weight_update is not None:
             is_first_microbatch = False
 


### PR DESCRIPTION
# Description

Different from non-MoE models like llama2, MoE models have dynamic shaped activations in FFN layers, so one cudagraph can only capture a part of one transformer layer, instead of covering the whole layer. We call this a "breaking-layer" cudagraph mode. This PR adds breaking-layer cudagraph supports for MoE models on the TE side, and fixes several related bugs in TE.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Add `is_initialized()` method in CudaRNGStatesTracker to align with what is already done in MCore.
- Fix wrong `per_callable_module_params` order bug in `_make_graphed_callables` when `_order` is given.
- Fix warmup argument mismatch bug in `_make_graphed_callables` when `_order` is given.
- Fix fp8 accuracy issue by adding `fp8_group` argument to `make_graphed_callables()` and modifing `is_first_microbatch`, `skip_fp8_weight_update` and `fp8_meta` code.
- Support MoE models cudagraph by filtering graphed TE modules and model weights during warmup.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
