### PR TITLE
Fix a bug for D being nullptr in grouped gemm

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -2138,14 +2138,18 @@ def test_grouped_gemm(shape, dtype, layout, accumulate):
         single_output = True
     elif layout == "NN":
         A = [torch.randn(n, k, dtype=dtype, device="cuda") for _ in range(z)]  # weight
-        B = list(torch.split(torch.randn(m, n, dtype=dtype, device="cuda"), m_splits))  # grad_output
+        B = list(
+            torch.split(torch.randn(m, n, dtype=dtype, device="cuda"), m_splits)
+        )  # grad_output
         out = list(torch.split(torch.randn(m, k, dtype=dtype, device="cuda"), m_splits))  # dgrad
         out_ref = [o.clone() for o in out]
         grad = True
         single_output = False
     else:  # layout == "NT"
         A = list(torch.split(torch.randn(m, k, dtype=dtype, device="cuda"), m_splits))  # input
-        B = list(torch.split(torch.randn(m, n, dtype=dtype, device="cuda"), m_splits))  # grad_output
+        B = list(
+            torch.split(torch.randn(m, n, dtype=dtype, device="cuda"), m_splits)
+        )  # grad_output
         out = [torch.randn(n, k, dtype=dtype, device="cuda") for _ in range(z)]  # wgrad
         out_ref = [o.clone() for o in out]
         grad = True

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -2141,7 +2141,7 @@ def test_grouped_gemm(shape, dtype, layout, accumulate):
         B = list(
             torch.split(torch.randn(m, n, dtype=dtype, device="cuda"), m_splits)
         )  # grad_output
-        out = [torch.randn(m, k, dtype=dtype, device="cuda")] # dgrad
+        out = [torch.randn(m, k, dtype=dtype, device="cuda")]  # dgrad
         out_ref = [o.clone() for o in torch.split(out[0], m_splits)]
         grad = True
         single_output = True

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -2141,10 +2141,10 @@ def test_grouped_gemm(shape, dtype, layout, accumulate):
         B = list(
             torch.split(torch.randn(m, n, dtype=dtype, device="cuda"), m_splits)
         )  # grad_output
-        out = list(torch.split(torch.randn(m, k, dtype=dtype, device="cuda"), m_splits))  # dgrad
-        out_ref = [o.clone() for o in out]
+        out = [torch.randn(m, k, dtype=dtype, device="cuda")] # dgrad
+        out_ref = [o.clone() for o in torch.split(out[0], m_splits)]
         grad = True
-        single_output = False
+        single_output = True
     else:  # layout == "NT"
         A = list(torch.split(torch.randn(m, k, dtype=dtype, device="cuda"), m_splits))  # input
         B = list(

--- a/transformer_engine/pytorch/csrc/extensions/gemm.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/gemm.cpp
@@ -342,7 +342,7 @@ std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
         out_tensor = at::from_blob(output_data_ptr, D_shape, opts);
       }
       char* char_ptr = reinterpret_cast<char*>(output_data_ptr);
-      char_ptr += m_splits[i] * te_A.size(0) * (*D)[0].element_size();
+      char_ptr += D_shape[0] * D_shape[1] * (*D)[0].element_size();
       output_data_ptr = reinterpret_cast<void*>(char_ptr);
       D_vectors.emplace_back(out_tensor);
     } else {

--- a/transformer_engine/pytorch/csrc/extensions/gemm.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/gemm.cpp
@@ -336,7 +336,11 @@ std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
     auto dtype = GetATenDType(D_type);
     auto opts = torch::TensorOptions().dtype(dtype).device(torch::kCUDA);
     if (single_output) {
-      out_tensor = at::from_blob(output_data_ptr, D_shape, opts);
+      if (output_data_ptr == nullptr) {
+        out_tensor = at::empty(D_shape, opts);
+      } else {
+        out_tensor = at::from_blob(output_data_ptr, D_shape, opts);
+      }
       char* char_ptr = reinterpret_cast<char*>(output_data_ptr);
       char_ptr += m_splits[i] * te_A.size(0) * (*D)[0].element_size();
       output_data_ptr = reinterpret_cast<void*>(char_ptr);

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -269,9 +269,10 @@ class _GroupedLinear(torch.autograd.Function):
                 general_grouped_gemm(
                     weights,
                     grad_output,
-                    torch.split(dgrad, ctx.m_splits),
+                    [dgrad],
                     ctx.activation_dtype,
                     get_multi_stream_cublas_workspace(),
+                    single_output=True,
                     layout="NN",
                     m_splits=ctx.m_splits,
                     grad=True,


### PR DESCRIPTION
# Description

`at::from_blob` cannot create CUDA tensors with `nullptr`, otherwise it will throw the error
```
RuntimeError: The specified pointer resides on host memory and is not registered with any CUDA device.
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
