### PR TITLE
[JAX] Added prepare phase for the FusedAttnForwardFFI

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -47,6 +47,7 @@ include_directories(${PROJECT_SOURCE_DIR}/..)
 set(transformer_engine_SOURCES)
 list(APPEND transformer_engine_SOURCES
      pycudnn.cpp
+     cudnn_utils.cpp
      transformer_engine.cpp
      common.cu
      transpose/cast_transpose.cu

--- a/transformer_engine/common/cudnn_utils.cpp
+++ b/transformer_engine/common/cudnn_utils.cpp
@@ -5,9 +5,7 @@
  ************************************************************************/
 
 #include "../fused_attn/utils.h"
-
 #include "transformer_engine/cudnn.h"
-
 
 namespace transformer_engine {
 

--- a/transformer_engine/common/cudnn_utils.cpp
+++ b/transformer_engine/common/cudnn_utils.cpp
@@ -1,0 +1,18 @@
+/*************************************************************************
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include "../fused_attn/utils.h"
+
+#include "transformer_engine/cudnn.h"
+
+
+namespace transformer_engine {
+
+void nvte_cudnn_handle_init() {
+  auto handle = cudnnExecutionPlanManager::Instance().GetCudnnHandle();
+}
+
+}  // namespace transformer_engine

--- a/transformer_engine/common/include/transformer_engine/cudnn.h
+++ b/transformer_engine/common/include/transformer_engine/cudnn.h
@@ -1,0 +1,29 @@
+/*************************************************************************
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+/*! \file cudnn.h
+ *  \brief Helper for cuDNN initialization
+ */
+
+#ifndef TRANSFORMER_ENGINE_CUDNN_H_
+#define TRANSFORMER_ENGINE_CUDNN_H_
+
+#include "transformer_engine.h"
+
+/*! \namespace transformer_engine
+ */
+namespace transformer_engine {
+
+/*! \brief TE/JAX cudaGraph requires the cuDNN initialization to happen outside of the capturing
+ * region. This function is a helper to call cudnnCreate() which allocate memory for the handle.
+ * The function will be called in the initialize() phase of the related XLA custom calls.
+ */
+
+void nvte_cudnn_handle_init();
+
+}  // namespace transformer_engine
+
+#endif  // TRANSFORMER_ENGINE_CUDNN_H_

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -379,7 +379,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
 
         wkspace_aval = ctx.avals_out[-1]
 
-        if is_ffi_enabled() and bool(os.getenv("NVTE_JAX_FUSED_ATTN_WITH_FFI")):
+        if is_ffi_enabled():
             name = "te_fused_attn_forward_ffi"
             out = ffi.ffi_lowering(name)(
                 ctx,

--- a/transformer_engine/jax/cpp_extensions/custom_call.py
+++ b/transformer_engine/jax/cpp_extensions/custom_call.py
@@ -27,18 +27,8 @@ class CustomCallAPIVersion(IntEnum):
     FFI = 1
 
 
-custom_call_with_cudnn = ["te_fused_attn_forward_ffi"]
-
 for _name, _value in transformer_engine_jax.registrations().items():
-    if _name in custom_call_with_cudnn:
-        if is_ffi_enabled():
-            jex.ffi.register_ffi_target(
-                _name,
-                {"prepare": transformer_engine_jax.te_cudnn_handle_init_ffi, "execute": _value},
-                platform="CUDA",
-                api_version=CustomCallAPIVersion.FFI.value,
-            )
-    elif _name.endswith("_ffi"):
+    if _name.endswith("_ffi"):
         if is_ffi_enabled():
             jex.ffi.register_ffi_target(
                 _name, _value, platform="CUDA", api_version=CustomCallAPIVersion.FFI.value

--- a/transformer_engine/jax/csrc/extensions.h
+++ b/transformer_engine/jax/csrc/extensions.h
@@ -283,6 +283,9 @@ pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
 
 void FusedAttnBackward(cudaStream_t stream, void **buffers, const char *opaque, size_t opaque_len);
 
+// Cudnn helpers
+XLA_FFI_DECLARE_HANDLER_SYMBOL(CudnnHandleInitHandler);
+
 }  // namespace jax
 }  // namespace transformer_engine
 

--- a/transformer_engine/jax/csrc/extensions/cudnn.cpp
+++ b/transformer_engine/jax/csrc/extensions/cudnn.cpp
@@ -1,0 +1,25 @@
+/*************************************************************************
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include "extensions.h"
+#include "transformer_engine/cudnn.h"
+#include "xla/ffi/api/c_api.h"
+
+namespace transformer_engine {
+namespace jax {
+
+Error_Type CudnnHandleInitFFI(Variadic_Buffer_Type args, Variadic_Result_Type rets, Dictionary attrs){
+  nvte_cudnn_handle_init();
+  return ffi_with_cuda_error_check();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(CudnnHandleInitHandler, CudnnHandleInitFFI,
+                              FFI::Bind<FFI_Prepare>()
+                              .RemainingArgs()
+                              .RemainingRets()
+                              .Attrs());
+}  // namespace jax
+}  // namespace transformer_engine

--- a/transformer_engine/jax/csrc/extensions/cudnn.cpp
+++ b/transformer_engine/jax/csrc/extensions/cudnn.cpp
@@ -4,22 +4,21 @@
  * See LICENSE for license information.
  ************************************************************************/
 
-#include "extensions.h"
 #include "transformer_engine/cudnn.h"
+
+#include "extensions.h"
 #include "xla/ffi/api/c_api.h"
 
 namespace transformer_engine {
 namespace jax {
 
-Error_Type CudnnHandleInitFFI(Variadic_Buffer_Type args, Variadic_Result_Type rets, Dictionary attrs){
+Error_Type CudnnHandleInitFFI(Variadic_Buffer_Type args, Variadic_Result_Type rets,
+                              Dictionary attrs) {
   nvte_cudnn_handle_init();
   return ffi_with_cuda_error_check();
 }
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(CudnnHandleInitHandler, CudnnHandleInitFFI,
-                              FFI::Bind<FFI_Prepare>()
-                              .RemainingArgs()
-                              .RemainingRets()
-                              .Attrs());
+                              FFI::Bind<FFI_Prepare>().RemainingArgs().RemainingRets().Attrs());
 }  // namespace jax
 }  // namespace transformer_engine

--- a/transformer_engine/jax/csrc/extensions/ffi.h
+++ b/transformer_engine/jax/csrc/extensions/ffi.h
@@ -16,10 +16,14 @@ namespace jax {
 
 using Buffer_Type = xla::ffi::AnyBuffer;
 using Result_Type = xla::ffi::Result<xla::ffi::AnyBuffer>;
+using Variadic_Buffer_Type = xla::ffi::RemainingArgs;
+using Variadic_Result_Type = xla::ffi::RemainingRets;
 using Error_Type = xla::ffi::Error;
 using FFI = xla::ffi::Ffi;
 using FFI_Stream_Type = xla::ffi::PlatformStream<cudaStream_t>;
 using Dictionary = xla::ffi::Dictionary;
+
+constexpr auto FFI_Prepare = xla::ffi::ExecutionStage::kPrepare;
 constexpr auto FFI_CudaGraph_Traits = {xla::ffi::Traits::kCmdBufferCompatible};
 
 DType convert_ffi_datatype_to_te_dtype(const xla::ffi::DataType& type);

--- a/transformer_engine/jax/csrc/extensions/pybind.cpp
+++ b/transformer_engine/jax/csrc/extensions/pybind.cpp
@@ -101,6 +101,9 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
   m.def("get_fused_attn_bwd_workspace_sizes", &GetFusedAttnBackwardWorkspaceSizes);
   m.def("nvte_get_qkv_format", &nvte_get_qkv_format);
 
+  // Cudnn Helpers
+  m.add_object("te_cudnn_handle_init_ffi", EncapsulateFFI(CudnnHandleInitHandler));
+
   pybind11::enum_<DType>(m, "DType", pybind11::module_local())
       .value("kByte", DType::kByte)
       .value("kInt32", DType::kInt32)

--- a/transformer_engine/jax/csrc/extensions/pybind.cpp
+++ b/transformer_engine/jax/csrc/extensions/pybind.cpp
@@ -73,7 +73,10 @@ pybind11::dict Registrations() {
   dict["te_rmsnorm_backward_ffi"] = EncapsulateFunction(RMSNormBackwardHandler);
 
   // Attention
-  dict["te_fused_attn_forward_ffi"] = EncapsulateFFI(FusedAttnForwardHandler);
+  pybind11::dict fused_attn_forward_ffi;
+  fused_attn_forward_ffi["prepare"] = EncapsulateFFI(CudnnHandleInitHandler);
+  fused_attn_forward_ffi["execute"] = EncapsulateFFI(FusedAttnForwardHandler);
+  dict["te_fused_attn_forward_ffi"] = fused_attn_forward_ffi;
 
   return dict;
 }
@@ -100,9 +103,6 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
   m.def("get_fused_attn_fwd_workspace_sizes", &GetFusedAttnForwardWorkspaceSizes);
   m.def("get_fused_attn_bwd_workspace_sizes", &GetFusedAttnBackwardWorkspaceSizes);
   m.def("nvte_get_qkv_format", &nvte_get_qkv_format);
-
-  // Cudnn Helpers
-  m.add_object("te_cudnn_handle_init_ffi", EncapsulateFFI(CudnnHandleInitHandler));
 
   pybind11::enum_<DType>(m, "DType", pybind11::module_local())
       .value("kByte", DType::kByte)


### PR DESCRIPTION
# Description

In this PR, the FusedAttnForwardFFI is registered to XLA via 2 phases:
1. `prepare` where the `te_cudnn_handle_init_ffi` is called.
2.  `execute` phase where the actual fused attention function is called.
In the past, the default was to have only the `execute` phase.
This helps to avoid memory allocation for the handle in the cudaGraph capturing area, thus resolving the issue we have in the distributed run with cudaGraph.

In general, all the custom calls that involve cuDNN kernels should be registered with these two phases in the future. Since the prepare function needs to have the same function argument list with the execute function ones, variadic args are used to make this `te_cudnn_handle_init_ffi` general so that it can be called in any custom calls.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
