### PR TITLE
[JAX] Bug Fix: WeightInit with field

### DIFF
--- a/transformer_engine/jax/praxis/module.py
+++ b/transformer_engine/jax/praxis/module.py
@@ -6,6 +6,7 @@ Praxis Modules
 """
 from functools import partial
 from typing import Callable, Iterable, Sequence, Tuple, Union
+from dataclasses import field
 
 from praxis import pax_fiddle
 from praxis.base_layer import init_var
@@ -74,7 +75,7 @@ class LayerNorm(TransformerEngineBaseLayer):
     zero_centered_gamma: bool = False
     scale_init: WeightInit = None
     scale_axes: Tuple[str, ...] = ()
-    bias_init: WeightInit = WeightInit.Constant(0.0)
+    bias_init: WeightInit = field(default_factory=WeightInit.Constant(0.0))
     bias_axes: Tuple[str, ...] = ()
     transpose_batch_sequence: bool = False
 
@@ -129,7 +130,7 @@ class Linear(TransformerEngineBaseLayer):
     out_features: int = 512
     kernel_axes: Tuple[str, ...] = ()
     use_bias: bool = True
-    bias_init: WeightInit = WeightInit.Constant(0.0)
+    bias_init: WeightInit = field(default_factory = WeightInit.Constant(0.0))
     bias_axes: Tuple[str, ...] = ()
     enable_low_rank_adaptation: bool = False
     low_rank_adaptation_dim: int = 32
@@ -174,11 +175,11 @@ class LayerNormLinear(TransformerEngineBaseLayer):
     zero_centered_gamma: bool = False
     scale_init: WeightInit = None
     scale_axes: Tuple[str, ...] = ()
-    ln_bias_init: WeightInit = WeightInit.Constant(1.0)
+    ln_bias_init: WeightInit = field(default_factory=WeightInit.Constant(1.0))
     ln_bias_axes: Tuple[str, ...] = ()
     kernel_axes: Tuple[str, ...] = ()
     use_bias: bool = False
-    bias_init: WeightInit = WeightInit.Constant(0.0)
+    bias_init: WeightInit = field(default_factory=WeightInit.Constant(0.0))
     bias_axes: Tuple[str, ...] = ()
     enable_low_rank_adaptation: bool = False
     low_rank_adaptation_dim: int = 32
@@ -237,12 +238,12 @@ class LayerNormMLP(TransformerEngineBaseLayer):
     zero_centered_gamma: bool = False
     scale_init: WeightInit = None
     scale_axes: Tuple[str, ...] = ()
-    ln_bias_init: WeightInit = WeightInit.Constant(1.0)
+    ln_bias_init: WeightInit = field(default_factory=WeightInit.Constant(1.0))
     ln_bias_axes: Tuple[str, ...] = ()
     kernel_axes_1: Tuple[str, ...] = ()
     kernel_axes_2: Tuple[str, ...] = ()
     use_bias: bool = False
-    bias_init: WeightInit = WeightInit.Constant(0.0)
+    bias_init: WeightInit = field(default_factory=WeightInit.Constant(0.0))
     bias_axes_1: Tuple[str, ...] = ()
     bias_axes_2: Tuple[str, ...] = ()
     enable_low_rank_adaptation: bool = False

--- a/transformer_engine/jax/praxis/transformer.py
+++ b/transformer_engine/jax/praxis/transformer.py
@@ -6,6 +6,7 @@ Praxis Modules related Transformer
 """
 from functools import partial
 from typing import Optional, Sequence, Tuple
+from dataclasses import field
 import warnings
 
 from praxis import pax_fiddle
@@ -36,7 +37,7 @@ class RelativePositionBiases(TransformerEngineBaseLayer):
         embedding_init = init
         if embedding_init is None:
             rb_stddev = (num_attention_heads * num_buckets) ** -0.5
-            embedding_init = WeightInit.Gaussian(rb_stddev)
+            embedding_init = field(default_factory=WeightInit.Gaussian(rb_stddev))
         return embedding_init
 
     def setup(self) -> None:
@@ -138,7 +139,7 @@ class MultiHeadAttention(TransformerEngineBaseLayer):
     zero_centered_gamma: bool = False
     return_layernorm_output: bool = False
     use_bias: bool = False
-    bias_init: WeightInit = WeightInit.Constant(0.0)
+    bias_init: WeightInit = field(default_factory=WeightInit.Constant(0.0))
     attn_mask_type: str = "causal"
     attn_bias_type: Optional[str] = None
     enable_rotary_pos_emb: bool = False
@@ -275,7 +276,7 @@ class TransformerLayer(TransformerEngineBaseLayer):
     dropout_rng_name: str = "dropout"
     mlp_activations: Sequence[str] = ("relu",)
     use_bias: bool = False
-    bias_init: WeightInit = WeightInit.Constant(0.0)
+    bias_init: WeightInit = field(default_factory=WeightInit.Constant(0.0))
     apply_residual_connection_post_layernorm: bool = False
     output_layernorm: bool = False
     float32_attention_logits: bool = False


### PR DESCRIPTION
# Description

Nightly CI failed last night with the error:
```
ValueError: mutable default <class 'praxis.base_layer.WeightInit'> for field bias_init is not allowed: use default_factory
```
We should not use mutable default value (praxis.base_layer.WeightInit) for a field named bias_init in a dataclass as Python dataclasses don't allow mutable default values to prevent unexpected behavior due to shared state across instances.

This PR fixes the issue by using the `default_factory` parameter of the `field()` function from the `dataclasses` module to create a new object for each instance, avoiding the shared mutable state problem.


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
