### PR TITLE
[PyTorch] Add caching for attention backend selection results

### DIFF
--- a/tests/pytorch/fused_attn/test_fused_attn.py
+++ b/tests/pytorch/fused_attn/test_fused_attn.py
@@ -187,8 +187,6 @@ def _get_attention_backends(
 model_configs_base = {
     #     test:             b,  h, hg,   d,   sq,  skv,   p,      mask,      bias   # attn , backend
     "base_1_0": ModelConfig(8, 16, 16, 64, 128, 128, 0.0, "no_mask", "no_bias"),  # self , 0
-    #"base_1_1": ModelConfig(8, 16, 16, 64, 128, 128, 0.0, "no_mask", "no_bias"),  # self , 0
-    #"base_2_1": ModelConfig(8, 16, 16, 64, 128, 128, 0.0, "no_mask", "no_bias"),  # self , 0
     "base_1_1": ModelConfig(4, 16, 16, 64, 128, 256, 0.0, "no_mask", "no_bias"),  # cross, 0
     "base_2_0": ModelConfig(2, 24, 24, 128, 2048, 2048, 0.0, "no_mask", "no_bias"),  # self , 1
     "base_2_1": ModelConfig(1, 24, 24, 128, 2048, 4096, 0.0, "no_mask", "no_bias"),  # cross, 1
@@ -244,7 +242,6 @@ def test_dot_product_attention(
         pad_between_seqs=pad_between_seqs,
     )
     flash_attn_supported, fused_attn_supported, unfused_attn_supported, fused_attn_backends = available_backends
-    print('----',flash_attn_supported, fused_attn_supported, unfused_attn_supported)
     # FlashAttention does not support pad_between_seqs, but _run_dot_product_attention
     # mannually pads and unpads the input and output of FlashAttention for testing purposes
     if pad_between_seqs and not (
@@ -674,7 +671,6 @@ def _run_dot_product_attention(
         os.environ["NVTE_FUSED_ATTN_FORCE_WORKSPACE_OPT"] = "1" if workspace_opt else "0"
     if backend == "UnfusedDotProductAttention":
         os.environ["NVTE_UNFUSED_ATTN"] = "1"
-    #_attention_backends["backend_selection_requires_update"] = True
     _attention_backends["update_env_vars_only"] = True
 
     # Create seqlens
@@ -1166,7 +1162,6 @@ def _run_transformer_layer(
         os.environ["NVTE_FUSED_ATTN"] = "1"
     if backend == "UnfusedDotProductAttention":
         os.environ["NVTE_UNFUSED_ATTN"] = "1"
-    #_attention_backends["backend_selection_requires_update"] = True
     _attention_backends["update_env_vars_only"] = True
 
     # Create input tensor
@@ -1358,7 +1353,6 @@ def test_mha_fp8_vs_f16(dtype, model, qkv_format, input_layernorm, fp8_dpa_bwd, 
         os.environ["NVTE_FLASH_ATTN"] = "1"
         os.environ["NVTE_FUSED_ATTN"] = "0"
         os.environ["NVTE_UNFUSED_ATTN"] = "0"
-        #_attention_backends["backend_selection_requires_update"] = True
         _attention_backends["update_selection"] = True
         logging.info("[test_mha_fp8_vs_f16]: run with fp8_mha = True")
         flash_attn_fwd_fp8, param_names, flash_attn_bwd_fp8 = _run_mha_fp8_vs_f16(
@@ -1368,7 +1362,6 @@ def test_mha_fp8_vs_f16(dtype, model, qkv_format, input_layernorm, fp8_dpa_bwd, 
     os.environ["NVTE_FLASH_ATTN"] = "0"
     os.environ["NVTE_FUSED_ATTN"] = "1"
     os.environ["NVTE_UNFUSED_ATTN"] = "0"
-    #_attention_backends["backend_selection_requires_update"] = True
     _attention_backends["update_selection"] = True
     logging.info("[test_mha_fp8_vs_f16]: run with fp8_mha = True")
     fused_attn_fwd_fp8, param_names, fused_attn_bwd_fp8 = _run_mha_fp8_vs_f16(
@@ -1541,7 +1534,6 @@ def test_dpa_fp8_vs_f16(dtype, model, qkv_layout, fp8_dpa_bwd, is_training):
         os.environ["NVTE_FLASH_ATTN"] = "1"
         os.environ["NVTE_FUSED_ATTN"] = "0"
         os.environ["NVTE_UNFUSED_ATTN"] = "0"
-        #_attention_backends["backend_selection_requires_update"] = True
         _attention_backends["update_selection"] = True
         logging.info("[test_dpa_fp8_vs_f16]: run with fp8_dpa = True")
         flash_attn_fwd_fp8, flash_attn_bwd_fp8 = _run_dpa_fp8_vs_f16(
@@ -1551,7 +1543,6 @@ def test_dpa_fp8_vs_f16(dtype, model, qkv_layout, fp8_dpa_bwd, is_training):
     os.environ["NVTE_FLASH_ATTN"] = "0"
     os.environ["NVTE_FUSED_ATTN"] = "1"
     os.environ["NVTE_UNFUSED_ATTN"] = "0"
-    #_attention_backends["backend_selection_requires_update"] = True
     _attention_backends["update_selection"] = True
     logging.info("[test_dpa_fp8_vs_f16]: run with fp8_dpa = True")
     fused_attn_fwd_fp8, fused_attn_bwd_fp8 = _run_dpa_fp8_vs_f16(
@@ -1794,7 +1785,6 @@ def _run_custom_mha_fp8(dtype, config, backend):
         os.environ["NVTE_FUSED_ATTN"] = "1"
     if backend == "UnfusedDotProductAttention":
         os.environ["NVTE_UNFUSED_ATTN"] = "1"
-    #_attention_backends["backend_selection_requires_update"] = True
     _attention_backends["update_selection"] = True
 
     inp = 0.0001 * torch.randint(
@@ -1852,7 +1842,6 @@ def _run_ref_mha_f16(dtype, config, backend):
         os.environ["NVTE_FUSED_ATTN"] = "1"
     if backend == "UnfusedDotProductAttention":
         os.environ["NVTE_UNFUSED_ATTN"] = "1"
-    #_attention_backends["backend_selection_requires_update"] = True
     _attention_backends["update_selection"] = True
 
     inp = torch.load("qkv.pt").to(device="cuda")

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -402,12 +402,6 @@ def get_attention_backend(
 
     # check if attention_params already exists in cache
     global _attention_backends
-    #print('entering .....',
-    #    attention_params in _attention_backends["attention_params"],
-    #    _attention_backends["update_env_vars_only"],
-    #    _attention_backends["update_selection"])
-    #print(_attention_backends["attention_params"])
-    #print(attention_params)
     if (
         attention_params in _attention_backends["attention_params"]
         and not _attention_backends["update_env_vars_only"]
@@ -416,7 +410,6 @@ def get_attention_backend(
         config_id = _attention_backends["attention_params"].index(attention_params)
         available_backends = _attention_backends["available_backends"][config_id]
         selected_backend = _attention_backends["selected_backend"][config_id]
-        print('retrieveing ',config_id) #, available_backends, selected_backend)
         return available_backends, selected_backend
 
     # if environment variables such as NVTE_FUSED_ATTN change in the middle of the run
@@ -453,7 +446,6 @@ def get_attention_backend(
         available_backends = _attention_backends["available_backends"][config_id]
         selected_backend = update_env_vars(logger, available_backends)
         _attention_backends["selected_backend"][config_id] = selected_backend
-        print('retrieveing update env var',config_id) #, available_backends, selected_backend)
         return available_backends, selected_backend
 
     # keep unique attention_params
@@ -1054,7 +1046,6 @@ def get_attention_backend(
         _attention_backends["available_backends"].pop(0)
         _attention_backends["selected_backend"].pop(0)
     _attention_backends["update_selection"] = False
-    print('addingggg ', len(_attention_backends["attention_params"])) #,available_backends, selected_backend)
 
     return (
         available_backends,

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -965,7 +965,6 @@ def get_attention_backend(
     available_backends = [use_flash_attention, use_fused_attention, use_unfused_attention, fused_attn_avail_backends]
 
     # Filter: Environment variables
-    #selected_backend = [use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend]
     use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend = update_env_vars(logger, available_backends)
 
     # `FusedAttention` and `FlashAttention` are faster backends than `UnfusedDotProductAttention`.

--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -206,13 +206,20 @@ else:
     _flash_attn_3_0_0_beta = PkgVersion("3.0.0b") < _flash_attn_3_version < PkgVersion("3.0.0")
     _use_flash_attn_3 = True
 
+# maximum number of configs allowed in _attention_backends cache
+_max_configs = 10
+# attention config cache
 _attention_backends = {
-    "attention_params": None,
-    "use_flash_attention": None,
-    "use_fused_attention": None,
-    "fused_attention_backend": None,
-    "use_unfused_attention": None,
-    "backend_selection_requires_update": False,
+    # list of configs [attention_params]
+    "attention_params": [],
+    # available backends for each cached config
+    "available_backends": [],
+    # last used backend for each cached config
+    "selected_backend": [],
+    # update selected_backend if only environment variables, e.g. NVTE_FUSED_ATTN, have changed
+    "update_env_vars_only": False,
+    # update both available_backends and selected_backend
+    "update_selection": True,
 }
 
 
@@ -366,7 +373,7 @@ def get_attention_backend(
     fp8 = attention_params.fp8
     fp8_meta = attention_params.fp8_meta
 
-    # Run config
+    # Print config
     logger = logging.getLogger("DotProductAttention")
     logger.setLevel(_log_level)
     if not logger.hasHandlers():
@@ -393,22 +400,78 @@ def get_attention_backend(
         run_config["NVTE_FP8_DPA_BWD"] = int(os.getenv("NVTE_FP8_DPA_BWD", "1"))
     logger.debug("Running with config=%s", run_config)
 
+    # check if attention_params already exists in cache
+    global _attention_backends
+    #print('entering .....',
+    #    attention_params in _attention_backends["attention_params"],
+    #    _attention_backends["update_env_vars_only"],
+    #    _attention_backends["update_selection"])
+    #print(_attention_backends["attention_params"])
+    #print(attention_params)
+    if (
+        attention_params in _attention_backends["attention_params"]
+        and not _attention_backends["update_env_vars_only"]
+        and not _attention_backends["update_selection"]
+        ):
+        config_id = _attention_backends["attention_params"].index(attention_params)
+        available_backends = _attention_backends["available_backends"][config_id]
+        selected_backend = _attention_backends["selected_backend"][config_id]
+        print('retrieveing ',config_id) #, available_backends, selected_backend)
+        return available_backends, selected_backend
+
+    # if environment variables such as NVTE_FUSED_ATTN change in the middle of the run
+    def update_env_vars(logger, available_backends):
+        # Filter: Environment variables
+        use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backends = available_backends
+        _use_flash_attention = int(os.getenv("NVTE_FLASH_ATTN", "1"))
+        _use_fused_attention = int(os.getenv("NVTE_FUSED_ATTN", "1"))
+        _use_unfused_attention = int(os.getenv("NVTE_UNFUSED_ATTN", "1"))
+        if use_flash_attention and not _use_flash_attention and _flash_attn_is_installed:
+            logger.debug("Disabling FlashAttention due to NVTE_FLASH_ATTN=0")
+        if use_fused_attention and not _use_fused_attention:
+            logger.debug("Disabling FusedAttention due to NVTE_FUSED_ATTN=0")
+        if use_unfused_attention and not _use_unfused_attention:
+            logger.debug("Disabling UnfusedDotProductAttention due to NVTE_UNFUSED_ATTN=0")
+        use_flash_attention = use_flash_attention and _use_flash_attention
+        use_fused_attention = use_fused_attention and _use_fused_attention
+        use_unfused_attention = use_unfused_attention and _use_unfused_attention
+        fused_attention_backend = None
+        if use_fused_attention:
+            if len(fused_attention_backends) == 1:
+                fused_attention_backend = fused_attention_backends[0]
+            if len(fused_attention_backends) == 2:
+                sub_backend = int(os.getenv("NVTE_FUSED_ATTN_BACKEND", "1"))
+                fused_attention_backend = fused_attention_backends[sub_backend]
+        selected_backend = [use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend]
+        return selected_backend
+    if (
+        attention_params in _attention_backends["attention_params"]
+        and _attention_backends["update_env_vars_only"]
+        and not _attention_backends["update_selection"]
+        ):
+        config_id = _attention_backends["attention_params"].index(attention_params)
+        available_backends = _attention_backends["available_backends"][config_id]
+        selected_backend = update_env_vars(logger, available_backends)
+        _attention_backends["selected_backend"][config_id] = selected_backend
+        print('retrieveing update env var',config_id) #, available_backends, selected_backend)
+        return available_backends, selected_backend
+
+    # keep unique attention_params
+    if attention_params in _attention_backends["attention_params"] and _attention_backends["update_selection"]:
+        config_id = _attention_backends["attention_params"].index(attention_params)
+        _attention_backends["attention_params"].pop(config_id)
+        _attention_backends["available_backends"].pop(config_id)
+        _attention_backends["selected_backend"].pop(config_id)
+
     # The following sections check if `FlashAttention` supports the provided attention params,
     # regardless of whether FA2 or FA3 is installed. If FA2 or FA3 is not installed but is
     # necessary for performance/functionality, a warning will be issued to prompt users to
     # install an appropriate FA version.
     global _flash_attn_version_required, _flash_attn_max_version, _use_flash_attn_3
 
-    # Filter: Environment variables
-    use_flash_attention = int(os.getenv("NVTE_FLASH_ATTN", "1"))
-    use_fused_attention = int(os.getenv("NVTE_FUSED_ATTN", "1"))
-    use_unfused_attention = int(os.getenv("NVTE_UNFUSED_ATTN", "1"))
-    if not use_flash_attention and _flash_attn_is_installed:
-        logger.debug("Disabling FlashAttention due to NVTE_FLASH_ATTN=0")
-    if not use_fused_attention:
-        logger.debug("Disabling FusedAttention due to NVTE_FUSED_ATTN=0")
-    if not use_unfused_attention:
-        logger.debug("Disabling UnfusedDotProductAttention due to NVTE_UNFUSED_ATTN=0")
+    use_flash_attention = True
+    use_fused_attention = True
+    use_unfused_attention = True
 
     # Filter: ONNX mode
     if is_in_onnx_export_mode():
@@ -799,6 +862,7 @@ def get_attention_backend(
             os.environ["NVTE_FUSED_ATTN_BACKEND"] = "1"
 
     # Filter: cuDNN support
+    fused_attn_avail_backends = []
     fused_attention_backend = None
     if use_fused_attention:
         q_type = TE_DType[qkv_dtype]
@@ -806,22 +870,37 @@ def get_attention_backend(
         if fp8 and fp8_meta["recipe"].fp8_dpa:
             q_type = get_fp8_te_dtype(fp8_meta["recipe"], fprop_tensor=True)
             kv_type = q_type
-        fused_attention_backend = tex.get_fused_attn_backend(
-            q_type,
-            kv_type,
-            QKVLayout[qkv_layout],
-            AttnBiasType[fu_core_attention_bias_type],
-            AttnMaskType[attn_mask_type],
-            attention_dropout,
-            num_heads,
-            num_gqa_groups,
-            max_seqlen_q,
-            max_seqlen_kv,
-            head_dim_qk,
-            head_dim_v,
-            window_size[0],
-            window_size[1],
-        )
+
+        def get_fused_attn_backend():
+            fused_attention_backend = tex.get_fused_attn_backend(
+                q_type,
+                kv_type,
+                QKVLayout[qkv_layout],
+                AttnBiasType[fu_core_attention_bias_type],
+                AttnMaskType[attn_mask_type],
+                attention_dropout,
+                num_heads,
+                num_gqa_groups,
+                max_seqlen_q,
+                max_seqlen_kv,
+                head_dim_qk,
+                head_dim_v,
+                window_size[0],
+                window_size[1],
+            )
+            return fused_attention_backend
+
+        # all available cuDNN sub-backends
+        for k,v in FusedAttnBackend.items():
+            if k != "No_Backend":
+                os.environ["NVTE_FUSED_ATTN_BACKEND"] = str(int(v))
+                backend = get_fused_attn_backend()
+                if backend == FusedAttnBackend[k]:
+                    fused_attn_avail_backends.append(backend)
+        del os.environ["NVTE_FUSED_ATTN_BACKEND"]
+        # selected cuDNN sub-backend
+        fused_attention_backend = get_fused_attn_backend()
+
         if fused_attention_backend == FusedAttnBackend["No_Backend"]:
             logger.debug("Disabling FusedAttention as no backend supports the provided input")
             use_fused_attention = False
@@ -833,7 +912,7 @@ def get_attention_backend(
             and fused_attention_backend != FusedAttnBackend["F16_arbitrary_seqlen"]
         ):
             logger.debug(
-                "Disabling FusedAttention as only sub-backend %s does not support "
+                "Disabling FusedAttention as sub-backend %s does not support "
                 "slidng window attention",
                 int(fused_attention_backend),
             )
@@ -891,7 +970,11 @@ def get_attention_backend(
             use_fused_attention = False
 
     # All available backends
-    available_backends = [use_flash_attention, use_fused_attention, use_unfused_attention]
+    available_backends = [use_flash_attention, use_fused_attention, use_unfused_attention, fused_attn_avail_backends]
+
+    # Filter: Environment variables
+    #selected_backend = [use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend]
+    use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend = update_env_vars(logger, available_backends)
 
     # `FusedAttention` and `FlashAttention` are faster backends than `UnfusedDotProductAttention`.
     # When `FusedAttention` does not support the provided attention params, and `FlashAttention`
@@ -909,16 +992,16 @@ def get_attention_backend(
         use_flash_attention = False
         available_backends[0] = False
 
+
+    fused_attn_str = ""
+    if len(fused_attn_avail_backends) > 0:
+        fused_attn_str = " (sub-backend " + " and ".join([str(int(x)) for x in fused_attn_avail_backends]) + ")"
     logger.debug(
         "Available backends = {FlashAttention=%s, FusedAttention=%s%s,"
         " UnfusedDotProductAttention=%s}",
         bool(available_backends[0]),
         bool(available_backends[1]),
-        (
-            f" (sub-backend {int(fused_attention_backend)})"
-            if fused_attention_backend is not None
-            else ""
-        ),
+        fused_attn_str,
         bool(available_backends[2]),
     )
 
@@ -949,31 +1032,33 @@ def get_attention_backend(
     # Selected backend
     if use_flash_attention:
         use_fused_attention = False
+        fused_attention_backend = []
         use_unfused_attention = False
     elif use_fused_attention:
         use_unfused_attention = False
-    selected_backend = "NoBackend"
+    backend = "NoBackend"
     if use_flash_attention:
-        selected_backend = "FlashAttention"
+        backend = "FlashAttention"
     elif use_fused_attention:
-        selected_backend = f"FusedAttention (sub-backend {int(fused_attention_backend)})"
+        backend = f"FusedAttention (sub-backend {int(fused_attention_backend)})"
     elif use_unfused_attention:
-        selected_backend = "UnfusedDotProductAttention"
-    logger.debug("Selected backend = %s", selected_backend)
+        backend = "UnfusedDotProductAttention"
+    logger.debug("Selected backend = %s", backend)
+    selected_backend = [use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend]
 
-    global _attention_backends
-    _attention_backends["use_flash_attention"] = use_flash_attention
-    _attention_backends["use_fused_attention"] = use_fused_attention
-    _attention_backends["fused_attention_backend"] = fused_attention_backend
-    _attention_backends["use_unfused_attention"] = use_unfused_attention
-    _attention_backends["backend_selection_requires_update"] = False
+    _attention_backends["attention_params"].append(attention_params)
+    _attention_backends["available_backends"].append(available_backends)
+    _attention_backends["selected_backend"].append(selected_backend)
+    if len(_attention_backends["attention_params"]) > _max_configs:
+        _attention_backends["attention_params"].pop(0)
+        _attention_backends["available_backends"].pop(0)
+        _attention_backends["selected_backend"].pop(0)
+    _attention_backends["update_selection"] = False
+    print('addingggg ', len(_attention_backends["attention_params"])) #,available_backends, selected_backend)
 
     return (
-        use_flash_attention,
-        use_fused_attention,
-        fused_attention_backend,
-        use_unfused_attention,
         available_backends,
+        selected_backend,
     )
 
 
@@ -8193,22 +8278,12 @@ class DotProductAttention(TransformerEngineBaseModule):
                 fp8=self.fp8,
                 fp8_meta=self.fp8_meta,
             )
-            global _attention_backends, _use_flash_attn_3
-            if (
-                _attention_backends["attention_params"] is None
-                or attention_params != _attention_backends["attention_params"]
-            ):
-                _attention_backends["attention_params"] = attention_params
-                _attention_backends["backend_selection_requires_update"] = True
-            if _attention_backends["backend_selection_requires_update"]:
-                _use_flash_attn_3 = _flash_attn_3_is_installed
-                (
-                    use_flash_attention,
-                    use_fused_attention,
-                    fused_attention_backend,
-                    use_unfused_attention,
-                    _,
-                ) = get_attention_backend(attention_params)
+            is_new_config = (attention_params not in _attention_backends["attention_params"]
+                or _attention_backends["update_env_vars_only"]
+                or _attention_backends["update_selection"])
+            _, selected_backend = get_attention_backend(attention_params)
+            use_flash_attention, use_fused_attention, use_unfused_attention, fused_attention_backend = selected_backend
+            if is_new_config:
                 if use_flash_attention:
                     self.logger.info(
                         "Running with FlashAttention backend (version %s)",
@@ -8221,11 +8296,7 @@ class DotProductAttention(TransformerEngineBaseModule):
                     )
                 elif use_unfused_attention:
                     self.logger.info("Running with UnfusedDotProductAttention backend")
-            else:
-                use_flash_attention = _attention_backends["use_flash_attention"]
-                use_fused_attention = _attention_backends["use_fused_attention"]
-                fused_attention_backend = _attention_backends["fused_attention_backend"]
-                use_unfused_attention = _attention_backends["use_unfused_attention"]
+
 
             if use_flash_attention:
                 if core_attention_bias_type == "alibi":


### PR DESCRIPTION
# Description

This PR adds caching for multiple attention configurations in the same run.

Currently we only cache one `attention_params` and its corresponding `available_backends` and `selected_backend`. If there are multiple configurations in the same training/inference job, for example, it runs like this: `config 1`, `config 2`, ..., `config 1`, `config 2`, ..., then the second `config 1` or `config 2` still needs to go through the `get_attention_backend()` call, which is CPU intensive. With this PR, we cache the backend analysis results for multiple configs, so the second time a config is run, no repeated analysis is needed. The max number of configs cached is currently set to 10.

Fixes #1349 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Add caching for attention backend selection results

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
