### PR TITLE
[PyTorch] `te.Linear` FP8 DGRAD+RS output bugfix

### DIFF
--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -568,9 +568,7 @@ class _Linear(torch.autograd.Function):
                 if dgrad is None:
                     if ctx.parallel_mode == "column" and ctx.sequence_parallel:
                         dgrad_shape[0] = dgrad_shape[0] * tp_world_size
-                    dgrad = torch.empty(
-                        dgrad_shape, dtype=output_dtype, device=grad_output.device
-                    )
+                    dgrad = torch.empty(dgrad_shape, dtype=output_dtype, device=grad_output.device)
 
             if ctx.requires_dgrad:
                 if ctx.fp8:


### PR DESCRIPTION
# Description

This PR corrects a bug where the BF16 DGRAD+RS output was being incorrectly fed into a `Float8Tensor` constructor.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
