### PR TITLE
[JAX] Flax module init with a given dtype

### DIFF
--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -252,8 +252,13 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         k_dtype = dtypes.canonicalize_dtype(k_aval.dtype)
         v_dtype = dtypes.canonicalize_dtype(v_aval.dtype)
         bias_dtype = dtypes.canonicalize_dtype(bias_aval.dtype)
-        # assert q_dtype == k_dtype == v_dtype == bias_dtype
-        assert q_seqlen_or_cu_seqlen_aval.dtype == kv_seqlen_or_cu_seqlen_aval.dtype
+        assert (
+            q_dtype == k_dtype == v_dtype == bias_dtype
+        ), f"q_dtype={q_dtype}, k_dtype={k_dtype}, v_dtype={v_dtype}, bias_dtype={bias_dtype}"
+        assert q_seqlen_or_cu_seqlen_aval.dtype == kv_seqlen_or_cu_seqlen_aval.dtype, (
+            f"q_seqlen_or_cu_seqlen_aval={q_seqlen_or_cu_seqlen_aval},"
+            f" kv_seqlen_or_cu_seqlen_aval={kv_seqlen_or_cu_seqlen_aval}"
+        )
 
         batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, head_dim = (
             FusedAttnHelper.parse_qkv_aval(q_aval, k_aval, v_aval, config.qkv_layout)

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -252,7 +252,7 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         k_dtype = dtypes.canonicalize_dtype(k_aval.dtype)
         v_dtype = dtypes.canonicalize_dtype(v_aval.dtype)
         bias_dtype = dtypes.canonicalize_dtype(bias_aval.dtype)
-        assert q_dtype == k_dtype == v_dtype == bias_dtype
+        # assert q_dtype == k_dtype == v_dtype == bias_dtype
         assert q_seqlen_or_cu_seqlen_aval.dtype == kv_seqlen_or_cu_seqlen_aval.dtype
 
         batch_shape, q_max_seqlen, kv_max_seqlen, attn_heads, num_gqa_groups, head_dim = (

--- a/transformer_engine/jax/dot.py
+++ b/transformer_engine/jax/dot.py
@@ -25,7 +25,6 @@ def type_safe_dot_general(
     """
 
     if fp8_meta_pkg is None:
-        kernel = jnp.asarray(kernel, x.dtype)
         return jax.lax.dot_general(x, kernel, (contracting_dims, ((), ())))
 
     amax_list = fp8_meta_pkg.amax_list

--- a/transformer_engine/jax/dot.py
+++ b/transformer_engine/jax/dot.py
@@ -26,8 +26,7 @@ def type_safe_dot_general(
 
     if fp8_meta_pkg is None:
         assert x.dtype == kernel.dtype, f"lhs dtype = {x.dtype}, rhs dtype = {kernel.dtype}"
-        output = jax.lax.dot_general(x, kernel, (contracting_dims, ((), ())))
-        return output
+        return jax.lax.dot_general(x, kernel, (contracting_dims, ((), ())))
 
     amax_list = fp8_meta_pkg.amax_list
     scale_list = fp8_meta_pkg.scale_list

--- a/transformer_engine/jax/dot.py
+++ b/transformer_engine/jax/dot.py
@@ -25,7 +25,9 @@ def type_safe_dot_general(
     """
 
     if fp8_meta_pkg is None:
-        return jax.lax.dot_general(x, kernel, (contracting_dims, ((), ())))
+        assert x.dtype == kernel.dtype, f"lhs dtype = {x.dtype}, rhs dtype = {kernel.dtype}"
+        output = jax.lax.dot_general(x, kernel, (contracting_dims, ((), ())))
+        return output.astype(x.dtype)
 
     amax_list = fp8_meta_pkg.amax_list
     scale_list = fp8_meta_pkg.scale_list

--- a/transformer_engine/jax/dot.py
+++ b/transformer_engine/jax/dot.py
@@ -27,7 +27,7 @@ def type_safe_dot_general(
     if fp8_meta_pkg is None:
         assert x.dtype == kernel.dtype, f"lhs dtype = {x.dtype}, rhs dtype = {kernel.dtype}"
         output = jax.lax.dot_general(x, kernel, (contracting_dims, ((), ())))
-        return output.astype(x.dtype)
+        return output
 
     amax_list = fp8_meta_pkg.amax_list
     scale_list = fp8_meta_pkg.scale_list

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -452,10 +452,8 @@ class DenseGeneral(TransformerEngineBase):
         kernel_shape = tuple(inputs.shape[ax] for ax in axis) + features
         kernel_param_shape = (np.prod([inputs.shape[ax] for ax in axis]),) + features
         kernel = nn_partitioning.param_with_axes(
-            "kernel", self.kernel_init, kernel_param_shape, self.dtype, axes=self.kernel_axes
+            "kernel", self.kernel_init, kernel_shape, self.dtype, axes=self.kernel_axes
         )
-
-        kernel = jnp.reshape(kernel, kernel_shape)
         kernel = kernel.astype(self.dtype)
 
         if self.use_bias:
@@ -714,10 +712,8 @@ class LayerNormDenseGeneral(TransformerEngineBase):
         kernel_shape = tuple(y.shape[ax] for ax in axis) + features
         kernel_param_shape = (np.prod([inputs.shape[ax] for ax in axis]),) + features
         kernel = nn_partitioning.param_with_axes(
-            "kernel", self.kernel_init, kernel_param_shape, self.dtype, axes=self.kernel_axes
+            "kernel", self.kernel_init, kernel_shape, self.dtype, axes=self.kernel_axes
         )
-
-        kernel = jnp.reshape(kernel, kernel_shape)
         kernel = kernel.astype(self.dtype)
 
         contract_ind = tuple(range(0, len(axis)))

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -1437,7 +1437,7 @@ class RelativePositionBiases(nn.Module):  # pylint: disable=too-few-public-metho
             "rel_embedding",
             self.embedding_init,
             (self.num_attention_heads, self.num_buckets),
-            jnp.float32,
+            self.dtype,
             axes=self.embedding_axes,
         )
 


### PR DESCRIPTION
# Description

Issue #1451 pointed out that TE Flax modules initialize all params with the `dtype=jnp.float32` and ignore the `module.dtype`. This PR introduced the fixes for that.

In addition, unnecessary reshape ops were removed. 

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
