### PR TITLE
Do not link against CUDA driver when building

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -88,7 +88,6 @@ target_include_directories(transformer_engine PUBLIC
 # Configure dependencies
 target_link_libraries(transformer_engine PUBLIC
                       CUDA::cublas
-                      CUDA::cuda_driver
                       CUDA::cudart)
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})


### PR DESCRIPTION
# Description

It is bad practice to link against the CUDA driver library (`libcuda.so.1` on Linux) at build time because it may differ from the library at run time. In particular, the CUDA Toolkit provides stubs in case CUDA code is being compiled on a system without GPUs. TE already has infrastructure to access with CUDA driver library indirectly via [`cudaGetDriverEntryPoint`](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DRIVER__ENTRY__POINT.html#group__CUDART__DRIVER__ENTRY__POINT_1gcf55d143722ccfa9252758181701c876) (see https://github.com/NVIDIA/TransformerEngine/pull/970 and https://github.com/NVIDIA/TransformerEngine/pull/138). However, we should avoid explicitly linking against the CUDA driver in CMake to reduce the risk of linker snafus, e.g. if a future developer accidentally adds a directly call to a CUDA driver function.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refractor

## Changes

- Do not link against CUDA driver when building

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
