### PR TITLE
Distopt with offload

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -351,7 +351,7 @@ class _LayerNormLinear(torch.autograd.Function):
             )
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
-            if cpu_offloading:
+            if cpu_offloading and hasattr(weight, "grad_added_to_main_grad"):
                 # If you are passing torch.nn.Parameter through the Torch hooks, you will
                 # get back torch.Tensor. Torch rips off the Parameter wrapper.
                 # You need to preserve the weight object to have all the attributes user

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -351,6 +351,14 @@ class _LayerNormLinear(torch.autograd.Function):
             )
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
+            if cpu_offloading:
+                # If you are passing torch.nn.Parameter through the Torch hooks, you will
+                # get back torch.Tensor. Torch rips off the Parameter wrapper.
+                # You need to preserve the weight object to have all the attributes user
+                # sets for the weights. Because of this, it is not recommended to offload
+                # weights if weights are externally touched outside this module
+                ctx.weight_object = weight
+
             tensors_to_save, tensor_objects = prepare_for_saving(
                 inputmat,
                 weightmat,
@@ -368,7 +376,6 @@ class _LayerNormLinear(torch.autograd.Function):
             ctx.quantized_weight = quantized_weight
             if fuse_wgrad_accumulation and weight.requires_grad:
                 ctx.main_grad = weight.main_grad
-                ctx.grad_added_to_main_grad = getattr(weight,"grad_added_to_main_grad",None)
             ctx.grad_input_quantizer = grad_input_quantizer
             ctx.grad_output_quantizer = grad_output_quantizer
             ctx.input_quantizer = input_quantizer
@@ -495,11 +502,9 @@ class _LayerNormLinear(torch.autograd.Function):
             # For CPU offloading, we offloaded weight and weight.main_grad to different tensors,
             # we need to connect them into one.
             if ctx.cpu_offloading:
-                origin_weight = torch.nn.Parameter(origin_weight, ctx.requires_wgrad)
+                origin_weight = ctx.weight_object
                 if ctx.requires_wgrad and ctx.fuse_wgrad_accumulation:
                     origin_weight.main_grad = main_grad
-                    if ctx.grad_added_to_main_grad is not None:
-                        origin_weight.grad_added_to_main_grad = ctx.grad_added_to_main_grad
 
             ctx.ub_obj_gradout = None
             ub_obj_dgrad = None

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -386,7 +386,7 @@ class _LayerNormLinear(torch.autograd.Function):
             if cpu_offloading:
                 ctx.grad_added_to_main_grad = hasattr(weight, "grad_added_to_main_grad")
 
-                if hasattr(weight, "grad_added_to_main_grad"):
+                if ctx.grad_added_to_main_grad:
                     # If you are passing torch.nn.Parameter through the Torch hooks, you will
                     # get back torch.Tensor. Torch rips off the Parameter wrapper.
                     # You need to preserve the weight object to have all the attributes user

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -383,13 +383,16 @@ class _LayerNormLinear(torch.autograd.Function):
             )
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
-            if cpu_offloading and hasattr(weight, "grad_added_to_main_grad"):
-                # If you are passing torch.nn.Parameter through the Torch hooks, you will
-                # get back torch.Tensor. Torch rips off the Parameter wrapper.
-                # You need to preserve the weight object to have all the attributes user
-                # sets for the weights. Because of this, it is not recommended to offload
-                # weights if weights are externally touched outside this module
-                ctx.weight_object = weight
+            if cpu_offloading:
+                ctx.grad_added_to_main_grad = hasattr(weight, "grad_added_to_main_grad")
+
+                if hasattr(weight, "grad_added_to_main_grad"):
+                    # If you are passing torch.nn.Parameter through the Torch hooks, you will
+                    # get back torch.Tensor. Torch rips off the Parameter wrapper.
+                    # You need to preserve the weight object to have all the attributes user
+                    # sets for the weights. Because of this, it is not recommended to offload
+                    # weights if weights are externally touched outside this module
+                    ctx.weight_object = weight
 
             tensors_to_save, tensor_objects = prepare_for_saving(
                 inputmat,
@@ -535,7 +538,8 @@ class _LayerNormLinear(torch.autograd.Function):
             # For CPU offloading, we offloaded weight and weight.main_grad to different tensors,
             # we need to connect them into one.
             if ctx.cpu_offloading:
-                origin_weight = ctx.weight_object
+                if ctx.grad_added_to_main_grad:
+                    origin_weight = ctx.weight_object
                 if ctx.requires_wgrad and ctx.fuse_wgrad_accumulation:
                     origin_weight.main_grad = main_grad
 

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -294,7 +294,7 @@ class _Linear(torch.autograd.Function):
             if cpu_offloading:
                 ctx.grad_added_to_main_grad = hasattr(weight, "grad_added_to_main_grad")
 
-                if hasattr(weight, "grad_added_to_main_grad"):
+                if ctx.grad_added_to_main_grad:
                     # If you are passing torch.nn.Parameter through the Torch hooks, you will
                     # get back torch.Tensor. Torch rips off the Parameter wrapper.
                     # You need to preserve the weight object to have all the attributes user

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -273,7 +273,7 @@ class _Linear(torch.autograd.Function):
             )
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
-            if cpu_offloading:
+            if cpu_offloading and hasattr(weight, "grad_added_to_main_grad"):
                 # If you are passing torch.nn.Parameter through the Torch hooks, you will
                 # get back torch.Tensor. Torch rips off the Parameter wrapper.
                 # You need to preserve the weight object to have all the attributes user

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -293,7 +293,7 @@ class _Linear(torch.autograd.Function):
 
             if cpu_offloading:
                 ctx.grad_added_to_main_grad = hasattr(weight, "grad_added_to_main_grad")
-                
+
                 if hasattr(weight, "grad_added_to_main_grad"):
                     # If you are passing torch.nn.Parameter through the Torch hooks, you will
                     # get back torch.Tensor. Torch rips off the Parameter wrapper.


### PR DESCRIPTION
# Description

This PR adds support for offloading with MCore DistOpt. 

DistOpt needs some backward hooks to be triggered, current offloading in TE modifies the weight tensor attributes which affects the hook triggering in MCore. Fixed the issue in this PR.