### PR TITLE
[PyTorch] Debug NeMo distributed optimizer

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -946,6 +946,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 assert (
                     quantizer is not None
                 )  # to use primary fp8 weight one needs to use FP8 autocast with specific recipe.
+                quantizer.internal = False
                 param = quantizer(param)
 
             # Redo parameter wrap in case we broke it above

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -515,6 +515,7 @@ class Float8Tensor(Float8TensorBase, QuantizedTensor):
 
         # Quantize to FP8
         assert self._quantizer is not None, "Can't quantize without a quantizer"
+        self._quantizer.internal = False
         self.data = self._quantizer.quantize(tensor)
         if self.requires_grad != tensor.requires_grad:
             self.requires_grad_(requires_grad=tensor.requires_grad)

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -429,16 +429,36 @@ class _ViewFunc(torch.autograd.Function):
         if shape is None:
             return tensor
 
+        # Canonicalize shape
+        if not isinstance(shape, Iterable):
+            shape = [shape]
+        elif len(shape) == 1 and isinstance(shape[0], Iterable):
+            shape = shape[0]
+        if -1 in shape:
+            shape = list(shape)
+            d_inferred = -math.prod(ctx.shape) // math.prod(shape)
+            for i, d in enumerate(shape):
+                if d == -1:
+                    shape[i] = d_inferred
+                    break
+        if shape[-1] != ctx.shape[-1]:
+            raise RuntimeError(
+                "MXFP8Tensor does not support reshaping inner dimension "
+                f"(attempted to reshape dims={tuple(tensor.shape)} to {tuple(shape)})"
+            )
+
         # Construct new tensor if shape is provided
-        new_data = tensor._data.view(*shape) if tensor._data is not None else None
+        new_rowwise_data = None
+        new_columnwise_data = None
+        if tensor._rowwise_data is not None:
+            new_rowwise_data = tensor._rowwise_data.view(*shape)
         if tensor._columnwise_data is not None:
-            new_columnwise_data = tensor._columnwise_data.view(shape)
-        else:
-            new_columnwise_data = None
+            columnwise_shape = [shape[-1]] + list(shape[:-1])
+            new_columnwise_data = tensor._columnwise_data.view(columnwise_shape)
         return MXFP8Tensor(
             shape,
             tensor.dtype,
-            rowwise_data=new_data,
+            rowwise_data=new_rowwise_data,
             rowwise_scale_inv=tensor._rowwise_scale_inv,
             columnwise_data=new_columnwise_data,
             columnwise_scale_inv=tensor._columnwise_scale_inv,
@@ -496,7 +516,9 @@ class _ReshapeFunc(torch.autograd.Function):
             return tensor
 
         # Canonicalize shape
-        if len(shape) == 1 and isinstance(shape, Iterable):
+        if not isinstance(shape, Iterable):
+            shape = [shape]
+        elif len(shape) == 1 and isinstance(shape[0], Iterable):
             shape = shape[0]
         if -1 in shape:
             shape = list(shape)


### PR DESCRIPTION
# Description

[NeMo's distributed optimizer](https://github.com/NVIDIA/NeMo/blob/main/nemo/core/optim/distributed_adam.py) interacts with the internals of `Float8Tensor` in order to perform FP8 casts. While debugging in https://github.com/NVIDIA/NeMo/pull/12004, I've also fixed some miscellaneous bugs in the quantized tensors.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Avoid internal quantized tensor class when creating params or setting `data` attr
- Debug `MXFP8Tensor` views

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
