### PR TITLE
[PyTorch] Preserve FP8 scaling factors for attention backward

### DIFF
--- a/transformer_engine/pytorch/attention.py
+++ b/transformer_engine/pytorch/attention.py
@@ -4676,7 +4676,7 @@ class FusedAttnFunc(torch.autograd.Function):
                 if is_output_fp8:
                     out_save = out_fp8.dequantize()
 
-            fp8_tensors = (q_fp8, k_fp8, v_fp8, out_fp8)
+            fp8_tensors = (q_fp8.clone(), k_fp8.clone(), v_fp8.clone(), out_fp8.clone())
         else:
             # q, k, v, out_ret: torch.float16 or torch.bfloat16
             out_ret, aux_ctx_tensors = fused_attn_fwd(


### PR DESCRIPTION
# Description

Since TE 2.0, the reduction of `q`, `k`, `v` scaling factors happens automatically with `QKV_quantizer`. If the forward and backward calls of `FusedAttnFunc` take place in two different `fp8_autocast` contexts, these scaling factors get updated in between. We need the unchanged scaling factors for the backward. This PR does that.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Save a clone of FP8 `q`, `k`, `v` tensors instead of letting their scaling factors be updated.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
