### PR TITLE
Improved performance of mxfp8 cast kernels

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -157,6 +157,7 @@ if (NVTE_BUILD_ACTIVATION_WITH_FAST_MATH)
   set_source_files_properties(activation/gelu.cu
                               activation/relu.cu
                               activation/swiglu.cu
+			      util/cast.cu
                               PROPERTIES
                               COMPILE_OPTIONS "--use_fast_math")
 endif()

--- a/transformer_engine/common/util/cast_kernels.cuh
+++ b/transformer_engine/common/util/cast_kernels.cuh
@@ -5,8 +5,8 @@
  ************************************************************************/
 
 /*! \file cast_kernels.cuh
-*  \brief CUDA kernels to cast to/from FP8/MXFP8.
-*/
+ *  \brief CUDA kernels to cast to/from FP8/MXFP8.
+ */
 
 #ifndef TRANSFORMER_ENGINE_CAST_KERNELS_CUH_
 #define TRANSFORMER_ENGINE_CAST_KERNELS_CUH_
@@ -29,58 +29,64 @@
 namespace transformer_engine {
 
 constexpr size_t ALIGNMENT = 128;
-struct __align__(ALIGNMENT) AlignedSharedMemory {
-  char data[ALIGNMENT];  // Aligned storage
-};
 
 namespace mxfp8_kernel {
 
 constexpr size_t SCALE_DIM_Y = 32;
 constexpr size_t SCALE_DIM_X = 32;
 
-constexpr size_t CHUNK_DIM_Y = 128;
-constexpr size_t CHUNK_DIM_X = 128;
-constexpr size_t THREADS_PER_CHUNK = 128;
-
-constexpr size_t WARPS = THREADS_PER_CHUNK / THREADS_PER_WARP;
-constexpr size_t THREADS_X = CHUNK_DIM_X / SCALE_DIM_X;
-constexpr size_t THREADS_Y = THREADS_PER_CHUNK / THREADS_X;
-
 constexpr size_t BUFFS_NUM = 2;
-constexpr size_t BUFF_DIM_Y = THREADS_Y;
-constexpr size_t BUFF_DIM_X = CHUNK_DIM_X;
-constexpr size_t BUFF_DIM = BUFF_DIM_Y * BUFF_DIM_X;
-static_assert(BUFF_DIM_Y == 32);
-static_assert(BUFF_DIM_X == 128);
-
-constexpr size_t STAGES = CHUNK_DIM_Y / BUFF_DIM_Y;
-static_assert(STAGES >= 1);
-
 constexpr size_t PACK_SIZE = 4;
 constexpr size_t WAVES = SCALE_DIM_X / PACK_SIZE;
 
-#define IDX3(buff, row, col) ((buff) * BUFF_DIM + (row) * BUFF_DIM_X + (col))
-#define IDX2(row, col) ((row) * BUFF_DIM_X + (col))
-#define IDX(buff) ((buff) * BUFF_DIM)
+template <typename ParamOP, float (*OP)(float, const ParamOP &)>
+constexpr __device__ __forceinline__ bool
+is_cached_act_op() {
+  return (OP ==    gelu<float,float>) || (OP ==    dgelu<float,float>) ||
+         (OP == sigmoid<float,float>) || (OP == dsigmoid<float,float>) ||
+         (OP ==   qgelu<float,float>) || (OP ==   dqgelu<float,float>) || 
+         (OP ==    silu<float,float>) || (OP ==    dsilu<float,float>);
+}
 
 template <bool IS_DBIAS, bool IS_DACT, bool IS_ACT, typename ParamOP,
-          float (*OP)(float, const ParamOP &), typename IType, typename OType, bool ROWWISE_SCALING,
-          bool COLWISE_SCALING, bool IS_CACHED_ACT_OP>
+          float (*OP)(float, const ParamOP &), typename IType, typename OType,
+          bool ROWWISE_SCALING, bool COLWISE_SCALING,
+          size_t CHUNK_DIM_Y, size_t CHUNK_DIM_X, size_t THREADS_PER_CHUNK>
 __global__ void __launch_bounds__(THREADS_PER_CHUNK)
     cast_mxfp8_2D_kernel(const __grid_constant__ CUtensorMap tensor_map_input,
                          const __grid_constant__ CUtensorMap tensor_map_act_input,
                          const __grid_constant__ CUtensorMap tensor_map_output_rowwise,
                          const __grid_constant__ CUtensorMap tensor_map_output_colwise,
                          e8m0_t *const scales_rowwise, e8m0_t *const scales_colwise,
-                         const float *noop, float *const dbias_workspace, float *const amax_ptr,
-                         const size_t rows, const size_t cols, const size_t scale_stride_rowwise,
-                         const size_t scale_stride_colwise) {
+                         const float *noop, float *const dbias_workspace,
+                         float *const amax_ptr, const size_t rows, const size_t cols,
+                         const size_t scale_stride_rowwise, const size_t scale_stride_colwise)
+{
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
-  if constexpr (!IS_DACT && !IS_ACT) {
+  constexpr bool COMPUTE_ACTIVATIONS = IS_DACT || IS_ACT;
+  constexpr bool NO_ACTIVATIONS = !COMPUTE_ACTIVATIONS;
+  constexpr bool CAST_DBIAS_ONLY = IS_DBIAS && NO_ACTIVATIONS;
+
+  if constexpr (NO_ACTIVATIONS) {
     if (noop != nullptr && noop[0] == 1.0f) {
       return;
     }
   }
+  constexpr size_t WARPS = THREADS_PER_CHUNK / THREADS_PER_WARP;
+  constexpr size_t THREADS_X = CHUNK_DIM_X / SCALE_DIM_X;
+  constexpr size_t THREADS_Y = THREADS_PER_CHUNK / THREADS_X;
+
+  constexpr size_t BUFF_DIM_Y = THREADS_Y;
+  constexpr size_t BUFF_DIM_X = CHUNK_DIM_X;
+  constexpr size_t BUFF_DIM = BUFF_DIM_Y * BUFF_DIM_X;
+  static_assert(BUFF_DIM_Y == 32);
+
+  constexpr size_t STAGES = CHUNK_DIM_Y / BUFF_DIM_Y;
+  static_assert(STAGES >= 1);
+
+  constexpr bool IS_CACHED_ACT_OP = COMPUTE_ACTIVATIONS && ROWWISE_SCALING && COLWISE_SCALING
+                                    && is_cached_act_op<ParamOP, OP>();
+
   const int block_offset_Y = blockIdx.y * CHUNK_DIM_Y;
   const int block_offset_X = blockIdx.x * CHUNK_DIM_X;
   const int scales_block_offset_Y_rowwise = blockIdx.y * CHUNK_DIM_Y;
@@ -112,39 +118,31 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   const int scales_offset_Y_colwise = scales_block_offset_Y_colwise + tid_Y_colwise;
   const int scales_offset_X_colwise = scales_block_offset_X_colwise + tid_X_colwise;
 
-  const int thread_group =
-      tid_Y_rowwise % (THREADS_PER_WARP / THREADS_X);  // helps to resolve bank conflicts in shmem
-  const int lane = tid_X_rowwise;                      // helps to resolve bank conflicts in shmem
+  const int thread_group = tid_Y_rowwise % (THREADS_PER_WARP / THREADS_X);   // helps to resolve bank conflicts in shmem
+  const int lane = tid_X_rowwise;   // helps to resolve bank conflicts in shmem
+  const int thread_lane = threadIdx.x % THREADS_PER_WARP;
 
-  extern __shared__ AlignedSharedMemory dsmem_aligned[];
-  char *dshmem = reinterpret_cast<char *>(dsmem_aligned);
+  extern __shared__ __align__(128) char dshmem[];
 
   constexpr size_t buff_elems = BUFF_DIM_Y * BUFF_DIM_X;
   constexpr size_t buff_elems_total = BUFFS_NUM * buff_elems;
-  constexpr size_t buff_size_aligned_in =
-      DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
-  constexpr size_t buff_size_aligned_out =
-      DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
-  constexpr size_t buff_size_aligned_cache =
-      DIVUP(buff_elems * sizeof(float), ALIGNMENT) * ALIGNMENT;
+  constexpr size_t buff_size_aligned_in = DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
+  constexpr size_t buff_size_aligned_out = DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
 
   constexpr size_t elt_input_mem = buff_size_aligned_in;
   constexpr size_t act_input_mem = (IS_DACT ? buff_size_aligned_in : 0);
-
   constexpr size_t in_mem = elt_input_mem + act_input_mem;
 
   constexpr size_t out_mem_rowwise = (ROWWISE_SCALING ? buff_size_aligned_out : 0);
   constexpr size_t out_mem_colwise = (COLWISE_SCALING ? buff_size_aligned_out : 0);
   constexpr size_t out_mem = out_mem_rowwise + out_mem_colwise;
 
-  constexpr size_t cache_buff_mem = (IS_CACHED_ACT_OP ? buff_size_aligned_cache : 0);
-
   // The destination shared memory buffer of a bulk tensor operation should be 16-byte aligned
   IType *in_sh = reinterpret_cast<IType *>(dshmem);
   IType *act_in_sh = reinterpret_cast<IType *>(dshmem + elt_input_mem);
   OType *out_rowwise_sh = reinterpret_cast<OType *>(dshmem + in_mem);
   OType *out_colwise_sh = reinterpret_cast<OType *>(dshmem + in_mem + out_mem_rowwise);
-  float *cached_act_sh = reinterpret_cast<float *>(dshmem + in_mem + out_mem);
+  IType *cached_act_sh = in_sh; // in_sh is used as a cache buffer
 
   constexpr int shmem_buff_size = buff_size_aligned_in / BUFFS_NUM;
 
@@ -153,7 +151,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   float partial_dbias_colwise = 0.0f;
   float thread_dbias_rowwise[SCALE_DIM_X];
   if constexpr (IS_DBIAS) {
-#pragma unroll
+    #pragma unroll
     for (int j = 0; j < SCALE_DIM_X; ++j) {
       thread_dbias_rowwise[SCALE_DIM_X] = 0.0f;
     }
@@ -161,8 +159,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
   float block_amax = 0.0f;
 
-// Initialize shared memory barrier with the number of threads participating in the barrier.
-#pragma nv_diag_suppress static_var_with_dynamic_init
+  // Initialize shared memory barrier with the number of threads participating in the barrier.
+  #pragma nv_diag_suppress static_var_with_dynamic_init
   __shared__ alignas(8) uint64_t mbar[STAGES];
 
   initialize_barriers<STAGES, THREADS_PER_CHUNK>(mbar, is_master_thread);
@@ -170,33 +168,37 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   int parity = 0;
 
   if constexpr (IS_DACT) {
-    copy_2d_to_sharedx2(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y, &act_in_sh[0],
-                        &tensor_map_act_input, block_offset_X, block_offset_Y, shmem_buff_size,
-                        &mbar[0], is_master_thread);
+    copy_2d_to_sharedx2(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y,
+                        &act_in_sh[0], &tensor_map_act_input, block_offset_X, block_offset_Y,
+                        shmem_buff_size, &mbar[0], is_master_thread);
   } else {
-    copy_2d_to_shared(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y, shmem_buff_size,
-                      &mbar[0], is_master_thread);
+    copy_2d_to_shared(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y,
+                      shmem_buff_size, &mbar[0], is_master_thread);
   }
 
-#pragma unroll
+  #pragma unroll
   for (int stage = 0; stage < STAGES; ++stage) {
     const int buff = stage % BUFFS_NUM;
     const int next_stage = stage + 1;
     const int stage_offset_Y = stage * BUFF_DIM_Y;
 
     if (next_stage < STAGES) {
+      // Wait for TMA transfer to have finished reading shared memory.
+      // I.e. the buffer is ready to be written to
+      ptx::cp_async_bulk_wait_group_read<1>();
+
       const int next_buff = next_stage % BUFFS_NUM;
       const int next_stage_offset_Y = next_stage * BUFF_DIM_Y;
       const int global_offset_Y = block_offset_Y + next_stage_offset_Y;
       const int global_offset_X = block_offset_X;
+      const int next_buff_offset = next_buff * BUFF_DIM;
       if constexpr (IS_DACT) {
-        copy_2d_to_sharedx2(&in_sh[IDX(next_buff)], &tensor_map_input, global_offset_X,
-                            global_offset_Y, &act_in_sh[IDX(next_buff)], &tensor_map_act_input,
-                            global_offset_X, global_offset_Y, shmem_buff_size, &mbar[next_stage],
-                            is_master_thread);
+        copy_2d_to_sharedx2(&in_sh[next_buff_offset], &tensor_map_input, global_offset_X, global_offset_Y,
+                            &act_in_sh[next_buff_offset], &tensor_map_act_input, global_offset_X, global_offset_Y,
+                            shmem_buff_size, &mbar[next_stage], is_master_thread);
       } else {
-        copy_2d_to_shared(&in_sh[IDX(next_buff)], &tensor_map_input, global_offset_X,
-                          global_offset_Y, shmem_buff_size, &mbar[next_stage], is_master_thread);
+        copy_2d_to_shared(&in_sh[next_buff_offset], &tensor_map_input, global_offset_X, global_offset_Y,
+                          shmem_buff_size, &mbar[next_stage], is_master_thread);
       }
     }
 
@@ -207,126 +209,47 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
     float thread_amax = 0.0f;
     if constexpr (COLWISE_SCALING) {
+      const int shmem_offset_base_colwise = buff * BUFF_DIM + tid_X_colwise;
       thread_amax = 0.0f;
       float in_compute_colwise[BUFF_DIM_Y];
-#pragma unroll
-      for (int i = 0; i < BUFF_DIM_Y; ++i) {
-        float elt = static_cast<float>(in_sh[IDX3(buff, i, tid_X_colwise)]);
-        if constexpr (IS_ACT) {
-          elt = OP(elt, {});
+      IType in_colwise_IType[BUFF_DIM_Y];
+      
+      // 1. Read/Compute elements. Find MXFP8-block AMAX
+      if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+        IType thread_amax_2x[2] = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
+        #pragma unroll
+        for (int i = 0; i < BUFF_DIM_Y; i += 2) {
+          const int shmem_offset_colwise_elt1 = shmem_offset_base_colwise + i * BUFF_DIM_X;
+          const int shmem_offset_colwise_elt2 = shmem_offset_base_colwise + (i + 1) * BUFF_DIM_X;
+          in_colwise_IType[i] = in_sh[shmem_offset_colwise_elt1];         
+          in_colwise_IType[i+1] = in_sh[shmem_offset_colwise_elt2];         
+          ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0], in_colwise_IType[i]);
         }
-        if constexpr (IS_DACT) {
-          float act_in_elt = static_cast<float>(act_in_sh[IDX3(buff, i, tid_X_colwise)]);
-          elt *= OP(act_in_elt, {});
-        }
-        if constexpr (IS_DBIAS) {
-          partial_dbias_colwise += elt;
-        }
-        // TODO: Cache Activations
-        // Cache computed activations to avoid computing them again in the 2nd pass along another dimension
-        // if constexpr (IS_CACHED_ACT_OP) {
-        //   cached_act_sh[IDX2(i,tid_X_colwise)] = elt;
-        // }
-
-        if constexpr (IS_ACT || IS_DACT) {
-          const bool row_out_of_bounds_colwise = (row_base_colwise + stage_offset_Y + i >= rows);
-          const bool out_of_bounds = (col_out_of_bounds_colwise || row_out_of_bounds_colwise);
-          if (!out_of_bounds) {
-            thread_amax = fmaxf(thread_amax, fabsf(elt));
-          }
-        } else {
-          // If no activation, elt is 0 so we can safely do this
-          thread_amax = fmaxf(thread_amax, fabsf(elt));
-        }
-        in_compute_colwise[i] = elt;
-      }
-
-      const e8m0_t biased_exponent =
-          float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
-
-      const int global_scales_offset_Y = scales_offset_Y_colwise + stage;
-      const int global_scales_offset_X = scales_offset_X_colwise;
-      const int scale_idx = global_scales_offset_Y * scale_stride_colwise + global_scales_offset_X;
-      scales_colwise[scale_idx] = biased_exponent;
-
-      const float block_scale_inverse = exp2f_rcp(biased_exponent);
-      const float2 block_scale_inverse_2x = make_float2(block_scale_inverse, block_scale_inverse);
-
-#pragma unroll
-      for (int i = 0; i < SCALE_DIM_Y; i += 2) {
-        OType out_c[2];
-        const float2 &in_2x = *reinterpret_cast<float2 *>(&in_compute_colwise[i]);
-        uint16_t &out_2x = *reinterpret_cast<uint16_t *>(out_c);
-        ptx::mul_cvt_2x<OType>(out_2x, in_2x, block_scale_inverse_2x);
-
-        out_colwise_sh[IDX3(buff, i, tid_X_colwise)] = out_c[0];
-        out_colwise_sh[IDX3(buff, i + 1, tid_X_colwise)] = out_c[1];
-      }
-    }
-
-    if constexpr (ROWWISE_SCALING) {
-      thread_amax = 0.0f;
-      float in_compute_rowwise[SCALE_DIM_X];
-// TODO: Cache Activations
-// if constexpr (IS_CACHED_ACT_OP) {
-//   // ensures that all writes to cache made in the section above are visible to all threads
-//   __syncthreads();
-//   #pragma unroll
-//   for (int j = 0; j < SCALE_DIM_X; ++j) {
-//     elt = cached_act_sh[IDX2(thread_offset_Y_rowwise, swizzled_elt_idx)];
-//   }
-// }
-#pragma unroll
-      for (int w = 0; w < WAVES; ++w) {
-        // const int j = w * PACK_SIZE;
-        // const int swizzled_idx = (j + thread_group * PACK_SIZE) % SCALE_DIM_X;
-        // const int swizzled_idx = thread_offset_X_rowwise + ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
-
-        const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
-        const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
-
-        Vec<IType, PACK_SIZE> in;
-        Vec<IType, PACK_SIZE> act_in;
-
-        // TODO: Cache Activations
-        // if constexpr (!IS_CACHED_ACT_OP) {
-        // }
-        in.load_from(&in_sh[IDX3(buff, thread_offset_Y_rowwise, swizzled_thread_idx)]);
-        if constexpr (IS_DACT) {
-          act_in.load_from(&act_in_sh[IDX3(buff, thread_offset_Y_rowwise, swizzled_thread_idx)]);
-        }
-#pragma unroll
-        for (int e = 0; e < PACK_SIZE; ++e) {
-          const int j = w * PACK_SIZE + e;
-
-          // TODO: Cache Activations
-          // float elt;
-          // if constexpr (IS_CACHED_ACT_OP) {
-          //   // Load cached element
-          //   const int swizzled_lane_idx = (e + lane) % PACK_SIZE;
-          //   const int swizzled_elt_idx = swizzled_thread_idx + swizzled_lane_idx;
-          //   elt = cached_act_sh[IDX2(thread_offset_Y_rowwise, swizzled_elt_idx)];
-          // } else {
-          // }
-
-          // Compute element
-          float elt = static_cast<float>(in.data.elt[e]);
+        thread_amax = static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
+      } else {
+        #pragma unroll
+        for (int i = 0; i < BUFF_DIM_Y; ++i) {
+          const int shmem_offset_colwise = shmem_offset_base_colwise + i * BUFF_DIM_X;
+  
+          float elt = static_cast<float>(in_sh[shmem_offset_colwise]);
           if constexpr (IS_ACT) {
             elt = OP(elt, {});
           }
           if constexpr (IS_DACT) {
-            float act_in_elt = static_cast<float>(act_in.data.elt[e]);
+            float act_in_elt = static_cast<float>(act_in_sh[shmem_offset_colwise]);
             elt *= OP(act_in_elt, {});
+          } 
+          if constexpr (IS_DBIAS) {
+            partial_dbias_colwise += elt;
           }
-
-          // No need to compute DBIAS again
-          if constexpr (IS_DBIAS && (!COLWISE_SCALING)) {
-            thread_dbias_rowwise[j] += elt;
+          // Cache computed activations to avoid computing them again in the 2nd pass along another dimension 
+          if constexpr (IS_CACHED_ACT_OP) {
+            cached_act_sh[shmem_offset_colwise] = static_cast<IType>(elt);
           }
-          if constexpr (IS_ACT || IS_DACT) {
-            const bool row_out_of_bounds_rowwise = (row_base_rowwise + stage_offset_Y >= rows);
-            const bool swizzled_col_out_of_bounds = (block_offset_X + swizzled_thread_idx >= cols);
-            const bool out_of_bounds = (row_out_of_bounds_rowwise || swizzled_col_out_of_bounds);
+          
+          if constexpr (COMPUTE_ACTIVATIONS) {
+            const bool row_out_of_bounds_colwise = (row_base_colwise + stage_offset_Y + i >= rows);
+            const bool out_of_bounds = (col_out_of_bounds_colwise || row_out_of_bounds_colwise);
             if (!out_of_bounds) {
               thread_amax = fmaxf(thread_amax, fabsf(elt));
             }
@@ -334,12 +257,147 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
             // If no activation, elt is 0 so we can safely do this
             thread_amax = fmaxf(thread_amax, fabsf(elt));
           }
-          in_compute_rowwise[j] = elt;
+          in_compute_colwise[i] = elt;
+        }
+      }
+  
+      // 2. Compute E8M0 scaling factor
+      const e8m0_t biased_exponent = float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
+  
+      const int global_scales_offset_Y = scales_offset_Y_colwise + stage;
+      const int global_scales_offset_X = scales_offset_X_colwise;
+      const int scale_idx = global_scales_offset_Y * scale_stride_colwise + global_scales_offset_X;
+      scales_colwise[scale_idx] = biased_exponent;
+  
+      const float block_scale_inverse = exp2f_rcp(biased_exponent);
+      const float2 block_scale_inverse_2x = make_float2(block_scale_inverse, block_scale_inverse);
+  
+      // 3. Scale elements
+      #pragma unroll
+      for (int i = 0; i < SCALE_DIM_Y; i += 2) {
+        OType out_c[2];
+        static_assert(sizeof(OType) == 1);
+        
+        if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+          ptx::mul_cvt_2x<OType, IType>(out_c[0], in_colwise_IType[i], block_scale_inverse_2x);
+        } else {
+          ptx::mul_cvt_2x<OType, float>(out_c[0], in_compute_colwise[i], block_scale_inverse_2x);
+        }
+        
+        const int shmem_offset_elt_1 = shmem_offset_base_colwise + i * BUFF_DIM_X;
+        const int shmem_offset_elt_2 = shmem_offset_base_colwise + (i + 1) * BUFF_DIM_X;
+        out_colwise_sh[shmem_offset_elt_1] = out_c[0];
+        out_colwise_sh[shmem_offset_elt_2] = out_c[1];
+      }
+    }
+
+    if constexpr (ROWWISE_SCALING) {
+      const int shmem_offset_base_rowwise = buff * BUFF_DIM + thread_offset_Y_rowwise * BUFF_DIM_X;
+      thread_amax = 0.0f;
+      float in_compute_rowwise[SCALE_DIM_X];
+      Vec<IType, PACK_SIZE> in_cached[WAVES];
+      Vec<IType, PACK_SIZE> in_IType[WAVES]; // used as an IType container for BF16/FP16 --> MXFP8 CAST ONLY  
+
+      // 1. Read/Compute elements. Find MXFP8-block AMAX
+      if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+        IType thread_amax_2x[2] = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
+        #pragma unroll
+        for (int w = 0; w < WAVES; ++w) { 
+          const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
+          const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
+          const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_thread_idx;
+          // Load elements
+          in_IType[w].load_from(&in_sh[shmem_offset_rowwise]);
+          #pragma unroll
+          for (int e = 0; e < PACK_SIZE; e += 2) {
+            ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0], in_IType[w].data.elt[e]);
+          }
+        }
+        thread_amax = static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
+      } else if constexpr (IS_CACHED_ACT_OP) {
+        // ensures that all writes to cache made in the section above are visible to all threads
+        __syncthreads();
+        IType thread_amax_2x[2] = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
+        #pragma unroll
+        for (int w = 0; w < WAVES; ++w) { 
+          const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
+          const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
+          const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_thread_idx;
+
+          const bool row_out_of_bounds_rowwise = (row_base_rowwise + stage_offset_Y >= rows);
+          const bool swizzled_col_out_of_bounds = (block_offset_X + swizzled_thread_idx >= cols);
+          const bool out_of_bounds = (row_out_of_bounds_rowwise || swizzled_col_out_of_bounds);
+
+          // Load cached elements
+          in_cached[w].load_from(&cached_act_sh[shmem_offset_rowwise]);
+          // Since TMA requirement for the data alignment is 16B (i.e. cols % 8 == 0, in case of BF16 elements)
+          // only single check (w.r.t. column direction) is sufficient to be sure the entire wave is inside the boundaries  
+          if (!out_of_bounds) {
+            if constexpr (std::is_same_v<IType, float>) {
+              #pragma unroll
+              for (int e = 0; e < PACK_SIZE; ++e) {
+                thread_amax = fmaxf(thread_amax, fabsf(in_cached[w].data.elt[e]));
+              }
+            } else {
+              #pragma unroll
+              for (int e = 0; e < PACK_SIZE; e += 2) {
+                ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0], in_cached[w].data.elt[e]);
+              }
+            }
+          }
+        }
+        if constexpr (!std::is_same_v<IType, float>) {
+          thread_amax = static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
+        }
+      } else {
+        #pragma unroll
+        for (int w = 0; w < WAVES; ++w) { 
+          const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
+          const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
+          const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_thread_idx;
+  
+          Vec<IType, PACK_SIZE> in;
+          Vec<IType, PACK_SIZE> act_in;
+  
+          in.load_from(&in_sh[shmem_offset_rowwise]);
+          if constexpr (IS_DACT) {
+            act_in.load_from(&act_in_sh[shmem_offset_rowwise]);
+          }
+          #pragma unroll
+          for (int e = 0; e < PACK_SIZE; ++e) {
+            const int j = w * PACK_SIZE + e;  
+            // Compute element
+            float elt = static_cast<float>(in.data.elt[e]);
+            if constexpr (IS_ACT) {
+              elt = OP(elt, {});
+            }
+            if constexpr (IS_DACT) {
+              float act_in_elt = static_cast<float>(act_in.data.elt[e]);
+              elt *= OP(act_in_elt, {});
+            }
+  
+            // If DBIAS was computed in the 1st pass (COLWISE) then no need to compute it again
+            if constexpr (IS_DBIAS && (!COLWISE_SCALING)) {
+              thread_dbias_rowwise[j] += elt;
+            }
+            if constexpr (COMPUTE_ACTIVATIONS) {
+              const bool row_out_of_bounds_rowwise = (row_base_rowwise + stage_offset_Y >= rows);
+              const bool swizzled_col_out_of_bounds = (block_offset_X + swizzled_thread_idx >= cols);
+              const bool out_of_bounds = (row_out_of_bounds_rowwise || swizzled_col_out_of_bounds);
+              if (!out_of_bounds) {
+                thread_amax = fmaxf(thread_amax, fabsf(elt));
+              }
+            } else {
+              // If no activation, elt is 0 so we can safely do this
+              thread_amax = fmaxf(thread_amax, fabsf(elt));
+            }
+            in_compute_rowwise[j] = elt;
+          }
         }
       }
 
-      const e8m0_t biased_exponent =
-          float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
+      // 2. Compute E8M0 scaling factor
+      const e8m0_t biased_exponent = float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
       const int stage_scales_offset_Y = scales_offset_Y_rowwise + stage_offset_Y;
       const int stage_scales_offset_X = scales_offset_X_rowwise;
       const int scale_idx = stage_scales_offset_Y * scale_stride_rowwise + stage_scales_offset_X;
@@ -347,19 +405,25 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
       const float block_scale_inverse = exp2f_rcp(biased_exponent);
       const float2 block_scale_inverse_2x = make_float2(block_scale_inverse, block_scale_inverse);
-#pragma unroll
+
+      // 3. Scale elements
+      #pragma unroll
       for (int w = 0; w < WAVES; ++w) {
         Vec<OType, PACK_SIZE> out;
-#pragma unroll
+        #pragma unroll
         for (int e = 0; e < PACK_SIZE; e += 2) {
-          const int j = w * PACK_SIZE + e;
-          const float2 &in_2x = *reinterpret_cast<float2 *>(&in_compute_rowwise[j]);
-          uint16_t &out_2x = *reinterpret_cast<uint16_t *>(&out.data.elt[e]);
-          ptx::mul_cvt_2x<OType>(out_2x, in_2x, block_scale_inverse_2x);
+          if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+            ptx::mul_cvt_2x<OType, IType>(out.data.elt[e], in_IType[w].data.elt[e], block_scale_inverse_2x);
+          } else if constexpr (IS_CACHED_ACT_OP) {
+            ptx::mul_cvt_2x<OType, IType>(out.data.elt[e], in_cached[w].data.elt[e], block_scale_inverse_2x);
+          } else {
+            const int j = w * PACK_SIZE + e;
+            ptx::mul_cvt_2x<OType, float>(out.data.elt[e], in_compute_rowwise[j], block_scale_inverse_2x);
+          }
         }
-        const int swizzled_idx =
-            thread_offset_X_rowwise + ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
-        out.store_to(&out_rowwise_sh[IDX3(buff, thread_offset_Y_rowwise, swizzled_idx)]);
+        const int swizzled_idx = thread_offset_X_rowwise + ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
+        const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_idx;
+        out.store_to(&out_rowwise_sh[shmem_offset_rowwise]);
       }
     }
 
@@ -376,27 +440,23 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
     if (is_master_thread) {
       const int global_offset_Y = block_offset_Y + stage_offset_Y;
       const int global_offset_X = block_offset_X;
+      const int buff_offset = buff * BUFF_DIM;
 
       if constexpr (ROWWISE_SCALING) {
         ptx::cp_async_bulk_tensor_2d_shared_to_global(
             reinterpret_cast<const uint64_t *>(&tensor_map_output_rowwise), global_offset_X,
-            global_offset_Y, reinterpret_cast<uint64_t *>(&out_rowwise_sh[IDX(buff)]));
+            global_offset_Y, reinterpret_cast<uint64_t *>(&out_rowwise_sh[buff_offset]));
       }
       if constexpr (COLWISE_SCALING) {
         ptx::cp_async_bulk_tensor_2d_shared_to_global(
-            reinterpret_cast<const uint64_t *>(&tensor_map_output_colwise), global_offset_X,
-            global_offset_Y, reinterpret_cast<uint64_t *>(&out_colwise_sh[IDX(buff)]));
+          reinterpret_cast<const uint64_t *>(&tensor_map_output_colwise), global_offset_X,
+          global_offset_Y, reinterpret_cast<uint64_t *>(&out_colwise_sh[buff_offset]));
       }
 
       // Create a "bulk async-group" out of the previous bulk copy operation.
       ptx::cp_async_bulk_commit_group();
