### PR TITLE
[JAX] THD ring attention

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -210,29 +210,29 @@ class TestDistributedCrossAttn:
     "data_shape",
     [
         # Sequence lengths will be scaled by CP so that we don't run with tiny sizes.
-        pytest.param([2, 128, 12, 128], id="2-128xCP-12-128"),
+        pytest.param([2, 128, 8, 128], id="2-128xCP-8-128"),
         pytest.param([4, 256, 16, 64], id="4-256xCP-16-64"),
     ],
 )
-@pytest.mark.parametrize("kv_groups", [1, 4, 8, 12, 16])
+@pytest.mark.parametrize("kv_groups", [1, 8])
+@pytest.mark.parametrize("dtype", [pytest.param(jnp.bfloat16, id="BF16")])
 @pytest.mark.parametrize(
-    "attn_mask_type",
+    "qkv_layout, attn_mask_type",
     [
-        pytest.param(AttnMaskType.CAUSAL_MASK, id="CAUSAL_MASK"),
-        pytest.param(AttnMaskType.NO_MASK, id="NO_MASK"),
-    ],
-)
-@pytest.mark.parametrize("dtype", [jnp.bfloat16])
-@pytest.mark.parametrize(
-    "qkv_layout",
-    [
-        pytest.param(QKVLayout.BSHD_BS2HD, id="COMBINED_KV"),
-        pytest.param(QKVLayout.BSHD_BSHD_BSHD, id="SEPARATE"),
+        pytest.param(QKVLayout.BSHD_BS2HD, AttnMaskType.CAUSAL_MASK, id="BSHD_KVPACKED-CAUSAL"),
+        pytest.param(QKVLayout.BSHD_BSHD_BSHD, AttnMaskType.CAUSAL_MASK, id="BSHD_SEPARATE-CAUSAL"),
+        pytest.param(QKVLayout.BSHD_BS2HD, AttnMaskType.NO_MASK, id="HD_KVPACKED-NO_MASK"),
+        pytest.param(QKVLayout.BSHD_BSHD_BSHD, AttnMaskType.NO_MASK, id="BSHD_SEPARATE-NO_MASK"),
+        pytest.param(
+            QKVLayout.THD_THD_THD,
+            AttnMaskType.PADDING_CAUSAL_MASK,
+            id="THD_SEPARATE-PADDING_CAUSAL",
+        ),
     ],
 )
 @pytest.mark.parametrize(
     "load_balanced",
-    [pytest.param(False, id="UNBALANCED"), pytest.param(True, id="BALANCED")],
+    [pytest.param(True, id="BALANCED"), pytest.param(False, id="UNBALANCED")],
 )
 class TestDistributedContextParallelSelfAttn:
 
@@ -265,7 +265,6 @@ class TestDistributedContextParallelSelfAttn:
         data_shape = batch, seqlen, num_head, hidden
 
         num_kv_heads = num_head // kv_groups
-        scaling_factor = 1.0 / np.sqrt(num_head)
 
         runner = FusedAttnRunner(
             batch,
@@ -282,7 +281,7 @@ class TestDistributedContextParallelSelfAttn:
             qkv_layout,
             bias_shape,
             None,
-            SeqDescFormat.Seqlens,
+            SeqDescFormat.SegmentIDs,
             number_of_devices=device_count,
             mesh_shape=mesh_shape,
             mesh_axes=mesh_axes,
@@ -297,7 +296,7 @@ class TestDistributedContextParallelSelfAttn:
                 dtype,
                 qkv_layout,
                 attn_bias_type,
-                attn_mask_type,
+                mask_type,
                 dropout_prob,
                 num_head,
                 num_kv_heads,
@@ -340,6 +339,8 @@ class TestDistributedContextParallelSelfAttn:
         qkv_layout,
         load_balanced,
     ):
