### PR TITLE
[PyTorch] Remove sequence parallel check for setting dropout RNG context

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -7446,7 +7446,7 @@ class DotProductAttention(TransformerEngineBaseModule):
         ), "The number of attention heads must be divisible by the number of GQA groups!"
 
         self.rng_states_tracker = None
-        if sequence_parallel or get_rng_state_tracker is None:
+        if get_rng_state_tracker is None:
             attention_dropout_ctx = nullcontext
         else:
             self.rng_states_tracker = get_rng_state_tracker()


### PR DESCRIPTION
# Description

When sequence parallelism is used, the RNG context for dropout is incorrectly set to a null.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Remove the check for sequence parallel when setting dropout context to null.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