-
-      // Wait for TMA transfer to have finished reading shared memory.
-      ptx::cp_async_bulk_wait_group_read<1>();
     }
   }
-  ptx::cp_async_bulk_wait_group_read<0>();
-  __syncthreads();
 
   parity ^= 1;
 
@@ -406,11 +466,11 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
     if constexpr (COLWISE_SCALING) {
       thread_partial_dbias = partial_dbias_colwise;
     } else {
-#pragma unroll
+      #pragma unroll
       for (int w = 0; w < WAVES; ++w) {
         const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
         const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
-#pragma unroll
+        #pragma unroll
         for (int e = 0; e < PACK_SIZE; ++e) {
           const int j = w * PACK_SIZE + e;
           const int swizzled_lane_idx = (e + lane) % PACK_SIZE;
@@ -419,7 +479,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
         }
       }
       __syncthreads();
-#pragma unroll
+      #pragma unroll
       for (int w = 0; w < WARPS; ++w) {
         thread_partial_dbias += partial_dbias_rowwise[w][threadIdx.x];
       }
@@ -447,11 +507,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   destroy_barriers<STAGES>(mbar, is_master_thread);
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
 }
-
-#undef IDX3
-#undef IDX2
-#undef IDX
-}  // namespace mxfp8_kernel
+} // namespace mxfp8_kernel
 
 constexpr size_t FP8_CHUNK_DIM_Y = 128;
 constexpr size_t FP8_CHUNK_DIM_X = 128;
