### PR TITLE
Fix dActivation

### DIFF
--- a/tests/cpp/operator/test_act.cu
+++ b/tests/cpp/operator/test_act.cu
@@ -116,10 +116,10 @@ void performTest(const size_t N, const size_t H) {
   DType itype = TypeInfo<IType>::dtype;
   DType otype = TypeInfo<OType>::dtype;
 
-  Tensor input({ N, H }, itype);
-  Tensor output({ N, H }, otype);
-  Tensor igrad({ N, H }, itype);
-  Tensor ograd({ N, H }, itype);
+  Tensor input("input", { N, H }, itype);
+  Tensor output("output", { N, H }, otype);
+  Tensor igrad("igrad", { N, H }, itype);
+  Tensor ograd("ograd", { N, H }, itype);
 
   fillUniform(&input);
   fillUniform(&ograd);

--- a/tests/cpp/operator/test_act.cu
+++ b/tests/cpp/operator/test_act.cu
@@ -171,10 +171,10 @@ void performTestGLU(const size_t N, const size_t H) {
   DType itype = TypeInfo<IType>::dtype;
   DType otype = TypeInfo<OType>::dtype;
 
-  Tensor input({N, H * 2}, itype);
-  Tensor output({N, H}, otype);
-  Tensor igrad({ N, H * 2 }, itype);
-  Tensor ograd({ N, H }, itype);
+  Tensor input("input", {N, H * 2}, itype);
+  Tensor output("output", {N, H}, otype);
+  Tensor igrad("igrad", { N, H * 2 }, itype);
+  Tensor ograd("ograd", { N, H }, itype);
 
   fillUniform(&input);
   fillUniform(&ograd);

--- a/tests/cpp/operator/test_cast.cu
+++ b/tests/cpp/operator/test_cast.cu
@@ -44,8 +44,8 @@ void performTest(const std::vector<size_t>& shape) {
   DType itype = TypeInfo<InputType>::dtype;
   DType otype = TypeInfo<OutputType>::dtype;
 
-  Tensor input(shape, itype);
-  Tensor output_c(shape, otype);
+  Tensor input("input", shape, itype);
+  Tensor output_c("output_c", shape, otype);
 
   std::unique_ptr<OutputType[]> ref_output_c = std::make_unique<OutputType[]>(full_size);
 

--- a/tests/cpp/operator/test_cast_dbias.cu
+++ b/tests/cpp/operator/test_cast_dbias.cu
@@ -66,11 +66,11 @@ void performTest(const std::vector<size_t>& shape) {
   const size_t N = first_dimension(shape);
   const size_t H = last_dimension(shape);
 
-  Tensor input(shape, itype);
+  Tensor input("input", shape, itype);
 
-  Tensor output_c(shape, otype);
+  Tensor output_c("output_c", shape, otype);
   // dbias has the same data type with "output grad"
-  Tensor dbias({H}, itype);
+  Tensor dbias("dbias", {H}, itype);
 
   fillUniform(&input);
   setRandomScale(&output_c);
@@ -94,7 +94,7 @@ void performTest(const std::vector<size_t>& shape) {
                       workspace.data(),
                       0);
 
-  workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+  workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
   nvte_quantize_dbias(input.data(),
                       output_c.data(),

--- a/tests/cpp/operator/test_cast_dbias_dgelu.cu
+++ b/tests/cpp/operator/test_cast_dbias_dgelu.cu
@@ -74,12 +74,12 @@ void performTest(const std::vector<size_t>& shape) {
   const size_t N = first_dimension(shape);
   const size_t H = last_dimension(shape);
 
-  Tensor input(shape, itype);
-  Tensor gelu_input(shape, itype);
+  Tensor input("input", shape, itype);
+  Tensor gelu_input("gelu_input", shape, itype);
 
-  Tensor output_c(shape, otype);
+  Tensor output_c("output_c", shape, otype);
   // dbias has the same data type with "output grad"
-  Tensor dbias({H}, itype);
+  Tensor dbias("dbias", {H}, itype);
 
   fillUniform(&input);
   fillUniform(&gelu_input);
@@ -106,7 +106,7 @@ void performTest(const std::vector<size_t>& shape) {
                             workspace.data(),
                             0);
 
-  workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+  workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
 
   nvte_quantize_dbias_dgelu(input.data(),

--- a/tests/cpp/operator/test_cast_gated_swiglu.cu
+++ b/tests/cpp/operator/test_cast_gated_swiglu.cu
@@ -72,9 +72,9 @@ void performTest(const std::vector<size_t>& shape) {
   const size_t rows = first_dimension(shape);
   const size_t cols = last_dimension(shape);
 
-  Tensor grad(shape, itype);
-  Tensor input(input_shape, itype);
-  Tensor output_c(input_shape, otype);
+  Tensor grad("grad", shape, itype);
+  Tensor input("input", input_shape, itype);
+  Tensor output_c("output_c", input_shape, otype);
 
   fillUniform(&grad);
   fillUniform(&input);

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -56,6 +56,10 @@ void scale_block(const ProcessingMethod processing_method,
         for (size_t j = j_min; j < j_max; ++j) {
             const size_t idx = i * cols + j;
             float elt = static_cast<float>(input[idx]);
+            if (processing_method == ProcessingMethod::CAST_DBIAS) {
+              // grad is the input
+              elt = static_cast<float>(grad[idx]);
+            }
             if (processing_method != ProcessingMethod::CAST_ONLY
                 && processing_method != ProcessingMethod::CAST_DBIAS) {
                 elt = OP(elt);
@@ -81,6 +85,10 @@ void scale_block(const ProcessingMethod processing_method,
         for (size_t j = j_min; j < j_max; ++j) {
             const size_t idx = i * cols + j;
             float elt = static_cast<float>(input[idx]);
+            if (processing_method == ProcessingMethod::CAST_DBIAS) {
+              // grad is the input
+              elt = static_cast<float>(grad[idx]);
+            }
             if (processing_method != ProcessingMethod::CAST_ONLY
                 && processing_method != ProcessingMethod::CAST_DBIAS) {
                 elt = OP(elt);

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -190,10 +190,10 @@ void performTest_x1(const ProcessingMethod processing_method,
     const size_t blocks_X = scale_dims[3];
     const size_t scales_stride = blocks_X;
 
-    Tensor input(shape, itype);
-    Tensor act_input(shape, itype);
-    Tensor output_c(shape, otype, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
-    Tensor output_dbias({ cols }, itype);
+    Tensor input("input", shape, itype);
+    Tensor act_input("act_input", shape, itype);
+    Tensor output_c("output_c", shape, otype, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
+    Tensor output_dbias("output_dbias", { cols }, itype);
 
     std::unique_ptr<OutputType[]> ref_output_c = std::make_unique<OutputType[]>(rows * cols);
     std::unique_ptr<InputType[]> ref_output_dbias = std::make_unique<InputType[]>(cols);
@@ -214,7 +214,7 @@ void performTest_x1(const ProcessingMethod processing_method,
                                 output_dbias.data(),
                                 workspace.data(),
                                 0);
-            workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+            workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
             nvte_quantize_dbias(input.data(),
                                 output_c.data(),
@@ -230,7 +230,7 @@ void performTest_x1(const ProcessingMethod processing_method,
                                       output_dbias.data(),
                                       workspace.data(),
                                       0);
-            workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+            workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
             nvte_quantize_dbias_dgelu(input.data(),
                                       act_input.data(),
@@ -328,10 +328,10 @@ void performTest_x2(const ProcessingMethod processing_method,
     const size_t blocks_X_colwise = scale_dims_colwise[3];
     const size_t scales_stride_colwise = blocks_X_colwise;
 
-    Tensor input(shape, itype);
-    Tensor act_input(shape, itype);
-    Tensor output(shape, otype, true, true, NVTE_MXFP8_1D_SCALING);
-    Tensor output_dbias({ cols }, itype);
+    Tensor input("input", shape, itype);
+    Tensor act_input("act_input", shape, itype);
+    Tensor output("output", shape, otype, true, true, NVTE_MXFP8_1D_SCALING);
+    Tensor output_dbias("output_dbias", { cols }, itype);
 
     std::unique_ptr<OutputType[]> ref_output_c_rowwise = std::make_unique<OutputType[]>(rows * cols);
     std::unique_ptr<OutputType[]> ref_output_c_colwise = std::make_unique<OutputType[]>(rows * cols);
@@ -354,7 +354,7 @@ void performTest_x2(const ProcessingMethod processing_method,
                                 output_dbias.data(),
                                 workspace.data(),
                                 0);
-            workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+            workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
             nvte_quantize_dbias(input.data(),
                                 output.data(),
@@ -370,7 +370,7 @@ void performTest_x2(const ProcessingMethod processing_method,
                                       output_dbias.data(),
                                       workspace.data(),
                                       0);
-            workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+            workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
             nvte_quantize_dbias_dgelu(input.data(),
                                       act_input.data(),

--- a/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
@@ -204,8 +204,8 @@ void performTest_x1(const size_t rows,
     // std::cout << "blocks_X: " << blocks_X << std::endl;
     // std::cout << "scales_stride: " << scales_stride << std::endl;
 
-    Tensor grad({ rows, cols }, itype);
-    Tensor input({ rows, cols * 2 }, itype);
+    Tensor grad("grad", { rows, cols }, itype);
+    Tensor input("input", { rows, cols * 2 }, itype);
 
     const size_t output_cols = (IS_DGATED ? 2 : 1) * cols;
 
@@ -218,7 +218,8 @@ void performTest_x1(const size_t rows,
     const size_t blocks_X = scale_dims[3];
     const size_t scales_stride = blocks_X;
 
-    Tensor output(std::vector<size_t>{ rows, output_cols }, otype, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
+    Tensor output("output", std::vector<size_t>{ rows, output_cols }, otype,
+                  rowwise, colwise, NVTE_MXFP8_1D_SCALING);
 
     std::unique_ptr<OType[]> ref_output = std::make_unique<OType[]>(rows * output_cols);
     std::unique_ptr<fp8e8m0[]> ref_output_scales = std::make_unique<fp8e8m0[]>(blocks_Y * blocks_X);
@@ -288,8 +289,8 @@ void performTest_x2(const size_t rows,
     DType itype = TypeInfo<IType>::dtype;
     DType otype = TypeInfo<OType>::dtype;
 
-    Tensor grad({ rows, cols }, itype);
-    Tensor input({ rows, cols * 2 }, itype);
+    Tensor grad("grad", { rows, cols }, itype);
+    Tensor input("input", { rows, cols * 2 }, itype);
 
     const size_t output_cols = (IS_DGATED ? 2 : 1) * cols;
 
@@ -308,7 +309,8 @@ void performTest_x2(const size_t rows,
     const size_t blocks_X_colwise = scale_dims_colwise[3];
     const size_t scales_stride_colwise = blocks_X_colwise;
 
-    Tensor output(std::vector<size_t>{ rows, output_cols }, otype, true, true, NVTE_MXFP8_1D_SCALING);
+    Tensor output("output", std::vector<size_t>{ rows, output_cols }, otype,
+                  true, true, NVTE_MXFP8_1D_SCALING);
 
     std::unique_ptr<OType[]> ref_output_rowwise = std::make_unique<OType[]>(rows * output_cols);
     std::unique_ptr<OType[]> ref_output_colwise = std::make_unique<OType[]>(rows * output_cols);

--- a/tests/cpp/operator/test_cast_transpose.cu
+++ b/tests/cpp/operator/test_cast_transpose.cu
@@ -45,8 +45,8 @@ void performTest(const size_t N, const size_t H) {
   DType itype = TypeInfo<InputType>::dtype;
   DType otype = TypeInfo<OutputType>::dtype;
 
-  Tensor input({ N, H }, itype);
-  Tensor output({ N, H }, otype, true, true);
+  Tensor input("input", { N, H }, itype);
+  Tensor output("output", { N, H }, otype, true, true);
 
   std::unique_ptr<OutputType[]> ref_output_c = std::make_unique<OutputType[]>(N * H);
   std::unique_ptr<OutputType[]> ref_output_t = std::make_unique<OutputType[]>(N * H);

--- a/tests/cpp/operator/test_cast_transpose_dbias.cu
+++ b/tests/cpp/operator/test_cast_transpose_dbias.cu
@@ -65,11 +65,11 @@ void performTest(const size_t N, const size_t H) {
   DType itype = TypeInfo<IType>::dtype;
   DType otype = TypeInfo<OType>::dtype;
 
-  Tensor input({N, H}, itype);
+  Tensor input("input", {N, H}, itype);
 
-  Tensor output({N, H}, otype, true, true);
+  Tensor output("output", {N, H}, otype, true, true);
   // dbias has the same data type with "output grad"
-  Tensor dbias({H}, itype);
+  Tensor dbias("dbias", {H}, itype);
 
   fillUniform(&input);
   setRandomScale(&output);
@@ -95,7 +95,7 @@ void performTest(const size_t N, const size_t H) {
                       workspace.data(),
                       0);
 
-  workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+  workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
 
   nvte_quantize_dbias(input.data(),

--- a/tests/cpp/operator/test_cast_transpose_dbias_dgelu.cu
+++ b/tests/cpp/operator/test_cast_transpose_dbias_dgelu.cu
@@ -76,12 +76,12 @@ void performTest(const size_t N, const size_t H) {
   DType itype = TypeInfo<IType>::dtype;
   DType otype = TypeInfo<OType>::dtype;
 
-  Tensor input({N, H}, itype);
-  Tensor gelu_input({N, H}, itype);
+  Tensor input("input"{N, H}, itype);
+  Tensor gelu_input("gelu_input", {N, H}, itype);
 
-  Tensor output({N, H}, otype, true, true);
+  Tensor output("output", {N, H}, otype, true, true);
   // dbias has the same data type with "output grad"
-  Tensor dbias({H}, itype);
+  Tensor dbias("dbias", {H}, itype);
 
   fillUniform(&input);
   fillUniform(&gelu_input);
@@ -110,7 +110,7 @@ void performTest(const size_t N, const size_t H) {
                                   workspace.data(),
                                   0);
 
-  workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+  workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
 
 
   nvte_cast_transpose_dbias_dgelu(input.data(),

--- a/tests/cpp/operator/test_cast_transpose_dbias_dgelu.cu
+++ b/tests/cpp/operator/test_cast_transpose_dbias_dgelu.cu
@@ -76,7 +76,7 @@ void performTest(const size_t N, const size_t H) {
   DType itype = TypeInfo<IType>::dtype;
   DType otype = TypeInfo<OType>::dtype;
 
-  Tensor input("input"{N, H}, itype);
+  Tensor input("input", {N, H}, itype);
   Tensor gelu_input("gelu_input", {N, H}, itype);
 
   Tensor output("output", {N, H}, otype, true, true);

--- a/tests/cpp/operator/test_cast_transpose_dgeglu.cu
+++ b/tests/cpp/operator/test_cast_transpose_dgeglu.cu
@@ -74,9 +74,9 @@ void performTest(const size_t N, const size_t H) {
   DType itype = TypeInfo<IType>::dtype;
   DType otype = TypeInfo<OType>::dtype;
 
-  Tensor grad({N, H}, itype);
-  Tensor input({N, H * 2}, itype);
-  Tensor output({N, H * 2}, otype, true, true);
+  Tensor grad("grad", {N, H}, itype);
+  Tensor input("input", {N, H * 2}, itype);
+  Tensor output("output", {N, H * 2}, otype, true, true);
 
   fillUniform(&grad);
   fillUniform(&input);

--- a/tests/cpp/operator/test_causal_softmax.cu
+++ b/tests/cpp/operator/test_causal_softmax.cu
@@ -153,11 +153,11 @@ void performTest(
 
   DType itype = TypeInfo<Type>::dtype;
 
-  Tensor data_in({ batches, heads, rows, cols }, itype);
-  Tensor softmax_out({ batches, heads, rows, cols }, itype);
-  Tensor softmax_in({ batches, heads, rows, cols }, itype);
-  Tensor grads_in({ batches, heads, rows, cols }, itype);
-  Tensor grads_out({ batches, heads, rows, cols }, itype);
+  Tensor data_in("data_in", { batches, heads, rows, cols }, itype);
+  Tensor softmax_out("softmax_out", { batches, heads, rows, cols }, itype);
+  Tensor softmax_in("softmax_in", { batches, heads, rows, cols }, itype);
+  Tensor grads_in("grads_in", { batches, heads, rows, cols }, itype);
+  Tensor grads_out("grads_out", { batches, heads, rows, cols }, itype);
 
   const size_t elements_total = batches * heads * rows * cols;
   std::unique_ptr<Type[]> softmax_out_ref = std::make_unique<Type[]>(elements_total);

--- a/tests/cpp/operator/test_dequantize_mxfp8.cu
+++ b/tests/cpp/operator/test_dequantize_mxfp8.cu
@@ -194,10 +194,10 @@ void performTest_x1(const size_t rows,
     const size_t blocks_num = rowwise ? blocks_num_rowwise : blocks_num_colwise;
     const size_t scales_stride = rowwise ? blocks_X_rowwise : blocks_X_colwise;
 
-    Tensor input({ rows, cols }, itype, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
+    Tensor input("input", { rows, cols }, itype, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
 
     // Output data are written to the rowwise ptr regardless of the scaling direction
-    Tensor output({ rows, cols }, otype, true, false);
+    Tensor output("output", { rows, cols }, otype, true, false);
 
     std::unique_ptr<OutputType[]> ref_output = std::make_unique<OutputType[]>(rows * cols);
     std::unique_ptr<fp8e8m0[]> scales = std::make_unique<fp8e8m0[]>(blocks_num);
@@ -247,11 +247,11 @@ void performTest_quantize_then_dequantize(const size_t rows,
 
     // input --> quantized --> output (dequantized)
     // input == output
-    Tensor input({ rows, cols }, in_type);
-    Tensor quantized({ rows, cols }, intermed_type, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
+    Tensor input("input", { rows, cols }, in_type);
+    Tensor quantized("quantized", { rows, cols }, intermed_type, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
 
     // Output data are written to the rowwise ptr regardless of the scaling direction
-    Tensor output({ rows, cols }, out_type, true, false);
+    Tensor output("output", { rows, cols }, out_type, true, false);
 
     // fillCase<EncodingType>(&input, InputsFillCase::minNorm_to_maxNorm);
     fillCase<EncodingType>(&input, InputsFillCase::uniform);
@@ -313,8 +313,8 @@ void performTest_x2(const size_t rows,
     const size_t blocks_num_rowwise = blocks_Y_rowwise * blocks_X_rowwise;
     const size_t blocks_num_colwise = blocks_Y_colwise * blocks_X_colwise;
 
-    Tensor input({ rows, cols }, itype, true, true, NVTE_MXFP8_1D_SCALING);
-    Tensor output({ rows, cols }, otype);
+    Tensor input("input", { rows, cols }, itype, true, true, NVTE_MXFP8_1D_SCALING);
+    Tensor output("output", { rows, cols }, otype);
 
     std::unique_ptr<OutputType[]> ref_output_rowwise = std::make_unique<OutputType[]>(rows * cols);
     std::unique_ptr<OutputType[]> ref_output_colwise = std::make_unique<OutputType[]>(rows * cols);

--- a/tests/cpp/operator/test_multi_cast_transpose.cu
+++ b/tests/cpp/operator/test_multi_cast_transpose.cu
@@ -81,8 +81,9 @@ void performTest() {
   for (size_t tensor_id = 0; tensor_id < num_tensors; ++tensor_id) {
     const size_t height = tensor_dims[tensor_id].first;
     const size_t width = tensor_dims[tensor_id].second;
-    input_list.emplace_back(Tensor({ height, width }, itype));
-    output_list.emplace_back(Tensor({ height, width }, otype, true, true));
+    input_list.emplace_back(Tensor("input_" + std::to_string(tensor_id), { height, width }, itype));
+    output_list.emplace_back(Tensor("output_" + std::to_string(tensor_id),
+                                    { height, width }, otype, true, true));
 
     auto& input = input_list.back();
     auto& output = output_list.back();

--- a/tests/cpp/operator/test_multi_padding.cu
+++ b/tests/cpp/operator/test_multi_padding.cu
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <memory>
 #include <random>
+#include <string>
 #include <vector>
 #include <cstdio>
 
@@ -84,8 +85,8 @@ void performTest() {
     const size_t height = tensor_dims[tensor_id].first;
     const size_t width = tensor_dims[tensor_id].second;
     const size_t padded_height = (height + align - 1) / align * align;
-    input_list.emplace_back(Tensor({ height, width }, itype));
-    output_list.emplace_back(Tensor({ padded_height, width }, otype));
+    input_list.emplace_back(Tensor("input_" + std::to_string(tensor_id), { height, width }, itype));
+    output_list.emplace_back(Tensor("output_" + std::to_string(tensor_id), { padded_height, width }, otype));
 
     auto& input = input_list.back();
     auto& output = output_list.back();

--- a/tests/cpp/operator/test_normalization.cu
+++ b/tests/cpp/operator/test_normalization.cu
@@ -191,16 +191,16 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
     return;
   }
 
-  Tensor input({ N, H }, itype);
-  Tensor z({ N, H }, otype);
-  Tensor gamma({ H }, wtype);
-  Tensor beta({ H }, wtype);
-  Tensor mu({ N }, DType::kFloat32);
-  Tensor rsigma({ N }, DType::kFloat32);
-  Tensor dz({ N, H }, wtype);
-  Tensor dx({ N, H }, itype);
-  Tensor dgamma({ H }, wtype);
-  Tensor dbeta({ H }, wtype);
+  Tensor input("input", { N, H }, itype);
+  Tensor z("z", { N, H }, otype);
+  Tensor gamma("gamma", { H }, wtype);
+  Tensor beta("beta", { H }, wtype);
+  Tensor mu("mu", { N }, DType::kFloat32);
+  Tensor rsigma("rsigma", { N }, DType::kFloat32);
+  Tensor dz("dz", { N, H }, wtype);
+  Tensor dx("dx", { N, H }, itype);
+  Tensor dgamma("dgamma", { H }, wtype);
+  Tensor dbeta("dbeta", { H }, wtype);
   Tensor workspace_fwd, workspace_bwd;
 
   fillUniform(&input);
@@ -230,7 +230,7 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
     nvte_layernorm_fwd(input.data(), gamma.data(), beta.data(), epsilon,
                        z.data(), mu.data(), rsigma.data(), workspace_fwd.data(),
                        prop.multiProcessorCount, zero_centered_gamma, 0);
-    workspace_fwd = Tensor(workspace_fwd.rowwise_shape(), workspace_fwd.dtype());
+    workspace_fwd = Tensor("workspace", workspace_fwd.rowwise_shape(), workspace_fwd.dtype());
     nvte_layernorm_fwd(input.data(), gamma.data(), beta.data(), epsilon,
                        z.data(), mu.data(), rsigma.data(), workspace_fwd.data(),
                        prop.multiProcessorCount, zero_centered_gamma, 0);
@@ -240,7 +240,7 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
                        dx.data(), dgamma.data(), dbeta.data(),
                        workspace_bwd.data(),
                        prop.multiProcessorCount, zero_centered_gamma, 0);
-    workspace_bwd = Tensor(workspace_bwd.rowwise_shape(), workspace_bwd.dtype());
+    workspace_bwd = Tensor("workspace", workspace_bwd.rowwise_shape(), workspace_bwd.dtype());
     nvte_layernorm_bwd(dz.data(), input.data(),
                        mu.data(), rsigma.data(), gamma.data(),
                        dx.data(), dgamma.data(), dbeta.data(),
@@ -250,7 +250,7 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
     nvte_rmsnorm_fwd(input.data(), gamma.data(), epsilon,
                      z.data(), rsigma.data(), workspace_fwd.data(),
                      prop.multiProcessorCount, zero_centered_gamma, 0);
-    workspace_fwd = Tensor(workspace_fwd.rowwise_shape(), workspace_fwd.dtype());
+    workspace_fwd = Tensor("workspace", workspace_fwd.rowwise_shape(), workspace_fwd.dtype());
     nvte_rmsnorm_fwd(input.data(), gamma.data(), epsilon,
                      z.data(), rsigma.data(), workspace_fwd.data(),
                      prop.multiProcessorCount, zero_centered_gamma, 0);
@@ -259,7 +259,7 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
                      dx.data(), dgamma.data(),
                      workspace_bwd.data(),
                      prop.multiProcessorCount, zero_centered_gamma, 0);
-    workspace_bwd = Tensor(workspace_bwd.rowwise_shape(), workspace_bwd.dtype());
+    workspace_bwd = Tensor("workspace", workspace_bwd.rowwise_shape(), workspace_bwd.dtype());
     nvte_rmsnorm_bwd(dz.data(), input.data(), rsigma.data(), gamma.data(),
                      dx.data(), dgamma.data(),
                      workspace_bwd.data(),

--- a/tests/cpp/operator/test_normalization_mxfp8.cu
+++ b/tests/cpp/operator/test_normalization_mxfp8.cu
@@ -179,12 +179,12 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
   DType wtype = TypeInfo<WeightType>::dtype;
   DType otype = TypeInfo<OutputType>::dtype;
 
-  Tensor input({ N, H }, itype);
-  Tensor z({ N, H }, otype, true, is_training, NVTE_MXFP8_1D_SCALING);
-  Tensor gamma({ H }, wtype);
-  Tensor beta({ H }, wtype);
-  Tensor mu({ N }, DType::kFloat32);
-  Tensor rsigma({ N }, DType::kFloat32);
+  Tensor input("input", { N, H }, itype);
+  Tensor z("z", { N, H }, otype, true, is_training, NVTE_MXFP8_1D_SCALING);
+  Tensor gamma("gamma", { H }, wtype);
+  Tensor beta("beta", { H }, wtype);
+  Tensor mu("mu", { N }, DType::kFloat32);
+  Tensor rsigma("rsigma", { N }, DType::kFloat32);
   Tensor workspace;
 
 
@@ -199,7 +199,7 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
                        z.data(), mu.data(), rsigma.data(), workspace.data(),
                        prop.multiProcessorCount, zero_centered_gamma,
                        0);
-    workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+    workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
     nvte_layernorm_fwd(input.data(), gamma.data(), beta.data(), epsilon,
                        z.data(), mu.data(), rsigma.data(), workspace.data(),
                        prop.multiProcessorCount, zero_centered_gamma,
@@ -210,14 +210,14 @@ void performTest(const size_t N, const size_t H, const bool zero_centered_gamma,
                      prop.multiProcessorCount, zero_centered_gamma,
                      0);
 
-    workspace = Tensor(workspace.rowwise_shape(), workspace.dtype());
+    workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
     nvte_rmsnorm_fwd(input.data(), gamma.data(), epsilon,
                      z.data(), rsigma.data(), workspace.data(),
                      prop.multiProcessorCount, zero_centered_gamma,
                      0);
   }
 
-  Tensor dequantized_output({ N, H }, DType::kFloat32, true, true);
+  Tensor dequantized_output("dequantized_output", { N, H }, DType::kFloat32, true, true);
 
   dequantize_2x<OutputType, fp8e8m0>(z, dequantized_output, is_training);
 

--- a/tests/cpp/operator/test_qdq.cu
+++ b/tests/cpp/operator/test_qdq.cu
@@ -58,8 +58,8 @@ void performTestQ(const size_t N) {
   DType itype = TypeInfo<InputType>::dtype;
   DType otype = TypeInfo<OutputType>::dtype;
 
-  Tensor input({ N }, itype);
-  Tensor output({ N }, otype);
+  Tensor input("input", { N }, itype);
+  Tensor output("output", { N }, otype);
 
   std::unique_ptr<OutputType[]> ref_output = std::make_unique<OutputType[]>(N);
 
@@ -89,8 +89,8 @@ void performTestDQ(const size_t N) {
   DType itype = TypeInfo<InputType>::dtype;
   DType otype = TypeInfo<OutputType>::dtype;
 
-  Tensor input({ N }, itype);
-  Tensor output({ N }, otype);
+  Tensor input("input", { N }, itype);
+  Tensor output("output", { N }, otype);
 
   std::unique_ptr<OutputType[]> ref_output = std::make_unique<OutputType[]>(N);
 

--- a/tests/cpp/operator/test_swizzle.cu
+++ b/tests/cpp/operator/test_swizzle.cu
@@ -83,8 +83,8 @@ void performTestSwizzle1D(const int num_tiles_M, const int num_tiles_K, bool row
   const auto scale_shape = std::vector<size_t>{data_shape[0] / SF_MODE_X, data_shape[1] /SF_MODE_Y};
 
   std::vector<int> scaling_mode = {SF_MODE_X, SF_MODE_Y, 0};
-  Tensor input(data_shape, dtype, rowwise, columnwise, NVTE_MXFP8_1D_SCALING);
-  Tensor output(data_shape, dtype, rowwise, columnwise, NVTE_MXFP8_1D_SCALING);
+  Tensor input("input", data_shape, dtype, rowwise, columnwise, NVTE_MXFP8_1D_SCALING);
+  Tensor output("output", data_shape, dtype, rowwise, columnwise, NVTE_MXFP8_1D_SCALING);
 
   fillUniform(&input);
 

--- a/tests/cpp/operator/test_transpose.cu
+++ b/tests/cpp/operator/test_transpose.cu
@@ -37,8 +37,8 @@ void performTest(const size_t N, const size_t H) {
 
   DType dtype = TypeInfo<Type>::dtype;
 
-  Tensor input({ N, H }, dtype);
-  Tensor output({ H, N }, dtype);
+  Tensor input("input", { N, H }, dtype);
+  Tensor output("output", { H, N }, dtype);
 
   std::unique_ptr<Type[]> ref_output = std::make_unique<Type[]>(N * H);
 

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -739,13 +739,13 @@ template void fillCase<fp8e4m3>(Tensor *t, const InputsFillCase fill_case);
 template void fillCase<fp8e5m2>(Tensor *t, const InputsFillCase fill_case);
 template void fillCase<fp32>(Tensor *t, const InputsFillCase fill_case);
 
-void setRandomScale(Tensor *t, const std::string& tensor_name) {
+void setRandomScale(Tensor *t) {
   std::uniform_real_distribution<> dis(-2.0, 1.0);
   const float scale = dis(t->gen());
   t->set_scale(scale);
 }
 
-void setRandomScaleInv(Tensor *t, const std::string& tensor_name) {
+void setRandomScaleInv(Tensor *t) {
   std::uniform_real_distribution<> dis(-2.0, 1.0);
   const float scale_inv = dis(t->gen());
   t->set_scale_inv(scale_inv);

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -12,6 +12,7 @@
 #include <random>
 #include <cassert>
 #include <cmath>
+#include <string>
 
 #include <gtest/gtest.h>
 #include <omp.h>
@@ -20,6 +21,12 @@
 #include "util/logging.h"
 
 namespace test {
+
+size_t create_seed_from_tensor_name(const std::string& tensor_name) {
+  auto full_name = std::string(testing::UnitTest::GetInstance()->current_test_info()->name()) +
+                   "/" + tensor_name;
+  return std::hash<std::string>{}(full_name);
+}
 
 std::vector<DType> all_fp_types = {DType::kFloat32,
                                    DType::kFloat16,
@@ -163,9 +170,13 @@ std::pair<scale_inv_meta, scale_inv_meta> get_scales(const NVTEShape& shape,
   NVTE_ERROR("Invalid scaling mode!");
 }
 
-Tensor::Tensor(const NVTEShape &shape, const DType type,
+Tensor::Tensor(const std::string& name,
+               const NVTEShape &shape, const DType type,
                const bool rowwise, const bool columnwise,
                const NVTEScalingMode &scaling_mode) {
+  name_ = name;
+  const size_t seed = create_seed_from_tensor_name(name);
+  gen_.seed(seed);
   rowwise_ = rowwise;
   columnwise_ = columnwise;
   size_t s = typeToSize(type);
@@ -371,11 +382,10 @@ void Tensor::set_scale_inv(float scale_inv) {
       if (num_scales == 1){
         rowwise_cpu_scale_inv_ptr<float>()[0] = scale_inv;
       } else{
-        static std::mt19937 gen(12345);
         std::uniform_int_distribution<uint8_t> dis(0, 127);
         auto* scale_inv_ptr = rowwise_cpu_scale_inv_ptr<uint8_t>();
         for (size_t i = 0; i < num_scales; i++){
-          scale_inv_ptr[i] = dis(gen);
+          scale_inv_ptr[i] = dis(gen_);
         }
       }
     }
@@ -384,11 +394,10 @@ void Tensor::set_scale_inv(float scale_inv) {
       if (num_scales == 1){
         columnwise_cpu_scale_inv_ptr<float>()[0] = scale_inv;
       } else{
-        static std::mt19937 gen(12345);
         std::uniform_int_distribution<uint8_t> dis(0, 127);
         auto* scale_inv_ptr = columnwise_cpu_scale_inv_ptr<uint8_t>();
         for (size_t i = 0; i < num_scales; i++){
-          scale_inv_ptr[i] = dis(gen);
+          scale_inv_ptr[i] = dis(gen_);
         }
       }
     }
@@ -632,18 +641,18 @@ std::pair<double, double> getTolerances(const DType type) {
 }
 
 template <typename T>
-void generate_data_uniformly(T* data, const size_t size) {
-  const int seed = 12345;
+void generate_data_uniformly(T* data, const size_t size, std::mt19937* gen) {
   #pragma omp parallel proc_bind(spread)
   {
-    std::mt19937 gen(seed);
-    gen.discard(omp_get_thread_num() * 599);
+    std::mt19937 gen_local = *gen;
+    gen_local.discard(omp_get_thread_num() * 599);
     std::uniform_real_distribution<> dis(-2.0, 1.0);
     #pragma omp for schedule(static)
     for (size_t i = 0; i < size; ++i) {
-      data[i] = static_cast<T>(dis(gen));
+      data[i] = static_cast<T>(dis(gen_local));
     }
   }
+  gen->discard(size);
 }
 
 void fillUniform(Tensor *t) {
@@ -652,7 +661,7 @@ void fillUniform(Tensor *t) {
     TRANSFORMER_ENGINE_TYPE_SWITCH_ALL(t->dtype(), T,
       {
         T *data = t->rowwise_cpu_dptr<T>();
-        generate_data_uniformly(data, size);
+        generate_data_uniformly(data, size, &(t->gen()));
       }
     );
   } else {
@@ -660,18 +669,17 @@ void fillUniform(Tensor *t) {
     TRANSFORMER_ENGINE_TYPE_SWITCH_ALL(t->dtype(), T,
       {
         T *data = t->columnwise_cpu_dptr<T>();
-        generate_data_uniformly(data, size);
+        generate_data_uniformly(data, size, &(t->gen()));
       }
     );
   }
-  static std::mt19937 gen(12345);
   std::uniform_real_distribution<> dis(-2.0, 1.0);
-  t->set_scale_inv(dis(gen));
+  t->set_scale_inv(dis(t->gen()));
   t->from_cpu();
 }
 
 template<typename InputEncoding, InputsFillCase Case>
-void fillCase_special(Tensor *t) {
+void fillCase_special(Tensor *t, const std::string& tensor_name) {
   const size_t size = product(t->rowwise_shape());
   const size_t rows = t->rowwise_shape().data[0];
   const size_t cols = t->rowwise_shape().data[1];
@@ -690,7 +698,6 @@ void fillCase_special(Tensor *t) {
       minAbs = Quantized_Limits<InputEncoding>::ranges[Case];
       maxAbs = Quantized_Limits<InputEncoding>::ranges[Case + 1];
     }
-    static std::mt19937 gen(12345);
     std::uniform_real_distribution<> dis(minAbs, maxAbs);
     std::uniform_real_distribution<> dis_sign(-1.0, 1.0);
     TRANSFORMER_ENGINE_TYPE_SWITCH_FP16_FP32_ONLY(t->dtype(), InputType, {
@@ -698,8 +705,8 @@ void fillCase_special(Tensor *t) {
       for (size_t i = 0; i < rows; ++i) {
         for (size_t j = 0; j < cols; ++j) {
           const size_t idx = i * cols + j;
-          const bool is_negative = (dis_sign(gen) < 0.0);
-          double val = dis(gen);
+          const bool is_negative = (dis_sign(t->gen()) < 0.0);
+          double val = dis(t->gen());
           if (is_negative) {
             val = -val;
           }
@@ -732,17 +739,15 @@ template void fillCase<fp8e4m3>(Tensor *t, const InputsFillCase fill_case);
 template void fillCase<fp8e5m2>(Tensor *t, const InputsFillCase fill_case);
 template void fillCase<fp32>(Tensor *t, const InputsFillCase fill_case);
 
-void setRandomScale(Tensor *t) {
-  static std::mt19937 gen(12345);
+void setRandomScale(Tensor *t, const std::string& tensor_name) {
   std::uniform_real_distribution<> dis(-2.0, 1.0);
-  const float scale = dis(gen);
+  const float scale = dis(t->gen());
   t->set_scale(scale);
 }
 
-void setRandomScaleInv(Tensor *t) {
-  static std::mt19937 gen(12345);
+void setRandomScaleInv(Tensor *t, const std::string& tensor_name) {
   std::uniform_real_distribution<> dis(-2.0, 1.0);
-  const float scale_inv = dis(gen);
+  const float scale_inv = dis(t->gen());
   t->set_scale_inv(scale_inv);
 }
 

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -679,7 +679,7 @@ void fillUniform(Tensor *t) {
 }
 
 template<typename InputEncoding, InputsFillCase Case>
-void fillCase_special(Tensor *t, const std::string& tensor_name) {
+void fillCase_special(Tensor *t) {
   const size_t size = product(t->rowwise_shape());
   const size_t rows = t->rowwise_shape().data[0];
   const size_t cols = t->rowwise_shape().data[1];

--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include <iostream>
 #include <memory>
 #include <vector>
 #include <array>
+#include <random>
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
@@ -97,17 +97,19 @@ struct TypeInfo{
 
 class Tensor {
  public:
-  Tensor(const NVTEShape &shape, const DType type,
+  Tensor(const std::string& name,
+         const NVTEShape &shape, const DType type,
          const bool rowwise = true,
          const bool columnwise = false,
          const NVTEScalingMode &mode = NVTE_DELAYED_TENSOR_SCALING);
 
-  Tensor(const std::vector<size_t> &shape,
+  Tensor(const std::string& name,
+         const std::vector<size_t> &shape,
          const DType type,
          const bool rowwise = true,
          const bool columnwise = false,
          const NVTEScalingMode &mode = NVTE_DELAYED_TENSOR_SCALING) :
-    Tensor(NVTEShape{shape.data(), shape.size()}, type, rowwise, columnwise, mode) {}
+    Tensor(name, NVTEShape{shape.data(), shape.size()}, type, rowwise, columnwise, mode) {}
 
   Tensor() {}
 
@@ -260,6 +262,8 @@ class Tensor {
   void set_scale_inv(float scale_inv);
   void shareFP8Meta(const Tensor &other);
 
+  std::mt19937& gen() { return gen_; }
+
  private:
   TensorWrapper tensor_;
   std::unique_ptr<unsigned char[]> cpu_data_rowwise_;
@@ -270,6 +274,8 @@ class Tensor {
   std::unique_ptr<unsigned char[]> columnwise_scale_inv_cpu_data_;
   bool rowwise_;
   bool columnwise_;
+  std::string name_;
+  std::mt19937 gen_;
 };
 
 constexpr uint32_t FP32_EXPONENT_BIAS = 127;

--- a/transformer_engine/common/activation/activation_template.h
+++ b/transformer_engine/common/activation/activation_template.h
@@ -30,9 +30,9 @@ void act_fn(const NVTETensor input, NVTETensor output, cudaStream_t stream) {
   constexpr bool IS_ACT = true;
   constexpr NVTETensor dbias = nullptr;
   constexpr NVTETensor workspace = nullptr;
-  constexpr const NVTETensor activation_input = nullptr;
+  constexpr const NVTETensor grad = nullptr;
 
-  quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, OP>(input, activation_input, nullptr, output,
+  quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, OP>(input, grad, nullptr, output,
                                                         dbias, workspace, stream);
 }
 

--- a/transformer_engine/common/activation/activation_template.h
+++ b/transformer_engine/common/activation/activation_template.h
@@ -32,8 +32,8 @@ void act_fn(const NVTETensor input, NVTETensor output, cudaStream_t stream) {
   constexpr NVTETensor workspace = nullptr;
   constexpr const NVTETensor grad = nullptr;
 
-  quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, OP>(input, grad, nullptr, output,
-                                                        dbias, workspace, stream);
+  quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, OP>(input, grad, nullptr, output, dbias,
+                                                        workspace, stream);
 }
 
 template <typename ComputeType, typename Param, ComputeType (*OP)(ComputeType, const Param &)>

--- a/transformer_engine/common/util/cast.cu
+++ b/transformer_engine/common/util/cast.cu
@@ -33,10 +33,10 @@ void nvte_quantize(const NVTETensor input, NVTETensor output, cudaStream_t strea
   constexpr bool IS_ACT = false;
   constexpr NVTETensor dbias = nullptr;
   constexpr NVTETensor workspace = nullptr;
-  constexpr const NVTETensor activation_input = nullptr;
+  constexpr const NVTETensor grad = nullptr;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      input, grad, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_noop(const NVTETensor input, NVTETensor output, NVTETensor noop,
@@ -49,10 +49,10 @@ void nvte_quantize_noop(const NVTETensor input, NVTETensor output, NVTETensor no
   constexpr bool IS_ACT = false;
   constexpr NVTETensor dbias = nullptr;
   constexpr NVTETensor workspace = nullptr;
-  constexpr const NVTETensor activation_input = nullptr;
+  constexpr const NVTETensor grad = nullptr;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(
-      input, activation_input, noop, output, dbias, workspace, stream);
+      input, grad, noop, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias(const NVTETensor input, NVTETensor output, NVTETensor dbias,
@@ -66,7 +66,7 @@ void nvte_quantize_dbias(const NVTETensor input, NVTETensor output, NVTETensor d
   constexpr const NVTETensor activation_input = nullptr;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      activation_input, input, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias_dgelu(const NVTETensor input, const NVTETensor activation_input,
@@ -80,7 +80,7 @@ void nvte_quantize_dbias_dgelu(const NVTETensor input, const NVTETensor activati
   constexpr bool IS_ACT = false;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, dgelu<fp32, fp32>>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      activation_input, input, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias_dsilu(const NVTETensor input, const NVTETensor activation_input,
@@ -94,7 +94,7 @@ void nvte_quantize_dbias_dsilu(const NVTETensor input, const NVTETensor activati
   constexpr bool IS_ACT = false;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, dsilu<fp32, fp32>>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      activation_input, input, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias_drelu(const NVTETensor input, const NVTETensor activation_input,
@@ -108,7 +108,7 @@ void nvte_quantize_dbias_drelu(const NVTETensor input, const NVTETensor activati
   constexpr bool IS_ACT = false;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, drelu<fp32, fp32>>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      activation_input, input, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias_dqgelu(const NVTETensor input, const NVTETensor activation_input,
@@ -122,7 +122,7 @@ void nvte_quantize_dbias_dqgelu(const NVTETensor input, const NVTETensor activat
   constexpr bool IS_ACT = false;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, dqgelu<fp32, fp32>>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      activation_input, input, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias_dsrelu(const NVTETensor input, const NVTETensor activation_input,
@@ -136,7 +136,7 @@ void nvte_quantize_dbias_dsrelu(const NVTETensor input, const NVTETensor activat
   constexpr bool IS_ACT = false;
 
   detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, dsrelu<fp32, fp32>>(
-      input, activation_input, nullptr, output, dbias, workspace, stream);
+      activation_input, input, nullptr, output, dbias, workspace, stream);
 }
 
 void nvte_dequantize(const NVTETensor input, NVTETensor output, cudaStream_t stream) {

--- a/transformer_engine/common/util/cast.cu
+++ b/transformer_engine/common/util/cast.cu
@@ -35,8 +35,8 @@ void nvte_quantize(const NVTETensor input, NVTETensor output, cudaStream_t strea
   constexpr NVTETensor workspace = nullptr;
   constexpr const NVTETensor grad = nullptr;
 
-  detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(
-      input, grad, nullptr, output, dbias, workspace, stream);
+  detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(input, grad, nullptr, output,
+                                                                     dbias, workspace, stream);
 }
 
 void nvte_quantize_noop(const NVTETensor input, NVTETensor output, NVTETensor noop,
@@ -51,8 +51,8 @@ void nvte_quantize_noop(const NVTETensor input, NVTETensor output, NVTETensor no
   constexpr NVTETensor workspace = nullptr;
   constexpr const NVTETensor grad = nullptr;
 
-  detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(
-      input, grad, noop, output, dbias, workspace, stream);
+  detail::quantize_helper<IS_DBIAS, IS_DACT, IS_ACT, Empty, nullptr>(input, grad, noop, output,
+                                                                     dbias, workspace, stream);
 }
 
 void nvte_quantize_dbias(const NVTETensor input, NVTETensor output, NVTETensor dbias,

--- a/transformer_engine/common/util/cast_kernels.cuh
+++ b/transformer_engine/common/util/cast_kernels.cuh
@@ -1063,9 +1063,9 @@ template <typename ParamOP, float (*OP)(float, const ParamOP &)>
 void CastVectorizedUnaryGradKernelLauncher(const Tensor &grad, const Tensor *input, Tensor *output,
                                            cudaStream_t stream) {
   constexpr float (*UnaryOP)(float, const ParamOP &) = (OP == nullptr) ? detail::identity : OP;
-  const size_t N = product(input.data.shape);
+  const size_t N = product(input->data.shape);
   TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
-      input.data.dtype, IType,
+      input->data.dtype, IType,
       TRANSFORMER_ENGINE_TYPE_SWITCH_OUTPUT(
           output->data.dtype, OType,
           if (!is_fp8_dtype(output->data.dtype) ||

--- a/transformer_engine/common/util/cast_kernels.cuh
+++ b/transformer_engine/common/util/cast_kernels.cuh
@@ -1196,9 +1196,9 @@ namespace detail {
 
 template <bool IS_DBIAS, bool IS_DACT, bool IS_ACT, typename ParamOP,
           float (*OP)(float, const ParamOP &)>
-void quantize_helper(const NVTETensor input, const NVTETensor grad,
-                     const NVTETensor noop, NVTETensor output, NVTETensor dbias,
-                     NVTETensor workspace, cudaStream_t stream) {
+void quantize_helper(const NVTETensor input, const NVTETensor grad, const NVTETensor noop,
+                     NVTETensor output, NVTETensor dbias, NVTETensor workspace,
+                     cudaStream_t stream) {
   const Tensor *input_tensor;
   const Tensor *activation_input_tensor;
   if constexpr (IS_DBIAS || IS_DACT) {


### PR DESCRIPTION
# Description

This PR supersedes PR #1460. There was a bug introduced in the dActivation kernels for Blackwell where the activation input and the gradient input were swapped. This uncovered the issue with the tests, where different tensors were seeded with the same values.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Properly seed the tensors in C++ tests
- Fix the dActivation logic

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
