### PR TITLE
[Core] Add function to convert container to string

### DIFF
--- a/tests/cpp/util/test_string.cpp
+++ b/tests/cpp/util/test_string.cpp
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -57,6 +58,12 @@ TEST(UtilTest, ToStringLike) {  // to_string_like
   EXPECT_EQ(std::stof(to_string_like(-2.5f)), -2.5f);
   EXPECT_EQ(std::stod(to_string_like(2.25)), 2.25);
   EXPECT_EQ(std::stod(to_string_like(-4.5)), -4.5);
+
+  // Container types
+  EXPECT_EQ(to_string_like(std::vector<int>{-3,1,-4}), "(-3,1,-4)");
+  EXPECT_EQ(to_string_like(std::vector<std::string>{"Accept", "no", "substitutes", ".",
+                                                    "Buy", "N", "V", "IDIA"}),
+            "(Accept,no,substitutes,.,Buy,N,V,IDIA)");
 }
 
 TEST(UtilTest, ConcatStringsTest) {  // concat_strings
@@ -88,6 +95,9 @@ TEST(UtilTest, ConcatStringsTest) {  // concat_strings
   EXPECT_EQ(std::stof(concat_strings(6.5f)), 6.5f);
   EXPECT_EQ(std::stod(concat_strings("-", 4.25)), -4.25);
   EXPECT_EQ(std::stod(concat_strings(8.5)), 8.5);
+
+  // Container types
+  EXPECT_EQ(concat_strings("vector ", std::vector<int>{1,-2,3}), "vector (1,-2,3)");
 }
 
 TEST(UtilTest, RegexReplaceTest) {  // regex_replace

--- a/transformer_engine/common/util/string.h
+++ b/transformer_engine/common/util/string.h
@@ -18,22 +18,20 @@ inline const std::string &to_string_like(const std::string &val) noexcept { retu
 constexpr const char *to_string_like(const char *val) noexcept { return val; }
 
 /* \brief Convert arithmetic type to string */
-template <typename T,
-          typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
 inline std::string to_string_like(const T &val) {
   return std::to_string(val);
 }
 
 /* \brief Convert container to string */
-template <typename T,
-          typename = typename std::enable_if<!std::is_arithmetic<T>::value>::type,
+template <typename T, typename = typename std::enable_if<!std::is_arithmetic<T>::value>::type,
           typename = decltype(std::declval<T>().begin())>
 inline std::string to_string_like(const T &container) {
   std::string str;
   str.reserve(1024);  // Assume strings are <1 KB
   str += "(";
   bool first = true;
-  for (const auto &val: container) {
+  for (const auto &val : container) {
     if (!first) {
       str += ",";
     }

--- a/transformer_engine/common/util/string.h
+++ b/transformer_engine/common/util/string.h
@@ -13,15 +13,36 @@
 
 namespace transformer_engine {
 
-/*! \brief Convert to C-style or C++-style string */
-template <typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+inline const std::string &to_string_like(const std::string &val) noexcept { return val; }
+
+constexpr const char *to_string_like(const char *val) noexcept { return val; }
+
+/* \brief Convert arithmetic type to string */
+template <typename T,
+          typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
 inline std::string to_string_like(const T &val) {
   return std::to_string(val);
 }
 
-inline const std::string &to_string_like(const std::string &val) noexcept { return val; }
-
-constexpr const char *to_string_like(const char *val) noexcept { return val; }
+/* \brief Convert container to string */
+template <typename T,
+          typename = typename std::enable_if<!std::is_arithmetic<T>::value>::type,
+          typename = decltype(std::declval<T>().begin())>
+inline std::string to_string_like(const T &container) {
+  std::string str;
+  str.reserve(1024);  // Assume strings are <1 KB
+  str += "(";
+  bool first = true;
+  for (const auto &val: container) {
+    if (!first) {
+      str += ",";
+    }
+    str += to_string_like(val);
+    first = false;
+  }
+  str += ")";
+  return str;
+}
 
 /*! \brief Convert arguments to strings and concatenate */
 template <typename... Ts>


### PR DESCRIPTION
# Description

This PR adds a C++ utility function that can convert some C++ containers (mainly `vector`) to a string. This can be used to generate more descriptive error messages:
```c++
NVTE_CHECK(in.shape == out.shape,
           "Input dims ", in.shape, " and output dims ", out.shape, " do not match");
// Assertion failed: in.shape == out.shape, Input dims (2,4) and output dims (8) do not match
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Add C++ utility function to convert container to string

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
