### PR TITLE
[PyTorch] Make breaking change in `InferenceParams.init` more explicit

### DIFF
--- a/transformer_engine/pytorch/dot_product_attention/inference.py
+++ b/transformer_engine/pytorch/dot_product_attention/inference.py
@@ -128,9 +128,9 @@ class InferenceParams:
         self,
         max_batch_size: int,
         max_sequence_length: int,
-        num_heads_kv: int = 16,
-        head_dim_k: int = 64,
-        dtype: torch.dtype = torch.bfloat16,
+        num_heads_kv: int = None,
+        head_dim_k: int = None,
+        dtype: torch.dtype = None,
         head_dim_v: int = None,
         is_paged: bool = False,
         total_num_pages: int = None,
@@ -141,6 +141,7 @@ class InferenceParams:
     ):
         self.max_batch_size = max_batch_size
         self.max_sequence_length = max_sequence_length
+        assert all(x is not None for x in [num_heads_kv, head_dim_k, dtype]), "num_heads_kv, head_dim_k, and dtype are required for InferenceParams since Transformer Engine 2.2."
         self.num_heads_kv = num_heads_kv
         self.head_dim_k = head_dim_k
         self.dtype = dtype


### PR DESCRIPTION
# Description

This PR resets three parameters `num_heads_kv`, `head_dim_k`, `dtype` in `InferenceParams.init` to `None`. This follows a slew of changes in #1355 and #1589, and we think this breaking change is needed for TE 2.2.

Before TE 2.2, the `num_heads_kv`, `head_dim_k`, `dtype` information was obtained through `DPA.forward()`. so there was no need for users to explicitly set them when initializing `InferenceParams`. TE 2.2+ has a new structure for `InferenceParams` and requires these params.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Set three params in `InferenceParams.init` to `None` and emit assertion errors if this requirement is not met

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