@@ -910,14 +966,6 @@ void cast_fp8_2D(const Tensor &input, const Tensor *act_input, Tensor *output, T
   );           // NOLINT(*)
 }
 
-template <typename ParamOP, float (*OP)(float, const ParamOP &)>
-constexpr bool is_cached_act_op() {
-  return (OP == gelu<float, float>) || (OP == dgelu<float, float>) ||
-         (OP == sigmoid<float, float>) || (OP == dsigmoid<float, float>) ||
-         (OP == qgelu<float, float>) || (OP == dqgelu<float, float>) ||
-         (OP == silu<float, float>) || (OP == dsilu<float, float>);
-}
-
 template <bool IS_DBIAS, bool IS_DACT, bool IS_ACT, typename ParamOP,
           float (*OP)(float, const ParamOP &)>
 void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
@@ -943,26 +991,31 @@ void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
   const size_t rows = input.flat_first_dim();
   const size_t cols = input.flat_last_dim();
 
-  const size_t block_dim_Y = mxfp8_kernel::CHUNK_DIM_Y;
-  const size_t block_dim_X = mxfp8_kernel::CHUNK_DIM_X;
-  const size_t buff_dim_Y = mxfp8_kernel::BUFF_DIM_Y;
-  const size_t buff_dim_X = mxfp8_kernel::BUFF_DIM_X;
-  const size_t buffs_num = mxfp8_kernel::BUFFS_NUM;
-  const size_t threads_per_block = mxfp8_kernel::THREADS_PER_CHUNK;
+  constexpr bool CAST_DBIAS_ONLY = IS_DBIAS && (!IS_DACT) && (!IS_ACT);
 
-  const size_t blocks_Y = DIVUP(rows, block_dim_Y);
-  const size_t blocks_X = DIVUP(cols, block_dim_X);
+  constexpr size_t CHUNK_DIM_Y       = CAST_DBIAS_ONLY ? 128 : 64;
+  constexpr size_t CHUNK_DIM_X       = CAST_DBIAS_ONLY ? 128 : 64;
+  constexpr size_t THREADS_PER_CHUNK = CAST_DBIAS_ONLY ? 128 : 64;
+
+  constexpr size_t THREADS_X = CHUNK_DIM_X / SCALE_DIM_X;
+  constexpr size_t THREADS_Y = THREADS_PER_CHUNK / THREADS_X;
+  constexpr size_t BUFF_DIM_Y = THREADS_Y;
+  constexpr size_t BUFF_DIM_X = CHUNK_DIM_X;
+
+  const size_t blocks_Y = DIVUP(rows, CHUNK_DIM_Y);
+  const size_t blocks_X = DIVUP(cols, CHUNK_DIM_X);
   const dim3 grid(blocks_X, blocks_Y);
-  const size_t block_size = threads_per_block;
+  const size_t block_size = THREADS_PER_CHUNK;
 
   const size_t scale_stride_rowwise = use_rowwise_scaling ? output->scale_inv.shape[1] : 1;
-  const size_t scale_stride_colwise =
-      use_colwise_scaling ? output->columnwise_scale_inv.shape[1] : 1;
+  const size_t scale_stride_colwise = use_colwise_scaling ? output->columnwise_scale_inv.shape[1] : 1;
 
-  e8m0_t *const scales_rowwise_ptr =
-      use_rowwise_scaling ? reinterpret_cast<e8m0_t *>(output->scale_inv.dptr) : nullptr;
-  e8m0_t *const scales_colwise_ptr =
-      use_colwise_scaling ? reinterpret_cast<e8m0_t *>(output->columnwise_scale_inv.dptr) : nullptr;
+  e8m0_t *const scales_rowwise_ptr = use_rowwise_scaling
+                                     ? reinterpret_cast<e8m0_t *>(output->scale_inv.dptr)
+                                     : nullptr;
+  e8m0_t *const scales_colwise_ptr = use_colwise_scaling
+                                     ? reinterpret_cast<e8m0_t *>(output->columnwise_scale_inv.dptr)
+                                     : nullptr;
   const size_t dbias_rows = blocks_Y;
   const size_t dbias_cols = cols;
 
@@ -989,102 +1042,100 @@ void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
 
   float *const workspace_ptr = IS_DBIAS ? reinterpret_cast<float *>(workspace->data.dptr) : nullptr;
   float *const amax_ptr = reinterpret_cast<float *>(output->amax.dptr);
-  const float *noop_ptr = reinterpret_cast<const float *>(noop->data.dptr);
+  const float * noop_ptr = reinterpret_cast<const float *>(noop->data.dptr);
 
