### PR TITLE
Add sanity test for lightning-thunder integration

### DIFF
--- a/qa/L0_pytorch_unittest/test.sh
+++ b/qa/L0_pytorch_unittest/test.sh
@@ -4,8 +4,9 @@
 
 
 : ${TE_PATH:=/opt/transformerengine}
+: ${LIGHTNING_THUNDER_PATH:=/opt/pytorch/lightning-thunder}
 
-pip install pytest==8.2.1
+pip install pytest==8.2.1 pytest-benchmark==5.1.0
 
 FAIL=0
 
@@ -24,5 +25,6 @@ pytest -v -s $TE_PATH/tests/pytorch/test_fusible_ops.py || FAIL=1
 pytest -v -s $TE_PATH/tests/pytorch/test_permutation.py || FAIL=1
 pytest -v -s $TE_PATH/tests/pytorch/test_parallel_cross_entropy.py || FAIL=1
 NVTE_TORCH_COMPILE=0 NVTE_DEBUG=1 NVTE_DEBUG_LEVEL=1 pytest -o log_cli=true --log-cli-level=INFO -v -s $TE_PATH/tests/pytorch/fused_attn/test_fused_attn.py || FAIL=1
+pytest -v -s ${LIGHTNING_THUNDER_PATH}/thunder/tests/test_transformer_engine_executor.py
 
 exit $FAIL


### PR DESCRIPTION
# Description

Runs the [TE integration test](https://github.com/Lightning-AI/lightning-thunder/blob/fb7a8714513a18ffd322a28db86e9c8e6baf710e/thunder/tests/test_transformer_engine_executor.py) from [lightning-thunder](https://github.com/Lightning-AI/lightning-thunder) as a sanity check.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [x] Testing

## Changes

- Introduces the integration test for `lightning-thunder`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
