### PR TITLE
[PyTorch] Support default process group with FP8 current scaling

### DIFF
--- a/tests/pytorch/distributed/run_numerics.py
+++ b/tests/pytorch/distributed/run_numerics.py
@@ -317,7 +317,6 @@ def _construct_quantizer(quantizer_class, fp8_dtype, device, tp_group, tp_size):
             device=device,
             with_amax_reduction=True,
             amax_reduction_group=tp_group,
-            amax_reduction_size=tp_size,
         )
         quantizer = quantizer_class(
             fp8_dtype=fp8_dtype,

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -149,7 +149,6 @@ class Float8CurrentScalingQuantizer : public Quantizer {
   DType dtype;
   bool with_amax_reduction;
   c10::intrusive_ptr<dist_group_type> amax_reduction_group;
-  int amax_reduction_size;
   bool force_pow_2_scales = false;
   float amax_epsilon = 0.0;
 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -36,7 +36,6 @@ from ..constants import dist_group_type
 from ..tensor import QuantizedTensor, Quantizer
 from ..tensor._internal.float8_tensor_base import Float8TensorBase
 from ..tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
-from ..utils import canonicalize_process_group
 
 __all__ = ["initialize_ub", "destroy_ub"]
 
@@ -689,7 +688,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         tp_group : ProcessGroup, default = `None`
                   tensor parallel process group.
         """
-        self.tp_group = canonicalize_process_group(tp_group)
+        self.tp_group = tp_group
         self.tp_group_initialized = True
 
     def _get_fp8_params(self) -> Union[List[torch.Tensor], None]:

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -36,6 +36,7 @@ from ..constants import dist_group_type
 from ..tensor import QuantizedTensor, Quantizer
 from ..tensor._internal.float8_tensor_base import Float8TensorBase
 from ..tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
+from ..utils import canonicalize_process_group
 
 __all__ = ["initialize_ub", "destroy_ub"]
 
@@ -688,7 +689,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         tp_group : ProcessGroup, default = `None`
                   tensor parallel process group.
         """
-        self.tp_group = tp_group
+        self.tp_group = canonicalize_process_group(tp_group)
         self.tp_group_initialized = True
 
     def _get_fp8_params(self) -> Union[List[torch.Tensor], None]:

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1416,9 +1416,6 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.quantizers["scaling_fwd"][
                     tex.FP8FwdTensors.GEMM1_INPUT
                 ].amax_reduction_group = self.tp_group
-                self.quantizers["scaling_fwd"][
-                    tex.FP8FwdTensors.GEMM1_INPUT
-                ].amax_reduction_size = self.tp_size
         else:
             # set grad_output_quantizer with amax epsilon and power_2_scale (no amax reduction here)
             self.quantizers["scaling_bwd"][

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -1576,9 +1576,6 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self.quantizers["scaling_fwd"][
                     tex.FP8FwdTensors.GEMM1_INPUT
                 ].amax_reduction_group = self.tp_group
-                self.quantizers["scaling_fwd"][
-                    tex.FP8FwdTensors.GEMM1_INPUT
-                ].amax_reduction_size = self.tp_size
         else:
             # grad_fc2_output_quantizer: set configs about amax epsilon and power_2_scale for grad_fc2_output_quantizer
             self.quantizers["scaling_bwd"][
@@ -1602,6 +1599,3 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self.quantizers["scaling_bwd"][
                     tex.FP8BwdTensors.GRAD_OUTPUT1
                 ].amax_reduction_group = self.tp_group
-                self.quantizers["scaling_bwd"][
-                    tex.FP8BwdTensors.GRAD_OUTPUT1
-                ].amax_reduction_size = self.tp_size

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1221,9 +1221,6 @@ class Linear(TransformerEngineBaseModule):
                 self.quantizers["scaling_fwd"][
                     tex.FP8FwdTensors.GEMM1_INPUT
                 ].amax_reduction_group = self.tp_group
-                self.quantizers["scaling_fwd"][
-                    tex.FP8FwdTensors.GEMM1_INPUT
-                ].amax_reduction_size = self.tp_size
         else:
             # set grad_output_quantizer with amax epsilon and power_2_scale
             self.quantizers["scaling_bwd"][
@@ -1241,6 +1238,3 @@ class Linear(TransformerEngineBaseModule):
                 self.quantizers["scaling_bwd"][
                     tex.FP8BwdTensors.GRAD_OUTPUT1
                 ].amax_reduction_group = self.tp_group
-                self.quantizers["scaling_bwd"][
-                    tex.FP8BwdTensors.GRAD_OUTPUT1
-                ].amax_reduction_size = self.tp_size

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -222,7 +222,9 @@ class Float8CurrentScalingQuantizer(Quantizer):
 
         # Deprecated option
         if amax_reduction_size is not None:
-            warnings.warn("amax_reduction_size kwarg is deprecated", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "amax_reduction_size kwarg is deprecated", DeprecationWarning, stacklevel=2
+            )
 
     def update_quantized(
         self,

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -4,7 +4,7 @@
 
 """Tensor class with FP8 data"""
 from __future__ import annotations
-from typing import Any, Optional, Tuple, Iterable
+from typing import Optional, Tuple, Iterable
 import warnings
 
 import torch
@@ -209,7 +209,6 @@ class Float8CurrentScalingQuantizer(Quantizer):
         amax_reduction_group: Optional[dist_group_type] = None,
         force_pow_2_scales: bool = False,
         amax_epsilon: float = 0.0,
-        amax_reduction_size: Any = None,  # deprecated
     ) -> None:
         super().__init__(rowwise=rowwise, columnwise=columnwise)
         self.scale = torch.ones(1, dtype=torch.float32, device=device)
@@ -219,12 +218,6 @@ class Float8CurrentScalingQuantizer(Quantizer):
         self.amax_reduction_group = amax_reduction_group
         self.force_pow_2_scales = force_pow_2_scales
         self.amax_epsilon = amax_epsilon
-
-        # Deprecated option
-        if amax_reduction_size is not None:
-            warnings.warn(
-                "amax_reduction_size kwarg is deprecated", DeprecationWarning, stacklevel=2
-            )
 
     def update_quantized(
         self,

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -4,7 +4,7 @@
 
 """Tensor class with FP8 data"""
 from __future__ import annotations
-from typing import Optional, Tuple, Iterable
+from typing import Any, Optional, Tuple, Iterable
 import warnings
 
 import torch

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -11,7 +11,7 @@ import torch
 import transformer_engine_torch as tex
 
 from transformer_engine_torch import DType as TE_DType
-from ..utils import devices_match, non_tn_fp8_gemm_supported
+from ..utils import canonicalize_process_group, devices_match, non_tn_fp8_gemm_supported
 from ._internal.float8_tensor_base import Float8TensorBase, _FromFloat8Func
 from .quantized_tensor import QuantizedTensor, Quantizer, _IdentityFunc
 from ..constants import dist_group_type
@@ -194,7 +194,6 @@ class Float8CurrentScalingQuantizer(Quantizer):
     """amax reduction options"""
     with_amax_reduction: bool
     amax_reduction_group: Optional[dist_group_type]
-    amax_reduction_size: Optional[int]
     """Options about how to quantize the tensor"""
     force_pow_2_scales: bool
     amax_epsilon: float
@@ -208,9 +207,9 @@ class Float8CurrentScalingQuantizer(Quantizer):
         columnwise: bool = True,
         with_amax_reduction: bool = False,
         amax_reduction_group: Optional[dist_group_type] = None,
-        amax_reduction_size: Optional[int] = 1,
         force_pow_2_scales: bool = False,
         amax_epsilon: float = 0.0,
+        amax_reduction_size: Any = None,  # deprecated
     ) -> None:
         super().__init__(rowwise=rowwise, columnwise=columnwise)
         self.scale = torch.ones(1, dtype=torch.float32, device=device)
@@ -218,9 +217,12 @@ class Float8CurrentScalingQuantizer(Quantizer):
         self.dtype = fp8_dtype
         self.with_amax_reduction = with_amax_reduction
         self.amax_reduction_group = amax_reduction_group
-        self.amax_reduction_size = amax_reduction_size
         self.force_pow_2_scales = force_pow_2_scales
         self.amax_epsilon = amax_epsilon
+
+        # Deprecated option
+        if amax_reduction_size is not None:
+            warnings.warn("amax_reduction_size kwarg is deprecated", DeprecationWarning, stacklevel=2)
 
     def update_quantized(
         self,
@@ -326,6 +328,10 @@ class Float8CurrentScalingQuantizer(Quantizer):
             data_transpose=None,
             quantizer=self,
         )
+
+    def _canonicalized_amax_reduction_group(self) -> dist_group_type:
+        """Get process group for amax reduction"""
+        return canonicalize_process_group(self.amax_reduction_group)
 
 
 class Float8Tensor(Float8TensorBase, QuantizedTensor):

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -386,3 +386,15 @@ def nvtx_range_pop(msg: Optional[str] = None) -> None:
 
     # Pop NVTX range
     torch.cuda.nvtx.range_pop()
+
+def canonicalize_process_group(
+    group: Optional[torch.distributed.ProcessGroup],
+) -> torch.distributed.ProcessGroup:
+    """Convert to PyTorch process group
+
+    If `None`, returns default process group.
+
+    """
+    if group is None:
+        return torch.distributed.distributed_c10d._get_default_group()
+    return group

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -387,6 +387,7 @@ def nvtx_range_pop(msg: Optional[str] = None) -> None:
     # Pop NVTX range
     torch.cuda.nvtx.range_pop()
 
+
 def canonicalize_process_group(
     group: Optional[torch.distributed.ProcessGroup],
 ) -> torch.distributed.ProcessGroup:


### PR DESCRIPTION
# Description

We currently experience segfaults when FP8 current scaling is configured with the default PyTorch process group (`None`). This is because we access the process group from C++ and don't handle the case where it is `None`. This PR adds logic to canonicalize the process group before using it.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Canonicalize amax reduction group before FP8 current scaling quantizer uses it
- Remove logic for amax reduction group size from FP8 current scaling quantizer

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
