### PR TITLE
[JAX] Support segment_ids/pos as FA inputs

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -2,31 +2,18 @@
 #
 # See LICENSE for license information.
 
-import pytest
-from functools import partial
-
 import jax
 import jax.numpy as jnp
 import numpy as np
-from flax.linen import dot_product_attention
 from jax import random
-from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from distributed_test_base import (
     generate_configs,
     generate_context_parallel_configs,
     generate_collectives_count,
-    compare_ops,
-)
-from utils import (
-    make_causal_mask,
-    make_self_mask,
-    assert_allclose,
-    print_debug_tensor_stats,
 )
 from transformer_engine.jax import fp8_autocast
 from transformer_engine.jax.attention import (
     is_fused_attn_kernel_available,
-    fused_attn,
     AttnBiasType,
     AttnMaskType,
     QKVLayout,
@@ -36,10 +23,11 @@ from transformer_engine.jax.attention import (
     CPStrategy,
 )
 from transformer_engine.jax.sharding import MeshResource
+import pytest
 
-from test_fused_attn import FusedAttnRunner, BiasShape, general_dot_product_attention, make_mask
+from test_fused_attn import FusedAttnRunner, BiasShape, SeqDescFormat
 
-DTYPES = [jnp.float16, jnp.bfloat16]
+DTYPES = [jnp.bfloat16]
 
 
 class TestDistributedSelfAttn:
@@ -141,6 +129,7 @@ class TestDistributedSelfAttn:
             QKVLayout.BS3HD,
             bias_shape,
             None,
+            SeqDescFormat.Seqlens,
             number_of_devices=device_count,
             mesh_shape=mesh_shape,
             mesh_axes=mesh_axes,
@@ -205,6 +194,7 @@ class TestDistributedCrossAttn:
             QKVLayout.BSHD_BS2HD,
             bias_shape,
             None,
+            SeqDescFormat.Seqlens,
             number_of_devices=device_count,
             mesh_shape=mesh_shape,
             mesh_axes=mesh_axes,
@@ -293,6 +283,7 @@ class TestDistributedContextParallelSelfAttn:
             qkv_layout,
             bias_shape,
             None,
+            SeqDescFormat.Seqlens,
             number_of_devices=device_count,
             mesh_shape=mesh_shape,
             mesh_axes=mesh_axes,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -192,8 +192,8 @@ def get_seqlens_and_offsets(segment_ids):
         ).squeeze(-1)
 
     offsets = _find_offsets(segment_ids)
