### PR TITLE
[PyTorch] Use or instead of and to combine swa mask with existing mask

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -1075,7 +1075,7 @@ def get_swa_mask(
     attn_mask_type = "arbitrary"
     mask = mask_lower.logical_not()
     if attention_mask is not None:
-        mask = torch.logical_and(attention_mask, mask)
+        mask = torch.logical_or(attention_mask, mask)
     return attn_mask_type, mask
 
 


### PR DESCRIPTION
# Description

Hello team,

when creating the sliding window attention mask, the existing mask is currently combined with the SWA mask using a logical and. I think at this point an or should be used, because True means masked out in this part of the code and attention scores should be masked out if they are either masked out in the existing mask or in the SWA mask.

Please have a look and check if this makes sense 😄 

Markus

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- change logical and to or in creation of sliding window attention mask

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
