### PR TITLE
[PyTorch] Support TP Overlap in Per-Tensor Current Scaling Recipe

### DIFF
--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# UB_SKIPMC=1 torchrun --nproc_per_node 2 run_layer_with_overlap.py --seq-length=1024 --batch-size=1 --num-heads=8 --head-dim=64 --layer-type=linear --fp8 --fp8-recipe=tensorwise
 
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -365,7 +365,9 @@ def _train(opts):
     dist_print(f"Initialized default NCCL process group with {WORLD_SIZE} GPUs")
 
     # Initialize the Transformer Engine layer with overlap
-    args, kwargs, input_shape = _get_layer_args(opts, nccl_world, opts.tp, num_layers=opts.num_layers)
+    args, kwargs, input_shape = _get_layer_args(
+        opts, nccl_world, opts.tp, num_layers=opts.num_layers
+    )
     # Intialize userbuffers
     ub_cfgs = None
     if opts.overlap_rs_dgrad:
@@ -391,7 +393,9 @@ def _train(opts):
     dist.barrier()
 
     # Initialize the reference model and copy all parameters
-    ref_args, ref_kwargs, _ = _get_layer_args(opts, nccl_world, opts.tp, num_layers=opts.num_layers, reference=True)
+    ref_args, ref_kwargs, _ = _get_layer_args(
+        opts, nccl_world, opts.tp, num_layers=opts.num_layers, reference=True
+    )
     with te.fp8_model_init(enabled=opts.fp8_init):
         ref_model = multi_module_model(opts.layer_type, opts.num_layers, *ref_args, **ref_kwargs)
     dist_print("Initialized reference model...", debug=True)

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -144,12 +144,12 @@ def _parse_args(argv=None, namespace=None):
         "--fp8", action="store_true", default=False, help="Enables the te.fp8_autocast() context."
     )
     parser.add_argument(
-        "--fp8-recipe", 
-        type=str.lower, 
-        default="delayed", 
-        choices=["delayed", "tensorwise"], 
-        help='Which fp8 recipe to use for FP8 tensors in the forward and backward pass',
-        dest='fp8_recipe'
+        "--fp8-recipe",
+        type=str.lower,
+        default="delayed",
+        choices=["delayed", "tensorwise"],
+        help="Which fp8 recipe to use for FP8 tensors in the forward and backward pass",
+        dest="fp8_recipe",
     )
     parser.add_argument(
         "--fp8-init", action="store_true", default=False, help="Initialize primary weights in FP8."
@@ -389,7 +389,9 @@ def _train(opts):
     # Fp8 recipe setup
     fp8_format = Format.HYBRID
     if opts.fp8_recipe == "delayed":
-        fp8_recipe = DelayedScaling(fp8_format=fp8_format, amax_history_len=32, amax_compute_algo="max")
+        fp8_recipe = DelayedScaling(
+            fp8_format=fp8_format, amax_history_len=32, amax_compute_algo="max"
+        )
     elif opts.fp8_recipe == "tensorwise":
         fp8_recipe = Float8CurrentScaling(fp8_format=fp8_format)
 

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -143,12 +143,11 @@ def _parse_args(argv=None, namespace=None):
         "--fp8", action="store_true", default=False, help="Enables the te.fp8_autocast() context."
     )
     parser.add_argument(
-        "--fp8-recipe",
+        "--quantization",
         type=str.lower,
-        default="delayed",
-        choices=["delayed", "tensorwise"],
-        help="Which fp8 recipe to use for FP8 tensors in the forward and backward pass",
-        dest="fp8_recipe",
+        default="none",
+        choices=["none", "fp8_delayed_scaling", "fp8_current_scaling"],
+        help="Quantization recipe",
     )
     parser.add_argument(
         "--fp8-init", action="store_true", default=False, help="Initialize primary weights in FP8."
@@ -387,11 +386,12 @@ def _train(opts):
 
     # Fp8 recipe setup
     fp8_format = Format.HYBRID
-    if opts.fp8_recipe == "delayed":
+    fp8_recipe = None
+    if opts.quantization == "fp8_delayed_scaling":
         fp8_recipe = DelayedScaling(
             fp8_format=fp8_format, amax_history_len=32, amax_compute_algo="max"
         )
-    elif opts.fp8_recipe == "tensorwise":
+    elif opts.quantization == "fp8_current_scaling":
         fp8_recipe = Float8CurrentScaling(fp8_format=fp8_format)
 
     # Prepare random input tensors

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -395,7 +395,7 @@ def _train(opts):
         pprint.pprint(kwargs)
         sys.stdout.write("\n")
     dist.barrier()
-    
+
     # Initialize the reference model and copy all parameters
     ref_args, ref_kwargs, _ = _get_layer_args(opts, nccl_world, opts.tp, num_layers=opts.num_layers, reference=True)
     with te.fp8_model_init(enabled=opts.fp8_init):

--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -395,11 +395,11 @@ def _train(opts):
         pprint.pprint(kwargs)
         sys.stdout.write("\n")
     dist.barrier()
-
+    
     # Initialize the reference model and copy all parameters
     ref_args, ref_kwargs, _ = _get_layer_args(opts, nccl_world, opts.tp, num_layers=opts.num_layers, reference=True)
     with te.fp8_model_init(enabled=opts.fp8_init):
-        ref_model = multi_module_model(opts.layer_type, opts.num_layers, *args, **kwargs)
+        ref_model = multi_module_model(opts.layer_type, opts.num_layers, *ref_args, **ref_kwargs)
     dist_print("Initialized reference model...", debug=True)
     for test_param, ref_param in zip(test_model.parameters(), ref_model.parameters()):
         with torch.no_grad():

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -196,7 +196,13 @@ def test_bulk_overlaps(comm_type, fp8, connections):
         _run_gemm_with_overlap(comm_type, True, False, False, fp8)
 
 
-@pytest.mark.parametrize("fp8", (False,), ids=[" BF16 ",])
+@pytest.mark.parametrize(
+    "fp8",
+    (False,),
+    ids=[
+        " BF16 ",
+    ],
+)
 @pytest.mark.parametrize(
     "layer_type,linear_parallel_mode,overlap_rs_dgrad",
     [
@@ -236,8 +242,17 @@ def test_layers_with_overlap_bf16(layer_type, linear_parallel_mode, overlap_rs_d
     """
     _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None)
 
-@pytest.mark.parametrize("fp8_recipe", ["delayed", "tensorwise"], ids=[" DELAYED SCALING ", " CURRENT SCALING "])
-@pytest.mark.parametrize("fp8", (True, ), ids=[" FP8  ",])
+
+@pytest.mark.parametrize(
+    "fp8_recipe", ["delayed", "tensorwise"], ids=[" DELAYED SCALING ", " CURRENT SCALING "]
+)
+@pytest.mark.parametrize(
+    "fp8",
+    (True,),
+    ids=[
+        " FP8  ",
+    ],
+)
 @pytest.mark.parametrize(
     "layer_type,linear_parallel_mode,overlap_rs_dgrad",
     [
@@ -271,7 +286,9 @@ def test_layers_with_overlap_bf16(layer_type, linear_parallel_mode, overlap_rs_d
         )
     ],
 )
-def test_layers_with_overlap_fp8(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, fp8_recipe):
+def test_layers_with_overlap_fp8(
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, fp8_recipe
+):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -83,7 +83,7 @@ def _run_gemm_with_overlap(comm_type, bulk, p2p, atomic, fp8):
         raise AssertionError(result.stderr.decode())
 
 
-def _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, fp8_recipe):
+def _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization):
     test_path = TEST_ROOT / "run_layer_with_overlap.py"
     test_cmd = LAUNCH_CMD + [
         str(test_path),
@@ -104,7 +104,7 @@ def _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, 
         if not fp8_available:
             pytest.skip(reason_for_no_fp8)
         test_cmd.append("--fp8")
-        test_cmd.append(f"--fp8-recipe={fp8_recipe}")
+        test_cmd.append(f"--quantization={quantization}")
 
     os.environ["PYTORCH_JIT"] = "0"
     os.environ["NVTE_TORCH_COMPILE"] = "0"
@@ -244,7 +244,8 @@ def test_layers_with_overlap_bf16(layer_type, linear_parallel_mode, overlap_rs_d
 
 
 @pytest.mark.parametrize(
-    "fp8_recipe", ["delayed", "tensorwise"], ids=[" DELAYED SCALING ", " CURRENT SCALING "]
+    "quantization", ["fp8_delayed_scaling", "fp8_current_scaling"], 
+    ids=[" DELAYED SCALING ", " CURRENT SCALING "]
 )
 @pytest.mark.parametrize(
     "fp8",
@@ -287,9 +288,9 @@ def test_layers_with_overlap_bf16(layer_type, linear_parallel_mode, overlap_rs_d
     ],
 )
 def test_layers_with_overlap_fp8(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, fp8_recipe
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization
 ):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """
-    _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, fp8_recipe)
+    _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization)

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -244,8 +244,9 @@ def test_layers_with_overlap_bf16(layer_type, linear_parallel_mode, overlap_rs_d
 
 
 @pytest.mark.parametrize(
-    "quantization", ["fp8_delayed_scaling", "fp8_current_scaling"], 
-    ids=[" DELAYED SCALING ", " CURRENT SCALING "]
+    "quantization",
+    ["fp8_delayed_scaling", "fp8_current_scaling"],
+    ids=[" DELAYED SCALING ", " CURRENT SCALING "],
 )
 @pytest.mark.parametrize(
     "fp8",

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -200,6 +200,15 @@ def test_bulk_overlaps(comm_type, fp8, connections):
 
 
 @pytest.mark.parametrize(
+    "test_times",
+    [1, 2, 5],
+    ids=[
+        " x 1 times ",
+        " x 2 times ",
+        " x 5 times ",
+    ],
+)
+@pytest.mark.parametrize(
     "fp8",
     (False,),
     ids=[
@@ -248,16 +257,26 @@ def test_bulk_overlaps(comm_type, fp8, connections):
     ],
 )
 def test_layers_with_overlap_bf16(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, num_layers
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, num_layers, test_times
 ):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """
-    _run_layer_with_overlap(
-        layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, num_layers
-    )
+    for _ in range(test_times):
+        _run_layer_with_overlap(
+            layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, num_layers
+        )
 
 
+@pytest.mark.parametrize(
+    "test_times",
+    [1, 2, 5],
+    ids=[
+        " x 1 times ",
+        " x 2 times ",
+        " x 5 times ",
+    ],
+)
 @pytest.mark.parametrize(
     "quantization",
     ["fp8_delayed_scaling", "fp8_current_scaling"],
@@ -312,11 +331,12 @@ def test_layers_with_overlap_bf16(
     ],
 )
 def test_layers_with_overlap_fp8(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers, test_times
 ):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """
-    _run_layer_with_overlap(
-        layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
-    )
+    for _ in range(test_times):
+        _run_layer_with_overlap(
+            layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
+        )

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -84,7 +84,7 @@ def _run_gemm_with_overlap(comm_type, bulk, p2p, atomic, fp8):
 
 
 def _run_layer_with_overlap(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers=1
 ):
     test_path = TEST_ROOT / "run_layer_with_overlap.py"
     test_cmd = LAUNCH_CMD + [
@@ -207,14 +207,6 @@ def test_bulk_overlaps(comm_type, fp8, connections):
     ],
 )
 @pytest.mark.parametrize(
-    "num_layers",
-    (1, 2),
-    ids=[
-        " 1 layer ",
-        " 2 layers ",
-    ],
-)
-@pytest.mark.parametrize(
     "layer_type,linear_parallel_mode,overlap_rs_dgrad",
     [
         (te.Linear.__name__, "row", False),
@@ -247,15 +239,11 @@ def test_bulk_overlaps(comm_type, fp8, connections):
         )
     ],
 )
-def test_layers_with_overlap_bf16(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, num_layers
-):
+def test_layers_with_overlap_bf16(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """
-    _run_layer_with_overlap(
-        layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, num_layers
-    )
+    _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None)
 
 
 @pytest.mark.parametrize(
@@ -268,14 +256,6 @@ def test_layers_with_overlap_bf16(
     (True,),
     ids=[
         " FP8  ",
-    ],
-)
-@pytest.mark.parametrize(
-    "num_layers",
-    (1, 2),
-    ids=[
-        " 1 layer ",
-        " 2 layers ",
     ],
 )
 @pytest.mark.parametrize(
@@ -312,6 +292,95 @@ def test_layers_with_overlap_bf16(
     ],
 )
 def test_layers_with_overlap_fp8(
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization
+):
+    """
+    Test Transformer Engine layers with comm+GEMM overlap.
+    """
+    _run_layer_with_overlap(layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization)
+
+
+@pytest.mark.parametrize(
+    "fp8",
+    (False,),
+    ids=[
+        " BF16  ",
+    ],
+)
+@pytest.mark.parametrize(
+    "num_layers",
+    (4, 10),
+    ids=[
+        " 4 layers ",
+        " 10 layers ",
+    ],
+)
+@pytest.mark.parametrize(
+    "layer_type,linear_parallel_mode,overlap_rs_dgrad",
+    list(
+        zip(
+            [te.TransformerLayer.__name__ for _ in range(2)],
+            [None] * 2,
+            [False, True],
+        )
+    ),
+    ids=[
+        " " + " - ".join(test_name_parts) + " "
+        for test_name_parts in zip(
+            [te.TransformerLayer.__name__ for _ in range(2)],
+            ["BULK DGRAD/WGRAD", "DGRAD+RS"],
+        )
+    ],
+)
+def test_multi_layer_with_overlap_bf16(
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, num_layers
+):
+    """
+    Test Transformer Engine layers with comm+GEMM overlap.
+    """
+    _run_layer_with_overlap(
+        layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, num_layers
+    )
+
+
+@pytest.mark.parametrize(
+    "quantization",
+    ["fp8_delayed_scaling", "fp8_current_scaling"],
+    ids=[" DELAYED SCALING ", " CURRENT SCALING "],
+)
+@pytest.mark.parametrize(
+    "fp8",
+    (True,),
+    ids=[
+        " FP8  ",
+    ],
+)
+@pytest.mark.parametrize(
+    "num_layers",
+    (4, 10),
+    ids=[
+        " 4 layers ",
+        " 10 layers ",
+    ],
+)
+@pytest.mark.parametrize(
+    "layer_type,linear_parallel_mode,overlap_rs_dgrad",
+    list(
+        zip(
+            [te.TransformerLayer.__name__ for _ in range(2)],
+            [None] * 2,
+            [False, True],
+        )
+    ),
+    ids=[
+        " " + " - ".join(test_name_parts) + " "
+        for test_name_parts in zip(
+            [te.TransformerLayer.__name__ for _ in range(2)],
+            ["BULK DGRAD/WGRAD", "DGRAD+RS"],
+        )
+    ],
+)
+def test_multi_layer_with_overlap_fp8(
     layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
 ):
     """

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -200,15 +200,6 @@ def test_bulk_overlaps(comm_type, fp8, connections):
 
 
 @pytest.mark.parametrize(
-    "test_times",
-    [1, 2, 5],
-    ids=[
-        " x 1 times ",
-        " x 2 times ",
-        " x 5 times ",
-    ],
-)
-@pytest.mark.parametrize(
     "fp8",
     (False,),
     ids=[
@@ -217,10 +208,10 @@ def test_bulk_overlaps(comm_type, fp8, connections):
 )
 @pytest.mark.parametrize(
     "num_layers",
-    (1, 4),
+    (1, 2),
     ids=[
         " 1 layer ",
-        " 4 layers ",
+        " 2 layers ",
     ],
 )
 @pytest.mark.parametrize(
@@ -257,26 +248,16 @@ def test_bulk_overlaps(comm_type, fp8, connections):
     ],
 )
 def test_layers_with_overlap_bf16(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, num_layers, test_times
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, num_layers
 ):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """
-    for _ in range(test_times):
-        _run_layer_with_overlap(
-            layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, num_layers
-        )
+    _run_layer_with_overlap(
+        layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, num_layers
+    )
 
 
-@pytest.mark.parametrize(
-    "test_times",
-    [1, 2, 5],
-    ids=[
-        " x 1 times ",
-        " x 2 times ",
-        " x 5 times ",
-    ],
-)
 @pytest.mark.parametrize(
     "quantization",
     ["fp8_delayed_scaling", "fp8_current_scaling"],
@@ -291,10 +272,10 @@ def test_layers_with_overlap_bf16(
 )
 @pytest.mark.parametrize(
     "num_layers",
-    (1, 4),
+    (1, 2),
     ids=[
         " 1 layer ",
-        " 4 layers ",
+        " 2 layers ",
     ],
 )
 @pytest.mark.parametrize(
@@ -331,12 +312,11 @@ def test_layers_with_overlap_bf16(
     ],
 )
 def test_layers_with_overlap_fp8(
-    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers, test_times
+    layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
 ):
     """
     Test Transformer Engine layers with comm+GEMM overlap.
     """
-    for _ in range(test_times):
-        _run_layer_with_overlap(
-            layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
-        )
+    _run_layer_with_overlap(
+        layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, quantization, num_layers
+    )

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -30,8 +30,11 @@ TE_LAYERS = [
 ]
 MAX_LAYER_NAME_LENGTH = max([len(layer.__name__) for layer in TE_LAYERS])
 
+# to avoid numerical tolerance issues of doing comm gemm overlap, limit the number of GPUs used
+MAX_GPUS_TO_USE = 4
+
 TEST_ROOT = Path(__file__).parent.resolve()
-NUM_PROCS: int = torch.cuda.device_count()
+NUM_PROCS: int = min(torch.cuda.device_count(), MAX_GPUS_TO_USE)
 LAUNCH_CMD = ["torchrun", f"--nproc_per_node={NUM_PROCS}"]
 if tex.ubuf_built_with_mpi():
     LAUNCH_CMD = ["mpirun", "-np", str(NUM_PROCS), "--oversubscribe", "--quiet", "python3"]
@@ -309,10 +312,9 @@ def test_layers_with_overlap_fp8(
 )
 @pytest.mark.parametrize(
     "num_layers",
-    (4, 10),
+    (2,),
     ids=[
-        " 4 layers ",
-        " 10 layers ",
+        " 2 layers ",
     ],
 )
 @pytest.mark.parametrize(
@@ -357,10 +359,9 @@ def test_multi_layer_with_overlap_bf16(
 )
 @pytest.mark.parametrize(
     "num_layers",
-    (4, 10),
+    (2,),
     ids=[
-        " 4 layers ",
-        " 10 layers ",
+        " 2 layers ",
     ],
 )
 @pytest.mark.parametrize(

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -242,8 +242,7 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
 #if CUDA_VERSION >= 12080
     cublasLtMatmulMatrixScale_t scaling_mode;
 #endif
-    if ((is_tensor_scaling(inputA->scaling_mode) &&
-         is_tensor_scaling(inputB->scaling_mode))) {
+    if ((is_tensor_scaling(inputA->scaling_mode) && is_tensor_scaling(inputB->scaling_mode))) {
       void *A_scale_inverse = param.A_scale_inv;
       void *B_scale_inverse = param.B_scale_inv;
       NVTE_CHECK_CUBLAS(cublasLtMatmulDescSetAttribute(operationDesc,

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -242,8 +242,8 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
 #if CUDA_VERSION >= 12080
     cublasLtMatmulMatrixScale_t scaling_mode;
 #endif
-    if ((is_delayed_tensor_scaling(inputA->scaling_mode) &&
-         is_delayed_tensor_scaling(inputB->scaling_mode))) {
+    if ((is_tensor_scaling(inputA->scaling_mode) &&
+         is_tensor_scaling(inputB->scaling_mode))) {
       void *A_scale_inverse = param.A_scale_inv;
       void *B_scale_inverse = param.B_scale_inv;
       NVTE_CHECK_CUBLAS(cublasLtMatmulDescSetAttribute(operationDesc,

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -77,9 +77,9 @@ class Recipe:
         """Whether the given recipe is (per-tensor) current scaling."""
         return isinstance(self, Float8CurrentScaling)
 
-    def per_tensor_scaling(self):
+    def float8_per_tensor_scaling(self):
         """Whether the given recipe is per-tensor scaling."""
-        return isinstance(self, DelayedScaling) or isinstance(self, Float8CurrentScaling)
+        return isinstance(self, (DelayedScaling, Float8CurrentScaling))
 
 
 @dataclass()

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -76,6 +76,10 @@ class Recipe:
     def float8_current_scaling(self):
         """Whether the given recipe is (per-tensor) current scaling."""
         return isinstance(self, Float8CurrentScaling)
+    
+    def per_tensor_scaling(self):
+        """Whether the given recipe is per-tensor scaling."""
+        return isinstance(self, DelayedScaling) or isinstance(self, Float8CurrentScaling)
 
 
 @dataclass()

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -76,7 +76,7 @@ class Recipe:
     def float8_current_scaling(self):
         """Whether the given recipe is (per-tensor) current scaling."""
         return isinstance(self, Float8CurrentScaling)
-    
+
     def per_tensor_scaling(self):
         """Whether the given recipe is per-tensor scaling."""
         return isinstance(self, DelayedScaling) or isinstance(self, Float8CurrentScaling)

--- a/transformer_engine/pytorch/csrc/extensions/quantizer.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/quantizer.cpp
@@ -223,9 +223,8 @@ std::pair<TensorWrapper, py::object> Float8CurrentScalingQuantizer::create_tenso
   }
   const py::object py_columnwise_data = create_transpose ? py::cast(columnwise_data) : py::none();
 
-  //unlike delayed scaling, in current scaling, scale is not known, so scale_inv should be empty buffer
-  opts = opts.dtype(torch::kFloat32).device(torch::kCUDA);
-  at::Tensor scale_inv = at::empty(scale_inv_torch_shape, opts);
+  // In current scaling, scale is not known but we initialize it with 1 to avoid division by zero. If scale is already calculated, it can be correctly set.
+  at::Tensor scale_inv = at::reciprocal(scale);
 
   py::object ret;
   if (internal) {

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -222,9 +222,9 @@ class _LayerNormLinear(torch.autograd.Function):
         # So the output of normalization is in high precision, and we need to quantize it to FP8 and put in the buffer.
         if ub_overlap_ag_fprop and isinstance(input_quantizer, Float8CurrentScalingQuantizer):
             ub_obj_fprop = get_ub(ub_name + "_fprop")
-            ln_out_local = input_quantizer.quantize(ln_out)
-            ub_obj_fprop.copy_into_buffer(ln_out_local, input_quantizer, local_chunk=True)
-            ln_out = ln_out_local
+            ln_out_local = ln_out
+            ln_out = ub_obj_fprop.get_buffer(input_quantizer, local_chunk=True)
+            input_quantizer.quantize(ln_out_local, out=ln_out)
 
         # Prepare GEMM input
         # Note: Cast to expected dtype and perform tensor-parallel communication

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -149,8 +149,7 @@ class _LayerNormLinear(torch.autograd.Function):
 
         if fp8:
             if any([ub_overlap_ag_fprop, ub_overlap_rs_fprop]) and not (
-                FP8GlobalStateManager.get_fp8_recipe().delayed()
-                or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling()
+                FP8GlobalStateManager.get_fp8_recipe().per_tensor_scaling()
             ):
                 raise NotImplementedError(
                     "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
@@ -477,7 +476,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 )
                 and (ctx.fp8_recipe is not None)
             ):
-                if not (ctx.fp8_recipe.delayed() or ctx.fp8_recipe.float8_current_scaling()):
+                if not (ctx.fp8_recipe.per_tensor_scaling()):
                     raise NotImplementedError(
                         "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
                         " current scaling"

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -148,12 +148,13 @@ class _LayerNormLinear(torch.autograd.Function):
         with_input_all_gather = parallel_mode == "column" and sequence_parallel
 
         if fp8:
-            if (
-                any([ub_overlap_ag_fprop, ub_overlap_rs_fprop])
-                and not (FP8GlobalStateManager.get_fp8_recipe().delayed() or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling())
+            if any([ub_overlap_ag_fprop, ub_overlap_rs_fprop]) and not (
+                FP8GlobalStateManager.get_fp8_recipe().delayed()
+                or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling()
             ):
                 raise NotImplementedError(
-                    "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor current scaling"
+                    "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
+                    " current scaling"
                 )
 
             if input_quantizer is None:
@@ -481,7 +482,8 @@ class _LayerNormLinear(torch.autograd.Function):
             ):
                 if not (ctx.fp8_recipe.delayed() or ctx.fp8_recipe.float8_current_scaling()):
                     raise NotImplementedError(
-                        "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor current scaling"
+                        "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
+                        " current scaling"
                     )
 
             saved_tensors = ctx.saved_tensors

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -177,7 +177,7 @@ class _LayerNormLinear(torch.autograd.Function):
                     rowwise=True,
                     columnwise=backward_needs_input,
                 )
-        
+
         # Reduce duplicated transpose in `_fix_gathered_fp8_transpose`
         if fp8 and FP8GlobalStateManager.get_fp8_recipe().per_tensor_scaling() and ub_bulk_dgrad:
             input_quantizer.set_usage(rowwise=True, columnwise=False)

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -187,8 +187,8 @@ class _LayerNormLinear(torch.autograd.Function):
 
         ub_obj_fprop = None
         ln_out = None
-        # For Delay scaling, output of normalization can be in fp8.
-        # For CurrentScaling, it will be fused in the future, but currently we need the output of normalization in high precision.
+        # For DelayScaling, output of normalization will be in fp8.
+        # For Float8CurrentScaling, we want the output of normalization in high precision, then quantize to fp8.
         if ub_overlap_ag_fprop and not isinstance(input_quantizer, Float8CurrentScalingQuantizer):
             ub_obj_fprop = get_ub(ub_name + "_fprop")
             ln_out = ub_obj_fprop.get_buffer(input_quantizer, local_chunk=True)

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -190,8 +190,7 @@ class _LayerNormLinear(torch.autograd.Function):
         # For DelayScaling, output of normalization will be in fp8.
         # For Float8CurrentScaling, we want the output of normalization in high precision, then quantize to fp8.
         if ub_overlap_ag_fprop and not isinstance(input_quantizer, Float8CurrentScalingQuantizer):
-            ub_obj_fprop = get_ub(ub_name + "_fprop")
-            ln_out = ub_obj_fprop.get_buffer(input_quantizer, local_chunk=True)
+            ln_out = input_quantizer.make_empty(inputmat.shape, dtype=inputmat.dtype, device="cuda")
         elif with_quantized_norm:
             if with_input_all_gather:
                 input_quantizer.set_usage(rowwise=True, columnwise=False)
@@ -220,11 +219,18 @@ class _LayerNormLinear(torch.autograd.Function):
 
         # For Float8CurrentScalingQuantizer, layernorm/rmsnorm has not been fused with quantizer.
         # So the output of normalization is in high precision, and we need to quantize it to FP8 and put in the buffer.
-        if ub_overlap_ag_fprop and isinstance(input_quantizer, Float8CurrentScalingQuantizer):
+        if (
+            ub_overlap_ag_fprop
+            and FP8GlobalStateManager.get_fp8_recipe().float8_per_tensor_scaling()
+        ):
             ub_obj_fprop = get_ub(ub_name + "_fprop")
-            ln_out_local = ln_out
-            ln_out = ub_obj_fprop.get_buffer(input_quantizer, local_chunk=True)
-            input_quantizer.quantize(ln_out_local, out=ln_out)
+            if isinstance(input_quantizer, Float8CurrentScalingQuantizer):
+                ln_out_local = input_quantizer.quantize(ln_out)
+                ub_obj_fprop.copy_into_buffer(ln_out_local, input_quantizer, local_chunk=True)
+                ln_out = ln_out_local
+            else:
+                ln_out_local = ln_out
+                ub_obj_fprop.copy_into_buffer(ln_out, input_quantizer, local_chunk=True)
 
         # Prepare GEMM input
         # Note: Cast to expected dtype and perform tensor-parallel communication
@@ -389,7 +395,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 weight,
                 bias,
                 ln_weight,
-                ln_out,
+                ln_out_local if ub_overlap_ag_fprop else ln_out,  # avoid saving a UB buffer
                 mu,
                 rsigma,
             )

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -191,8 +191,7 @@ class _LayerNormMLP(torch.autograd.Function):
         if fp8:
             assert_dim_for_fp8_exec(inputmat, fc1_weight, fc2_weight)
             if any([ub_overlap_ag, ub_overlap_rs]) and not (
-                FP8GlobalStateManager.get_fp8_recipe().delayed()
-                or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling()
+                FP8GlobalStateManager.get_fp8_recipe().per_tensor_scaling()
             ):
                 raise NotImplementedError(
                     "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
@@ -602,7 +601,7 @@ class _LayerNormMLP(torch.autograd.Function):
                 )
                 and (ctx.fp8_recipe is not None)
             ):
-                if not (ctx.fp8_recipe.delayed() or ctx.fp8_recipe.float8_current_scaling()):
+                if not ctx.fp8_recipe.per_tensor_scaling():
                     raise NotImplementedError(
                         "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
                         " current scaling"

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -190,12 +190,13 @@ class _LayerNormMLP(torch.autograd.Function):
         inputmat = inp.view((-1, in_features))
         if fp8:
             assert_dim_for_fp8_exec(inputmat, fc1_weight, fc2_weight)
-            if (
-                any([ub_overlap_ag, ub_overlap_rs])
-                and not (FP8GlobalStateManager.get_fp8_recipe().delayed() or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling())
+            if any([ub_overlap_ag, ub_overlap_rs]) and not (
+                FP8GlobalStateManager.get_fp8_recipe().delayed()
+                or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling()
             ):
                 raise NotImplementedError(
-                    "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor current scaling"
+                    "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
+                    " current scaling"
                 )
 
         activation_func = _act_func(
@@ -599,7 +600,8 @@ class _LayerNormMLP(torch.autograd.Function):
             ):
                 if not (ctx.fp8_recipe.delayed() or ctx.fp8_recipe.float8_current_scaling()):
                     raise NotImplementedError(
-                        "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor current scaling"
+                        "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
+                        " current scaling"
                     )
 
             saved_tensors = ctx.saved_tensors

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -209,7 +209,7 @@ class _LayerNormMLP(torch.autograd.Function):
         if ln_bias is not None:
             ln_bias = cast_if_needed(ln_bias, activation_dtype)
 
-        # for standard fp8: layernorm output = FP8
+        # for fp8 DelayedScaling: layernorm output = FP8
         #                   only output of the linear is returned
         # for return_layernorm_output: layernorm output = High precision, then cast to FP8
         #                              high precision layernorm output and output of the linear are returned
@@ -247,6 +247,8 @@ class _LayerNormMLP(torch.autograd.Function):
 
         ub_obj_lnout = None
         ln_out = None
+        # For DelayScaling, output of normalization will be in fp8.
+        # For Float8CurrentScaling, we want the output of normalization in high precision, then quantize to fp8.
         if ub_overlap_ag and not isinstance(fc1_input_quantizer, Float8CurrentScalingQuantizer):
             ub_obj_lnout = get_ub("fc1_fprop")
             ln_out = ub_obj_lnout.get_buffer(fc1_input_quantizer, local_chunk=True)

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -277,9 +277,9 @@ class _LayerNormMLP(torch.autograd.Function):
         # So the output of normalization is in high precision, and we need to quantize it to FP8 and put in the buffer.
         if ub_overlap_ag and isinstance(fc1_input_quantizer, Float8CurrentScalingQuantizer):
             ub_obj_lnout = get_ub("fc1_fprop")
-            ln_out_local = fc1_input_quantizer.quantize(ln_out)
-            ub_obj_lnout.copy_into_buffer(ln_out_local, fc1_input_quantizer, local_chunk=True)
-            ln_out = ln_out_local
+            ln_out_local = ln_out
+            ln_out = ub_obj_lnout.get_buffer(fc1_input_quantizer, local_chunk=True)
+            fc1_input_quantizer.quantize(ln_out_local, out=ln_out)
 
         # Prepare GEMM input
         # Note: Cast to expected dtype and perform tensor-parallel communication

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -592,7 +592,7 @@ class _Linear(torch.autograd.Function):
                         wgrad_gemm_use_split_accumulator = (
                             recipe.fp8_gemm_wgrad.use_split_accumulator
                         )
-                        
+
                 wgrad, grad_bias_, _, rs_out = general_gemm(
                     inputmat_total,
                     grad_output,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -592,7 +592,7 @@ class _Linear(torch.autograd.Function):
                         wgrad_gemm_use_split_accumulator = (
                             recipe.fp8_gemm_wgrad.use_split_accumulator
                         )
-
+                        
                 wgrad, grad_bias_, _, rs_out = general_gemm(
                     inputmat_total,
                     grad_output,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -63,7 +63,6 @@ from ..cpu_offload import is_cpu_offload_enabled, set_offloading_param
 __all__ = ["Linear"]
 
 
-
 class _Linear(torch.autograd.Function):
     """Linear semi-top level module
     Calls custom cuda extensions.
@@ -130,12 +129,13 @@ class _Linear(torch.autograd.Function):
         own_quantized_input = False
         if fp8:
             assert_dim_for_fp8_exec(inputmat, weight)
-            if (
-                any([ub_overlap_ag_fprop, ub_overlap_rs_fprop])
-                and not (FP8GlobalStateManager.get_fp8_recipe().delayed() or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling())
+            if any([ub_overlap_ag_fprop, ub_overlap_rs_fprop]) and not (
+                FP8GlobalStateManager.get_fp8_recipe().delayed()
+                or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling()
             ):
                 raise NotImplementedError(
-                    "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor current scaling"
+                    "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
+                    " current scaling"
                 )
 
             if input_quantizer is None:
@@ -371,7 +371,8 @@ class _Linear(torch.autograd.Function):
             ):
                 if not (ctx.fp8_recipe.delayed() or ctx.fp8_recipe.float8_current_scaling()):
                     raise NotImplementedError(
-                        "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor current scaling"
+                        "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
+                        " current scaling"
                     )
 
             saved_tensors = ctx.saved_tensors

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -130,8 +130,7 @@ class _Linear(torch.autograd.Function):
         if fp8:
             assert_dim_for_fp8_exec(inputmat, weight)
             if any([ub_overlap_ag_fprop, ub_overlap_rs_fprop]) and not (
-                FP8GlobalStateManager.get_fp8_recipe().delayed()
-                or FP8GlobalStateManager.get_fp8_recipe().float8_current_scaling()
+                FP8GlobalStateManager.get_fp8_recipe().per_tensor_scaling()
             ):
                 raise NotImplementedError(
                     "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
@@ -369,7 +368,7 @@ class _Linear(torch.autograd.Function):
                 )
                 and (ctx.fp8_recipe is not None)
             ):
-                if not (ctx.fp8_recipe.delayed() or ctx.fp8_recipe.float8_current_scaling()):
+                if not (ctx.fp8_recipe.per_tensor_scaling()):
                     raise NotImplementedError(
                         "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
                         " current scaling"

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -130,7 +130,7 @@ class _Linear(torch.autograd.Function):
         if fp8:
             assert_dim_for_fp8_exec(inputmat, weight)
             if any([ub_overlap_ag_fprop, ub_overlap_rs_fprop]) and not (
-                FP8GlobalStateManager.get_fp8_recipe().per_tensor_scaling()
+                FP8GlobalStateManager.get_fp8_recipe().float8_per_tensor_scaling()
             ):
                 raise NotImplementedError(
                     "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
@@ -150,7 +150,10 @@ class _Linear(torch.autograd.Function):
                     quantizer=input_quantizer,
                 )
             else:
-                if ub_bulk_dgrad:
+                if (
+                    FP8GlobalStateManager.get_fp8_recipe().float8_per_tensor_scaling()
+                    and ub_bulk_dgrad
+                ):
                     # reduce duplicated transpose in `_fix_gathered_fp8_transpose`
                     input_quantizer.set_usage(rowwise=True, columnwise=False)
                 else:
@@ -368,7 +371,7 @@ class _Linear(torch.autograd.Function):
                 )
                 and (ctx.fp8_recipe is not None)
             ):
-                if not (ctx.fp8_recipe.per_tensor_scaling()):
+                if not ctx.fp8_recipe.float8_per_tensor_scaling():
                     raise NotImplementedError(
                         "Comm+GEMM overlap is only supported with FP8 delayed scaling or per-tensor"
                         " current scaling"
@@ -439,7 +442,6 @@ class _Linear(torch.autograd.Function):
                     ub_obj_dgrad = ctx.ub_obj_gradout
                     ub_type_dgrad = tex.CommOverlapType.AG
                     ub_obj_dgrad.copy_into_buffer(inputmat, ctx.input_quantizer, local_chunk=True)
-                    inputmat = ub_obj_dgrad.get_buffer(ctx.input_quantizer)
 
                 if ctx.ub_bulk_wgrad:
                     # Overlap dgrad reduce-scatter with wgrad compute
@@ -452,7 +454,7 @@ class _Linear(torch.autograd.Function):
             # Note: Cast to expected dtype and perform tensor-parallel communication
             if ctx.grad_output_quantizer is not None:
                 # Reduce duplicated transpose, which is performed in grad_output.update_usage
-                if ctx.ub_overlap_ag and ctx.fp8_recipe.per_tensor_scaling():
+                if ctx.ub_overlap_ag and ctx.fp8_recipe.float8_per_tensor_scaling():
                     ctx.grad_output_quantizer.set_usage(rowwise=True, columnwise=False)
                 else:
                     ctx.grad_output_quantizer.set_usage(rowwise=True, columnwise=True)

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -213,7 +213,7 @@ class Float8CurrentScalingQuantizer(Quantizer):
         amax_epsilon: float = 0.0,
     ) -> None:
         super().__init__(rowwise=rowwise, columnwise=columnwise)
-        self.scale = torch.empty(1, dtype=torch.float32, device=device)
+        self.scale = torch.ones(1, dtype=torch.float32, device=device)
         self.amax = torch.empty(1, dtype=torch.float32, device=device)
         self.dtype = fp8_dtype
         self.with_amax_reduction = with_amax_reduction


### PR DESCRIPTION
# Description

Enable TP/Comm Overlap for Per-Tensor Current Scaling Recipe.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- [x] Unit test related code changes
- [x] Module related code changes (i.e., linear, layernorm_linear, layernorm_mlp)
- [x] Quantization related code changes (help to use the correct `scale_inv` value)

## Unit Tests
Python Unit Tests
```
# Test Current Scaling only
pytest -s tests/pytorch/distributed/test_comm_gemm_overlap.py -k "FP8 and CURRENT" -v

# Test all overlapping cases
pytest -s tests/pytorch/distributed/test_comm_gemm_overlap.py -v

# Particular pattern test, take `LayernormLinear` module as an example
# Set UB_SKIPMC=1 if necessary
torchrun --nproc_per_node 2 tests/pytorch/distributed/run_layer_with_overlap.py --seq-length=1024 --batch-size=1 --num-heads=8 --head-dim=64 --layer-type=layernormlinear --fp8 --quantization=fp8_current_scaling
```

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
