### PR TITLE
make sure dout is contiguous

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -2858,6 +2858,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
             # [b, np, sq] -> [b, np, sq, 1] or
             # [t, np] -> [t, np, 1]
             softmax_lse.unsqueeze_(-1)
+            dout = dout.contiguous()
 
         dq = None
         dout_dtype = dout.dtype


### PR DESCRIPTION
# Description

Loss curve of CP>1 and CP=1 does not match with cuDNN fused attention while batch size > 1, this is due to the non-contiguous dout. This PR fixed it.

cuDNN Fused Attn and Tri Dao' Flash Attn has different requirements on tensor memory format. Tri Dao's Attn only requires the last dim to be contiguous. TE integration of cuDNN Attn specifies qkv_format (bshd, sbhd, thd), tensors need to be contiguous in the specified format, this is a stronger requirement than Tri Dao's Attn. This is why it only shows issue with cuDNN Attn.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
