### PR TITLE
[CMake] Add CUDNN::cudnn_all target to include CUDNN_INCLUDE_DIR

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -99,10 +99,10 @@ target_include_directories(transformer_engine PUBLIC
 # Configure dependencies
 target_link_libraries(transformer_engine PUBLIC
                       CUDA::cublas
-                      CUDA::cudart)
+                      CUDA::cudart
+                      CUDNN::cudnn_all)
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-target_include_directories(transformer_engine PRIVATE "${CUDNN_INCLUDE_DIR}")
 target_include_directories(transformer_engine PRIVATE "${CUDNN_FRONTEND_INCLUDE_DIR}")
 
 # Compiling Userbuffers with native MPI bootstrapping requires linking against MPI

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(transformer_engine PUBLIC
                       CUDA::cudart)
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+target_include_directories(transformer_engine PRIVATE "${CUDNN_INCLUDE_DIR}")
 target_include_directories(transformer_engine PRIVATE "${CUDNN_FRONTEND_INCLUDE_DIR}")
 
 # Compiling Userbuffers with native MPI bootstrapping requires linking against MPI


### PR DESCRIPTION
# Description

* In conda environments, we have seen build issues like #954
* Setting `CUDNN_PATH` or `CUDNN_ROOT` doesn't help, [see this comment](https://github.com/NVIDIA/TransformerEngine/issues/918#issuecomment-2746076263) in #918

Fixes #918

## Type of change

- [X] Infra/Build change

## Changes

- Add `CUDNN::cudnn_all` target to propagate necessary include directories for cudnn 


# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


_____

As multiple users have reported this error, I am curious if there is a reason to not explicitly add `CUDNN_INCLUDE_DIR` as done in this PR.