### PR TITLE
[PyTorch] Remove MXFP8 scale-inv padding in MXFP8 all-gather

### DIFF
--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -944,7 +944,7 @@ def _all_gather_mxfp8(
         flattened_in_shape0 = math.prod(in_shape[:-1])
         if in_scale_inv.size(0) != flattened_in_shape0:
             in_scale_inv = in_scale_inv[:flattened_in_shape0]
-            out_scale_inv = out_scale_inv[:flattened_in_shape0 * world_size]
+            out_scale_inv = out_scale_inv[: flattened_in_shape0 * world_size]
 
         # Launch all-gathers
         with torch.distributed._coalescing_manager(

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager, AbstractContextManager, ContextDecorator
 from functools import lru_cache
+import math
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
@@ -915,23 +916,37 @@ def _all_gather_mxfp8(
     out_shape: Optional[list[int]] = None,
 ) -> tuple[MXFP8TensorBase, Optional[torch.distributed.Work]]:
     """All-gather MXFP8 tensor along first dimension."""
-    world_size = get_distributed_world_size(process_group)
 
-    # Output tensor dims
+    # Tensor dims
+    world_size = get_distributed_world_size(process_group)
+    in_shape = list(input_.size())
     if out_shape is None:
-        out_shape = list(input_.size())
-        out_shape[0] *= world_size
+        out_shape = [in_shape[0] * world_size] + in_shape[1:]
 
     # Gather MXFP8 data for row-wise usage
     if quantizer.rowwise_usage and not quantizer.columnwise_usage:
+
+        # Cast input tensor to MXFP8 if needed
         if not isinstance(input_, MXFP8TensorBase):
             input_ = quantizer(input_)
+
+        # Construct MXFP8 output tensor
         dtype = torch.float32
         device = "cuda"
         if isinstance(input_, MXFP8Tensor):
             dtype = input_.dtype
             device = input_.device
         out = quantizer.make_empty(out_shape, dtype=dtype, device=device)
+
+        # Remove padding from MXFP8 scale-inverses
+        in_scale_inv = input_._rowwise_scale_inv
+        out_scale_inv = out._rowwise_scale_inv
+        flattened_in_shape0 = math.prod(in_shape[:-1])
+        if in_scale_inv.size(0) != flattened_in_shape0:
+            in_scale_inv = in_scale_inv[:flattened_in_shape0]
+            out_scale_inv = out_scale_inv[:flattened_in_shape0 * world_size]
+
+        # Launch all-gathers
         with torch.distributed._coalescing_manager(
             group=process_group,
             device=device,
@@ -943,8 +958,8 @@ def _all_gather_mxfp8(
                 group=process_group,
             )
             torch.distributed.all_gather_into_tensor(
-                out._rowwise_scale_inv,
-                input_._rowwise_scale_inv,
+                out_scale_inv,
+                in_scale_inv,
                 group=process_group,
             )
         handle = coalescing_manager if async_op else None

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -944,6 +944,7 @@ def _all_gather_mxfp8(
         flattened_in_shape0 = math.prod(in_shape[:-1])
         if in_scale_inv.size(0) != flattened_in_shape0:
             in_scale_inv = in_scale_inv[:flattened_in_shape0]
+            out_scale_inv[flattened_in_shape0 * world_size :].zero_()
             out_scale_inv = out_scale_inv[: flattened_in_shape0 * world_size]
 
         # Launch all-gathers


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1431 added padding to MXFP8 scale-inverses to satisfy alignment requirements in MXFP8 kernels. However, we didn't properly handle the padding in tensor-parallel all-gathers. This PR makes sure to remove padding when necessary.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Remove MXFP8 scale-inv padding in MXFP8 all-gather

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
