### PR TITLE
[Paddle] Debug wheel test

### DIFF
--- a/qa/L0_paddle_wheel/test.sh
+++ b/qa/L0_paddle_wheel/test.sh
@@ -6,7 +6,11 @@ set -e
 
 : "${TE_PATH:=/opt/transformerengine}"
 
-pip install wheel==0.44.0 pydantic
+# Install dependencies
+# Note: Need to install wheel locally since PaddlePaddle container
+# already contains APT install.
+pip install pydantic
+pip install --user wheel=0.44.0
 
 cd $TE_PATH
 pip uninstall -y transformer-engine transformer-engine-cu12 transformer-engine-paddle
@@ -16,11 +20,11 @@ WHL_BASE="transformer_engine-${VERSION}"
 
 # Core wheel.
 NVTE_RELEASE_BUILD=1 python setup.py bdist_wheel
-wheel unpack dist/*
+python -m wheel unpack dist/*
 sed -i "s/Name: transformer-engine/Name: transformer-engine-cu12/g" "transformer_engine-${VERSION}/transformer_engine-${VERSION}.dist-info/METADATA"
 sed -i "s/Name: transformer_engine/Name: transformer_engine_cu12/g" "transformer_engine-${VERSION}/transformer_engine-${VERSION}.dist-info/METADATA"
 mv "${WHL_BASE}/${WHL_BASE}.dist-info" "${WHL_BASE}/transformer_engine_cu12-${VERSION}.dist-info"
-wheel pack ${WHL_BASE}
+python -m wheel pack ${WHL_BASE}
 rm dist/*.whl
 mv *.whl dist/
 NVTE_RELEASE_BUILD=1 NVTE_BUILD_METAPACKAGE=1 python setup.py bdist_wheel

--- a/qa/L0_paddle_wheel/test.sh
+++ b/qa/L0_paddle_wheel/test.sh
@@ -10,7 +10,7 @@ set -e
 # Note: Need to install wheel locally since PaddlePaddle container
 # already contains APT install.
 pip install pydantic
-pip install --user wheel=0.44.0
+pip install --user wheel==0.44.0
 
 cd $TE_PATH
 pip uninstall -y transformer-engine transformer-engine-cu12 transformer-engine-paddle


### PR DESCRIPTION
# Description

We have experienced test failures in the PaddlePaddle test for building Python wheels because the base container has installed `python3-wheel` with APT. This causes problems when we try installing the correct `wheel` version with Pip. This PR works around this issue by installing `wheel` locally.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor
- [x] Testing

## Changes

- Install `wheel` locally in PaddlePaddle test for building Python wheels

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