-  TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
-      input.dtype(), IType,
-      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(
-          output->dtype(), OType,
-
+  TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(input.dtype(), IType,
+      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(output->dtype(), OType,
           alignas(64) CUtensorMap tensor_map_input{};
           alignas(64) CUtensorMap tensor_map_act_input{};
           alignas(64) CUtensorMap tensor_map_output_rowwise{};
           alignas(64) CUtensorMap tensor_map_output_colwise{};
 
-          create_2D_tensor_map(tensor_map_input, input.data, rows, cols, buff_dim_Y, buff_dim_X,
-                               cols, 0, sizeof(IType));
+          create_2D_tensor_map(tensor_map_input, input.data, rows, cols,
+                               BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(IType));
 
           if constexpr (IS_DACT) {
-            create_2D_tensor_map(tensor_map_act_input, act_input->data, rows, cols, buff_dim_Y,
-                                 buff_dim_X, cols, 0, sizeof(IType));
+            create_2D_tensor_map(tensor_map_act_input, act_input->data, rows, cols,
+                                 BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(IType));
           }
 
           if (use_rowwise_scaling) {
-            create_2D_tensor_map(tensor_map_output_rowwise, output->data, rows, cols, buff_dim_Y,
-                                 buff_dim_X, cols, 0, sizeof(OType));
+            create_2D_tensor_map(tensor_map_output_rowwise, output->data, rows, cols,
+                                 BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(OType));
           }
 
           if (use_colwise_scaling) {
             create_2D_tensor_map(tensor_map_output_colwise, output->columnwise_data, rows, cols,
-                                 buff_dim_Y, buff_dim_X, cols, 0, sizeof(OType));
+                                 BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(OType));
           }
+          constexpr size_t buff_elems = BUFF_DIM_Y * BUFF_DIM_X;
+          constexpr size_t buff_elems_total = mxfp8_kernel::BUFFS_NUM * buff_elems;
+          constexpr size_t buff_size_aligned_in = DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
+          constexpr size_t buff_size_aligned_out = DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
 
-          const size_t buff_elems = buff_dim_Y * buff_dim_X;
-          const size_t buff_elems_total = buffs_num * buff_elems;
-          const size_t buff_size_aligned_in =
-              DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
-          const size_t buff_size_aligned_out =
-              DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
-          const size_t buff_size_aligned_cache =
-              DIVUP(buff_elems * sizeof(float), ALIGNMENT) * ALIGNMENT;
-
-          const size_t elt_input_mem = buff_size_aligned_in;
-          const size_t act_input_mem = (IS_DACT ? buff_size_aligned_in : 0);
-          const size_t in_mem = elt_input_mem + act_input_mem;
+          constexpr size_t elt_input_mem = buff_size_aligned_in;
+          constexpr size_t act_input_mem = (IS_DACT ? buff_size_aligned_in : 0);
+          constexpr size_t in_mem = elt_input_mem + act_input_mem;
 
           const size_t out_rowwise_mem = (use_rowwise_scaling ? buff_size_aligned_out : 0);
           const size_t out_colwise_mem = (use_colwise_scaling ? buff_size_aligned_out : 0);
           const size_t out_mem = out_rowwise_mem + out_colwise_mem;
 
-          constexpr bool IS_CACHED_ACT_OP = (IS_DACT || IS_ACT) && is_cached_act_op<ParamOP, OP>();
-          const bool cache_activations =
-              IS_CACHED_ACT_OP && (scaling_type == ScalingType::BIDIMENSIONAL);
-          const size_t cache_buff_mem = (cache_activations ? buff_size_aligned_cache : 0);
-
-          // TODO: Cache Activations
-          // const size_t dshmem_size = in_mem + out_mem + cache_buff_mem;
           const size_t dshmem_size = in_mem + out_mem;
 
           switch (scaling_type) {
             case ScalingType::ROWWISE:
-              cudaFuncSetAttribute(cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP,
-                                                        IType, OType, true, false, false>,
-                                   cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
+              cudaFuncSetAttribute(cast_mxfp8_2D_kernel
+                    <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, false,
+                     CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
+                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size
+              );
 
-              cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true,
-                                   false, false><<<grid, block_size, dshmem_size, stream>>>(
-                  tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
-                  tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
-                  workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise);
+              cast_mxfp8_2D_kernel
+                <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, false,
+                 CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
+                <<<grid, block_size, dshmem_size, stream>>>
+                    (tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
+                    tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr,
+                    noop_ptr, workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise); 
               break;
             case ScalingType::COLWISE:
-              cudaFuncSetAttribute(cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP,
-                                                        IType, OType, false, true, false>,
-                                   cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
-
-              cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false,
-                                   true, false><<<grid, block_size, dshmem_size, stream>>>(
-                  tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
-                  tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
-                  workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise);
+              cudaFuncSetAttribute(cast_mxfp8_2D_kernel
+                    <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false, true,
+                    CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
+                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size
+              );
+            
+              cast_mxfp8_2D_kernel
+                <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false, true,
+                 CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
+                <<<grid, block_size, dshmem_size, stream>>>
+                    (tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
+                    tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr,
+                    noop_ptr, workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise); 
               break;
             case ScalingType::BIDIMENSIONAL:
-              cudaFuncSetAttribute(cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP,
-                                                        IType, OType, true, true, IS_CACHED_ACT_OP>,
-                                   cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
-
-              cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, true,
-                                   IS_CACHED_ACT_OP><<<grid, block_size, dshmem_size, stream>>>(
-                  tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
-                  tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
-                  workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise);
+              cudaFuncSetAttribute(cast_mxfp8_2D_kernel
+                    <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, true,
+                     CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
+                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size
+              );
+            
+              cast_mxfp8_2D_kernel
+                <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, true,
+                 CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
+                <<<grid, block_size, dshmem_size, stream>>>
+                    (tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
+                    tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr,
+                    noop_ptr, workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise); 
               break;
           }
 
           if constexpr (IS_DBIAS) {
             reduce_dbias<IType>(workspace_ptr, dbias, dbias_rows, dbias_cols, stream);
-          });  // NOLINT(*)
-  );           // NOLINT(*)
+          }
+      );  // NOLINT(*)
+  );  // NOLINT(*)
 }
 
 namespace detail {
@@ -1329,3 +1380,4 @@ void quantize_helper(const NVTETensor input, const NVTETensor grad, const NVTETe
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_CAST_KERNELS_CUH_
+

--- a/transformer_engine/common/util/cast_kernels.cuh
+++ b/transformer_engine/common/util/cast_kernels.cuh
@@ -153,7 +153,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   if constexpr (IS_DBIAS) {
 #pragma unroll
     for (int j = 0; j < SCALE_DIM_X; ++j) {
-      thread_dbias_rowwise[SCALE_DIM_X] = 0.0f;
+      thread_dbias_rowwise[j] = 0.0f;
     }
   }
 

--- a/transformer_engine/common/util/cast_kernels.cuh
+++ b/transformer_engine/common/util/cast_kernels.cuh
@@ -40,28 +40,25 @@ constexpr size_t PACK_SIZE = 4;
 constexpr size_t WAVES = SCALE_DIM_X / PACK_SIZE;
 
 template <typename ParamOP, float (*OP)(float, const ParamOP &)>
-constexpr __device__ __forceinline__ bool
-is_cached_act_op() {
-  return (OP ==    gelu<float,float>) || (OP ==    dgelu<float,float>) ||
-         (OP == sigmoid<float,float>) || (OP == dsigmoid<float,float>) ||
-         (OP ==   qgelu<float,float>) || (OP ==   dqgelu<float,float>) || 
-         (OP ==    silu<float,float>) || (OP ==    dsilu<float,float>);
+constexpr __device__ __forceinline__ bool is_cached_act_op() {
+  return (OP == gelu<float, float>) || (OP == dgelu<float, float>) ||
+         (OP == sigmoid<float, float>) || (OP == dsigmoid<float, float>) ||
+         (OP == qgelu<float, float>) || (OP == dqgelu<float, float>) ||
+         (OP == silu<float, float>) || (OP == dsilu<float, float>);
 }
 
 template <bool IS_DBIAS, bool IS_DACT, bool IS_ACT, typename ParamOP,
-          float (*OP)(float, const ParamOP &), typename IType, typename OType,
-          bool ROWWISE_SCALING, bool COLWISE_SCALING,
-          size_t CHUNK_DIM_Y, size_t CHUNK_DIM_X, size_t THREADS_PER_CHUNK>
+          float (*OP)(float, const ParamOP &), typename IType, typename OType, bool ROWWISE_SCALING,
+          bool COLWISE_SCALING, size_t CHUNK_DIM_Y, size_t CHUNK_DIM_X, size_t THREADS_PER_CHUNK>
 __global__ void __launch_bounds__(THREADS_PER_CHUNK)
     cast_mxfp8_2D_kernel(const __grid_constant__ CUtensorMap tensor_map_input,
                          const __grid_constant__ CUtensorMap tensor_map_act_input,
                          const __grid_constant__ CUtensorMap tensor_map_output_rowwise,
                          const __grid_constant__ CUtensorMap tensor_map_output_colwise,
                          e8m0_t *const scales_rowwise, e8m0_t *const scales_colwise,
-                         const float *noop, float *const dbias_workspace,
-                         float *const amax_ptr, const size_t rows, const size_t cols,
-                         const size_t scale_stride_rowwise, const size_t scale_stride_colwise)
-{
+                         const float *noop, float *const dbias_workspace, float *const amax_ptr,
+                         const size_t rows, const size_t cols, const size_t scale_stride_rowwise,
+                         const size_t scale_stride_colwise) {
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
   constexpr bool COMPUTE_ACTIVATIONS = IS_DACT || IS_ACT;
   constexpr bool NO_ACTIVATIONS = !COMPUTE_ACTIVATIONS;
@@ -84,8 +81,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   constexpr size_t STAGES = CHUNK_DIM_Y / BUFF_DIM_Y;
   static_assert(STAGES >= 1);
 
-  constexpr bool IS_CACHED_ACT_OP = COMPUTE_ACTIVATIONS && ROWWISE_SCALING && COLWISE_SCALING
-                                    && is_cached_act_op<ParamOP, OP>();
+  constexpr bool IS_CACHED_ACT_OP =
+      COMPUTE_ACTIVATIONS && ROWWISE_SCALING && COLWISE_SCALING && is_cached_act_op<ParamOP, OP>();
 
   const int block_offset_Y = blockIdx.y * CHUNK_DIM_Y;
   const int block_offset_X = blockIdx.x * CHUNK_DIM_X;
@@ -118,16 +115,19 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   const int scales_offset_Y_colwise = scales_block_offset_Y_colwise + tid_Y_colwise;
   const int scales_offset_X_colwise = scales_block_offset_X_colwise + tid_X_colwise;
 
-  const int thread_group = tid_Y_rowwise % (THREADS_PER_WARP / THREADS_X);   // helps to resolve bank conflicts in shmem
-  const int lane = tid_X_rowwise;   // helps to resolve bank conflicts in shmem
+  const int thread_group =
+      tid_Y_rowwise % (THREADS_PER_WARP / THREADS_X);  // helps to resolve bank conflicts in shmem
+  const int lane = tid_X_rowwise;                      // helps to resolve bank conflicts in shmem
   const int thread_lane = threadIdx.x % THREADS_PER_WARP;
 
   extern __shared__ __align__(128) char dshmem[];
 
   constexpr size_t buff_elems = BUFF_DIM_Y * BUFF_DIM_X;
   constexpr size_t buff_elems_total = BUFFS_NUM * buff_elems;
-  constexpr size_t buff_size_aligned_in = DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
-  constexpr size_t buff_size_aligned_out = DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
+  constexpr size_t buff_size_aligned_in =
+      DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
+  constexpr size_t buff_size_aligned_out =
+      DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
 
   constexpr size_t elt_input_mem = buff_size_aligned_in;
   constexpr size_t act_input_mem = (IS_DACT ? buff_size_aligned_in : 0);
@@ -142,7 +142,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   IType *act_in_sh = reinterpret_cast<IType *>(dshmem + elt_input_mem);
   OType *out_rowwise_sh = reinterpret_cast<OType *>(dshmem + in_mem);
   OType *out_colwise_sh = reinterpret_cast<OType *>(dshmem + in_mem + out_mem_rowwise);
-  IType *cached_act_sh = in_sh; // in_sh is used as a cache buffer
+  IType *cached_act_sh = in_sh;  // in_sh is used as a cache buffer
 
   constexpr int shmem_buff_size = buff_size_aligned_in / BUFFS_NUM;
 
@@ -151,7 +151,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   float partial_dbias_colwise = 0.0f;
   float thread_dbias_rowwise[SCALE_DIM_X];
   if constexpr (IS_DBIAS) {
-    #pragma unroll
+#pragma unroll
     for (int j = 0; j < SCALE_DIM_X; ++j) {
       thread_dbias_rowwise[SCALE_DIM_X] = 0.0f;
     }
@@ -159,8 +159,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
   float block_amax = 0.0f;
 
-  // Initialize shared memory barrier with the number of threads participating in the barrier.
-  #pragma nv_diag_suppress static_var_with_dynamic_init
+// Initialize shared memory barrier with the number of threads participating in the barrier.
+#pragma nv_diag_suppress static_var_with_dynamic_init
   __shared__ alignas(8) uint64_t mbar[STAGES];
 
   initialize_barriers<STAGES, THREADS_PER_CHUNK>(mbar, is_master_thread);
@@ -168,15 +168,15 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   int parity = 0;
 
   if constexpr (IS_DACT) {
-    copy_2d_to_sharedx2(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y,
-                        &act_in_sh[0], &tensor_map_act_input, block_offset_X, block_offset_Y,
-                        shmem_buff_size, &mbar[0], is_master_thread);
+    copy_2d_to_sharedx2(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y, &act_in_sh[0],
+                        &tensor_map_act_input, block_offset_X, block_offset_Y, shmem_buff_size,
+                        &mbar[0], is_master_thread);
   } else {
-    copy_2d_to_shared(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y,
-                      shmem_buff_size, &mbar[0], is_master_thread);
+    copy_2d_to_shared(&in_sh[0], &tensor_map_input, block_offset_X, block_offset_Y, shmem_buff_size,
+                      &mbar[0], is_master_thread);
   }
 
-  #pragma unroll
+#pragma unroll
   for (int stage = 0; stage < STAGES; ++stage) {
     const int buff = stage % BUFFS_NUM;
     const int next_stage = stage + 1;
@@ -193,12 +193,13 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       const int global_offset_X = block_offset_X;
       const int next_buff_offset = next_buff * BUFF_DIM;
       if constexpr (IS_DACT) {
-        copy_2d_to_sharedx2(&in_sh[next_buff_offset], &tensor_map_input, global_offset_X, global_offset_Y,
-                            &act_in_sh[next_buff_offset], &tensor_map_act_input, global_offset_X, global_offset_Y,
-                            shmem_buff_size, &mbar[next_stage], is_master_thread);
+        copy_2d_to_sharedx2(&in_sh[next_buff_offset], &tensor_map_input, global_offset_X,
+                            global_offset_Y, &act_in_sh[next_buff_offset], &tensor_map_act_input,
+                            global_offset_X, global_offset_Y, shmem_buff_size, &mbar[next_stage],
+                            is_master_thread);
       } else {
-        copy_2d_to_shared(&in_sh[next_buff_offset], &tensor_map_input, global_offset_X, global_offset_Y,
-                          shmem_buff_size, &mbar[next_stage], is_master_thread);
+        copy_2d_to_shared(&in_sh[next_buff_offset], &tensor_map_input, global_offset_X,
+                          global_offset_Y, shmem_buff_size, &mbar[next_stage], is_master_thread);
       }
     }
 
@@ -213,24 +214,25 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       thread_amax = 0.0f;
       float in_compute_colwise[BUFF_DIM_Y];
       IType in_colwise_IType[BUFF_DIM_Y];
-      
+
       // 1. Read/Compute elements. Find MXFP8-block AMAX
       if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
         IType thread_amax_2x[2] = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < BUFF_DIM_Y; i += 2) {
           const int shmem_offset_colwise_elt1 = shmem_offset_base_colwise + i * BUFF_DIM_X;
           const int shmem_offset_colwise_elt2 = shmem_offset_base_colwise + (i + 1) * BUFF_DIM_X;
-          in_colwise_IType[i] = in_sh[shmem_offset_colwise_elt1];         
-          in_colwise_IType[i+1] = in_sh[shmem_offset_colwise_elt2];         
+          in_colwise_IType[i] = in_sh[shmem_offset_colwise_elt1];
+          in_colwise_IType[i + 1] = in_sh[shmem_offset_colwise_elt2];
           ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0], in_colwise_IType[i]);
         }
-        thread_amax = static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
+        thread_amax =
+            static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
       } else {
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < BUFF_DIM_Y; ++i) {
           const int shmem_offset_colwise = shmem_offset_base_colwise + i * BUFF_DIM_X;
-  
+
           float elt = static_cast<float>(in_sh[shmem_offset_colwise]);
           if constexpr (IS_ACT) {
             elt = OP(elt, {});
@@ -238,15 +240,15 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           if constexpr (IS_DACT) {
             float act_in_elt = static_cast<float>(act_in_sh[shmem_offset_colwise]);
             elt *= OP(act_in_elt, {});
-          } 
+          }
           if constexpr (IS_DBIAS) {
             partial_dbias_colwise += elt;
           }
-          // Cache computed activations to avoid computing them again in the 2nd pass along another dimension 
+          // Cache computed activations to avoid computing them again in the 2nd pass along another dimension
           if constexpr (IS_CACHED_ACT_OP) {
             cached_act_sh[shmem_offset_colwise] = static_cast<IType>(elt);
           }
-          
+
           if constexpr (COMPUTE_ACTIVATIONS) {
             const bool row_out_of_bounds_colwise = (row_base_colwise + stage_offset_Y + i >= rows);
             const bool out_of_bounds = (col_out_of_bounds_colwise || row_out_of_bounds_colwise);
@@ -260,30 +262,31 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           in_compute_colwise[i] = elt;
         }
       }
-  
+
       // 2. Compute E8M0 scaling factor
-      const e8m0_t biased_exponent = float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
-  
+      const e8m0_t biased_exponent =
+          float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
+
       const int global_scales_offset_Y = scales_offset_Y_colwise + stage;
       const int global_scales_offset_X = scales_offset_X_colwise;
       const int scale_idx = global_scales_offset_Y * scale_stride_colwise + global_scales_offset_X;
       scales_colwise[scale_idx] = biased_exponent;
-  
+
       const float block_scale_inverse = exp2f_rcp(biased_exponent);
       const float2 block_scale_inverse_2x = make_float2(block_scale_inverse, block_scale_inverse);
-  
-      // 3. Scale elements
-      #pragma unroll
+
+// 3. Scale elements
+#pragma unroll
       for (int i = 0; i < SCALE_DIM_Y; i += 2) {
         OType out_c[2];
         static_assert(sizeof(OType) == 1);
-        
+
         if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
           ptx::mul_cvt_2x<OType, IType>(out_c[0], in_colwise_IType[i], block_scale_inverse_2x);
         } else {
           ptx::mul_cvt_2x<OType, float>(out_c[0], in_compute_colwise[i], block_scale_inverse_2x);
         }
-        
+
         const int shmem_offset_elt_1 = shmem_offset_base_colwise + i * BUFF_DIM_X;
         const int shmem_offset_elt_2 = shmem_offset_base_colwise + (i + 1) * BUFF_DIM_X;
         out_colwise_sh[shmem_offset_elt_1] = out_c[0];
@@ -296,30 +299,32 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       thread_amax = 0.0f;
       float in_compute_rowwise[SCALE_DIM_X];
       Vec<IType, PACK_SIZE> in_cached[WAVES];
-      Vec<IType, PACK_SIZE> in_IType[WAVES]; // used as an IType container for BF16/FP16 --> MXFP8 CAST ONLY  
+      Vec<IType, PACK_SIZE>
+          in_IType[WAVES];  // used as an IType container for BF16/FP16 --> MXFP8 CAST ONLY
 
       // 1. Read/Compute elements. Find MXFP8-block AMAX
       if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
         IType thread_amax_2x[2] = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
-        #pragma unroll
-        for (int w = 0; w < WAVES; ++w) { 
+#pragma unroll
+        for (int w = 0; w < WAVES; ++w) {
           const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
           const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
           const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_thread_idx;
           // Load elements
           in_IType[w].load_from(&in_sh[shmem_offset_rowwise]);
-          #pragma unroll
+#pragma unroll
           for (int e = 0; e < PACK_SIZE; e += 2) {
             ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0], in_IType[w].data.elt[e]);
           }
         }
