### PR TITLE
[PyTorch] Add heuristics for intializing FP8 params

### DIFF
--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -78,6 +78,7 @@ class FP8GlobalStateManager:
     IS_FIRST_FP8_MODULE = False
     FP8_GRAPH_CAPTURING = False
     FP8_AUTOCAST_DEPTH = 0
+    FP8_HEURISTIC = None
     global_amax_buffer = {}
     global_amax_history_buffer = {}
     global_scale_buffer = {}
@@ -264,6 +265,10 @@ class FP8GlobalStateManager:
     def fp8_graph_capturing(cls) -> bool:
         """Is CUDA graph capture under way?"""
         return cls.FP8_GRAPH_CAPTURING or torch.cuda.is_current_stream_capturing()
+
+    @classmethod
+    def fp8_heuristic(cls) -> Optional[str]:
+        return cls.FP8_HEURISTIC
 
     @classmethod
     def is_first_fp8_module(cls):
@@ -486,7 +491,10 @@ class FP8GlobalStateManager:
 
 
 @contextmanager
-def fp8_model_init(enabled: bool = True) -> None:
+def fp8_model_init(
+    enabled: bool = True,
+    heuristic: Optional[str] = None,
+) -> None:
     """
     Context manager for FP8 initialization of parameters.
 
@@ -514,11 +522,14 @@ def fp8_model_init(enabled: bool = True) -> None:
              This functionality is *EXPERIMENTAL*.
     """
     _fp8_parameters = FP8GlobalStateManager.FP8_PARAMETERS
+    _fp8_heuristic  = FP8GlobalStateManager.FP8_HEURISTIC
     FP8GlobalStateManager.FP8_PARAMETERS = enabled
+    FP8GlobalStateManager.FP8_HEURISTIC = heuristic
     try:
         yield
     finally:
         FP8GlobalStateManager.FP8_PARAMETERS = _fp8_parameters
+        FP8GlobalStateManager.FP8_HEURISTIC = _fp8_heuristic
 
 
 @contextmanager

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -522,7 +522,7 @@ def fp8_model_init(
              This functionality is *EXPERIMENTAL*.
     """
     _fp8_parameters = FP8GlobalStateManager.FP8_PARAMETERS
-    _fp8_heuristic  = FP8GlobalStateManager.FP8_HEURISTIC
+    _fp8_heuristic = FP8GlobalStateManager.FP8_HEURISTIC
     FP8GlobalStateManager.FP8_PARAMETERS = enabled
     FP8GlobalStateManager.FP8_HEURISTIC = heuristic
     try:

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -268,6 +268,7 @@ class FP8GlobalStateManager:
 
     @classmethod
     def fp8_heuristic(cls) -> Optional[str]:
+        """Heuristic for FP8 data format"""
         return cls.FP8_HEURISTIC
 
     @classmethod
@@ -495,14 +496,13 @@ def fp8_model_init(
     enabled: bool = True,
     heuristic: Optional[str] = None,
 ) -> None:
-    """
-    Context manager for FP8 initialization of parameters.
+    """Context manager for FP8 initialization of parameters.
 
     Example usage:
 
     .. code-block:: python
 
-        with fp8_model_init(enabled=True):
+        with fp8_model_init():
             model = transformer_engine.pytorch.Linear(768, 768)
 
     Parameters
@@ -520,6 +520,11 @@ def fp8_model_init(
              * LoRA-like fine-tuning, where the main parameters of the model do not change.
 
              This functionality is *EXPERIMENTAL*.
+    heuristic: string, optional
+               Heuristic for FP8 data format. Supported options are
+               "performance" (maximize runtime performance, default)
+               and "memory" (minimize memory usage).
+
     """
     _fp8_parameters = FP8GlobalStateManager.FP8_PARAMETERS
     _fp8_heuristic = FP8GlobalStateManager.FP8_HEURISTIC


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1127 changed the default behavior of `Float8Tensor` so that the FP8 transpose is no longer memoized, but rather treated as part of the data layout. This helps us avoid headaches where the cache is invalidated (since the FP8 data and transpose are updated together in `Float8Tensor.quantize_`) and reduces the FP8-specific logic in the TE modules (e.g. whether to update the transpose in the first microbatch). However, it also means that `Float8Tensor` needs to know whether to store the FP8 transpose at construction time.

This PR adds a `heuristic` kwarg to the `fp8_model_init` context. Right now the only supported value is `"memory"`, which will cause TE modules to initialize FP8 params without FP8 transposes. In the future, I can imagine extending this logic to `fp8_autocast` so it can handle FP8 data tensors. We could also support other heuristics (e.g. `"performance"`, `"communication"`, etc) and add logic for other quantization schemes. However, I've purposely kept this PR small to avoid interfering with other changes in the quantization infrastructure (see https://github.com/NVIDIA/TransformerEngine/pull/1251).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Add heuristic option to `fp8_model_init` context

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
