### PR TITLE
[PyTorch] fix fuse_wgrad_accumulation in LayerNormMLP backward

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -734,7 +734,9 @@ class _LayerNormMLP(torch.autograd.Function):
                     act_out,
                     grad_output,
                     get_workspace(),
-                    out_dtype=ctx.activation_dtype,
+                    out_dtype=(
+                        fc2_weight.main_grad.dtype if ctx.fuse_wgrad_accumulation else ctx.activation_dtype
+                    ),
                     quantization_params=None,  # wgrad in high precision
                     layout="NT",
                     grad=True,
@@ -894,7 +896,9 @@ class _LayerNormMLP(torch.autograd.Function):
                     ln_out_total,
                     dact,
                     get_workspace(),
-                    out_dtype=ctx.activation_dtype,
+                    out_dtype=(
+                        fc1_weight.main_grad.dtype if ctx.fuse_wgrad_accumulation else ctx.activation_dtype
+                    ),
                     layout="NT",
                     grad=fuse_gemm_and_bias_fc1_wgrad,
                     bias=fc1_bias if fuse_gemm_and_bias_fc1_wgrad else None,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -735,7 +735,9 @@ class _LayerNormMLP(torch.autograd.Function):
                     grad_output,
                     get_workspace(),
                     out_dtype=(
-                        fc2_weight.main_grad.dtype if ctx.fuse_wgrad_accumulation else ctx.activation_dtype
+                        fc2_weight.main_grad.dtype
+                        if ctx.fuse_wgrad_accumulation
+                        else ctx.activation_dtype
                     ),
                     quantization_params=None,  # wgrad in high precision
                     layout="NT",
@@ -897,7 +899,9 @@ class _LayerNormMLP(torch.autograd.Function):
                     dact,
                     get_workspace(),
                     out_dtype=(
-                        fc1_weight.main_grad.dtype if ctx.fuse_wgrad_accumulation else ctx.activation_dtype
+                        fc1_weight.main_grad.dtype
+                        if ctx.fuse_wgrad_accumulation
+                        else ctx.activation_dtype
                     ),
                     layout="NT",
                     grad=fuse_gemm_and_bias_fc1_wgrad,


### PR DESCRIPTION
# Description

The out_dtype in the computation of the weight gradient for the LayerNormMLP class ist not set properly if `fuse_wgrad_accumulation` is active. This leads to the following error:

```
RuntimeError: /tmp/builds/transformer-engine/TransformerEngine/transformer_engine/pytorch/csrc/extensions/gemm.cpp:117 in function gemm: Assertion failed: *out_dtype == D_tensor.dtype(). GEMM output has invalid dtype (expected 5, found 3)
```

For `Linear` and `LayerNormLinear` this is already properly handled, see https://github.com/NVIDIA/TransformerEngine/blob/0356010ca068b4205bda4e2f5feffa7fbd5e38ae/transformer_engine/pytorch/module/linear.py#L623-L625 for example.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

