### PR TITLE
[JAX] Backward compatible Fixes

### DIFF
--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -83,7 +83,8 @@ _load_library()
 from . import flax
 from . import quantize
 
-from .quantize import fp8_autocast
+from .quantize import fp8_autocast, update_collections, get_delayed_scaling
+from .quantize import NVTE_FP8_COLLECTION_NAME
 
 from .sharding import MeshResource
 from .sharding import MajorShardingType, ShardingResource, ShardingType
@@ -101,11 +102,14 @@ ShardingResource = deprecate_wrapper(
 )
 
 __all__ = [
+    "NVTE_FP8_COLLECTION_NAME",
     "fp8_autocast",
+    "update_collections",
+    "get_delayed_scaling",
     "MeshResource",
     "MajorShardingType",
     "ShardingResource",
     "ShardingType",
     "flax",
-    "praxis",
+    "quantize",
 ]

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -27,12 +27,18 @@ from transformer_engine.jax.sharding import global_shard_guard, MeshResource
 from .scaling_modes import ScalingMode
 from .. import cpp_extensions as tex
 
-__all__ = ["QuantizeConfig", "fp8_autocast", "is_fp8_available", "update_collections", "get_delayed_scaling"]
+__all__ = [
+        "QuantizeConfig",
+        "fp8_autocast",
+        "is_fp8_available",
+        "update_collections",
+        "get_delayed_scaling",
+        "NVTE_FP8_COLLECTION_NAME",
+        ]
 
 _is_fp8_available = None
 _reason_for_no_fp8 = ""
 Collection = Union[Dict, FrozenDict]
-
 
 def _check_delayed_scaling_fp8_support(gpu_arch) -> Tuple[bool, str]:
     """Check if delayed scaling FP8 is supported on the given GPU architecture.
@@ -439,3 +445,6 @@ def update_collections(new: Collection, original: Collection) -> Collection:
     if not isinstance(original, FrozenDict):
         new_coll = new_coll.unfreeze()
     return new_coll
+
+
+NVTE_FP8_COLLECTION_NAME = QuantizeConfig.COLLECTION_NAME

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -28,17 +28,18 @@ from .scaling_modes import ScalingMode
 from .. import cpp_extensions as tex
 
 __all__ = [
-        "QuantizeConfig",
-        "fp8_autocast",
-        "is_fp8_available",
-        "update_collections",
-        "get_delayed_scaling",
-        "NVTE_FP8_COLLECTION_NAME",
-        ]
+    "QuantizeConfig",
+    "fp8_autocast",
+    "is_fp8_available",
+    "update_collections",
+    "get_delayed_scaling",
+    "NVTE_FP8_COLLECTION_NAME",
+]
 
 _is_fp8_available = None
 _reason_for_no_fp8 = ""
 Collection = Union[Dict, FrozenDict]
+
 
 def _check_delayed_scaling_fp8_support(gpu_arch) -> Tuple[bool, str]:
     """Check if delayed scaling FP8 is supported on the given GPU architecture.


### PR DESCRIPTION
# Description

PR #1627 removed some of the exposed API that broke some of the current user's code.

This PR exposes those back:
- `NVTE_FP8_COLLECTION_NAME`
- `update_collections`
-  `get_delayed_scaling`

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
