### PR TITLE
Fix DAct input ordering of gradient input and activation input

### DIFF
--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -241,7 +241,7 @@ void performTest_x1(const ProcessingMethod processing_method,
             break;
         }
         case ProcessingMethod::CAST_DACT: {
-            nvte_dgelu(act_input.data(), input.data(), output_c.data(), 0);
+            nvte_dgelu(input.data(), act_input.data(), output_c.data(), 0);
             break;
         }
         case ProcessingMethod::CAST_ACT: {
@@ -381,7 +381,7 @@ void performTest_x2(const ProcessingMethod processing_method,
             break;
         }
         case ProcessingMethod::CAST_DACT: {
-            nvte_dgelu(act_input.data(), input.data(), output.data(), 0);
+            nvte_dgelu(input.data(), act_input.data(), output.data(), 0);
             break;
         }
         case ProcessingMethod::CAST_ACT: {

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -731,6 +731,11 @@ void fillCase(Tensor *t, const InputsFillCase fill_case) {
 template void fillCase<fp8e4m3>(Tensor *t, const InputsFillCase fill_case);
 template void fillCase<fp8e5m2>(Tensor *t, const InputsFillCase fill_case);
 template void fillCase<fp32>(Tensor *t, const InputsFillCase fill_case);
+template void fillCase<bf16>(Tensor *t, const InputsFillCase fill_case);
+template void fillCase<fp16>(Tensor *t, const InputsFillCase fill_case);
+template void fillCase<int64_t>(Tensor *t, const InputsFillCase fill_case);
+template void fillCase<int32_t>(Tensor *t, const InputsFillCase fill_case);
+template void fillCase<uint8_t>(Tensor *t, const InputsFillCase fill_case);
 
 void setRandomScale(Tensor *t) {
   static std::mt19937 gen(12345);

--- a/transformer_engine/common/activation/activation_template.h
+++ b/transformer_engine/common/activation/activation_template.h
@@ -46,7 +46,7 @@ void dact_fn(const NVTETensor grad, const NVTETensor input, NVTETensor output,
   constexpr NVTETensor dbias = nullptr;
   constexpr NVTETensor workspace = nullptr;
 
-  quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, OP>(input, grad, nullptr, output, dbias,
+  quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, OP>(grad, input, nullptr, output, dbias,
                                                         workspace, stream);
 }
 


### PR DESCRIPTION
# Description

Fixes an issue where nvte_quantize_dbias_<dact> and `cast_fp8_2D` where the gradient input and activation inputs were incorrectly swapped in their usages.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix internal functions used by nvte_quantize_dbias_<dact> so it can now be used correctly with inputs of gradient input followed by activation input
- Update `dact_fn` in activation_template.h to undo the swapping of parameters
- Update `cast_fp8_2D_kernel` to fix usages of input and act_input tensors to correctly usage input as the gradient and act_input as the original activation input from the forward pass
- Add unit tests for DAct where the output is FP8 to test these kernels. Included a test where the input gradient is all zeros to highlight a case that was failing without this change where the output gradient was not all zeroes

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
