### PR TITLE
Fix MXFP8 normalization

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -99,7 +99,6 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
   std::unique_ptr<Quantizer> my_quantizer = convert_quantizer(quantizer);
   py::object ln_output;
 
-
   if (my_quantizer->get_scaling_mode() == NVTE_MXFP8_1D_SCALING) {
     // Use high precision output from normalization
     NoneQuantizer q{none};


### PR DESCRIPTION
# Description

cuDNN MXFP8 normalization does not support the strided scaling factors.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
