### PR TITLE
[PyTorch] Fix fusible ops checkpoint

### DIFF
--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -527,13 +527,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         # See: https://github.com/NVIDIA/TransformerEngine/pull/351
         # See: https://github.com/NVIDIA/TransformerEngine/pull/363
 
-        # Return immediately if op has no FP8 state
-        has_fp8_state = any(
-            self.num_fp8_scales(mode) > 0 for mode in ("input", "param", "grad_output")
-        )
-        if not has_fp8_state:
-            return torch.Tensor()
-
         def to_cpu(src: torch.Tensor) -> torch.Tensor:
             """Helper function to make CPU copy of tensor
 
@@ -548,12 +541,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         # Store FP8 state
         state = {}
         for mode in ("input", "param", "grad_output"):
-
-            # Get state for a given FP8 tensor
-            if self.num_fp8_scales(mode) == 0:
-                state[mode] = None
-                continue
-            fp8_meta = self.get_fp8_meta(mode)
+            fp8_meta = self._fp8_metas
             if fp8_meta is None:
                 continue
             state[mode] = {}


### PR DESCRIPTION
# Description

Checkpointing of certain `te.sequential` operations is currently crashing due to accessing undefined variables in `get_extra_state`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Fix `get_extra_state` method in `op.py`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
