### PR TITLE
[PyTorch] Defer torch compilation steps until first function call

### DIFF
--- a/tests/pytorch/test_jit.py
+++ b/tests/pytorch/test_jit.py
@@ -60,6 +60,6 @@ def test_torch_dynamo(model_name: str):
 
 def test_lazy_compile():
     """Smoke test to ensure lazy compilation is working."""
-    from transformer_engine.pytorch.jit import bgrad_dgelu_fused_
+    from transformer_engine.pytorch.jit import dgelu_fused_
 
-    bgrad_dgelu_fused_(torch.randn(10, 10), torch.randn(10, 10))
+    dgelu_fused_(torch.randn(10, 10), torch.randn(10, 10))

--- a/tests/pytorch/test_jit.py
+++ b/tests/pytorch/test_jit.py
@@ -56,3 +56,10 @@ def test_torch_dynamo(model_name: str):
     # Forward and backward pass
     out = model(*inputs)
     out.backward(torch.zeros_like(out))
+
+
+def test_lazy_compile():
+    """Smoke test to ensure lazy compilation is working."""
+    from transformer_engine.pytorch.jit import bgrad_dgelu_fused_
+
+    bgrad_dgelu_fused_(torch.randn(10, 10), torch.randn(10, 10))

--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -11,6 +11,7 @@ import torch
 
 # pylint: disable=unnecessary-lambda-assignment
 
+
 def lazy_compile(func):
     """Lazy compile a function with torch.compile
 

--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -4,21 +4,40 @@
 
 """NVFuser functions and JIT utilities"""
 import os
+from functools import wraps
 from typing import Callable, Optional, Tuple
 
 import torch
 
 # pylint: disable=unnecessary-lambda-assignment
 
+def lazy_compile(func):
+    """Lazy compile a function with torch.compile
+
+    This decorator defers the compilation of a function until the first call, speeding up the
+    overall module's import time if these functions are not used.
+    """
+    compiled_func = None
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        nonlocal compiled_func
+        if compiled_func is None:
+            compiled_func = torch.compile(func)
+        return compiled_func(*args, **kwargs)
+
+    return wrapper
+
+
 jit_fuser = lambda func: func
 if torch.__version__ >= "2" and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
-    jit_fuser = torch.compile
+    jit_fuser = lazy_compile
 
 
 # See: https://github.com/NVIDIA/TransformerEngine/issues/597
 dropout_fuser = torch.jit.script
 if torch.__version__ >= "2.2" and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
-    dropout_fuser = torch.compile
+    dropout_fuser = lazy_compile
 
 
 # Decorator to disable Torch Dynamo


### PR DESCRIPTION
# Description

Currently, running `import transformer_engine` invokes torch.compile for a bunch of jit-functions, causing the inductor backend to spawn a number of processes. This defers the torch.compile step until the first time these functions are used to try to speed up the module's import time.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Changes `jit_fuser` to use a lazy compile function, rather than torch.compile directly
- Adds a test to ensure these lazily-compiled functions are callable.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
