### PR TITLE
[PyTorch] Bugfix for wgrad bulk overlap conflict when dgrad overlap is reduce-scatter

### DIFF
--- a/examples/pytorch/comm_gemm_overlap/te_layer_with_overlap.py
+++ b/examples/pytorch/comm_gemm_overlap/te_layer_with_overlap.py
@@ -176,8 +176,8 @@ def _get_ub_cfg(layer_type):
     if layer_type in [te.Linear, te.MultiheadAttention, te.TransformerLayer]:
         ub_cfg.update(
             {
-                "proj_fprop" : dict(),
-                "proj_dgrad" : dict(),
+                "proj_fprop": dict(),
+                "proj_dgrad": dict(),
             }
         )
     if layer_type in [te.LayerNormMLP, te.TransformerLayer]:

--- a/examples/pytorch/comm_gemm_overlap/te_layer_with_overlap.py
+++ b/examples/pytorch/comm_gemm_overlap/te_layer_with_overlap.py
@@ -163,6 +163,36 @@ def _get_layer_args(config, tp_group, tp_size, reference=False):
     return args, kwargs, input_shape
 
 
+def _get_ub_cfg(layer_type):
+    ub_cfg = dict()
+    if layer_type in [te.LayerNormLinear, te.MultiheadAttention, te.TransformerLayer]:
+        ub_cfg.update(
+            {
+                "qkv_fprop": dict(),
+                "qkv_dgrad": dict(),
+                "qkv_wgrad": dict(),
+            }
+        )
+    if layer_type in [te.Linear, te.MultiheadAttention, te.TransformerLayer]:
+        ub_cfg.update(
+            {
+                "proj_fprop" : dict(),
+                "proj_dgrad" : dict(),
+            }
+        )
+    if layer_type in [te.LayerNormMLP, te.TransformerLayer]:
+        ub_cfg.update(
+            {
+                "fc1_fprop": dict(),
+                "fc1_dgrad": dict(),
+                "fc1_wgrad": dict(),
+                "fc2_fprop": dict(),
+                "fc2_dgrad": dict(),
+            }
+        )
+    return ub_cfg
+
+
 def _train(opts):
     if "OMPI_COMM_WORLD_SIZE" in os.environ:
         # Execution with `mpirun -np N`
@@ -324,6 +354,7 @@ def _train(opts):
             use_fp8=opts.fp8,
             dtype=torch.bfloat16,
             bootstrap_backend=opts.bootstrap_backend,
+            ub_cfg=_get_ub_cfg(opts.layer_type),
         )
 
     # Initialize the fused LayerNorm + Multi-layer Perceptron module

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -266,7 +266,7 @@ def _train(opts):
         use_fp8=opts.fp8,
         dtype=torch.bfloat16,
         bootstrap_backend=opts.bootstrap_backend,
-        ub_cfg=_get_ub_cfg(opts.layer_type),
+        ub_cfgs=_get_ub_cfg(opts.layer_type),
     )
 
     # Initialize the Transformer Engine layer with overlap

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -96,8 +96,8 @@ def _get_ub_cfg(layer_type):
     if layer_type in [te.Linear, te.MultiheadAttention, te.TransformerLayer]:
         ub_cfg.update(
             {
-                "proj_fprop" : dict(),
-                "proj_dgrad" : dict(),
+                "proj_fprop": dict(),
+                "proj_dgrad": dict(),
             }
         )
     if layer_type in [te.LayerNormMLP, te.TransformerLayer]:

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -92,7 +92,7 @@ def _get_ub_cfg(config):
                 "qkv_fprop": dict(),
                 "qkv_dgrad": {
                     "method": "pipeline" if config.rs_dgrad_overlap else "bulk",
-                    "fp8_buf": True if config.fp8_buf and config.rs_dgrad_overlap else False
+                    "fp8_buf": True if config.fp8_buf and config.rs_dgrad_overlap else False,
                 },
             }
         )
@@ -101,9 +101,7 @@ def _get_ub_cfg(config):
     if config.layer_type in [te.Linear, te.MultiheadAttention, te.TransformerLayer]:
         ub_cfg.update(
             {
-                "proj_fprop": {
-                    "fp8_buf": True if config.fp8_buf else False
-                },
+                "proj_fprop": {"fp8_buf": True if config.fp8_buf else False},
                 "proj_dgrad": dict(),
             }
         )