-    offsets = jnp.insert(offsets, -1, values=-1, axis=-1)
-    seqlens = jnp.insert(seqlens, -1, values=0, axis=-1)
+    offsets = jnp.insert(offsets, offsets.shape[-1], values=-1, axis=-1)
+    seqlens = jnp.insert(seqlens, seqlens.shape[-1], values=0, axis=-1)
     seqlens = jnp.where(seqlens, seqlens, -1)
     return seqlens, offsets
 

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -589,6 +589,8 @@ def _fused_attn_fwd_rule(
         kv_seq_lens,
         q_seq_offsets,
         kv_seq_offsets,
+        None,
+        None,
         seed,
         attn_bias_type=attn_bias_type.value,
         attn_mask_type=attn_mask_type.value,

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -669,14 +669,10 @@ def _fused_attn_fwd_rule(
     output = checkpoint_name(output, "context")
     softmax_aux = checkpoint_name(softmax_aux, "context")
     rng_state = checkpoint_name(rng_state, "context")
-    seq_offsets = mask_descriptor.seq_offsets
-    if seq_offsets is None:
-        seq_offsets = (None, None)
     return output, (
         qkv,
         bias,
-        *mask_descriptor.seqlens,
-        *seq_offsets,
+        mask_descriptor,
         softmax_aux,
         rng_state,
         output,
@@ -701,10 +697,7 @@ def _fused_attn_bwd_rule(
     (
         qkv,
         bias,
-        q_seq_lens,
-        kv_seq_lens,
-        q_seq_offsets,
-        kv_seq_offsets,
+        mask_descriptor,
         softmax_aux,
         rng_state,
         output,
@@ -716,10 +709,7 @@ def _fused_attn_bwd_rule(
         rng_state,
         output,
         dz,
-        q_seq_lens,
-        kv_seq_lens,
-        q_seq_offsets,
-        kv_seq_offsets,
+        mask_descriptor,
         attn_bias_type=attn_bias_type.value,
         attn_mask_type=attn_mask_type.value,
         qkv_layout=qkv_layout.value,

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -303,7 +303,6 @@ def _get_seqlens_and_offsets(segment_ids, max_segments_per_seq):
         ).squeeze(-1)
 
     offsets = _find_offsets(segment_ids)
-    seqlens = jnp.insert(seqlens, seqlens.shape[-1], values=0, axis=-1)
     return seqlens, offsets
 
 

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -290,7 +290,7 @@ def inverse_reorder_causal_load_balancing(tensor, cp_size: int, tensor_format: Q
 
 def _get_seqlens_and_offsets(segment_ids, max_segments_per_seq):
     # bincount map with 0s
-    bincount_vmap = jax.vmap(partial(jnp.bincount, length=(max_segments_per_seq + 1)))
+    bincount_vmap = jax.vmap(partial(jnp.bincount, length=max_segments_per_seq + 1))
     seqlens_with_zero = bincount_vmap(segment_ids.astype(jnp.int32))
     seqlens = seqlens_with_zero[..., 1:]
 

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -289,7 +289,8 @@ def inverse_reorder_causal_load_balancing(tensor, cp_size: int, tensor_format: Q
 
 
 def _get_seqlens_and_offsets(segment_ids, max_segments_per_seq):
-    bincount_vmap = jax.vmap(partial(jnp.bincount, length=max_segments_per_seq))
+    # bincount map with 0s
+    bincount_vmap = jax.vmap(partial(jnp.bincount, length=(max_segments_per_seq + 1)))
     seqlens_with_zero = bincount_vmap(segment_ids.astype(jnp.int32))
     seqlens = seqlens_with_zero[..., 1:]
 
@@ -303,7 +304,6 @@ def _get_seqlens_and_offsets(segment_ids, max_segments_per_seq):
 
     offsets = _find_offsets(segment_ids)
     seqlens = jnp.insert(seqlens, seqlens.shape[-1], values=0, axis=-1)
-    seqlens = jnp.where(seqlens, seqlens, -1)
     return seqlens, offsets
 
 

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -499,7 +499,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         )
 
         (q_seqlen, kv_seqlen), (q_seq_offsets, k_seq_offsets) = (
-            sequence_descriptor.get_seqlens_and_offsets()
+            sequence_descriptor.get_seqlens_and_offsets(config.attn_mask_type, config.window_size)
         )
 
         if nvte_get_qkv_format(config.qkv_layout) == NVTE_QKV_Format.NVTE_THD:

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -17,6 +17,8 @@ from jax.interpreters.mlir import ir
 from jax.sharding import PartitionSpec, NamedSharding
 from jax.extend import ffi
 
+from flax.linen import make_attention_mask
+
 from transformer_engine.jax.attention import CPStrategy, MaskDescriptor
 
 from transformer_engine import transformer_engine_jax
@@ -215,6 +217,68 @@ def generate_cu_seqlen(actual_seqlen):
     cu_seqlen = jnp.where(actual_seqlen < 0, -1, cu_seqlen)
     cu_seqlen = jnp.insert(cu_seqlen, 0, values=0, axis=-1)
     return cu_seqlen
+
+
+def get_seqlens_and_offsets(segment_ids):
+    batch, max_seqlen = segment_ids.shape
+    bincount_vmap = jax.vmap(partial(jnp.bincount, length=max_seqlen))
+    seqlens_with_zero = bincount_vmap(segment_ids.astype(jnp.int32))
+    seqlens = seqlens_with_zero[..., 1:]
+
+    def _find_offsets(x):
+        same_as_previous = jnp.logical_and(x[..., 1:] != x[..., :-1], x[..., 1:] != 0)
+        first_column = x[..., :1] != 0
+        same_as_previous = jnp.hstack((first_column, same_as_previous))
+        return jax.vmap(partial(jnp.argwhere, size=x.shape[1], fill_value=-1))(
+            same_as_previous
+        ).squeeze(-1)
+
+    offsets = _find_offsets(segment_ids)
+    offsets = jnp.insert(offsets, offsets.shape[-1], values=-1, axis=-1)
+    seqlens = jnp.insert(seqlens, seqlens.shape[-1], values=0, axis=-1)
+    seqlens = jnp.where(seqlens, seqlens, -1)
+    return seqlens, offsets
+
+
+def segment_ids_pos_to_seqlen_offset(
+    segment_ids_q,
+    segment_ids_kv,
+    segment_pos_q,
+    segment_pos_kv,
+):
+    # Satisified condition will be marked as true
+    segment_mask = make_attention_mask(
+        segment_ids_q,
+        segment_ids_kv,
+        lambda x, y: jnp.equal(x, y),
+    )
+
+    segment_mask_with_id = make_attention_mask(
+        segment_ids_q,
+        segment_ids_kv,
+        lambda x, y: jnp.equal(x, y) * x,
+    )
+
+    causal_mask = make_attention_mask(
+        segment_pos_q,
+        segment_pos_kv,
+        lambda x, y: jnp.greater_equal(x, y),
+    )
+
+    attn_mask = jnp.logical_and(segment_mask, causal_mask)
+    attn_mask_with_id = jnp.where(attn_mask, segment_mask_with_id, 0)
+
+    q_seqlen, q_offset, kv_seqlen, kv_offset = mask_to_seqlens_offset(attn_mask_with_id)
+    return attn_mask_with_id, q_seqlen, q_offset, kv_seqlen, kv_offset
+
+
+def mask_to_seqlens_offset(mask):
+    assert mask.shape[1] == 1
+    row_ids = mask.squeeze(axis=1).max(axis=-1)
+    q_seqlen, q_offset = get_seqlens_and_offsets(row_ids)
+    col_ids = mask.squeeze(axis=1).max(axis=-2)
+    kv_seqlen, kv_offset = get_seqlens_and_offsets(col_ids)
+    return q_seqlen, q_offset, kv_seqlen, kv_offset
 
 
 class FusedAttnFwdPrimitive(BasePrimitive):
@@ -490,6 +554,11 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         config: _FusedAttnConfig,
     ):
         assert FusedAttnFwdPrimitive.inner_primitive is not None
+
+        if _q_segment_ids.size != 0:
+            _, q_seqlen, q_seq_offsets, kv_seqlen, k_seq_offsets = segment_ids_pos_to_seqlen_offset(
+                _q_segment_ids, _kv_segment_ids, _q_segment_pos, _kv_segment_pos
+            )
 
         if nvte_get_qkv_format(config.qkv_layout) == NVTE_QKV_Format.NVTE_THD:
 

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -499,7 +499,9 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         )
 
         (q_seqlen, kv_seqlen), (q_seq_offsets, k_seq_offsets) = (
-            sequence_descriptor.get_seqlens_and_offsets(config.attn_mask_type, config.window_size)
+            sequence_descriptor.get_seqlens_and_offsets(
+                config.attn_mask_type, config.qkv_layout, config.window_size
+            )
         )
 
         if nvte_get_qkv_format(config.qkv_layout) == NVTE_QKV_Format.NVTE_THD:
@@ -900,7 +902,9 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         )
 
         (q_seqlen, kv_seqlen), (q_seq_offsets, k_seq_offsets) = (
-            sequence_descriptor.get_seqlens_and_offsets(config.attn_mask_type, config.window_size)
+            sequence_descriptor.get_seqlens_and_offsets(
+                config.attn_mask_type, config.qkv_layout, config.window_size
+            )
         )
 
         if nvte_get_qkv_format(config.qkv_layout) == NVTE_QKV_Format.NVTE_THD:
@@ -2182,8 +2186,6 @@ def fused_attn_fwd(
     seed = _FusedAttnRNGStateChecker().check_seed(seed, dropout_probability, is_training)
     # For optional tensors, which custom calls doesn't support None
     _not_used = jnp.zeros(0, dtype=qkv[0].dtype)
-
-    is_ragged = nvte_get_qkv_format(qkv_layout) == NVTE_QKV_Format.NVTE_THD
 
     match qkv_layout:
         case NVTE_QKV_Layout.NVTE_BS3HD | NVTE_QKV_Layout.NVTE_T3HD:

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -1317,7 +1317,7 @@ class FusedAttnCPWithAllGatherFwdPrimitive(FusedAttnFwdPrimitive):
             mesh, PartitionSpec(get_all_mesh_axes(), None)
         )
         arg_shardings = [arg_i.sharding for arg_i in arg_infos]
-        arg_shardings[-2] = seed_sharding
+        arg_shardings[4] = seed_sharding
         arg_shardings = tuple(arg_shardings)
         out_shardings = (out_sharding, softmax_aux_sharding, rng_state_sharding)
 
@@ -1718,7 +1718,7 @@ class FusedRingAttnFwdPrimitive(FusedAttnFwdPrimitive):
             mesh, PartitionSpec(get_all_mesh_axes(), None)
         )
         arg_shardings = [arg_i.sharding for arg_i in arg_infos]
-        arg_shardings[-2] = seed_sharding
+        arg_shardings[4] = seed_sharding
         arg_shardings = tuple(arg_shardings)
         out_shardings = (out_sharding, softmax_aux_sharding, rng_state_sharding)
 

--- a/transformer_engine/jax/csrc/extensions/attention.cpp
+++ b/transformer_engine/jax/csrc/extensions/attention.cpp
@@ -643,9 +643,9 @@ Error_Type FusedAttnBackwardFFI(cudaStream_t stream, Buffer_Type q_buf, Buffer_T
                                 Buffer_Type output_buf, Buffer_Type doutput_buf,
                                 Buffer_Type q_cu_seqlens_buf, Buffer_Type kv_cu_seqlens_buf,
                                 Buffer_Type q_seq_offsets_buf, Buffer_Type k_seq_offsets_buf,
-                                Result_Type dq_buf, Result_Type dk_buf, Result_Type dv_buf,
-                                Result_Type dbias_buf, Result_Type workspace_buf,
-                                Dictionary attrs) {
+                                Variadic_Buffer_Type _unused_args, Result_Type dq_buf,
+                                Result_Type dk_buf, Result_Type dv_buf, Result_Type dbias_buf,
+                                Result_Type workspace_buf, Dictionary attrs) {
   FUSED_ATTN_FFI_GET_ATTRS;
 
   FusedAttnBackwardImpl(
@@ -678,6 +678,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(FusedAttnBackwardHandler, FusedAttnBackwardFFI,
                                   .Arg<Buffer_Type>()      // kv_cu_seqlens
                                   .Arg<Buffer_Type>()      // q_seq_offsets
                                   .Arg<Buffer_Type>()      // k_seq_offsets
+                                  .RemainingArgs()         // _cp_aux_args unused
                                   .Ret<Buffer_Type>()      // dq
                                   .Ret<Buffer_Type>()      // dk
                                   .Ret<Buffer_Type>()      // dv

--- a/transformer_engine/jax/csrc/extensions/attention.cpp
+++ b/transformer_engine/jax/csrc/extensions/attention.cpp
@@ -357,9 +357,10 @@ Error_Type FusedAttnForwardFFI(cudaStream_t stream, Buffer_Type q_buf, Buffer_Ty
                                Buffer_Type v_buf, Buffer_Type bias_buf,
                                Buffer_Type q_cu_seqlens_buf, Buffer_Type kv_cu_seqlens_buf,
                                Buffer_Type q_seq_offsets_buf, Buffer_Type k_seq_offsets_buf,
-                               Buffer_Type seed_buf, Result_Type output_buf,
-                               Result_Type softmax_aux_buf, Result_Type rng_state_buf,
-                               Result_Type workspace_buf, Dictionary attrs) {
+                               Buffer_Type seed_buf, Variadic_Buffer_Type _unused_args,
+                               Result_Type output_buf, Result_Type softmax_aux_buf,
+                               Result_Type rng_state_buf, Result_Type workspace_buf,
+                               Dictionary attrs) {
   FUSED_ATTN_FFI_GET_ATTRS;
 
   FusedAttnForwardImpl(
@@ -388,6 +389,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(FusedAttnForwardHandler, FusedAttnForwardFFI,
                                   .Arg<Buffer_Type>()      // q_seq_offsets
                                   .Arg<Buffer_Type>()      // k_seq_offsets
                                   .Arg<Buffer_Type>()      // seed_buf
+                                  .RemainingArgs()         // _cp_aux_args unused
                                   .Ret<Buffer_Type>()      // output
                                   .Ret<Buffer_Type>()      // softmax_aux
                                   .Ret<Buffer_Type>()      // rng_state

--- a/transformer_engine/jax/csrc/extensions/attention.cpp
+++ b/transformer_engine/jax/csrc/extensions/attention.cpp
@@ -213,14 +213,14 @@ pybind11::tuple GetFusedAttnForwardWorkspaceSizes(
   auto layout_group = nvte_get_qkv_layout_group(qkv_layout);
 
 static void FusedAttnForwardImpl(
-    cudaStream_t stream, void *q, void *k, void *v, void *bias, void *q_cu_seqlens,
-    void *kv_cu_seqlens, void *q_seq_offsets, void *k_seq_offsets, void *seed, void *output,
-    void *softmax_aux, void *rng_state, void *workspace, size_t input_batch, size_t bias_batch,
-    size_t q_max_seqlen, size_t kv_max_seqlen, size_t attn_heads, size_t num_gqa_groups,
-    size_t bias_heads, size_t head_dim, size_t max_segments_per_seq, size_t wkspace_size,
-    float scaling_factor, float dropout_probability, NVTE_Bias_Type bias_type,
-    NVTE_Mask_Type mask_type, NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype,
-    bool is_training, bool deterministic, int64_t window_size_left, int64_t window_size_right) {
+    cudaStream_t stream, void *q, void *k, void *v, void *bias, void *seed, void *q_cu_seqlens,
+    void *kv_cu_seqlens, void *q_seq_offsets, void *k_seq_offsets, void *output, void *softmax_aux,
+    void *rng_state, void *workspace, size_t input_batch, size_t bias_batch, size_t q_max_seqlen,
+    size_t kv_max_seqlen, size_t attn_heads, size_t num_gqa_groups, size_t bias_heads,
+    size_t head_dim, size_t max_segments_per_seq, size_t wkspace_size, float scaling_factor,
+    float dropout_probability, NVTE_Bias_Type bias_type, NVTE_Mask_Type mask_type,
+    NVTE_QKV_Layout qkv_layout, DType dtype, DType wkspace_dtype, bool is_training,
+    bool deterministic, int64_t window_size_left, int64_t window_size_right) {
   FUSED_ATTN_IMPL_COMMON_BLOCK;
 
   /* Input tensors */
@@ -303,11 +303,11 @@ void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, s
   void *k = buffers[1];
   void *v = buffers[2];
   void *bias = buffers[3];
-  void *q_cu_seqlens = buffers[4];
-  void *kv_cu_seqlens = buffers[5];
-  void *q_seq_offsets = is_ragged ? buffers[6] : nullptr;
-  void *k_seq_offsets = is_ragged ? buffers[7] : nullptr;
-  void *seed = buffers[8];
+  void *seed = buffers[4];
+  void *q_cu_seqlens = buffers[5];
+  void *kv_cu_seqlens = buffers[6];
+  void *q_seq_offsets = is_ragged ? buffers[7] : nullptr;
+  void *k_seq_offsets = is_ragged ? buffers[8] : nullptr;
 
   /* Output buffer from XLA */
   void *output = buffers[9];
@@ -316,7 +316,7 @@ void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, s
   void *workspace = buffers[12];
 
   FusedAttnForwardImpl(
-      stream, q, k, v, bias, q_cu_seqlens, kv_cu_seqlens, q_seq_offsets, k_seq_offsets, seed,
+      stream, q, k, v, bias, seed, q_cu_seqlens, kv_cu_seqlens, q_seq_offsets, k_seq_offsets,
       output, softmax_aux, rng_state, workspace, descriptor.input_batch, descriptor.bias_batch,
       descriptor.q_max_seqlen, descriptor.kv_max_seqlen, descriptor.attn_heads,
       descriptor.num_gqa_groups, descriptor.bias_heads, descriptor.head_dim,
@@ -354,25 +354,24 @@ void FusedAttnForward(cudaStream_t stream, void **buffers, const char *opaque, s
   DType wkspace_dtype = convert_ffi_datatype_to_te_dtype(workspace_buf->element_type());
 
 Error_Type FusedAttnForwardFFI(cudaStream_t stream, Buffer_Type q_buf, Buffer_Type k_buf,
-                               Buffer_Type v_buf, Buffer_Type bias_buf,
+                               Buffer_Type v_buf, Buffer_Type bias_buf, Buffer_Type seed_buf,
                                Buffer_Type q_cu_seqlens_buf, Buffer_Type kv_cu_seqlens_buf,
                                Buffer_Type q_seq_offsets_buf, Buffer_Type k_seq_offsets_buf,
-                               Buffer_Type seed_buf, Variadic_Buffer_Type _unused_args,
-                               Result_Type output_buf, Result_Type softmax_aux_buf,
-                               Result_Type rng_state_buf, Result_Type workspace_buf,
-                               Dictionary attrs) {
+                               Variadic_Buffer_Type _unused_args, Result_Type output_buf,
+                               Result_Type softmax_aux_buf, Result_Type rng_state_buf,
+                               Result_Type workspace_buf, Dictionary attrs) {
   FUSED_ATTN_FFI_GET_ATTRS;
 
   FusedAttnForwardImpl(
       stream, q_buf.untyped_data(), k_buf.untyped_data(), v_buf.untyped_data(),
-      bias_buf.untyped_data(), q_cu_seqlens_buf.untyped_data(), kv_cu_seqlens_buf.untyped_data(),
-      is_ragged ? q_seq_offsets_buf.untyped_data() : nullptr,
-      is_ragged ? k_seq_offsets_buf.untyped_data() : nullptr, seed_buf.untyped_data(),
-      output_buf->untyped_data(), softmax_aux_buf->untyped_data(), rng_state_buf->untyped_data(),
-      workspace_buf->untyped_data(), input_batch, bias_batch, q_max_seqlen, kv_max_seqlen,
-      attn_heads, num_gqa_groups, bias_heads, head_dim, max_segments_per_seq, wkspace_size,
-      scaling_factor, dropout_probability, bias_type, mask_type, qkv_layout, dtype, wkspace_dtype,
-      is_training, deterministic, window_size_left, window_size_right);
+      bias_buf.untyped_data(), seed_buf.untyped_data(), q_cu_seqlens_buf.untyped_data(),
+      kv_cu_seqlens_buf.untyped_data(), is_ragged ? q_seq_offsets_buf.untyped_data() : nullptr,
+      is_ragged ? k_seq_offsets_buf.untyped_data() : nullptr, output_buf->untyped_data(),
+      softmax_aux_buf->untyped_data(), rng_state_buf->untyped_data(), workspace_buf->untyped_data(),
+      input_batch, bias_batch, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, bias_heads,
+      head_dim, max_segments_per_seq, wkspace_size, scaling_factor, dropout_probability, bias_type,
+      mask_type, qkv_layout, dtype, wkspace_dtype, is_training, deterministic, window_size_left,
+      window_size_right);
 
   return ffi_with_cuda_error_check();
 }
@@ -384,11 +383,11 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(FusedAttnForwardHandler, FusedAttnForwardFFI,
                                   .Arg<Buffer_Type>()      // k
                                   .Arg<Buffer_Type>()      // v
                                   .Arg<Buffer_Type>()      // bias
+                                  .Arg<Buffer_Type>()      // seed_buf
                                   .Arg<Buffer_Type>()      // q_cu_seqlens
                                   .Arg<Buffer_Type>()      // kv_cu_seqlens
                                   .Arg<Buffer_Type>()      // q_seq_offsets
                                   .Arg<Buffer_Type>()      // k_seq_offsets
-                                  .Arg<Buffer_Type>()      // seed_buf
                                   .RemainingArgs()         // _cp_aux_args unused
                                   .Ret<Buffer_Type>()      // output
                                   .Ret<Buffer_Type>()      // softmax_aux


### PR DESCRIPTION
# Description

This PR adds `segment_ids/pos` limited support and deprecated `fused_attn_thd` API.

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

- Add a new `SequenceDescriptor` class for different sequence descriptions scenario.
   - `from_seqlens` for non-THD
   - `from_seqlens_and_offsets` for THD
   - `from_segment_ids_and_pos` for THD + ring attn (haven't implemented)
- Change the old `fused_attn` `mask` parameter to `SequenceDescriptor`. Passing `mask` in the position argument will work for a while but generating deprecation warning.
- Deprecate `fused_attn_thd` API as the refactored `fused_attn` can also support THD format.
- Remove small inputs in `test_fused_attn.py` as the long sequence inputs should cover.
- Add different sequence inputs tests in `test_fused_attn.py`

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
