### PR TITLE
[PyTorch] Fix multiple calls to saved_tensors in CP attention

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -4060,9 +4060,7 @@ class AttnFuncWithCPAndQKVOA2A(torch.autograd.Function):
 
         (*saved_tensors,) = ctx.saved_tensors
         q, k, v, out = saved_tensors[:4]
-        cu_seqlens_q, cu_seqlens_kv, cu_seqlens_q_padded, cu_seqlens_kv_padded = saved_tensors[
-            4:8
-        ]
+        cu_seqlens_q, cu_seqlens_kv, cu_seqlens_q_padded, cu_seqlens_kv_padded = saved_tensors[4:8]
         fp8_fwd_scales, fp8_fwd_scale_invs = saved_tensors[8:10]
         aux_ctx_tensors = saved_tensors[10:]
 


### PR DESCRIPTION
# Description

The torch autograd functions for attention with context parallelism incorrectly make multiple calls to `ctx.saved_tensors` in backward pass resulting in the following error:

```
Unpack is being triggered for a tensor that was already unpacked once. If you are calling ctx.saved_tensors in backward, make sure to do so only once. Otherwise please open an issue with details on your use case.
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Call `ctx.saved_tensors` exactly once before unpacking into separate variables

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
