### PR TITLE
[PyTorch] Fix ONNX export bug with operation-based API

### DIFF
--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -505,7 +505,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             basic_op_kwargs=[kwargs],
         )
 
-    def get_extra_state(self) -> Optional[torch.Tensor]:
+    def get_extra_state(self) -> torch.Tensor:
         """Serialize extra state
 
         Contains metadata for FP8 casting.
@@ -534,7 +534,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             self.num_fp8_scales(mode) > 0 for mode in ("input", "param", "grad_output")
         )
         if not has_fp8_state:
-            return None
+            return torch.Tensor()
 
         def to_cpu(src: torch.Tensor) -> torch.Tensor:
             """Helper function to make CPU copy of tensor
@@ -588,7 +588,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
 
     def set_extra_state(self, state: Optional[torch.Tensor]) -> None:
         """Load extra state"""
-        if state is None:
+        if state is None or state.numel() == 0:
             return
 
         # Deserialize state from byte tensor


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1063 added logic so that TE ops include FP8 scaling factors in checkpoints by implementing the `get_extra_state`/`set_extra_state` functions. When running without FP8, it sets the extra state to `None`. However, ONNX export assumes that the extra state is a tensor and it fails when calling the `detach` function:
https://github.com/pytorch/pytorch/blob/d3788190685685cb828bdf6bed90270c0b60affc/torch/jit/_trace.py#L81
This PR changes the checkpointing logic so that the ops return an empty tensor if FP8 is not enabled.

The TE modules work around this issue by having a separate code path when ONNX export is enabled: https://github.com/NVIDIA/TransformerEngine/blob/e5ffaa7696092bfa2d8a8973024a26e1655e4353/transformer_engine/pytorch/module/base.py#L613-L614

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- TE ops always return extra state as tensor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
