### PR TITLE
[JAX] Bug fix for distributed normalization

### DIFF
--- a/transformer_engine/common/normalization/common.h
+++ b/transformer_engine/common/normalization/common.h
@@ -287,9 +287,8 @@ class CudnnNormalizationPlan : public NormalizationPlanBase {
 
 class NormalizationPlanRegistry {
  public:
-  // TODO thread-safe
   static NormalizationPlanRegistry& getInstance() {
-    static NormalizationPlanRegistry instance;
+    static thread_local NormalizationPlanRegistry instance;
     return instance;
   }
 

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -147,7 +147,7 @@ class LayerNormFwdPrimitive(BasePrimitive):
             batch_shape = out_shape[:-1]
             batch_size = reduce(operator.mul, x_shape) // hidden_size
 
-            wkspace_aval = ctx.avals_out[-2:]
+            wkspace_aval = ctx.avals_out[-1]
 
             out_types = [
                 ir.RankedTensorType.get(out_shape, output_type),
@@ -441,7 +441,7 @@ class LayerNormBwdPrimitive(BasePrimitive):
 
             sm_margin = get_backward_sm_margin()
 
-            wkspace_aval = ctx.avals_out[-4:]
+            wkspace_aval = ctx.avals_out[-1]
             opaque = transformer_engine_jax.pack_norm_descriptor(
                 batch_size,
                 hidden_size,
@@ -650,7 +650,7 @@ class RmsNormFwdPrimitive(BasePrimitive):
             batch_shape = out_shape[:-1]
             batch_size = reduce(operator.mul, x_shape) // hidden_size
 
-            wkspace_aval = ctx.avals_out[-2:]
+            wkspace_aval = ctx.avals_out[-1]
 
             out_types = [
                 ir.RankedTensorType.get(out_shape, x_type.element_type),
@@ -841,7 +841,7 @@ class RmsNormBwdPrimitive(BasePrimitive):
             hidden_size = reduce(operator.mul, g_shape)
             batch_size = reduce(operator.mul, x_shape) // hidden_size
 
-            wkspace_aval = ctx.avals_out[-3:]
+            wkspace_aval = ctx.avals_out[-1]
 
             out_types = [
                 ir.RankedTensorType.get(x_shape, x_type.element_type),
@@ -1088,7 +1088,7 @@ class LayerNormFwdFp8Primitive(BasePrimitive):
             batch_shape = out_shape[:-1]
             batch_size = reduce(operator.mul, x_shape) // hidden_size
 
-            wkspace_aval = ctx.avals_out[-2:]
+            wkspace_aval = ctx.avals_out[-1]
 
             out_types = [
                 ir.RankedTensorType.get(out_shape, ir_out_dtype),
@@ -1394,7 +1394,7 @@ class RmsNormFwdFp8Primitive(BasePrimitive):
             batch_shape = out_shape[:-1]
             batch_size = reduce(operator.mul, x_shape) // hidden_size
 
-            wkspace_aval = ctx.avals_out[-2:]
+            wkspace_aval = ctx.avals_out[-1]
 
             out_types = [
                 ir.RankedTensorType.get(out_shape, ir_out_dtype),

--- a/transformer_engine/jax/csrc/extensions/pybind.cpp
+++ b/transformer_engine/jax/csrc/extensions/pybind.cpp
@@ -83,12 +83,30 @@ pybind11::dict Registrations() {
       EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxBackwardHandler);
 
   // Normalization
-  dict["te_layernorm_forward_ffi"] = EncapsulateFFI(LayerNormForwardHandler);
-  dict["te_layernorm_forward_fp8_ffi"] = EncapsulateFFI(LayerNormForwardFP8Handler);
-  dict["te_layernorm_backward_ffi"] = EncapsulateFFI(LayerNormBackwardHandler);
-  dict["te_rmsnorm_forward_ffi"] = EncapsulateFunction(RMSNormForwardHandler);
-  dict["te_rmsnorm_forward_fp8_ffi"] = EncapsulateFunction(RMSNormForwardFP8Handler);
-  dict["te_rmsnorm_backward_ffi"] = EncapsulateFunction(RMSNormBackwardHandler);
+  dict["te_layernorm_forward_ffi"] = pybind11::dict(
+    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+    pybind11::arg("execute") = EncapsulateFFI(LayerNormForwardHandler)
+  );
+  dict["te_layernorm_forward_fp8_ffi"] = pybind11::dict(
+    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+    pybind11::arg("execute") = EncapsulateFFI(LayerNormForwardFP8Handler)
+  );
+  dict["te_layernorm_backward_ffi"] = pybind11::dict(
+    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+    pybind11::arg("execute") = EncapsulateFFI(LayerNormBackwardHandler)
+  );
+  dict["te_rmsnorm_forward_ffi"] = pybind11::dict(
+    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+    pybind11::arg("execute") = EncapsulateFFI(RMSNormForwardHandler)
+  );
+  dict["te_rmsnorm_forward_fp8_ffi"] = pybind11::dict(
+    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+    pybind11::arg("execute") = EncapsulateFFI(RMSNormForwardFP8Handler)
+  );
+  dict["te_rmsnorm_backward_ffi"] = pybind11::dict(
+    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+    pybind11::arg("execute") = EncapsulateFFI(RMSNormBackwardHandler)
+  );
 
   // Attention
   pybind11::dict fused_attn_forward_ffi;

--- a/transformer_engine/jax/csrc/extensions/pybind.cpp
+++ b/transformer_engine/jax/csrc/extensions/pybind.cpp
@@ -83,30 +83,24 @@ pybind11::dict Registrations() {
       EncapsulateFunction(ScaledUpperTriangMaskedSoftmaxBackwardHandler);
 
   // Normalization
-  dict["te_layernorm_forward_ffi"] = pybind11::dict(
-    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
-    pybind11::arg("execute") = EncapsulateFFI(LayerNormForwardHandler)
-  );
-  dict["te_layernorm_forward_fp8_ffi"] = pybind11::dict(
-    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
-    pybind11::arg("execute") = EncapsulateFFI(LayerNormForwardFP8Handler)
-  );
-  dict["te_layernorm_backward_ffi"] = pybind11::dict(
-    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
-    pybind11::arg("execute") = EncapsulateFFI(LayerNormBackwardHandler)
-  );
-  dict["te_rmsnorm_forward_ffi"] = pybind11::dict(
-    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
-    pybind11::arg("execute") = EncapsulateFFI(RMSNormForwardHandler)
-  );
-  dict["te_rmsnorm_forward_fp8_ffi"] = pybind11::dict(
-    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
-    pybind11::arg("execute") = EncapsulateFFI(RMSNormForwardFP8Handler)
-  );
-  dict["te_rmsnorm_backward_ffi"] = pybind11::dict(
-    pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
-    pybind11::arg("execute") = EncapsulateFFI(RMSNormBackwardHandler)
-  );
+  dict["te_layernorm_forward_ffi"] =
+      pybind11::dict(pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+                     pybind11::arg("execute") = EncapsulateFFI(LayerNormForwardHandler));
+  dict["te_layernorm_forward_fp8_ffi"] =
+      pybind11::dict(pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+                     pybind11::arg("execute") = EncapsulateFFI(LayerNormForwardFP8Handler));
+  dict["te_layernorm_backward_ffi"] =
+      pybind11::dict(pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+                     pybind11::arg("execute") = EncapsulateFFI(LayerNormBackwardHandler));
+  dict["te_rmsnorm_forward_ffi"] =
+      pybind11::dict(pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+                     pybind11::arg("execute") = EncapsulateFFI(RMSNormForwardHandler));
+  dict["te_rmsnorm_forward_fp8_ffi"] =
+      pybind11::dict(pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+                     pybind11::arg("execute") = EncapsulateFFI(RMSNormForwardFP8Handler));
+  dict["te_rmsnorm_backward_ffi"] =
+      pybind11::dict(pybind11::arg("prepare") = EncapsulateFFI(CudnnHandleInitHandler),
+                     pybind11::arg("execute") = EncapsulateFFI(RMSNormBackwardHandler));
 
   // Attention
   pybind11::dict fused_attn_forward_ffi;


### PR DESCRIPTION
# Description

- Added CudnnHandlerInit into the `prepare` phases of normalization custom calls. 
- Make `NormalizationPlanRegistry` `thread_local`.

These changes should fix the failures in `test_distributed_layernorm.py`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
