### PR TITLE
[PyTorch] Rename and clean up MXFP8 recipe class

### DIFF
--- a/tests/pytorch/distributed/run_numerics.py
+++ b/tests/pytorch/distributed/run_numerics.py
@@ -16,9 +16,9 @@ from torch import nn
 import torch.distributed as dist
 
 from transformer_engine.common.recipe import (
-    MXFP8BlockScaling,
     DelayedScaling,
     Format,
+    MXFP8Recipe,
     Recipe,
 )
 from run_layer_with_overlap import _compare_tensors
@@ -44,7 +44,7 @@ def quantization_recipe() -> Recipe:
             fp8_format=Format.HYBRID, amax_history_len=32, amax_compute_algo="max"
         )
     if QUANTIZATION == "mxfp8":
-        return MXFP8BlockScaling()
+        return MXFP8Recipe()
     return te.fp8.get_default_fp8_recipe()
 
 

--- a/tests/pytorch/distributed/test_fusible_ops.py
+++ b/tests/pytorch/distributed/test_fusible_ops.py
@@ -136,7 +136,7 @@ def make_recipe(name: Optional[str] = None) -> Optional[Recipe]:
             fp8_format=transformer_engine.common.recipe.Format.E4M3,
         )
     if name == "mxfp8":
-        return transformer_engine.common.recipe.MXFP8BlockScaling(
+        return transformer_engine.common.recipe.MXFP8Recipe(
             fp8_format=transformer_engine.common.recipe.Format.E4M3,
         )
     raise ValueError(f"Unsupported quantization scheme ({name})")

--- a/tests/pytorch/test_cuda_graphs.py
+++ b/tests/pytorch/test_cuda_graphs.py
@@ -315,7 +315,7 @@ def test_make_graphed_callables(
         pytest.skip("FP8 needed for FP8 parameters.")
     if fp8_weight_caching and not fp8:
         pytest.skip("FP8 needed for FP8 parameters.")
-    if fp8_recipe.is_mxfp8() and not mxfp8_available:
+    if fp8_recipe.is_mxfp8 and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
 
     # Run model with different CUDA graph settings.

--- a/tests/pytorch/test_cuda_graphs.py
+++ b/tests/pytorch/test_cuda_graphs.py
@@ -53,7 +53,7 @@ model_configs = {"small": ModelConfig(2, 32, 64, 2, 32)}
 
 fp8_recipes = [
     recipe.DelayedScaling(),
-    recipe.MXFP8BlockScaling(),
+    recipe.MXFP8Recipe(),
 ]
 
 # Supported data types
@@ -315,7 +315,7 @@ def test_make_graphed_callables(
         pytest.skip("FP8 needed for FP8 parameters.")
     if fp8_weight_caching and not fp8:
         pytest.skip("FP8 needed for FP8 parameters.")
-    if fp8_recipe.mxfp8() and not mxfp8_available:
+    if fp8_recipe.is_mxfp8() and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
 
     # Run model with different CUDA graph settings.

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -148,7 +148,7 @@ def make_recipe(name: Optional[str] = None) -> Optional[Recipe]:
             fp8_format=transformer_engine.common.recipe.Format.E4M3,
         )
     if name == "mxfp8":
-        return transformer_engine.common.recipe.MXFP8BlockScaling(
+        return transformer_engine.common.recipe.MXFP8Recipe(
             fp8_format=transformer_engine.common.recipe.Format.E4M3,
         )
     raise ValueError(f"Unsupported quantization scheme ({name})")

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1416,7 +1416,7 @@ def _test_grouped_linear_accuracy(block, num_gemms, bs, dtype, config, recipe, f
     if num_gemms > 1:
         split_size = 1
         if fp8:
-            if recipe.delayed():
+            if recipe.is_delayed_scaling():
                 split_size = 16
             if recipe.is_mxfp8():
                 split_size = 128
@@ -1465,7 +1465,7 @@ def test_grouped_linear_accuracy(
         pytest.skip(reason_for_no_fp8)
     if recipe.is_mxfp8() and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
-    if fp8 and not recipe.delayed():  # TODO(ksivamani): debug mismatches
+    if fp8 and not recipe.is_delayed_scaling():  # TODO(ksivamani): debug mismatches
         pytest.skip("Grouped linear only supports FP8 delayed scaling")
 
     config = model_configs[model]
@@ -1650,7 +1650,7 @@ def test_padding_grouped_linear_accuracy(
         pytest.skip(reason_for_no_fp8)
     if recipe.is_mxfp8() and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
-    if fp8 and not recipe.delayed():  # TODO(ksivamani): debug mismatches
+    if fp8 and not recipe.is_delayed_scaling():  # TODO(ksivamani): debug mismatches
         pytest.skip("Grouped linear only supports FP8 delayed scaling.")
 
     config = model_configs[model]

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -556,7 +556,7 @@ def _test_e2e_selective_recompute(
 def test_gpt_selective_activation_recompute(dtype, bs, model, fp8, recipe, fp8_model_params):
     if fp8 and not fp8_available:
         pytest.skip(reason_for_no_fp8)
-    if recipe.is_mxfp8() and not mxfp8_available:
+    if recipe.is_mxfp8 and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
 
     config = model_configs[model]
@@ -668,7 +668,7 @@ def test_gpt_full_activation_recompute(
 ):
     if fp8 and not fp8_available:
         pytest.skip(reason_for_no_fp8)
-    if recipe.is_mxfp8() and not mxfp8_available:
+    if recipe.is_mxfp8 and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
 
     config = model_configs[model]
@@ -1416,9 +1416,9 @@ def _test_grouped_linear_accuracy(block, num_gemms, bs, dtype, config, recipe, f
     if num_gemms > 1:
         split_size = 1
         if fp8:
-            if recipe.is_delayed_scaling():
+            if recipe.is_delayed_scaling:
                 split_size = 16
-            if recipe.is_mxfp8():
+            if recipe.is_mxfp8:
                 split_size = 128
         m = config.seq_len // split_size
         dist = torch.sort(torch.randint(0, m, (num_gemms - 2,))).values.tolist()
@@ -1463,9 +1463,9 @@ def test_grouped_linear_accuracy(
 ):
     if fp8 and not fp8_available:
         pytest.skip(reason_for_no_fp8)
-    if recipe.is_mxfp8() and not mxfp8_available:
+    if recipe.is_mxfp8 and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
-    if fp8 and not recipe.is_delayed_scaling():  # TODO(ksivamani): debug mismatches
+    if fp8 and not recipe.is_delayed_scaling:  # TODO(ksivamani): debug mismatches
         pytest.skip("Grouped linear only supports FP8 delayed scaling")
 
     config = model_configs[model]
@@ -1648,9 +1648,9 @@ def test_padding_grouped_linear_accuracy(
 ):
     if fp8 and not fp8_available:
         pytest.skip(reason_for_no_fp8)
-    if recipe.is_mxfp8() and not mxfp8_available:
+    if recipe.is_mxfp8 and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
-    if fp8 and not recipe.is_delayed_scaling():  # TODO(ksivamani): debug mismatches
+    if fp8 and not recipe.is_delayed_scaling:  # TODO(ksivamani): debug mismatches
         pytest.skip("Grouped linear only supports FP8 delayed scaling.")
 
     config = model_configs[model]
@@ -1860,7 +1860,7 @@ def _test_gpt_fp8_parameters(bs, dtype, config, fp8_model_params, recipe):
 def test_gpt_fp8_parameters(dtype, bs, model, recipe):
     if not fp8_available:
         pytest.skip(reason_for_no_fp8)
-    if recipe.is_mxfp8() and not mxfp8_available:
+    if recipe.is_mxfp8 and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
 
     config = model_configs[model]

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -48,7 +48,7 @@ class Recipe:
         """Whether the given recipe is MXFP8."""
         return False
 
-    def delayed(self) -> bool:
+    def is_delayed_scaling(self) -> bool:
         """Whether the given recipe is FP8 with delayed scaling."""
         return False
 
@@ -152,7 +152,7 @@ class DelayedScaling(Recipe):
                 DeprecationWarning,
             )
 
-    def delayed(self) -> bool:
+    def is_delayed_scaling(self) -> bool:
         """Whether the given recipe is FP8 with delayed scaling."""
         return True
 

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -44,19 +44,20 @@ class Recipe:
     Base recipe class.
     """
 
-    def mxfp8(self):
-        """Whether the given recipe is MXFP8 block scaling."""
-        return isinstance(self, MXFP8BlockScaling)
+    def is_mxfp8(self) -> bool:
+        """Whether the given recipe is MXFP8."""
+        return False
 
-    def delayed(self):
-        """Whether the given recipe is delayed scaling."""
-        return isinstance(self, DelayedScaling)
+    def delayed(self) -> bool:
+        """Whether the given recipe is FP8 with delayed scaling."""
+        return False
 
 
 @dataclass()
 class DelayedScaling(Recipe):
     """
-    Use the delayed scaling factor strategy. Use scale factor from previous
+
+    Use the FP8 with delayed scaling factor strategy. Use scale factor from previous
     iteration and record amax history of `amax_history_len` steps.
 
     Parameters
@@ -151,6 +152,10 @@ class DelayedScaling(Recipe):
                 DeprecationWarning,
             )
 
+    def delayed(self) -> bool:
+        """Whether the given recipe is FP8 with delayed scaling."""
+        return True
+
     def __repr__(self) -> str:
         return (
             f"margin={self.margin}, "
@@ -162,9 +167,9 @@ class DelayedScaling(Recipe):
 
 
 @dataclass()
-class MXFP8BlockScaling(Recipe):
+class MXFP8Recipe(Recipe):
     """
-    Use the current scaling factor strategy.
+    Use the MXFP8 1D strategy.
 
     Parameters
     ----------
@@ -182,6 +187,10 @@ class MXFP8BlockScaling(Recipe):
 
     def __post_init__(self) -> None:
         assert self.fp8_format != Format.E5M2, "Pure E5M2 training is not supported."
+
+    def is_mxfp8(self) -> bool:
+        """Whether the given recipe is MXFP8."""
+        return True
 
     def __repr__(self) -> str:
         return f"margin={self.margin}, format={str(self.fp8_format).split('.')[1]},"

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -53,7 +53,6 @@ class Recipe:
 @dataclass()
 class DelayedScaling(Recipe):
     """
-
     Use the FP8 with delayed scaling factor strategy. Use scale factor from previous
     iteration and record amax history of `amax_history_len` steps.
 

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 import warnings
 from enum import Enum
-from typing import Literal, Optional, Union, Callable, NamedTuple
+from typing import Callable, ClassVar, Literal, NamedTuple, Optional, Union
 from pydantic.dataclasses import dataclass
 
 
@@ -44,13 +44,10 @@ class Recipe:
     Base recipe class.
     """
 
-    def is_mxfp8(self) -> bool:
-        """Whether the given recipe is MXFP8."""
-        return False
-
-    def is_delayed_scaling(self) -> bool:
-        """Whether the given recipe is FP8 with delayed scaling."""
-        return False
+    # Whether the recipe is MXFP8
+    is_delayed_scaling: bool = False
+    # Whether the recipe is FP8 with delayed scaling
+    is_mxfp8: bool = False
 
 
 @dataclass()
@@ -142,6 +139,7 @@ class DelayedScaling(Recipe):
     reduce_amax: bool = True
     fp8_dpa: bool = False
     fp8_mha: bool = False
+    is_delayed_scaling: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         assert self.fp8_format != Format.E5M2, "Pure E5M2 training is not supported."
@@ -151,10 +149,6 @@ class DelayedScaling(Recipe):
                 "It will be removed in an upcoming release.",
                 DeprecationWarning,
             )
-
-    def is_delayed_scaling(self) -> bool:
-        """Whether the given recipe is FP8 with delayed scaling."""
-        return True
 
     def __repr__(self) -> str:
         return (
@@ -184,13 +178,10 @@ class MXFP8Recipe(Recipe):
     fp8_format: Format = Format.E4M3
     fp8_dpa: bool = False
     fp8_mha: bool = False
+    is_mxfp8: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         assert self.fp8_format != Format.E5M2, "Pure E5M2 training is not supported."
-
-    def is_mxfp8(self) -> bool:
-        """Whether the given recipe is MXFP8."""
-        return True
 
     def __repr__(self) -> str:
         return f"margin={self.margin}, format={str(self.fp8_format).split('.')[1]},"

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -211,7 +211,7 @@ class FP8GlobalStateManager:
         wrapper. For non CG case, it's called from within the module.
         """
 
-        if not fp8_meta["recipe"].delayed():
+        if not fp8_meta["recipe"].is_delayed_scaling():
             return
 
         # Every module must call this function exactly once since
@@ -434,7 +434,7 @@ class FP8GlobalStateManager:
         to ensure both forward steps are numerically same.
         """
 
-        if not fp8_meta["recipe"].delayed():
+        if not fp8_meta["recipe"].is_delayed_scaling():
             return
 
         buffer_position_key = "global_fp8_buffer_pos_fwd_recompute"
@@ -460,7 +460,7 @@ class FP8GlobalStateManager:
         1 forward for indentical numerical outputs.
         """
 
-        if not fp8_meta["recipe"].delayed():
+        if not fp8_meta["recipe"].is_delayed_scaling():
             return
 
         # Store updated amaxes and scales from phase 1 post forward.
@@ -479,7 +479,7 @@ class FP8GlobalStateManager:
     def restore_fp8_meta_tensors(fp8_meta: Dict[str, Any]) -> None:
         """Restore latest scaling factors and amaxes after recompute forward run."""
 
-        if not fp8_meta["recipe"].delayed():
+        if not fp8_meta["recipe"].is_delayed_scaling():
             return
 
         fp8_meta["scaling_fwd"].amax_history.copy_(fp8_meta["updated_amax_history_fwd"])
@@ -739,7 +739,7 @@ class RecipeState(abc.ABC):
         """
 
         cls = None
-        if recipe.delayed():
+        if recipe.is_delayed_scaling():
             cls = DelayedScalingRecipeState
         elif recipe.is_mxfp8():
             cls = MXFP8RecipeState

--- a/transformer_engine/pytorch/fp8.py
+++ b/transformer_engine/pytorch/fp8.py
@@ -211,7 +211,7 @@ class FP8GlobalStateManager:
         wrapper. For non CG case, it's called from within the module.
         """
 
-        if not fp8_meta["recipe"].is_delayed_scaling():
+        if not fp8_meta["recipe"].is_delayed_scaling:
             return
 
         # Every module must call this function exactly once since
@@ -434,7 +434,7 @@ class FP8GlobalStateManager:
         to ensure both forward steps are numerically same.
         """
 
-        if not fp8_meta["recipe"].is_delayed_scaling():
+        if not fp8_meta["recipe"].is_delayed_scaling:
             return
 
         buffer_position_key = "global_fp8_buffer_pos_fwd_recompute"
@@ -460,7 +460,7 @@ class FP8GlobalStateManager:
         1 forward for indentical numerical outputs.
         """
 
-        if not fp8_meta["recipe"].is_delayed_scaling():
+        if not fp8_meta["recipe"].is_delayed_scaling:
             return
 
         # Store updated amaxes and scales from phase 1 post forward.
@@ -479,7 +479,7 @@ class FP8GlobalStateManager:
     def restore_fp8_meta_tensors(fp8_meta: Dict[str, Any]) -> None:
         """Restore latest scaling factors and amaxes after recompute forward run."""
 
-        if not fp8_meta["recipe"].is_delayed_scaling():
+        if not fp8_meta["recipe"].is_delayed_scaling:
             return
 
         fp8_meta["scaling_fwd"].amax_history.copy_(fp8_meta["updated_amax_history_fwd"])
@@ -739,9 +739,9 @@ class RecipeState(abc.ABC):
         """
 
         cls = None
-        if recipe.is_delayed_scaling():
+        if recipe.is_delayed_scaling:
             cls = DelayedScalingRecipeState
-        elif recipe.is_mxfp8():
+        elif recipe.is_mxfp8:
             cls = MXFP8RecipeState
         else:
             raise ValueError("{recipe.__class__.__name__} is not supported")

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -22,7 +22,7 @@ from transformer_engine.common.recipe import Recipe
 
 from ._common import _ParameterInitMeta
 from ..fp8 import (
-    MXFP8BlockScalingRecipeState,
+    MXFP8RecipeState,
     DelayedScalingRecipeState,
     FP8GlobalStateManager,
     RecipeState,
@@ -540,7 +540,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             if recipe.delayed() and isinstance(recipe_state, DelayedScalingRecipeState):
                 self.adjust_amax_history_length(recipe.amax_history_len, fwd=fwd)
                 return
-            if recipe.mxfp8() and isinstance(recipe_state, MXFP8BlockScalingRecipeState):
+            if recipe.is_mxfp8() and isinstance(recipe_state, MXFP8RecipeState):
                 return
 
         # Max. number of fp8 tensors per GEMM = 3 (input, weight, output) for fwd and

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -537,10 +537,10 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         # Return early if recipe state matches recipe
         if self.fp8_meta_tensors_initialized:
             recipe_state = self.fp8_meta[fp8_meta_tensor_key]
-            if recipe.is_delayed_scaling() and isinstance(recipe_state, DelayedScalingRecipeState):
+            if recipe.is_delayed_scaling and isinstance(recipe_state, DelayedScalingRecipeState):
                 self.adjust_amax_history_length(recipe.amax_history_len, fwd=fwd)
                 return
-            if recipe.is_mxfp8() and isinstance(recipe_state, MXFP8RecipeState):
+            if recipe.is_mxfp8 and isinstance(recipe_state, MXFP8RecipeState):
                 return
 
         # Max. number of fp8 tensors per GEMM = 3 (input, weight, output) for fwd and
@@ -635,7 +635,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             # Copy tensors to CPU and store
             state = {}
             state["recipe"] = self.fp8_meta["recipe"]
-            if state["recipe"].is_delayed_scaling():
+            if state["recipe"].is_delayed_scaling:
                 state["scale_fwd"] = to_cpu(self.fp8_meta["scaling_fwd"].scale)
                 state["amax_history_fwd"] = to_cpu(self.fp8_meta["scaling_fwd"].amax_history)
                 state["scale_bwd"] = to_cpu(self.fp8_meta["scaling_bwd"].scale)
@@ -694,7 +694,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             dst.copy_(src, non_blocking=True)
 
         # Load tensors
-        if self.fp8_meta["recipe"].is_delayed_scaling():
+        if self.fp8_meta["recipe"].is_delayed_scaling:
             copy_tensor(state["scale_fwd"], self.fp8_meta["scaling_fwd"].scale)
             copy_tensor(state["amax_history_fwd"], self.fp8_meta["scaling_fwd"].amax_history)
             copy_tensor(state["scale_bwd"], self.fp8_meta["scaling_bwd"].scale)
@@ -814,7 +814,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             if (
                 self.fp8
                 and self.sequence_parallel
-                and self.fp8_meta["recipe"].is_delayed_scaling()
+                and self.fp8_meta["recipe"].is_delayed_scaling
             ):
                 assert self.fp8_meta["recipe"].reduce_amax, (
                     "Amax reduction across tensor parallel group is "

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -811,11 +811,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             self.set_activation_dtype(inp)
             self.init_fp8_metadata(num_gemms=num_gemms)
 
-            if (
-                self.fp8
-                and self.sequence_parallel
-                and self.fp8_meta["recipe"].is_delayed_scaling
-            ):
+            if self.fp8 and self.sequence_parallel and self.fp8_meta["recipe"].is_delayed_scaling:
                 assert self.fp8_meta["recipe"].reduce_amax, (
                     "Amax reduction across tensor parallel group is "
                     "necessary when using sequence parallelism with FP8."

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -537,7 +537,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         # Return early if recipe state matches recipe
         if self.fp8_meta_tensors_initialized:
             recipe_state = self.fp8_meta[fp8_meta_tensor_key]
-            if recipe.delayed() and isinstance(recipe_state, DelayedScalingRecipeState):
+            if recipe.is_delayed_scaling() and isinstance(recipe_state, DelayedScalingRecipeState):
                 self.adjust_amax_history_length(recipe.amax_history_len, fwd=fwd)
                 return
             if recipe.is_mxfp8() and isinstance(recipe_state, MXFP8RecipeState):
@@ -635,7 +635,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             # Copy tensors to CPU and store
             state = {}
             state["recipe"] = self.fp8_meta["recipe"]
-            if state["recipe"].delayed():
+            if state["recipe"].is_delayed_scaling():
                 state["scale_fwd"] = to_cpu(self.fp8_meta["scaling_fwd"].scale)
                 state["amax_history_fwd"] = to_cpu(self.fp8_meta["scaling_fwd"].amax_history)
                 state["scale_bwd"] = to_cpu(self.fp8_meta["scaling_bwd"].scale)
@@ -694,7 +694,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             dst.copy_(src, non_blocking=True)
 
         # Load tensors
-        if self.fp8_meta["recipe"].delayed():
+        if self.fp8_meta["recipe"].is_delayed_scaling():
             copy_tensor(state["scale_fwd"], self.fp8_meta["scaling_fwd"].scale)
             copy_tensor(state["amax_history_fwd"], self.fp8_meta["scaling_fwd"].amax_history)
             copy_tensor(state["scale_bwd"], self.fp8_meta["scaling_bwd"].scale)
@@ -811,7 +811,11 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             self.set_activation_dtype(inp)
             self.init_fp8_metadata(num_gemms=num_gemms)
 
-            if self.fp8 and self.sequence_parallel and self.fp8_meta["recipe"].delayed():
+            if (
+                self.fp8
+                and self.sequence_parallel
+                and self.fp8_meta["recipe"].is_delayed_scaling()
+            ):
                 assert self.fp8_meta["recipe"].reduce_amax, (
                     "Amax reduction across tensor parallel group is "
                     "necessary when using sequence parallelism with FP8."

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -86,8 +86,8 @@ class _GroupedLinear(torch.autograd.Function):
         device = inp.device
 
         # TODO Support MXFP8  # pylint: disable=fixme
-        if fp8 and FP8GlobalStateManager.get_fp8_recipe().mxfp8():
-            raise NotImplementedError("GroupedLinear does not yet support MXFP8")
+        if fp8 and not FP8GlobalStateManager.get_fp8_recipe().delayed():
+            raise NotImplementedError("GroupedLinear only supports FP8 delayed scaling")
 
         # Make sure input dimensions are compatible
         in_features = weights[0].shape[-1]

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -86,7 +86,7 @@ class _GroupedLinear(torch.autograd.Function):
         device = inp.device
 
         # TODO Support MXFP8  # pylint: disable=fixme
-        if fp8 and not FP8GlobalStateManager.get_fp8_recipe().is_delayed_scaling():
+        if fp8 and not FP8GlobalStateManager.get_fp8_recipe().is_delayed_scaling:
             raise NotImplementedError("GroupedLinear only supports FP8 delayed scaling")
 
         # Make sure input dimensions are compatible

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -86,7 +86,7 @@ class _GroupedLinear(torch.autograd.Function):
         device = inp.device
 
         # TODO Support MXFP8  # pylint: disable=fixme
-        if fp8 and not FP8GlobalStateManager.get_fp8_recipe().delayed():
+        if fp8 and not FP8GlobalStateManager.get_fp8_recipe().is_delayed_scaling():
             raise NotImplementedError("GroupedLinear only supports FP8 delayed scaling")
 
         # Make sure input dimensions are compatible

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -259,9 +259,9 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 continue
             recipe_state = self._fp8_metas[mode][fp8_meta_key]
             need_to_reset_recipe_state = (
-                recipe.is_delayed_scaling()
+                recipe.is_delayed_scaling
                 and not isinstance(recipe_state, DelayedScalingRecipeState)
-            ) or (recipe.is_mxfp8() and not isinstance(recipe_state, MXFP8RecipeState))
+            ) or (recipe.is_mxfp8 and not isinstance(recipe_state, MXFP8RecipeState))
             if need_to_reset_recipe_state:
                 self._reset_quantization_recipe_state(recipe=recipe)
                 return
@@ -284,7 +284,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             recipe_state = fp8_meta[fp8_meta_key]
 
             # Reallocate amax history if needed
-            if recipe.is_delayed_scaling():
+            if recipe.is_delayed_scaling:
                 current_length = recipe_state.amax_history.size(0)
                 target_length = recipe.amax_history_len
                 if current_length != target_length:

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -15,7 +15,7 @@ import torch
 
 from transformer_engine.common.recipe import Recipe
 from ..fp8 import (
-    MXFP8BlockScalingRecipeState,
+    MXFP8RecipeState,
     DelayedScalingRecipeState,
     FP8GlobalStateManager,
     RecipeState,
@@ -260,7 +260,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             recipe_state = self._fp8_metas[mode][fp8_meta_key]
             need_to_reset_recipe_state = (
                 recipe.delayed() and not isinstance(recipe_state, DelayedScalingRecipeState)
-            ) or (recipe.mxfp8() and not isinstance(recipe_state, MXFP8BlockScalingRecipeState))
+            ) or (recipe.is_mxfp8() and not isinstance(recipe_state, MXFP8RecipeState))
             if need_to_reset_recipe_state:
                 self._reset_quantization_recipe_state(recipe=recipe)
                 return
@@ -283,23 +283,21 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             recipe_state = fp8_meta[fp8_meta_key]
 
             # Reallocate amax history if needed
-            if recipe.mxfp8():
-                continue
-
-            current_length = recipe_state.amax_history.size(0)
-            target_length = recipe.amax_history_len
-            if current_length != target_length:
-                with torch.no_grad():
-                    if target_length < current_length:
-                        recipe_state.amax_history = recipe_state.amax_history[
-                            :target_length
-                        ].clone()
-                    else:
-                        recipe_state.amax_history = torch.nn.functional.pad(
-                            recipe_state.amax_history,
-                            pad=(0, 0, 0, target_length - current_length),
-                        )
-                self._quantizers[mode] = recipe_state.make_quantizers()
+            if recipe.delayed():
+                current_length = recipe_state.amax_history.size(0)
+                target_length = recipe.amax_history_len
+                if current_length != target_length:
+                    with torch.no_grad():
+                        if target_length < current_length:
+                            recipe_state.amax_history = recipe_state.amax_history[
+                                :target_length
+                            ].clone()
+                        else:
+                            recipe_state.amax_history = torch.nn.functional.pad(
+                                recipe_state.amax_history,
+                                pad=(0, 0, 0, target_length - current_length),
+                            )
+                    self._quantizers[mode] = recipe_state.make_quantizers()
 
     def get_quantizer(
         self,

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -259,7 +259,8 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 continue
             recipe_state = self._fp8_metas[mode][fp8_meta_key]
             need_to_reset_recipe_state = (
-                recipe.delayed() and not isinstance(recipe_state, DelayedScalingRecipeState)
+                recipe.is_delayed_scaling()
+                and not isinstance(recipe_state, DelayedScalingRecipeState)
             ) or (recipe.is_mxfp8() and not isinstance(recipe_state, MXFP8RecipeState))
             if need_to_reset_recipe_state:
                 self._reset_quantization_recipe_state(recipe=recipe)
@@ -283,7 +284,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             recipe_state = fp8_meta[fp8_meta_key]
 
             # Reallocate amax history if needed
-            if recipe.delayed():
+            if recipe.is_delayed_scaling():
                 current_length = recipe_state.amax_history.size(0)
                 target_length = recipe.amax_history_len
                 if current_length != target_length:

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -15,9 +15,9 @@ import torch
 
 from transformer_engine.common.recipe import Recipe
 from ..fp8 import (
-    MXFP8RecipeState,
     DelayedScalingRecipeState,
     FP8GlobalStateManager,
+    MXFP8RecipeState,
     RecipeState,
 )
 from ..tensor import Quantizer


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1442 changed `BlockScaling` to `MXFP8BlockScaling`, a big improvement since a certain other 1x128 block scaling recipe has been in the news. That said, it is still a redundant name since [MXFP8](https://arxiv.org/pdf/2310.10537) will never not use block scaling. This PR changes the name to `MXFP8Recipe` and makes several other non-functional quality-of-life improvements.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Rename `MXFP8BlockScaling` to `MXFP8Recipe` and `MXFP8BlockScalingRecipeState` to `MXFP8RecipeState`
- Rename recipe type checkers to `is_delayed_scaling` and `is_mxfp8` to make it more obvious they are boolean
- Make `is_delayed_scaling` and `is_mxfp8` class variables instead of functions
- Use `is_delayed_scaling` instead of `is_mxfp8` when dealing with delayed scaling logic

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