-        thread_amax = static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
+        thread_amax =
+            static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
       } else if constexpr (IS_CACHED_ACT_OP) {
         // ensures that all writes to cache made in the section above are visible to all threads
         __syncthreads();
         IType thread_amax_2x[2] = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
-        #pragma unroll
-        for (int w = 0; w < WAVES; ++w) { 
+#pragma unroll
+        for (int w = 0; w < WAVES; ++w) {
           const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
           const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
           const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_thread_idx;
@@ -331,41 +336,43 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           // Load cached elements
           in_cached[w].load_from(&cached_act_sh[shmem_offset_rowwise]);
           // Since TMA requirement for the data alignment is 16B (i.e. cols % 8 == 0, in case of BF16 elements)
-          // only single check (w.r.t. column direction) is sufficient to be sure the entire wave is inside the boundaries  
+          // only single check (w.r.t. column direction) is sufficient to be sure the entire wave is inside the boundaries
           if (!out_of_bounds) {
             if constexpr (std::is_same_v<IType, float>) {
-              #pragma unroll
+#pragma unroll
               for (int e = 0; e < PACK_SIZE; ++e) {
                 thread_amax = fmaxf(thread_amax, fabsf(in_cached[w].data.elt[e]));
               }
             } else {
-              #pragma unroll
+#pragma unroll
               for (int e = 0; e < PACK_SIZE; e += 2) {
-                ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0], in_cached[w].data.elt[e]);
+                ptx::abs_max_2x<IType>(thread_amax_2x[0], thread_amax_2x[0],
+                                       in_cached[w].data.elt[e]);
               }
             }
           }
         }
         if constexpr (!std::is_same_v<IType, float>) {
-          thread_amax = static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
+          thread_amax =
+              static_cast<float>(__hmax(__habs(thread_amax_2x[0]), __habs(thread_amax_2x[1])));
         }
       } else {
-        #pragma unroll
-        for (int w = 0; w < WAVES; ++w) { 
+#pragma unroll
+        for (int w = 0; w < WAVES; ++w) {
           const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
           const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
           const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_thread_idx;
-  
+
           Vec<IType, PACK_SIZE> in;
           Vec<IType, PACK_SIZE> act_in;
-  
+
           in.load_from(&in_sh[shmem_offset_rowwise]);
           if constexpr (IS_DACT) {
             act_in.load_from(&act_in_sh[shmem_offset_rowwise]);
           }
-          #pragma unroll
+#pragma unroll
           for (int e = 0; e < PACK_SIZE; ++e) {
-            const int j = w * PACK_SIZE + e;  
+            const int j = w * PACK_SIZE + e;
             // Compute element
             float elt = static_cast<float>(in.data.elt[e]);
             if constexpr (IS_ACT) {
@@ -375,14 +382,15 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
               float act_in_elt = static_cast<float>(act_in.data.elt[e]);
               elt *= OP(act_in_elt, {});
             }
-  
+
             // If DBIAS was computed in the 1st pass (COLWISE) then no need to compute it again
             if constexpr (IS_DBIAS && (!COLWISE_SCALING)) {
               thread_dbias_rowwise[j] += elt;
             }
             if constexpr (COMPUTE_ACTIVATIONS) {
               const bool row_out_of_bounds_rowwise = (row_base_rowwise + stage_offset_Y >= rows);
-              const bool swizzled_col_out_of_bounds = (block_offset_X + swizzled_thread_idx >= cols);
+              const bool swizzled_col_out_of_bounds =
+                  (block_offset_X + swizzled_thread_idx >= cols);
               const bool out_of_bounds = (row_out_of_bounds_rowwise || swizzled_col_out_of_bounds);
               if (!out_of_bounds) {
                 thread_amax = fmaxf(thread_amax, fabsf(elt));
@@ -397,7 +405,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       }
 
       // 2. Compute E8M0 scaling factor
-      const e8m0_t biased_exponent = float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
+      const e8m0_t biased_exponent =
+          float_to_e8m0(thread_amax * Quantized_Limits<OType>::max_norm_rcp);
       const int stage_scales_offset_Y = scales_offset_Y_rowwise + stage_offset_Y;
       const int stage_scales_offset_X = scales_offset_X_rowwise;
       const int scale_idx = stage_scales_offset_Y * scale_stride_rowwise + stage_scales_offset_X;
@@ -406,22 +415,26 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       const float block_scale_inverse = exp2f_rcp(biased_exponent);
       const float2 block_scale_inverse_2x = make_float2(block_scale_inverse, block_scale_inverse);
 
-      // 3. Scale elements
-      #pragma unroll
+// 3. Scale elements
+#pragma unroll
       for (int w = 0; w < WAVES; ++w) {
         Vec<OType, PACK_SIZE> out;
-        #pragma unroll
+#pragma unroll
         for (int e = 0; e < PACK_SIZE; e += 2) {
           if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
-            ptx::mul_cvt_2x<OType, IType>(out.data.elt[e], in_IType[w].data.elt[e], block_scale_inverse_2x);
+            ptx::mul_cvt_2x<OType, IType>(out.data.elt[e], in_IType[w].data.elt[e],
+                                          block_scale_inverse_2x);
           } else if constexpr (IS_CACHED_ACT_OP) {
-            ptx::mul_cvt_2x<OType, IType>(out.data.elt[e], in_cached[w].data.elt[e], block_scale_inverse_2x);
+            ptx::mul_cvt_2x<OType, IType>(out.data.elt[e], in_cached[w].data.elt[e],
+                                          block_scale_inverse_2x);
           } else {
             const int j = w * PACK_SIZE + e;
-            ptx::mul_cvt_2x<OType, float>(out.data.elt[e], in_compute_rowwise[j], block_scale_inverse_2x);
+            ptx::mul_cvt_2x<OType, float>(out.data.elt[e], in_compute_rowwise[j],
+                                          block_scale_inverse_2x);
           }
         }
-        const int swizzled_idx = thread_offset_X_rowwise + ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
+        const int swizzled_idx =
+            thread_offset_X_rowwise + ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
         const int shmem_offset_rowwise = shmem_offset_base_rowwise + swizzled_idx;
         out.store_to(&out_rowwise_sh[shmem_offset_rowwise]);
       }
@@ -449,8 +462,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       }
       if constexpr (COLWISE_SCALING) {
         ptx::cp_async_bulk_tensor_2d_shared_to_global(
-          reinterpret_cast<const uint64_t *>(&tensor_map_output_colwise), global_offset_X,
-          global_offset_Y, reinterpret_cast<uint64_t *>(&out_colwise_sh[buff_offset]));
+            reinterpret_cast<const uint64_t *>(&tensor_map_output_colwise), global_offset_X,
+            global_offset_Y, reinterpret_cast<uint64_t *>(&out_colwise_sh[buff_offset]));
       }
 
       // Create a "bulk async-group" out of the previous bulk copy operation.
@@ -466,11 +479,11 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
     if constexpr (COLWISE_SCALING) {
       thread_partial_dbias = partial_dbias_colwise;
     } else {
-      #pragma unroll
+#pragma unroll
       for (int w = 0; w < WAVES; ++w) {
         const int swizzled_group_idx = ((w + thread_group) * PACK_SIZE) % SCALE_DIM_X;
         const int swizzled_thread_idx = thread_offset_X_rowwise + swizzled_group_idx;
-        #pragma unroll
+#pragma unroll
         for (int e = 0; e < PACK_SIZE; ++e) {
           const int j = w * PACK_SIZE + e;
           const int swizzled_lane_idx = (e + lane) % PACK_SIZE;
@@ -479,7 +492,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
         }
       }
       __syncthreads();
-      #pragma unroll
+#pragma unroll
       for (int w = 0; w < WARPS; ++w) {
         thread_partial_dbias += partial_dbias_rowwise[w][threadIdx.x];
       }
@@ -507,7 +520,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   destroy_barriers<STAGES>(mbar, is_master_thread);
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
 }
-} // namespace mxfp8_kernel
+}  // namespace mxfp8_kernel
 
 constexpr size_t FP8_CHUNK_DIM_Y = 128;
 constexpr size_t FP8_CHUNK_DIM_X = 128;