+        if qkv_layout.is_thd():
+            pytest.skip("THD doesn't support all gather context parallelism.")
         return self.impl_test_context_parallel_attn(
             device_count,
             mesh_shape,
@@ -377,7 +378,10 @@ class TestDistributedContextParallelSelfAttn:
         else:
             os.environ["NVTE_FUSED_RING_ATTENTION_USE_SCAN"] = "0"
 
-        self.impl_test_context_parallel_attn(
+        if qkv_layout.is_thd() and not load_balanced:
+            pytest.skip("THD + ring doesn't support unbalanced context parallelism.")
+
+        return self.impl_test_context_parallel_attn(
             device_count,
             mesh_shape,
             mesh_axes,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -349,9 +349,9 @@ class FusedAttnRunner:
         self.backend = FusedAttnHelper(
             self.dtype,
             self.dtype,
-            self.qkv_layout.value,
-            self.attn_bias_type.value,
-            self.attn_mask_type.value,
+            self.qkv_layout,
+            self.attn_bias_type,
+            self.attn_mask_type,
             self.dropout_prob,
             self.num_heads_q,
             self.num_heads_kv,

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -136,6 +136,9 @@ class QKVLayout(Enum):
         return self in [QKVLayout.T3HD, QKVLayout.THD_T2HD, QKVLayout.THD_THD_THD]
 
     def to_qkvpacked(self):
+        """
+        Return the corresponding qkvpacked format, useful when adjusting q, k, v layout
+        """
         qkv_format = self.get_qkv_format()
         if qkv_format == QKVFormat.BSHD:
             return QKVLayout.BS3HD
@@ -144,6 +147,9 @@ class QKVLayout(Enum):
         raise ValueError(f"Unsupported {qkv_format=}")
 
     def to_kvpacked(self):
+        """
+        Return the corresponding kvpacked format, useful when adjusting q, k, v layout
+        """
         qkv_format = self.get_qkv_format()
         if qkv_format == QKVFormat.BSHD:
             return QKVLayout.BSHD_BS2HD
@@ -152,6 +158,9 @@ class QKVLayout(Enum):
         raise ValueError(f"Unsupported {qkv_format=}")
 
     def to_separate(self):
+        """
+        Return the corresponding separate format, useful when adjusting q, k, v layout
+        """
         qkv_format = self.get_qkv_format()
         if qkv_format == QKVFormat.BSHD:
             return QKVLayout.BSHD_BSHD_BSHD
@@ -324,10 +333,9 @@ def reorder_causal_load_balancing(tensor, strategy: ReorderStrategy, cp_size: in
     """Reorders a tensor for load balancing the compute of causal attention."""
     if strategy == ReorderStrategy.DualChunkSwap:
         return tex.attention.reorder_causal_load_balancing(tensor, cp_size, seq_dim, False)
-    elif strategy == ReorderStrategy.Striped:
+    if strategy == ReorderStrategy.Striped:
         return _reorder_causal_striped(tensor, cp_size, seq_dim)
-    else:
-        raise ValueError(f"Unsupported {strategy=}")
+    raise ValueError(f"Unsupported {strategy=}")
 
 
 def inverse_reorder_causal_load_balancing(
@@ -336,10 +344,9 @@ def inverse_reorder_causal_load_balancing(
     """Inverse operation of `reorder_causal_load_balancing`."""
     if strategy == ReorderStrategy.DualChunkSwap:
         return tex.attention.reorder_causal_load_balancing(tensor, cp_size, seq_dim, True)
-    elif strategy == ReorderStrategy.Striped:
+    if strategy == ReorderStrategy.Striped:
         return _inverse_reorder_causal_striped(tensor, cp_size, seq_dim)
-    else:
-        raise ValueError(f"Unsupported {strategy=}")
+    raise ValueError(f"Unsupported {strategy=}")
 
 
 def _reorder_causal_striped(tensor, cp_size: int, seq_dim: int):

--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -189,7 +189,9 @@ class ReorderStrategy(Enum):
     - DualChunkSwap: This strategy splits each query into two chunks and do the mirror swap between
     GPUs. This is currently used for non-THD load balance. It requires the max_seqlens be the
     mulitple of 2 * cp_size.
-      Examples: 8 GPUs, GPU0 swaps with GPU7; GPU1 swaps with GPU6; GPU2 swaps with GPU5 ...
+      Examples:
+      - Before reorder: GPU0: [0, 1, 2, 3]; GPU1: [4, 5, 6, 7]; GPU2: [8, 9, 10, 11]; GPU3: [12, 13, 14, 15];
+      - After reorder: GPU0: [0, 1, 14, 15]; GPU1: [4, 5, 10, 11]; GPU2: [8, 9, 6, 7]; GPU3: [12, 13, 2, 3]
 
     - Striped: This strategy distributes the tokens in a striped (interleaved) manner across
       the sequence. This is currently used for THD load balance.

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -1205,7 +1205,7 @@ class _FusedAttnCPWithAllGatherHelper:
 
         if self.config.qkv_layout.is_kvpacked():
             return ag(k), v
-        elif self.config.qkv_layout.is_separate():
+        if self.config.qkv_layout.is_separate():
             return ag(k), ag(v)
 
         return k, v  # fall through
@@ -1229,7 +1229,7 @@ class _FusedAttnCPWithAllGatherHelper:
 
         if self.config.qkv_layout.is_kvpacked():
             return rs(dk), dv
-        elif self.config.qkv_layout.is_separate():
+        if self.config.qkv_layout.is_separate():
             return rs(dk), rs(dv)
 
         return dk, dv  # fall through
@@ -1269,7 +1269,7 @@ class _FusedAttnCPWithAllGatherHelper:
 
         if self.config.qkv_layout.is_kvpacked():
             return sliced(k), v
-        elif self.config.qkv_layout.is_separate():
+        if self.config.qkv_layout.is_separate():
             return sliced(k), sliced(v)
 
         return k, v  # fall through
@@ -1283,7 +1283,7 @@ class _FusedAttnCPWithAllGatherHelper:
         if self.config.qkv_layout.is_kvpacked():
             npad = [[0, 0], [0, pad_seq_len], [0, 0], [0, 0], [0, 0]]
             return pad(dk, npad), dv
-        elif self.config.qkv_layout.is_separate():
+        if self.config.qkv_layout.is_separate():
             npad = [[0, 0], [0, pad_seq_len], [0, 0], [0, 0]]
             return pad(dk, npad), pad(dv, npad)
 

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -1109,7 +1109,7 @@ def reorder_causal_load_balancing(tensor, cp_size: int, seq_dim: int, to_contigu
 
     # Need to ensure we have 2 pairs to swap for balancing between cp ranks
     if tensor.shape[seq_dim] % (cp_size * 2) != 0:
-        raise ValueError(f"{tensor.shape=} is not a multiple of {cp_size*2=}")
+        raise ValueError(f"{tensor.shape[seq_dim]=} is not a multiple of {cp_size*2=}")
 
     # [B, S, H, D] -> [B, 2*cp_size, S/2*cp_size, D]
     # [S, B, H, D] -> [2*cp_size, S/2*cp_size, B, H, D]

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -2172,6 +2172,9 @@ class FusedRingAttnStripedFwdPrimitive(FusedAttnFwdPrimitive):
             q_segment_pos,
             kv_segment_pos,
         ):
+            if q_segment_ids.size == 0 or kv_segment_ids.size == 0:
+                raise ValueError("THD + ring attn only supports passing seqment_ids/pos")
+
             _not_used = jnp.zeros(0, dtype=v.dtype)
 
             # Combine KV tensors if separate for better permute scheduling and performance.
@@ -2305,6 +2308,10 @@ class FusedRingAttnStripedBwdPrimitive(FusedAttnBwdPrimitive):
             q_segment_pos,
             kv_segment_pos,
         ):
+
+            if q_segment_ids.size == 0 or kv_segment_ids.size == 0:
+                raise ValueError("THD + ring attn only supports passing seqment_ids/pos")
+
             _not_used = jnp.zeros(0, dtype=output.dtype)
 
             # Combine KV tensors if separate for better permute scheduling and performance.

--- a/transformer_engine/jax/csrc/extensions/attention.cpp
+++ b/transformer_engine/jax/csrc/extensions/attention.cpp
@@ -229,6 +229,10 @@ static void FusedAttnForwardImpl(
   if (is_ragged) {
     auto output_size = input_batch * q_max_seqlen * attn_heads * head_dim;
     cudaMemsetAsync(output, 0, output_size * typeToSize(dtype), stream);
+
+    // Memset to 0xF0 for filling large negative numbers
+    auto softmax_aux_size = input_batch * q_max_seqlen * attn_heads;
+    cudaMemsetAsync(softmax_aux, 0xF0, softmax_aux_size * sizeof(float), stream);
   }
 
   /* Output tensors */


### PR DESCRIPTION
# Description

Support P2P context parallel (ring attn) with THD format. This feature is only available for self attn + causal + segment_ids/pos + load balancing (reorder before the attn and inverse-reorder after the attn).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Refactor reorder/inverse_reorder_causal_loading_balancing API to support different reorder strategy.
- Support P2P context parallel. The limitations are list above.
- Reduce the number of test configs of `kv_groups` in `test_distributed_fused_attn`
- Use `AttnBiasType`, `AttnMaskType`, `QKVLayout` in cpp_extenion/attention.py for maintaining the readibility.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
