### PR TITLE
[PyTorch] Fix AttentionParams comparison logic

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -303,6 +303,24 @@ class AttentionParams:
     fp8: bool = False
     fp8_meta: Union[Dict[str, Any], None] = None
 
+    def __eq__(self, other):
+        """
+        Overwrite dataclass.__eq__ so that only fp8_meta["recipe"] is compared,
+        since all other entries of fp8_meta are unused in get_attention_backend.
+        """
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        for field in fields(self):
+            fname = field.name
+            sf = getattr(self, fname)
+            of = getattr(other, fname)
+            if fname != "fp8_meta":
+                if sf != of:
+                    return False
+            elif sf["recipe"] != of["recipe"]:
+                return False
+        return True
+
 
 _alibi_cache = {
     "_num_heads": None,


### PR DESCRIPTION
# Description

`DotProductAttention` calls `get_attention_backend()` to choose an appropriate backend for a given `AttentionParams`. This call is CPU intensive and is only called when `attention_params != _attention_backends["attention_params"]`. For FP8, there are a number of entries in `AttentionParams.fp8_meta`, for example, `fp8_meta["scaling_fwd"]`, but what's really important is `fp8_meta["recipe"]`. This PR overwrites the `__eq__` function of `AttentionParams` to only compare the recipe entry for FP8 configs.

Before this PR, `NVTE_DEBUG=1 NVTE_DEBUG_LEVEL=1 pytest -o log_cli=true --log-cli-level=INFO -s -v tests/pytorch/test_sanity.py::test_sanity_attention_extra_state[dtype0-large]` produces:
```
INFO     DotProductAttention:attention.py:8245 Running with FusedAttention backend (sub-backend 2)
INFO     DotProductAttention:attention.py:8245 Running with FusedAttention backend (sub-backend 2)
INFO     DotProductAttention:attention.py:8245 Running with FusedAttention backend (sub-backend 2)
INFO     DotProductAttention:attention.py:8245 Running with FusedAttention backend (sub-backend 2)
INFO     DotProductAttention:attention.py:8245 Running with FusedAttention backend (sub-backend 2)
PASSED
```
After this PR:
```
INFO     DotProductAttention:attention.py:8245 Running with FusedAttention backend (sub-backend 2)
PASSED
```
This `test_sanity_attention_extra_state` test runs an FP8 config in multiple ways (i.e. with and without checkpointing), but it's the same FP8 config, so there should be only one INFO message (i.e. one `get_attention_backend` call), which is what's happening after the PR change.

Fixes #1348 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Restrict `AttentionParams.fp8_meta` comparison to just `fp8_meta["recipe"]`

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