@@ -993,8 +1006,8 @@ void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
 
   constexpr bool CAST_DBIAS_ONLY = IS_DBIAS && (!IS_DACT) && (!IS_ACT);
 
-  constexpr size_t CHUNK_DIM_Y       = CAST_DBIAS_ONLY ? 128 : 64;
-  constexpr size_t CHUNK_DIM_X       = CAST_DBIAS_ONLY ? 128 : 64;
+  constexpr size_t CHUNK_DIM_Y = CAST_DBIAS_ONLY ? 128 : 64;
+  constexpr size_t CHUNK_DIM_X = CAST_DBIAS_ONLY ? 128 : 64;
   constexpr size_t THREADS_PER_CHUNK = CAST_DBIAS_ONLY ? 128 : 64;
 
   constexpr size_t THREADS_X = CHUNK_DIM_X / SCALE_DIM_X;
@@ -1008,14 +1021,13 @@ void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
   const size_t block_size = THREADS_PER_CHUNK;
 
   const size_t scale_stride_rowwise = use_rowwise_scaling ? output->scale_inv.shape[1] : 1;
-  const size_t scale_stride_colwise = use_colwise_scaling ? output->columnwise_scale_inv.shape[1] : 1;
+  const size_t scale_stride_colwise =
+      use_colwise_scaling ? output->columnwise_scale_inv.shape[1] : 1;
 
-  e8m0_t *const scales_rowwise_ptr = use_rowwise_scaling
-                                     ? reinterpret_cast<e8m0_t *>(output->scale_inv.dptr)
-                                     : nullptr;
-  e8m0_t *const scales_colwise_ptr = use_colwise_scaling
-                                     ? reinterpret_cast<e8m0_t *>(output->columnwise_scale_inv.dptr)
-                                     : nullptr;
+  e8m0_t *const scales_rowwise_ptr =
+      use_rowwise_scaling ? reinterpret_cast<e8m0_t *>(output->scale_inv.dptr) : nullptr;
+  e8m0_t *const scales_colwise_ptr =
+      use_colwise_scaling ? reinterpret_cast<e8m0_t *>(output->columnwise_scale_inv.dptr) : nullptr;
   const size_t dbias_rows = blocks_Y;
   const size_t dbias_cols = cols;
 
@@ -1042,36 +1054,38 @@ void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
 
   float *const workspace_ptr = IS_DBIAS ? reinterpret_cast<float *>(workspace->data.dptr) : nullptr;
   float *const amax_ptr = reinterpret_cast<float *>(output->amax.dptr);
-  const float * noop_ptr = reinterpret_cast<const float *>(noop->data.dptr);
+  const float *noop_ptr = reinterpret_cast<const float *>(noop->data.dptr);
 
