### PR TITLE
[JAX] Add THD + SWA unit tests

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -148,29 +148,41 @@ def make_mask(
     segment_ids: [1, 1, 1, 0, 2, 2, 2, 3, 3, 3, 4, 0, 0, 5, 5, 5]
     segment_pos: [0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
     """
+    # segment masks
     inv_mask = make_attention_mask(
         segment_ids_q, segment_ids_kv, lambda x, y: (jnp.logical_and(jnp.equal(x, y), x != 0))
     )
+
+    if segment_pos_q is None:
+        segment_pos_q = jnp.broadcast_to(
+            jnp.arange(segment_ids_q.shape[-1], dtype=jnp.int32), segment_ids_q.shape
+        )
+    if segment_pos_kv is None:
+        segment_pos_kv = jnp.broadcast_to(
+            jnp.arange(segment_ids_kv.shape[-1], dtype=jnp.int32), segment_ids_kv.shape
+        )
+
+    # causal mask
     if attn_mask_type.is_causal():
-        if segment_pos_q is None:
-            segment_pos_q = jnp.broadcast_to(
-                jnp.arange(segment_ids_q.shape[-1], dtype=jnp.int32), segment_ids_q.shape
-            )
-        if segment_pos_kv is None:
-            segment_pos_kv = jnp.broadcast_to(
-                jnp.arange(segment_ids_kv.shape[-1], dtype=jnp.int32), segment_ids_kv.shape
-            )
         inv_causal_mask = make_attention_mask(
             segment_pos_q, segment_pos_kv, lambda x, y: jnp.greater_equal(x, y)
         )
         inv_mask = combine_masks(inv_causal_mask, inv_mask)
 
+    # sliding window mask
     if window_size is not None:
-        max_seqlen_q = inv_mask.shape[-2]
-        max_seqlen_kv = inv_mask.shape[-1]
-        inv_swa_mask = make_swa_mask(max_seqlen_q, max_seqlen_kv, window_size, attn_mask_type)
-        inv_swa_mask = jnp.broadcast_to(inv_swa_mask, inv_mask.shape)
-        inv_mask = combine_masks(inv_mask, inv_swa_mask)
+
+        def local_mask(pos_q, pos_kv, window_size):
+            left_window, right_window = window_size
+            return (pos_kv >= pos_q - left_window) & (pos_kv <= pos_q + right_window)
+
+        inv_swa_mask = local_mask(
+            jnp.expand_dims(segment_pos_q, axis=-1),
+            jnp.expand_dims(segment_pos_kv, axis=-2),
+            window_size,
+        )
+        inv_swa_mask = jnp.expand_dims(inv_swa_mask, axis=-3)
+        inv_mask = combine_masks(inv_swa_mask, inv_mask)
 
     mask = jnp.logical_not(inv_mask)
     return mask
@@ -314,13 +326,6 @@ class FusedAttnRunner:
             return self.num_segments_per_seq + 1
 
     def _check_configs(self):
-        # TODO(rewang): Fix THD + PADDING_CAUSAL + SWA reference
-        if (
-            self.qkv_layout.is_thd()
-            and self.attn_mask_type == AttnMaskType.PADDING_CAUSAL_MASK
-            and self.window_size is not None
-        ):
-            pytest.skip("THD + PADDING_CAUSAL + SWA reference is not implemented.")
         # TODO(rewang): probably adds this in is_fused_attn_available
         if self.qkv_layout.is_thd() and not self.attn_mask_type.is_padding():
             pytest.skip("THD format requires padding masks.")
@@ -432,7 +437,12 @@ class FusedAttnRunner:
             return tokens, jnp.logical_not(tokens)
 
         def generate_random_segment_ids(
-            batch_size, sequence_length, num_segments, seed, with_segment_pad=True
+            batch_size,
+            sequence_length,
+            num_segments,
+            seed,
+            with_segment_pad=True,
+            min_segment_len=None,
         ):
             rng = np.random.default_rng(seed=seed)
             # [1, 1, 1, 2, 2, 3, 3, 3, 3, 0, 0], 0 means pad
@@ -448,15 +458,20 @@ class FusedAttnRunner:
                 current_pos = 0
                 segment_id = 1
 
-                for _ in range(num_segments):
-                    segment_size = rng.integers(1, max_segment_size + 1)
+                for seg_id in range(num_segments):
+                    # min_segment_len is to force kv_len >= q_len because cuDNN kernels failed
+                    # TODO(rewang): Remove this constrain after cuDNN supports
+                    min_segment_size = 1
+                    if min_segment_len is not None:
+                        min_segment_size = min_segment_len[i][seg_id]
+                    segment_size = rng.integers(min_segment_size, max_segment_size + 1)
                     if current_pos + segment_size > sequence_length:
                         break
                     segment_end = current_pos + segment_size
                     segment_ids[i, current_pos:segment_end] = segment_id
                     segment_pos[i, current_pos:segment_end] = np.arange(segment_size)
                     if with_segment_pad:
-                        num_valid = rng.integers(1, segment_size + 1)
+                        num_valid = rng.integers(min_segment_size, segment_size + 1)
                         segment_pad[i, current_pos + num_valid : segment_end] = 1
                     current_pos = segment_end
                     segment_id += 1
@@ -473,18 +488,21 @@ class FusedAttnRunner:
             self.segment_ids_q, self.segment_pos_q, self.pad_q = generate_random_segment_ids(
                 self.batch_size, self.max_seqlen_q, self.num_segments_per_seq, seed=42
             )
+            self.seqlens_q, self.offsets_q = get_seqlens_and_offsets(self.segment_ids_q)
             if self.qkv_layout == QKVLayout.T3HD:
                 self.segment_ids_kv = self.segment_ids_q
                 self.segment_pos_kv = self.segment_pos_q
                 self.pad_kv = self.pad_q
             else:
+                # Force kv_len >= q_len for swa, otherwise, cuDNN kernels don't support
+                min_segment_len = None if self.window_size is None else self.seqlens_q
                 self.segment_ids_kv, self.segment_pos_kv, self.pad_kv = generate_random_segment_ids(
                     self.batch_size,
                     self.max_seqlen_kv,
                     self.num_segments_per_seq,
                     seed=2024,
+                    min_segment_len=min_segment_len,
                 )
-            self.seqlens_q, self.offsets_q = get_seqlens_and_offsets(self.segment_ids_q)
             self.seqlens_kv, self.offsets_kv = get_seqlens_and_offsets(self.segment_ids_kv)
         else:
             self.num_segments_per_seq = 1

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -170,20 +170,8 @@ def make_mask(
         inv_mask = combine_masks(inv_causal_mask, inv_mask)
 
     # sliding window mask
-    if window_size is not None:
-
-        def local_mask(pos_q, pos_kv, window_size):
-            left_window, right_window = window_size
-            return (pos_kv >= pos_q - left_window) & (pos_kv <= pos_q + right_window)
-
-        inv_swa_mask = local_mask(
-            jnp.expand_dims(segment_pos_q, axis=-1),
-            jnp.expand_dims(segment_pos_kv, axis=-2),
-            window_size,
-        )
-        inv_swa_mask = jnp.expand_dims(inv_swa_mask, axis=-3)
-        inv_mask = combine_masks(inv_swa_mask, inv_mask)
-
+    inv_swa_mask = make_swa_mask(segment_pos_q, segment_pos_kv, window_size, jnp.bool_)
+    inv_mask = combine_masks(inv_mask, inv_swa_mask)
     mask = jnp.logical_not(inv_mask)
     return mask
 

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -919,14 +919,14 @@ def apply_swa_mask(
     """Apply the sliding window mask to a given mask"""
     _attn_mask_type = canonicalize_attn_mask_type(attn_mask_type)
     assert _attn_mask_type is not None
+    batch = original_mask.shape[0]
     max_seqlen_q = original_mask.shape[-2]
     max_seqlen_kv = original_mask.shape[-1]
-    swa_mask = make_swa_mask(
-        max_seqlen_q, max_seqlen_kv, window_size, _attn_mask_type, dtype=original_mask.dtype
-    )
+    pos_q = jnp.broadcast_to(jnp.arange(max_seqlen_q), (batch, max_seqlen_q))
+    pos_kv = jnp.broadcast_to(jnp.arange(max_seqlen_kv), (batch, max_seqlen_kv))
+    swa_mask = make_swa_mask(pos_q, pos_kv, window_size, original_mask.dtype)
     # In swa_mask and original_mask 0 is masked out
-    swa_mask_bcast = jnp.broadcast_to(swa_mask, original_mask.shape)
-    new_mask = jnp.where(original_mask == 1, swa_mask_bcast, original_mask)
+    new_mask = jnp.where(original_mask == 1, swa_mask, original_mask)
     return new_mask
 
 

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -194,7 +194,7 @@ class _UnfusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-
             if self.attn_bias_type == AttnBiasType.PRE_SCALE_BIAS:
                 attn_weights += bias
 
-        def apply_swa_mask(attn_mask_type: AttnMaskType, original_mask: Array) -> Array:
+        def apply_swa_mask(original_mask: Array) -> Array:
             """Apply the sliding window mask to a given mask"""
             batch = original_mask.shape[0]
             max_seqlen_q = original_mask.shape[-2]
@@ -216,7 +216,7 @@ class _UnfusedDotProductAttention(nn.Module):  # pylint: disable=too-few-public-
             if attn_mask_type == AttnMaskType.CAUSAL_MASK and self.window_size is None:
                 mask = None
             if mask is not None:
-                mask = apply_swa_mask(attn_mask_type, mask)
+                mask = apply_swa_mask(mask)
             # Currently cuDNN backend only supports SWA for causal/padding_causal, follow this
             if attn_mask_type in [AttnMaskType.CAUSAL_MASK, AttnMaskType.PADDING_CAUSAL_MASK]:
                 return SoftmaxType.SCALED_UPPER_TRIANG_MASKED, mask


### PR DESCRIPTION
# Description

- Adds THD + SWA unit tests
- Generalizes make_swa_mask by accepting pos_q and pos_kv instead of seqlen, making it work for THD/non-THD and both top-left and bottom-right alignments.
  - Previously, make_swa_mask took seqlen and relied on an attn_mask_type (e.g., CAUSAL_MASK or CAUSAL_BOTTOM_RIGHT_MASK) to differentiate top-left vs. bottom-right alignments.
  - Now, by providing pos_q and pos_kv directly, we can generate the same patterns without a separate attn_mask_type.

For examples, consider non-THD case with q_seqlen=2, kv_seqlen=4.
In the past, we can pass q_seqlen=2, kv_seqlen=4, attn_mask=AttnMaskType.CAUSAL_BOTTOM_RIGHT_MASK for bottom-right alignment, window_size=(-1, 0), which generates mask like
```
1 1 1 0
1 1 1 1
```
And passing attn_mask=AttnMaskType.CAUSAL_MASK for top-left alignment
```
1 0 0 0
1 1 0 0
```
Now, we can do the same thing without passing attn_mask type by passing appropriate pos_q and pos_kv:
```
# make_swa_mask(jnp.asarray([[2, 3]]), jnp.asarray([[0, 1, 2, 3]]), window_size=(-1, 0))
1 1 1 0
1 1 1 1
# make_swa_mask(jnp.asarray([[0, 1]]), jnp.asarray([[0, 1, 2, 3]]), window_size=(-1, 0))
1 0 0 0
1 1 0 0
```

Besides, the new `make_swa_mask` can support the complicated THD case even with the reordering
```
>>> segment_ids_q = jnp.asarray([[1, 1, 1, 2, 2, 2]])
>>> segment_ids_kv = jnp.asarray([[1, 1, 1, 1, 2, 2, 2, 2]])
>>> segment_pos_q = jnp.asarray([[0, 1, 2, 2, 1, 0]])
>>> segment_pos_kv = jnp.asarray([[0, 1, 2, 3, 3, 2, 1, 0]])
>>> swa_mask = make_swa_mask(segment_pos_q, segment_pos_kv, window_size=(2, 0))
>>> segment_mask = make_attention_mask(segment_ids_q, segment_ids_kv, jnp.equal)
>>> mask = combine_masks(swa_mask, segment_mask)
>>> mask
Array([[[[1., 0., 0., 0., 0., 0., 0., 0.],
         [1., 1., 0., 0., 0., 0., 0., 0.],
         [0., 1., 1., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 1., 1., 0.],
         [0., 0., 0., 0., 0., 0., 1., 1.],
         [0., 0., 0., 0., 0., 0., 0., 1.]]]], dtype=float32)
```

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Adds THD + SWA unit tests
- Generalizes make_swa_mask by accepting pos_q and pos_kv instead of seqlen

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
