### PR TITLE
Fix return_bias option in LayerNormLinear and LayerNormMLP

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -312,7 +312,7 @@ class _LayerNormLinear(torch.autograd.Function):
             get_workspace(),
             quantization_params=output_quantizer,
             out_dtype=activation_dtype,
-            bias=bias,
+            bias=bias if use_bias else None,
             use_split_accumulator=fprop_gemm_use_split_accumulator,
             ub=ub_obj,
             ub_type=ub_type,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -424,7 +424,7 @@ class _LayerNormMLP(torch.autograd.Function):
             act_out,
             get_workspace(),
             out_dtype=activation_dtype,
-            bias=fc2_bias,
+            bias=fc2_bias if use_fc2_bias else None,
             quantization_params=output_quantizer,
             out=fc2_out,
             use_split_accumulator=_2X_ACC_FPROP,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -520,7 +520,7 @@ class _LayerNormMLP(torch.autograd.Function):
             ctx.is_first_microbatch = is_first_microbatch
             ctx.use_fc1_bias = use_fc1_bias
             ctx.use_fc2_bias = use_fc2_bias
-            ctx.use_bias = ctx.use_fc1_bias
+            ctx.use_bias = ctx.use_fc2_bias
             ctx.sequence_parallel = sequence_parallel
             ctx.tensor_parallel = tensor_parallel
             ctx.inp_shape = inp_shape


### PR DESCRIPTION
# Description

return_bias option was ignored silently in LayerNormLinear and LayerNormMLP after the 2.0 refactor.


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