-  TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(input.dtype(), IType,
-      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(output->dtype(), OType,
-          alignas(64) CUtensorMap tensor_map_input{};
+  TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(
+      input.dtype(), IType,
+      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(
+          output->dtype(), OType, alignas(64) CUtensorMap tensor_map_input{};
           alignas(64) CUtensorMap tensor_map_act_input{};
           alignas(64) CUtensorMap tensor_map_output_rowwise{};
           alignas(64) CUtensorMap tensor_map_output_colwise{};
 
-          create_2D_tensor_map(tensor_map_input, input.data, rows, cols,
-                               BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(IType));
+          create_2D_tensor_map(tensor_map_input, input.data, rows, cols, BUFF_DIM_Y, BUFF_DIM_X,
+                               cols, 0, sizeof(IType));
 
           if constexpr (IS_DACT) {
-            create_2D_tensor_map(tensor_map_act_input, act_input->data, rows, cols,
-                                 BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(IType));
+            create_2D_tensor_map(tensor_map_act_input, act_input->data, rows, cols, BUFF_DIM_Y,
+                                 BUFF_DIM_X, cols, 0, sizeof(IType));
           }
 
           if (use_rowwise_scaling) {
-            create_2D_tensor_map(tensor_map_output_rowwise, output->data, rows, cols,
-                                 BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(OType));
+            create_2D_tensor_map(tensor_map_output_rowwise, output->data, rows, cols, BUFF_DIM_Y,
+                                 BUFF_DIM_X, cols, 0, sizeof(OType));
           }
 
           if (use_colwise_scaling) {
             create_2D_tensor_map(tensor_map_output_colwise, output->columnwise_data, rows, cols,
                                  BUFF_DIM_Y, BUFF_DIM_X, cols, 0, sizeof(OType));
-          }
-          constexpr size_t buff_elems = BUFF_DIM_Y * BUFF_DIM_X;
+          } constexpr size_t buff_elems = BUFF_DIM_Y * BUFF_DIM_X;
           constexpr size_t buff_elems_total = mxfp8_kernel::BUFFS_NUM * buff_elems;
-          constexpr size_t buff_size_aligned_in = DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
-          constexpr size_t buff_size_aligned_out = DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
+          constexpr size_t buff_size_aligned_in =
+              DIVUP(buff_elems_total * sizeof(IType), ALIGNMENT) * ALIGNMENT;
+          constexpr size_t buff_size_aligned_out =
+              DIVUP(buff_elems_total * sizeof(OType), ALIGNMENT) * ALIGNMENT;
 
           constexpr size_t elt_input_mem = buff_size_aligned_in;
           constexpr size_t act_input_mem = (IS_DACT ? buff_size_aligned_in : 0);
@@ -1085,57 +1099,53 @@ void mxfp8_quantize(const Tensor &input, const Tensor *act_input,
 
           switch (scaling_type) {
             case ScalingType::ROWWISE:
-              cudaFuncSetAttribute(cast_mxfp8_2D_kernel
-                    <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, false,
-                     CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
-                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size
-              );
+              cudaFuncSetAttribute(
+                  cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true,
+                                       false, CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
+                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
 
-              cast_mxfp8_2D_kernel
-                <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, false,
-                 CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
-                <<<grid, block_size, dshmem_size, stream>>>
-                    (tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
-                    tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr,
-                    noop_ptr, workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise); 
+              cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true,
+                                   false, CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
+                  <<<grid, block_size, dshmem_size, stream>>>(
+                      tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
+                      tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
+                      workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise,
+                      scale_stride_colwise);
               break;
             case ScalingType::COLWISE:
-              cudaFuncSetAttribute(cast_mxfp8_2D_kernel
-                    <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false, true,
-                    CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
-                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size
-              );
-            
-              cast_mxfp8_2D_kernel
-                <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false, true,
-                 CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
-                <<<grid, block_size, dshmem_size, stream>>>
-                    (tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
-                    tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr,
-                    noop_ptr, workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise); 
+              cudaFuncSetAttribute(
+                  cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false,
+                                       true, CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
+                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
+
+              cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, false,
+                                   true, CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
+                  <<<grid, block_size, dshmem_size, stream>>>(
+                      tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
+                      tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
+                      workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise,
+                      scale_stride_colwise);
               break;
             case ScalingType::BIDIMENSIONAL:
-              cudaFuncSetAttribute(cast_mxfp8_2D_kernel
-                    <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, true,
-                     CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
-                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size
-              );
-            
-              cast_mxfp8_2D_kernel
-                <IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, true,
-                 CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
-                <<<grid, block_size, dshmem_size, stream>>>
-                    (tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
-                    tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr,
-                    noop_ptr, workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise); 
+              cudaFuncSetAttribute(
+                  cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true,
+                                       true, CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>,
+                  cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
+
+              cast_mxfp8_2D_kernel<IS_DBIAS, IS_DACT, IS_ACT, ParamOP, OP, IType, OType, true, true,
+                                   CHUNK_DIM_Y, CHUNK_DIM_X, THREADS_PER_CHUNK>
+                  <<<grid, block_size, dshmem_size, stream>>>(
+                      tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
+                      tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
+                      workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise,
+                      scale_stride_colwise);
               break;
           }
 
           if constexpr (IS_DBIAS) {
             reduce_dbias<IType>(workspace_ptr, dbias, dbias_rows, dbias_cols, stream);
-          }
-      );  // NOLINT(*)
-  );  // NOLINT(*)
+          });  // NOLINT(*)
+  );           // NOLINT(*)
 }
 
 namespace detail {
@@ -1380,4 +1390,3 @@ void quantize_helper(const NVTETensor input, const NVTETensor grad, const NVTETe
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_CAST_KERNELS_CUH_
-

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -166,43 +166,36 @@ __device__ __forceinline__ void fence_proxy_async_shared_cta() {
 
 // SIMD like "Fused" cast + multiplication (x2)
 template <typename T>
-__device__ __forceinline__ void 
-mul_cvt_2x(uint16_t& c, const float2& a, const float2& b);
+__device__ __forceinline__ void mul_cvt_2x(uint16_t &c, const float2 &a, const float2 &b);
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e4m3>(uint16_t& c, const float2& a, const float2& b) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e4m3>(uint16_t &c, const float2 &a, const float2 &b) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        "mul.f32x2 val_pair, %1, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair; \n\t"
-        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(c)
-    :  "l"(reinterpret_cast<const uint64_t&>(a)),
-      "l"(reinterpret_cast<const uint64_t&>(b))
-  );
+      "{\n"
+      ".reg.b64 val_pair; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      "mul.f32x2 val_pair, %1, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair; \n\t"
+      "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(c)
+      : "l"(reinterpret_cast<const uint64_t &>(a)), "l"(reinterpret_cast<const uint64_t &>(b)));
 }
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e5m2>(uint16_t& c, const float2& a, const float2& b) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e5m2>(uint16_t &c, const float2 &a, const float2 &b) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        "mul.f32x2 val_pair, %1, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair; \n\t"
-        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(c)
-    :  "l"(reinterpret_cast<const uint64_t&>(a)),
-      "l"(reinterpret_cast<const uint64_t&>(b))
-  );
+      "{\n"
+      ".reg.b64 val_pair; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      "mul.f32x2 val_pair, %1, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair; \n\t"
+      "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(c)
+      : "l"(reinterpret_cast<const uint64_t &>(a)), "l"(reinterpret_cast<const uint64_t &>(b)));
 }
 
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
@@ -339,5 +332,3 @@ __forceinline__ __device__ void copy_2d_to_sharedx3(
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_PTX_CUH_
-
-

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -166,166 +166,155 @@ __device__ __forceinline__ void fence_proxy_async_shared_cta() {
 
 // SIMD like "Fused" cast + multiplication (x2)
 template <typename T1, typename T2>
-__device__ __forceinline__ void 
-mul_cvt_2x(T1& out_2x, const T2& in_2x, const float2& scale_2x);
+__device__ __forceinline__ void mul_cvt_2x(T1 &out_2x, const T2 &in_2x, const float2 &scale_2x);
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e4m3, float>(fp8e4m3& out_2x, const float& in_2x, const float2& scale_2x) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e4m3, float>(fp8e4m3 &out_2x, const float &in_2x,
+                                                           const float2 &scale_2x) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        "mul.f32x2 val_pair, %1, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair; \n\t"
-        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
-    :  "l"(reinterpret_cast<const uint64_t&>(in_2x)),
-       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
-  );
+      "{\n"
+      ".reg.b64 val_pair; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      "mul.f32x2 val_pair, %1, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair; \n\t"
+      "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(reinterpret_cast<uint16_t &>(out_2x))
+      : "l"(reinterpret_cast<const uint64_t &>(in_2x)),
+        "l"(reinterpret_cast<const uint64_t &>(scale_2x)));
 }
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e5m2, float>(fp8e5m2& out_2x, const float& in_2x, const float2& scale_2x) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e5m2, float>(fp8e5m2 &out_2x, const float &in_2x,
+                                                           const float2 &scale_2x) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        "mul.f32x2 val_pair, %1, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair; \n\t"
-        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
-    :  "l"(reinterpret_cast<const uint64_t&>(in_2x)),
-       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
-  );
+      "{\n"
+      ".reg.b64 val_pair; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      "mul.f32x2 val_pair, %1, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair; \n\t"
+      "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(reinterpret_cast<uint16_t &>(out_2x))
+      : "l"(reinterpret_cast<const uint64_t &>(in_2x)),
+        "l"(reinterpret_cast<const uint64_t &>(scale_2x)));
 }
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e4m3, bf16>(fp8e4m3& out_2x, const bf16& in_2x, const float2& scale_2x) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e4m3, bf16>(fp8e4m3 &out_2x, const bf16 &in_2x,
+                                                          const float2 &scale_2x) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair_before; \n\t"
-        ".reg.b64 val_pair_after; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        ".reg.b16 val1_bf16; \n\t"
-        ".reg.b16 val2_bf16; \n\t"
-        "mov.b32 {val1_bf16, val2_bf16} , %1; \n\t"
-        "cvt.f32.bf16 val1, val1_bf16; \n\t"
-        "cvt.f32.bf16 val2, val2_bf16; \n\t"
-        "mov.b64 val_pair_before, {val1,val2}; \n\t"
-        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair_after; \n\t"
-        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
-    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
-       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
-  );
+      "{\n"
+      ".reg.b64 val_pair_before; \n\t"
+      ".reg.b64 val_pair_after; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      ".reg.b16 val1_bf16; \n\t"
+      ".reg.b16 val2_bf16; \n\t"
+      "mov.b32 {val1_bf16, val2_bf16} , %1; \n\t"
+      "cvt.f32.bf16 val1, val1_bf16; \n\t"
+      "cvt.f32.bf16 val2, val2_bf16; \n\t"
+      "mov.b64 val_pair_before, {val1,val2}; \n\t"
+      "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair_after; \n\t"
+      "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(reinterpret_cast<uint16_t &>(out_2x))
+      : "r"(reinterpret_cast<const uint32_t &>(in_2x)),
+        "l"(reinterpret_cast<const uint64_t &>(scale_2x)));
 }
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e5m2, bf16>(fp8e5m2& out_2x, const bf16& in_2x, const float2& scale_2x) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e5m2, bf16>(fp8e5m2 &out_2x, const bf16 &in_2x,
+                                                          const float2 &scale_2x) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair_before; \n\t"
-        ".reg.b64 val_pair_after; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        ".reg.b16 val1_bf16; \n\t"
-        ".reg.b16 val2_bf16; \n\t"
-        "mov.b32 {val1_bf16, val2_bf16} , %1; \n\t"
-        "cvt.f32.bf16 val1, val1_bf16; \n\t"
-        "cvt.f32.bf16 val2, val2_bf16; \n\t"
-        "mov.b64 val_pair_before, {val1,val2}; \n\t"
-        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair_after; \n\t"
-        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
-    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
-       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
-  );
+      "{\n"
+      ".reg.b64 val_pair_before; \n\t"
+      ".reg.b64 val_pair_after; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      ".reg.b16 val1_bf16; \n\t"
+      ".reg.b16 val2_bf16; \n\t"
+      "mov.b32 {val1_bf16, val2_bf16} , %1; \n\t"
+      "cvt.f32.bf16 val1, val1_bf16; \n\t"
+      "cvt.f32.bf16 val2, val2_bf16; \n\t"
+      "mov.b64 val_pair_before, {val1,val2}; \n\t"
+      "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair_after; \n\t"
+      "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(reinterpret_cast<uint16_t &>(out_2x))
+      : "r"(reinterpret_cast<const uint32_t &>(in_2x)),
+        "l"(reinterpret_cast<const uint64_t &>(scale_2x)));
 }
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e4m3, fp16>(fp8e4m3& out_2x, const fp16& in_2x, const float2& scale_2x) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e4m3, fp16>(fp8e4m3 &out_2x, const fp16 &in_2x,
+                                                          const float2 &scale_2x) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair_before; \n\t"
-        ".reg.b64 val_pair_after; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        ".reg.b16 val1_fp16; \n\t"
-        ".reg.b16 val2_fp16; \n\t"
-        "mov.b32 {val1_fp16, val2_fp16} , %1; \n\t"
-        "cvt.f32.f16 val1, val1_fp16; \n\t"
-        "cvt.f32.f16 val2, val2_fp16; \n\t"
-        "mov.b64 val_pair_before, {val1,val2}; \n\t"
-        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair_after; \n\t"
-        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
-    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
-       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
-  );
+      "{\n"
+      ".reg.b64 val_pair_before; \n\t"
+      ".reg.b64 val_pair_after; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      ".reg.b16 val1_fp16; \n\t"
+      ".reg.b16 val2_fp16; \n\t"
+      "mov.b32 {val1_fp16, val2_fp16} , %1; \n\t"
+      "cvt.f32.f16 val1, val1_fp16; \n\t"
+      "cvt.f32.f16 val2, val2_fp16; \n\t"
+      "mov.b64 val_pair_before, {val1,val2}; \n\t"
+      "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair_after; \n\t"
+      "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(reinterpret_cast<uint16_t &>(out_2x))
+      : "r"(reinterpret_cast<const uint32_t &>(in_2x)),
+        "l"(reinterpret_cast<const uint64_t &>(scale_2x)));
 }
 
 template <>
-__device__ __forceinline__ void 
-mul_cvt_2x<fp8e5m2, fp16>(fp8e5m2& out_2x, const fp16& in_2x, const float2& scale_2x) {
+__device__ __forceinline__ void mul_cvt_2x<fp8e5m2, fp16>(fp8e5m2 &out_2x, const fp16 &in_2x,
+                                                          const float2 &scale_2x) {
   asm volatile(
-    "{\n"
-        ".reg.b64 val_pair_before; \n\t"
-        ".reg.b64 val_pair_after; \n\t"
-        ".reg.b32 val1; \n\t"
-        ".reg.b32 val2; \n\t"
-        ".reg.b16 val1_fp16; \n\t"
-        ".reg.b16 val2_fp16; \n\t"
-        "mov.b32 {val1_fp16, val2_fp16} , %1; \n\t"
-        "cvt.f32.f16 val1, val1_fp16; \n\t"
-        "cvt.f32.f16 val2, val2_fp16; \n\t"
-        "mov.b64 val_pair_before, {val1,val2}; \n\t"
-        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
-        "mov.b64 {val2,val1}, val_pair_after; \n\t"
-        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
-    "}"
-    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
-    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
-       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
-  );
+      "{\n"
+      ".reg.b64 val_pair_before; \n\t"
+      ".reg.b64 val_pair_after; \n\t"
+      ".reg.b32 val1; \n\t"
+      ".reg.b32 val2; \n\t"
+      ".reg.b16 val1_fp16; \n\t"
+      ".reg.b16 val2_fp16; \n\t"
+      "mov.b32 {val1_fp16, val2_fp16} , %1; \n\t"
+      "cvt.f32.f16 val1, val1_fp16; \n\t"
+      "cvt.f32.f16 val2, val2_fp16; \n\t"
+      "mov.b64 val_pair_before, {val1,val2}; \n\t"
+      "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+      "mov.b64 {val2,val1}, val_pair_after; \n\t"
+      "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+      "}"
+      : "=h"(reinterpret_cast<uint16_t &>(out_2x))
+      : "r"(reinterpret_cast<const uint32_t &>(in_2x)),
+        "l"(reinterpret_cast<const uint64_t &>(scale_2x)));
 }
 
 template <typename T>
-__device__ __forceinline__ void abs_max_2x(T& dest, const T& p1, const T& p2);
+__device__ __forceinline__ void abs_max_2x(T &dest, const T &p1, const T &p2);
 
 template <>
-__device__ __forceinline__ void
-abs_max_2x<bf16>(bf16& dst, const bf16& p1, const bf16& p2) {
-  asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;"
-    : "=r"(reinterpret_cast<uint32_t&>(dst))
-    :  "r"(reinterpret_cast<const uint32_t&>(p1))
-       "r"(reinterpret_cast<const uint32_t&>(p2))
-  );
+__device__ __forceinline__ void abs_max_2x<bf16>(bf16 &dst, const bf16 &p1, const bf16 &p2) {
+  asm volatile(
+      "max.xorsign.abs.bf16x2 %0, %1, %2;"
+      : "=r"(reinterpret_cast<uint32_t &>(dst))
+      : "r"(reinterpret_cast<const uint32_t &>(p1)) "r"(reinterpret_cast<const uint32_t &>(p2)));
 }
 
 template <>
