### PR TITLE
Fix TE ops API compatibility with PyTorch versions < 2.4.3

### DIFF
--- a/tests/pytorch/distributed/test_torch_fsdp2.py
+++ b/tests/pytorch/distributed/test_torch_fsdp2.py
@@ -7,19 +7,10 @@ import pytest
 import subprocess
 from pathlib import Path
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
+from transformer_engine.pytorch.utils import get_torch_version
+
 import torch
 from packaging.version import Version as PkgVersion
-
-
-def get_torch_version():
-    """Get PyTorch version from __version__"""
-
-    def get_torch_version_str():
-        import torch
-
-        return str(torch.__version__)
-
-    return PkgVersion(get_torch_version_str())
 
 
 fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()

--- a/tests/pytorch/distributed/test_torch_fsdp2.py
+++ b/tests/pytorch/distributed/test_torch_fsdp2.py
@@ -7,10 +7,9 @@ import pytest
 import subprocess
 from pathlib import Path
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
-from transformer_engine.pytorch.utils import get_torch_version
+from transformer_engine.pytorch.utils import torch_version
 
 import torch
-from packaging.version import Version as PkgVersion
 
 
 fp8_available, reason_for_no_fp8 = FP8GlobalStateManager.is_fp8_available()
@@ -35,7 +34,7 @@ def _run_test(fp_init, sharding_dims):
 
 @pytest.mark.skipif(NUM_PROCS < 4, reason="Requires 4+ GPUs")
 @pytest.mark.skipif(NUM_PROCS % 2 != 0, reason="Requires even number of GPUs")
-@pytest.mark.skipif(not get_torch_version() >= PkgVersion("2.4"), reason="Requires PyTorch 2.4.0+")
+@pytest.mark.skipif(not torch_version() >= (2, 4, 0), reason="Requires PyTorch 2.4.0+")
 @pytest.mark.parametrize("sharding_dims", ([NUM_PROCS], [2, NUM_PROCS // 2]))
 @pytest.mark.parametrize("fp8_init", (False, True))
 def test_distributed(fp8_init, sharding_dims):

--- a/transformer_engine/pytorch/ops/_common.py
+++ b/transformer_engine/pytorch/ops/_common.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 from typing import Any, Iterable, Optional
+from packaging.version import Version as PkgVersion
 
 import torch
 
@@ -16,6 +17,7 @@ from ..utils import (
     canonicalize_device,
     canonicalize_dtype,
     devices_match,
+    get_torch_version,
 )
 
 
@@ -98,8 +100,10 @@ def maybe_autocast_dtype(
     default_dtype: Optional[torch.dtype] = None,
 ) -> torch.dtype:
     """Get autocast dtype if enabled"""
-    if torch.is_autocast_enabled(device_type):
+    if get_torch_version() >= PkgVersion("2.4.3") and torch.is_autocast_enabled(device_type):
         return torch.get_autocast_dtype(device_type)
+    if torch.is_autocast_enabled():
+        return torch.get_autocast_gpu_dtype()
     return canonicalize_dtype(default_dtype)
 
 

--- a/transformer_engine/pytorch/ops/_common.py
+++ b/transformer_engine/pytorch/ops/_common.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 from typing import Any, Iterable, Optional
-from packaging.version import Version as PkgVersion
 
 import torch
 
@@ -17,7 +16,7 @@ from ..utils import (
     canonicalize_device,
     canonicalize_dtype,
     devices_match,
-    get_torch_version,
+    torch_version,
 )
 
 
@@ -100,10 +99,13 @@ def maybe_autocast_dtype(
     default_dtype: Optional[torch.dtype] = None,
 ) -> torch.dtype:
     """Get autocast dtype if enabled"""
-    if get_torch_version() >= PkgVersion("2.4.3") and torch.is_autocast_enabled(device_type):
-        return torch.get_autocast_dtype(device_type)
-    if torch.is_autocast_enabled():
-        return torch.get_autocast_gpu_dtype()
+
+    if torch_version() >= (2, 4, 3):
+        if torch.is_autocast_enabled(device_type):
+            return torch.get_autocast_dtype(device_type)
+    else:
+        if torch.is_autocast_enabled():
+            return torch.get_autocast_gpu_dtype()
     return canonicalize_dtype(default_dtype)
 
 

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -8,6 +8,7 @@ import functools
 import math
 import os
 from typing import Any, Callable, List, Optional, Tuple
+from packaging.version import Version as PkgVersion
 
 import torch
 import transformer_engine.pytorch.cpp_extensions as ext
@@ -386,3 +387,12 @@ def nvtx_range_pop(msg: Optional[str] = None) -> None:
 
     # Pop NVTX range
     torch.cuda.nvtx.range_pop()
+
+
+def get_torch_version():
+    """Get PyTorch version from __version__"""
+
+    def get_torch_version_str():
+        return str(torch.__version__)
+
+    return PkgVersion(get_torch_version_str())

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -389,10 +389,7 @@ def nvtx_range_pop(msg: Optional[str] = None) -> None:
     torch.cuda.nvtx.range_pop()
 
 
-def get_torch_version():
-    """Get PyTorch version from __version__"""
-
-    def get_torch_version_str():
-        return str(torch.__version__)
-
-    return PkgVersion(get_torch_version_str())
+@functools.lru_cache(maxsize=None)
+def torch_version() -> tuple[int, ...]:
+    """Get PyTorch version"""
+    return PkgVersion(str(torch.__version__)).release


### PR DESCRIPTION
# Description

TE sequential currently uses some newer PyTorch APIs that were introduced in v2.4.3 which break execution for older versions.

Fixes #1473 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Restore PyTorch compatibility for operations API for versions 2.4.2 and lower.
- Move `get_torch_version` from the FSDP test file to utils.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
