### PR TITLE
Don't touch nor send messages to the root logger.

### DIFF
--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -12,6 +12,8 @@ from importlib.metadata import version
 from transformer_engine.common import get_te_path, is_package_installed
 from transformer_engine.common import _get_sys_extension
 
+_logger = logging.getLogger(__name__)
+
 
 def _load_library():
     """Load shared library with Transformer Engine C extensions"""
@@ -36,7 +38,7 @@ def _load_library():
 
     if is_package_installed("transformer-engine-cu12"):
         if not is_package_installed(module_name):
-            logging.info(
+            _logger.info(
                 "Could not find package %s. Install transformer-engine using 'pip"
                 " install transformer-engine[jax]==VERSION'",
                 module_name,

--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -16,6 +16,8 @@ from importlib.metadata import version
 from transformer_engine.common import get_te_path, is_package_installed
 from transformer_engine.common import _get_sys_extension
 
+_logger = logging.getLogger(__name__)
+
 
 def _load_library():
     """Load shared library with Transformer Engine C extensions"""
@@ -40,7 +42,7 @@ def _load_library():
 
     if is_package_installed("transformer-engine-cu12"):
         if not is_package_installed(module_name):
-            logging.info(
+            _logger.info(
                 "Could not find package %s. Install transformer-engine using 'pip"
                 " install transformer-engine[pytorch]==VERSION'",
                 module_name,

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -98,7 +98,7 @@ _log_level = _log_levels[_log_level if _log_level in [0, 1, 2] else 2]
 _formatter = logging.Formatter("[%(levelname)-8s | %(name)-19s]: %(message)s")
 _stream_handler = logging.StreamHandler()
 _stream_handler.setFormatter(_formatter)
-fa_logger = logging.getLogger()
+fa_logger = logging.getLogger(__name__)
 fa_logger.setLevel(_log_level)
 if not fa_logger.hasHandlers():
     fa_logger.addHandler(_stream_handler)


### PR DESCRIPTION
# Description

Currently transformer_engine is writing to the root logger upon import, which implicitly initializes the root logger preventing downstream applications from controlling it effectively. 

For further motivation on why the root logger should not be used by a library see https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library

> Note It is strongly advised that you do not log to the root logger in your library. Instead, use a logger with a unique and easily identifiable name, such as the __name__ for your library’s top-level package or module. Logging to the root logger will make it difficult or impossible for the application developer to configure the logging verbosity or handlers of your library as they wish.

This PR addresses this problem by ensuring all logging calls are done through dedicated transformer_engine loggers.

Fixes #1294

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Removes all calls to `logging.info` during `transfomer_engine`'s (python) import which implicitly initializes the root logger preventing downstream applications from controlling it effectively. 
- Prevent sending messages to the root logger in `transformer_engine/pytorch/attention.py`, for similar reasons as the previous point.



# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Prior to this change, despite the user setting the basicConfig after the import, it's ignore because transformer_engine already implicitly initialized it.

```python
>>> import logging
>>> import transformer_engine
>>> _logger = logging.getLogger("my logger")
>>> logging.basicConfig(level=logging.INFO)
>>> _logger.info("Hello")
>>>
```

after the change

```python
>>> import logging
>>> import transformer_engine
>>> _logger = logging.getLogger("my logger")
>>> logging.basicConfig(level=logging.INFO)
>>> _logger.info("Hello")
INFO:my logger:Hello
>>>
```