-__device__ __forceinline__ void
-abs_max_2x<fp16>(fp16& dst, const fp16& p1, const fp16& p2) {
-  asm volatile("max.xorsign.abs.f16x2 %0, %1, %2;"
-    : "=r"(reinterpret_cast<uint32_t&>(dst))
-    :  "r"(reinterpret_cast<const uint32_t&>(p1))
-       "r"(reinterpret_cast<const uint32_t&>(p2))
-  );
+__device__ __forceinline__ void abs_max_2x<fp16>(fp16 &dst, const fp16 &p1, const fp16 &p2) {
+  asm volatile(
+      "max.xorsign.abs.f16x2 %0, %1, %2;"
+      : "=r"(reinterpret_cast<uint32_t &>(dst))
+      : "r"(reinterpret_cast<const uint32_t &>(p1)) "r"(reinterpret_cast<const uint32_t &>(p2)));
 }
 
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
@@ -462,4 +451,3 @@ __forceinline__ __device__ void copy_2d_to_sharedx3(
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_PTX_CUH_
-

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -164,6 +164,47 @@ __device__ __forceinline__ void fence_proxy_async_shared_cta() {
   asm volatile("fence.proxy.async.shared::cta;");
 }
 
+// SIMD like "Fused" cast + multiplication (x2)
+template <typename T>
+__device__ __forceinline__ void 
+mul_cvt_2x(uint16_t& c, const float2& a, const float2& b);
+
+template <>
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e4m3>(uint16_t& c, const float2& a, const float2& b) {
+  asm volatile(
+    "{\n"
+        ".reg.b64 val_pair; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        "mul.f32x2 val_pair, %1, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair; \n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(c)
+    :  "l"(reinterpret_cast<const uint64_t&>(a)),
+      "l"(reinterpret_cast<const uint64_t&>(b))
+  );
+}
+
+template <>
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e5m2>(uint16_t& c, const float2& a, const float2& b) {
+  asm volatile(
+    "{\n"
+        ".reg.b64 val_pair; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        "mul.f32x2 val_pair, %1, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair; \n\t"
+        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(c)
+    :  "l"(reinterpret_cast<const uint64_t&>(a)),
+      "l"(reinterpret_cast<const uint64_t&>(b))
+  );
+}
+
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
 
 }  // namespace ptx
@@ -298,3 +339,5 @@ __forceinline__ __device__ void copy_2d_to_sharedx3(
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_PTX_CUH_
+
+

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -165,37 +165,167 @@ __device__ __forceinline__ void fence_proxy_async_shared_cta() {
 }
 
 // SIMD like "Fused" cast + multiplication (x2)
-template <typename T>
-__device__ __forceinline__ void mul_cvt_2x(uint16_t &c, const float2 &a, const float2 &b);
+template <typename T1, typename T2>
+__device__ __forceinline__ void 
+mul_cvt_2x(T1& out_2x, const T2& in_2x, const float2& scale_2x);
 
 template <>
-__device__ __forceinline__ void mul_cvt_2x<fp8e4m3>(uint16_t &c, const float2 &a, const float2 &b) {
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e4m3, float>(fp8e4m3& out_2x, const float& in_2x, const float2& scale_2x) {
   asm volatile(
-      "{\n"
-      ".reg.b64 val_pair; \n\t"
-      ".reg.b32 val1; \n\t"
-      ".reg.b32 val2; \n\t"
-      "mul.f32x2 val_pair, %1, %2; \n\t"
-      "mov.b64 {val2,val1}, val_pair; \n\t"
-      "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
-      "}"
-      : "=h"(c)
-      : "l"(reinterpret_cast<const uint64_t &>(a)), "l"(reinterpret_cast<const uint64_t &>(b)));
+    "{\n"
+        ".reg.b64 val_pair; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        "mul.f32x2 val_pair, %1, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair; \n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
+    :  "l"(reinterpret_cast<const uint64_t&>(in_2x)),
+       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
+  );
 }
 
 template <>
-__device__ __forceinline__ void mul_cvt_2x<fp8e5m2>(uint16_t &c, const float2 &a, const float2 &b) {
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e5m2, float>(fp8e5m2& out_2x, const float& in_2x, const float2& scale_2x) {
   asm volatile(
-      "{\n"
-      ".reg.b64 val_pair; \n\t"
-      ".reg.b32 val1; \n\t"
-      ".reg.b32 val2; \n\t"
-      "mul.f32x2 val_pair, %1, %2; \n\t"
-      "mov.b64 {val2,val1}, val_pair; \n\t"
-      "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
-      "}"
-      : "=h"(c)
-      : "l"(reinterpret_cast<const uint64_t &>(a)), "l"(reinterpret_cast<const uint64_t &>(b)));
+    "{\n"
+        ".reg.b64 val_pair; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        "mul.f32x2 val_pair, %1, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair; \n\t"
+        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
+    :  "l"(reinterpret_cast<const uint64_t&>(in_2x)),
+       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
+  );
+}
+
+template <>
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e4m3, bf16>(fp8e4m3& out_2x, const bf16& in_2x, const float2& scale_2x) {
+  asm volatile(
+    "{\n"
+        ".reg.b64 val_pair_before; \n\t"
+        ".reg.b64 val_pair_after; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        ".reg.b16 val1_bf16; \n\t"
+        ".reg.b16 val2_bf16; \n\t"
+        "mov.b32 {val1_bf16, val2_bf16} , %1; \n\t"
+        "cvt.f32.bf16 val1, val1_bf16; \n\t"
+        "cvt.f32.bf16 val2, val2_bf16; \n\t"
+        "mov.b64 val_pair_before, {val1,val2}; \n\t"
+        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair_after; \n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
+    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
+       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
+  );
+}
+
+template <>
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e5m2, bf16>(fp8e5m2& out_2x, const bf16& in_2x, const float2& scale_2x) {
+  asm volatile(
+    "{\n"
+        ".reg.b64 val_pair_before; \n\t"
+        ".reg.b64 val_pair_after; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        ".reg.b16 val1_bf16; \n\t"
+        ".reg.b16 val2_bf16; \n\t"
+        "mov.b32 {val1_bf16, val2_bf16} , %1; \n\t"
+        "cvt.f32.bf16 val1, val1_bf16; \n\t"
+        "cvt.f32.bf16 val2, val2_bf16; \n\t"
+        "mov.b64 val_pair_before, {val1,val2}; \n\t"
+        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair_after; \n\t"
+        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
+    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
+       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
+  );
+}
+
+template <>
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e4m3, fp16>(fp8e4m3& out_2x, const fp16& in_2x, const float2& scale_2x) {
+  asm volatile(
+    "{\n"
+        ".reg.b64 val_pair_before; \n\t"
+        ".reg.b64 val_pair_after; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        ".reg.b16 val1_fp16; \n\t"
+        ".reg.b16 val2_fp16; \n\t"
+        "mov.b32 {val1_fp16, val2_fp16} , %1; \n\t"
+        "cvt.f32.f16 val1, val1_fp16; \n\t"
+        "cvt.f32.f16 val2, val2_fp16; \n\t"
+        "mov.b64 val_pair_before, {val1,val2}; \n\t"
+        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair_after; \n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
+    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
+       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
+  );
+}
+
+template <>
+__device__ __forceinline__ void 
+mul_cvt_2x<fp8e5m2, fp16>(fp8e5m2& out_2x, const fp16& in_2x, const float2& scale_2x) {
+  asm volatile(
+    "{\n"
+        ".reg.b64 val_pair_before; \n\t"
+        ".reg.b64 val_pair_after; \n\t"
+        ".reg.b32 val1; \n\t"
+        ".reg.b32 val2; \n\t"
+        ".reg.b16 val1_fp16; \n\t"
+        ".reg.b16 val2_fp16; \n\t"
+        "mov.b32 {val1_fp16, val2_fp16} , %1; \n\t"
+        "cvt.f32.f16 val1, val1_fp16; \n\t"
+        "cvt.f32.f16 val2, val2_fp16; \n\t"
+        "mov.b64 val_pair_before, {val1,val2}; \n\t"
+        "mul.f32x2 val_pair_after, val_pair_before, %2; \n\t"
+        "mov.b64 {val2,val1}, val_pair_after; \n\t"
+        "cvt.rn.satfinite.e5m2x2.f32 %0, val1, val2; \n\t"
+    "}"
+    : "=h"(reinterpret_cast<uint16_t&>(out_2x))
+    :  "r"(reinterpret_cast<const uint32_t&>(in_2x)),
+       "l"(reinterpret_cast<const uint64_t&>(scale_2x))
+  );
+}
+
+template <typename T>
+__device__ __forceinline__ void abs_max_2x(T& dest, const T& p1, const T& p2);
+
+template <>
+__device__ __forceinline__ void
+abs_max_2x<bf16>(bf16& dst, const bf16& p1, const bf16& p2) {
+  asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;"
+    : "=r"(reinterpret_cast<uint32_t&>(dst))
+    :  "r"(reinterpret_cast<const uint32_t&>(p1))
+       "r"(reinterpret_cast<const uint32_t&>(p2))
+  );
+}
+
+template <>
+__device__ __forceinline__ void
+abs_max_2x<fp16>(fp16& dst, const fp16& p1, const fp16& p2) {
+  asm volatile("max.xorsign.abs.f16x2 %0, %1, %2;"
+    : "=r"(reinterpret_cast<uint32_t&>(dst))
+    :  "r"(reinterpret_cast<const uint32_t&>(p1))
+       "r"(reinterpret_cast<const uint32_t&>(p2))
+  );
 }
 
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
@@ -332,3 +462,4 @@ __forceinline__ __device__ void copy_2d_to_sharedx3(
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_PTX_CUH_
+

--- a/transformer_engine/common/utils.cuh
+++ b/transformer_engine/common/utils.cuh
@@ -904,7 +904,7 @@ using e8m0_t = uint8_t;
 constexpr uint32_t FP32_MANTISSA_BITS = 23;
 constexpr uint32_t FP32_EXPONENT_BIAS = 127;
 
-enum ScalingType { ROWWISE = 0, COLWISE = 1, BIDIMENTIONAL = 2 };
+enum ScalingType { ROWWISE = 0, COLWISE = 1, BIDIMENSIONAL = 2 };
 
 template <typename T>
 struct Numeric_Traits;
@@ -931,6 +931,12 @@ struct Quantized_Limits {
 };
 
 __device__ __forceinline__ e8m0_t float_to_e8m0(float val) {
+#if ((__CUDA_ARCH_HAS_FEATURE__(SM100_ALL)) || (__CUDA_ARCH_HAS_FEATURE__(SM101_ALL)) || \
+     (__CUDA_ARCH_HAS_FEATURE__(SM120_ALL)))
+    uint16_t out;
+    asm volatile("cvt.rp.satfinite.ue8m0x2.f32  %0, 0.0, %1;\n" : "=h"(out) : "f"(val));
+    return *reinterpret_cast<e8m0_t *>(&out);
+#else
   // TODO: nan/inf needs to be set for any value
   // of nan/inf in input not just amax.
   if (isnan(val)) {
@@ -939,17 +945,6 @@ __device__ __forceinline__ e8m0_t float_to_e8m0(float val) {
   if (isinf(val)) {
     return 0xFE;
   }
-#if ((__CUDA_ARCH_HAS_FEATURE__(SM100_ALL)) || (__CUDA_ARCH_HAS_FEATURE__(SM101_ALL)) || \
-     (__CUDA_ARCH_HAS_FEATURE__(SM120_ALL)))
-  uint16_t out;
-  asm volatile(
-      "{\n"
-      "cvt.rp.satfinite.ue8m0x2.f32  %0, 0.0, %1;\n"
-      "}"
-      : "=h"(out)
-      : "f"(val));
-  return *reinterpret_cast<e8m0_t *>(&out);
-#else
   if (val == 0.0f) {
     return 0x00;
   }
@@ -971,3 +966,5 @@ __device__ __forceinline__ float exp2f_rcp(e8m0_t biased_exp) {
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_COMMON_UTILS_CUH_
+
+

--- a/transformer_engine/common/utils.cuh
+++ b/transformer_engine/common/utils.cuh
@@ -933,9 +933,9 @@ struct Quantized_Limits {
 __device__ __forceinline__ e8m0_t float_to_e8m0(float val) {
 #if ((__CUDA_ARCH_HAS_FEATURE__(SM100_ALL)) || (__CUDA_ARCH_HAS_FEATURE__(SM101_ALL)) || \
      (__CUDA_ARCH_HAS_FEATURE__(SM120_ALL)))
-    uint16_t out;
-    asm volatile("cvt.rp.satfinite.ue8m0x2.f32  %0, 0.0, %1;\n" : "=h"(out) : "f"(val));
-    return *reinterpret_cast<e8m0_t *>(&out);
+  uint16_t out;
+  asm volatile("cvt.rp.satfinite.ue8m0x2.f32  %0, 0.0, %1;\n" : "=h"(out) : "f"(val));
+  return *reinterpret_cast<e8m0_t *>(&out);
 #else
   // TODO: nan/inf needs to be set for any value
   // of nan/inf in input not just amax.
@@ -966,5 +966,3 @@ __device__ __forceinline__ float exp2f_rcp(e8m0_t biased_exp) {
 }  // namespace transformer_engine
 
 #endif  // TRANSFORMER_ENGINE_COMMON_UTILS_CUH_
-
-


### PR DESCRIPTION
# Description

Modified and tuned fused cast mxfp8 kernels for better performance.

Work is still in progress, and some further optimizations will be included in the next few days:
1. Caching the computed activations in the first pass to avoid recomputing them in the second pass (along the other dim)
2. Reducing the block size for CAST+DBIAS+DACT kernel specifically 
3. Swapping the order of DBIAS computation

The performance comparison data will also be provided. 

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Increased block size from `64x64` to `128x128`
- Modified the scheme of how tensor elements are processed. ROWWISE: 32 elements per thread (i.e. one scaling factor)
- Added micro-optimizations (e.g. using `MUL2` instructions; fusing MUL and CVT instructions directly in PTX)

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