@@ -113,7 +111,7 @@ def _get_ub_cfg(config):
                 "fc1_fprop": dict(),
                 "fc1_dgrad": {
                     "method": "pipeline" if config.rs_dgrad_overlap else "bulk",
-                    "fp8_buf": True if config.fp8_buf and config.rs_dgrad_overlap else False
+                    "fp8_buf": True if config.fp8_buf and config.rs_dgrad_overlap else False,
                 },
                 "fc2_fprop": {
                     "fp8_buf": True if config.fp8_buf else False,
@@ -150,7 +148,7 @@ def _parse_args(argv=None, namespace=None):
         "--fp8-buf",
         action="store_true",
         default=False,
-        help="Allocate FP8 communication buffers for layers that support it."
+        help="Allocate FP8 communication buffers for layers that support it.",
     )
     parser.add_argument(
         "--rs-dgrad-overlap",

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -274,11 +274,7 @@ def test_bulk_overlaps(comm_type, fp8, connections):
 )
 @pytest.mark.parametrize(
     "fp8,fp8_init",
-    [
-        (False, False),
-        (True, False),
-        (True, True)
-    ],
+    [(False, False), (True, False), (True, True)],
     ids=[
         " BF16 GEMM - BF16 PARAMS ",
         " FP8  GEMM - BF16 PARAMS ",

--- a/transformer_engine/common/comm_gemm_overlap/comm_gemm_overlap.cpp
+++ b/transformer_engine/common/comm_gemm_overlap/comm_gemm_overlap.cpp
@@ -232,9 +232,9 @@ void CommOverlapBase::atomic_gemm_overlap_rs(TensorWrapper &A, bool transa, Tens
   _ub_comm->sms = _num_comm_sm;
   _ub_comm->cga_size = _cga_size;
   // Get GEMM dimensions
-  size_t m = A.size(0);
-  size_t k = A.size(1);
-  size_t n = B.size(0);
+  size_t m = (transa) ? A.size(0) : A.size(1);
+  size_t k = (transa) ? A.size(1) : A.size(0);
+  size_t n = (transb) ? B.size(1) : B.size(0);
   size_t m_chunk = m / _num_splits;
   size_t workspace_size_chunk = workspace.numel() / _stream_compute.size();
 
@@ -332,9 +332,9 @@ void CommOverlapBase::split_overlap_rs(TensorWrapper &A, bool transa, TensorWrap
   _ub_comm->use_ce = _use_ce;
   _ub_comm->sms = _num_comm_sm;
   _ub_comm->cga_size = _cga_size;
-  size_t m = A.size(0);
-  size_t k = A.size(1);
-  size_t n = B.size(0);
+  size_t m = (transa) ? A.size(0) : A.size(1);
+  size_t k = (transa) ? A.size(1) : A.size(0);
+  size_t n = (transb) ? B.size(1) : B.size(0);
   size_t m_chunk = m / _num_splits;
   size_t input_a_chunk_size = m_chunk * k;
   size_t output_chunk_size = n * m_chunk;
@@ -930,8 +930,8 @@ void CommOverlapP2PBase::split_overlap_rs(TensorWrapper &A, bool transa, TensorW
   _ub_comm->use_ce = _use_ce;
   _ub_comm->sms = _num_comm_sm;
   _ub_comm->cga_size = _cga_size;
-  size_t k = A.size(1);
-  size_t n = B.size(0);
+  size_t k = (transa) ? A.size(1) : A.size(0);
+  size_t n = (transb) ? B.size(1) : B.size(0);
 
   // Get communication and GEMM input chunk sizes
   size_t n_chunk = n / _tp_size;

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -391,7 +391,7 @@ def initialize_ub(
 
     # Loop over user configs and disable dgrad and wgrad bulk overlaps for every layer that has a
     # reduce-scatter dgrad overlap.
-    ub_cfg = dict() if ub_cfg is None else ub_cfg
+    ub_cfg = {} if ub_cfg is None else ub_cfg
     for name in dgrad_reduce_scatter_overlap:
         if name in ub_cfgs:
             final_cfg = get_default_config(name)

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -418,9 +418,8 @@ def initialize_ub(
         if name in ub_cfgs:
             final_cfg = get_default_config(name)
             final_cfg.update(ub_cfgs[name])
-            final_cfg["fp8_buf"] = (
-                (name in layers_all_gather_overlap)
-                or ub_cfgs[name].get("fp8_buf", False)
+            final_cfg["fp8_buf"] = (name in layers_all_gather_overlap) or ub_cfgs[name].get(
+                "fp8_buf", False
             )
             add_ub(name, **final_cfg)
 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -404,6 +404,7 @@ def initialize_ub(
                 layers_reduce_scatter_overlap.remove(wgrad_name)
                 layers_all_gather_overlap.remove(name)
                 layers_reduce_scatter_overlap.append(name)
+                final_cfg["is_reduce_scatter"] = True
 
                 methods["bulk"].remove(name)
                 methods["bulk"].remove(wgrad_name)


### PR DESCRIPTION
# Description

When Userbuffers config dictionary sets overlap method to `ring-exchange` or `pipeline` for any `*_dgrad` layer, that layer's `*_wgrad` overlap needs to be disabled in order for `ub_overlap_rs_dgrad=True` option for related TE modules to function correctly.

This PR fixes a bug where the "*_wgrad" overlap was persisting in the Userbuffer configuration and the corresponding UB object was being initialized even when it was not needed.

+ @fanshiqing for viz.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- `*_wgrad` overlap is now removed from `methods["bulk"]` list when the same layer's `*_dgrad` overlap has its method set to either `ring-exchange` or `pipeline`.
- `add_ub(name, **ub_cfg)` is now only called if `name` is in the original user-provided `ub_cfg`. This avoids creating UB objects with default configs that may conflict with the user's intended TP overlap use.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
