### PR TITLE
Add experimental Shardy support.

### DIFF
--- a/examples/jax/encoder/run_test_multiprocessing_encoder.sh
+++ b/examples/jax/encoder/run_test_multiprocessing_encoder.sh
@@ -21,3 +21,15 @@ do
   pytest -c $TE_PATH/tests/jax/pytest.ini -v $TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py::TestEncoder::test_te_mxfp8 --num-process=$NUM_GPUS --process-id=$i &
 done
 wait
+
+for i in $(seq 0 $(($NUM_GPUS-1)))
+do
+  pytest -c $TE_PATH/tests/jax/pytest.ini -v $TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py::TestEncoder::test_te_bf16_shardy --num-process=$NUM_GPUS --process-id=$i &
+done
+wait
+
+for i in $(seq 0 $(($NUM_GPUS-1)))
+do
+  pytest -c $TE_PATH/tests/jax/pytest.ini -v $TE_PATH/examples/jax/encoder/test_multiprocessing_encoder.py::TestEncoder::test_te_delayed_scaling_fp8_shardy --num-process=$NUM_GPUS --process-id=$i &
+done
+wait

--- a/examples/jax/encoder/test_model_parallel_encoder.py
+++ b/examples/jax/encoder/test_model_parallel_encoder.py
@@ -258,6 +258,8 @@ def get_state_sharding(state, params_sharding):
 def train_and_evaluate(args):
     """Execute model training and evaluation loop."""
     print(args)
+    jax.config.update("jax_use_shardy_partitioner", args.enable_shardy)
+
     train_ds, test_ds, num_embed = get_datasets(args.max_seq_len)
 
     num_gpu = jax.local_device_count()
@@ -441,6 +443,9 @@ def encoder_parser(args):
     parser.add_argument(
         "--enable-sp", action="store_true", default=False, help="Enable sequence parallelism."
     )
+    parser.add_argument(
+        "--enable-shardy", action="store_true", default=False, help="Enable Shardy (experimental)."
+    )
 
     return parser.parse_args(args)
 
@@ -451,10 +456,9 @@ class TestEncoder(unittest.TestCase):
     is_fp8_supported, fp8_reason = is_fp8_available(ScalingMode.DELAYED_TENSOR_SCALING)
     is_mxfp8_supported, mxfp8_reason = is_fp8_available(ScalingMode.MXFP8_1D_SCALING)
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         """Run 3 epochs for testing"""
-        cls.args = encoder_parser(["--epochs", "3"])
+        self.args = encoder_parser(["--epochs", "3"])
 
     @unittest.skipIf(not is_bf16_supported(), "Device compute capability 8.0+ is required for BF16")
     def test_te_bf16(self):
@@ -502,6 +506,13 @@ class TestEncoder(unittest.TestCase):
         self.args.fp8_recipe = "MXFP8BlockScaling"
         actual = train_and_evaluate(self.args)
         assert actual[0] < 0.455 and actual[1] > 0.785
+
+    @unittest.skipIf(not is_bf16_supported(), "Device compute capability 8.0+ is required for BF16")
+    def test_te_bf16_shardy(self):
+        """Test Transformer Engine with BF16"""
+        self.args.enable_shardy = True
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.45 and actual[1] > 0.79
 
 
 if __name__ == "__main__":

--- a/examples/jax/encoder/test_model_parallel_encoder.py
+++ b/examples/jax/encoder/test_model_parallel_encoder.py
@@ -512,7 +512,28 @@ class TestEncoder(unittest.TestCase):
         """Test Transformer Engine with BF16"""
         self.args.enable_shardy = True
         actual = train_and_evaluate(self.args)
-        assert actual[0] < 0.45 and actual[1] > 0.79
+        assert actual[0] < 0.455 and actual[1] > 0.785
+
+    @unittest.skipIf(not is_fp8_supported, fp8_reason)
+    def test_te_delayed_scaling_fp8_shardy(self):
+        """Test Transformer Engine with DelayedScaling FP8"""
+        self.args.enable_shardy = True
+        self.args.use_fp8 = True
+        self.args.fp8_recipe = "DelayedScaling"
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.455 and actual[1] > 0.785
+
+    @unittest.skipIf(not is_fp8_supported, fp8_reason)
+    def test_te_delayed_scaling_fp8_with_sp_shardy(self):
+        """Test Transformer Engine with DelayedScaling FP8 + SP"""
+        self.args.enable_shardy = True
+        self.args.enable_sp = True
+        self.args.use_fp8 = True
+        self.args.fp8_recipe = "DelayedScaling"
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.455 and actual[1] > 0.785
+
+    # TODO(jreiffers): Add mxfp8 Shardy tests once supported in JAX.
 
 
 if __name__ == "__main__":

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -454,7 +454,7 @@ class TestEncoder(unittest.TestCase):
         """Test Transformer Engine with BF16"""
         self.args.enable_shardy = True
         actual = train_and_evaluate(self.args)
-        assert actual[0] < 0.50 and actual[1] > 0.76
+        assert actual[0] < 0.535 and actual[1] > 0.73
 
 
 if __name__ == "__main__":

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -414,7 +414,6 @@ def encoder_parser(args):
         "--enable-shardy", action="store_true", default=False, help="Enable Shardy (experimental)."
     )
 
-
     return parser.parse_args(args)
 
 

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -456,6 +456,17 @@ class TestEncoder(unittest.TestCase):
         actual = train_and_evaluate(self.args)
         assert actual[0] < 0.535 and actual[1] > 0.73
 
+    @unittest.skipIf(not is_fp8_supported, fp8_reason)
+    def test_te_delayed_scaling_fp8_shardy(self):
+        """Test Transformer Engine with DelayedScaling FP8"""
+        self.args.enable_shardy = True
+        self.args.use_fp8 = True
+        self.args.fp8_recipe = "DelayedScaling"
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.535 and actual[1] > 0.73
+
+    # TODO(jreiffers): Add mxfp8 Shardy tests once supported in JAX.
+
 
 if __name__ == "__main__":
     train_and_evaluate(encoder_parser(None))

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -577,7 +577,7 @@ def encoder_parser(args):
 class TestEncoder(unittest.TestCase):
     """Encoder unittests"""
 
-    def exec(self, use_fp8, fp8_recipe, *, enable_shardy = False):
+    def exec(self, use_fp8, fp8_recipe, *, enable_shardy=False):
         """Run 3 epochs for testing"""
         args = encoder_parser([])
 
@@ -625,12 +625,14 @@ class TestEncoder(unittest.TestCase):
         result = self.exec(False, None, enable_shardy=True)
         assert result[0] < 0.45 and result[1] > 0.79
 
-    @unittest.skipIf(not is_fp8_supported(),
-                     "Device compute capability 9.0+ is required for DelayedScaling FP8")
+    @unittest.skipIf(
+        not is_fp8_supported(), "Device compute capability 9.0+ is required for DelayedScaling FP8"
+    )
     def test_te_delayed_scaling_fp8_shardy(self):
         """Test Transformer Engine with DelayedScaling FP8"""
         result = self.exec(True, "DelayedScaling", enable_shardy=True)
         assert result[0] < 0.455 and result[1] > 0.79
+
 
 if __name__ == "__main__":
     train_and_evaluate(encoder_parser(None))

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -623,7 +623,7 @@ class TestEncoder(unittest.TestCase):
     def test_te_bf16_shardy(self):
         """Test Transformer Engine with BF16"""
         result = self.exec(False, None, enable_shardy=True)
-        assert result[0] < 0.45 and result[1] > 0.79
+        assert result[0] < 0.505 and result[1] > 0.755
 
     @unittest.skipIf(
         not is_fp8_supported(), "Device compute capability 9.0+ is required for DelayedScaling FP8"
@@ -631,7 +631,7 @@ class TestEncoder(unittest.TestCase):
     def test_te_delayed_scaling_fp8_shardy(self):
         """Test Transformer Engine with DelayedScaling FP8"""
         result = self.exec(True, "DelayedScaling", enable_shardy=True)
-        assert result[0] < 0.455 and result[1] > 0.79
+        assert result[0] < 0.505 and result[1] > 0.755
 
 
 if __name__ == "__main__":

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -633,6 +633,8 @@ class TestEncoder(unittest.TestCase):
         result = self.exec(True, "DelayedScaling", enable_shardy=True)
         assert result[0] < 0.505 and result[1] > 0.755
 
+    # TODO(jreiffers): Add mxfp8 Shardy tests once supported in JAX.
+
 
 if __name__ == "__main__":
     train_and_evaluate(encoder_parser(None))

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -631,7 +631,7 @@ class TestEncoder(unittest.TestCase):
     def test_te_delayed_scaling_fp8_shardy(self):
         """Test Transformer Engine with DelayedScaling FP8"""
         result = self.exec(True, "DelayedScaling", enable_shardy=True)
-        assert result[0] < 0.505 and result[1] > 0.755
+        assert result[0] < 0.505 and result[1] > 0.754
 
     # TODO(jreiffers): Add mxfp8 Shardy tests once supported in JAX.
 

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -343,6 +343,7 @@ def get_state_sharding(state, params_sharding):
 def train_and_evaluate(args):
     """Execute model training and evaluation loop."""
     print(args)
+    jax.config.update("jax_use_shardy_partitioner", args.enable_shardy)
     if args.process_id == 0:
         nltk.download("punkt_tab")
 
@@ -565,6 +566,9 @@ def encoder_parser(args):
         default=0,
         help="the ID number of the current process (default: 0)",
     )
+    parser.add_argument(
+        "--enable-shardy", action="store_true", default=False, help="Enable Shardy (experimental)."
+    )
 
     return parser.parse_args(args)
 
@@ -573,7 +577,7 @@ def encoder_parser(args):
 class TestEncoder(unittest.TestCase):
     """Encoder unittests"""
 
-    def exec(self, use_fp8, fp8_recipe):
+    def exec(self, use_fp8, fp8_recipe, *, enable_shardy = False):
         """Run 3 epochs for testing"""
         args = encoder_parser([])
 
@@ -589,6 +593,7 @@ class TestEncoder(unittest.TestCase):
         args.num_process = num_gpu
         args.process_id = self.process_id
         args.fp8_recipe = fp8_recipe
+        args.enable_shardy = enable_shardy
 
         return train_and_evaluate(args)
 
@@ -614,6 +619,18 @@ class TestEncoder(unittest.TestCase):
         result = self.exec(True, "MXFP8BlockScaling")
         assert result[0] < 0.505 and result[1] > 0.754
 
+    @unittest.skipIf(not is_bf16_supported(), "Device compute capability 8.0+ is required for BF16")
+    def test_te_bf16_shardy(self):
+        """Test Transformer Engine with BF16"""
+        result = self.exec(False, None, enable_shardy=True)
+        assert result[0] < 0.45 and result[1] > 0.79
+
+    @unittest.skipIf(not is_fp8_supported(),
+                     "Device compute capability 9.0+ is required for DelayedScaling FP8")
+    def test_te_delayed_scaling_fp8_shardy(self):
+        """Test Transformer Engine with DelayedScaling FP8"""
+        result = self.exec(True, "DelayedScaling", enable_shardy=True)
+        assert result[0] < 0.455 and result[1] > 0.79
 
 if __name__ == "__main__":
     train_and_evaluate(encoder_parser(None))

--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -203,6 +203,7 @@ def check_fp8(state, var_collect, inputs, masks, labels):
 def train_and_evaluate(args):
     """Execute model training and evaluation loop."""
     print(args)
+    jax.config.update("jax_use_shardy_partitioner", args.enable_shardy)
     train_ds, test_ds, num_embed = get_datasets(args.max_seq_len)
 
     rng = jax.random.PRNGKey(args.seed)
@@ -320,6 +321,9 @@ def encoder_parser(args):
         default="DelayedScaling",
         help="Use FP8 recipe (default: DelayedScaling)",
     )
+    parser.add_argument(
+        "--enable-shardy", action="store_true", default=False, help="Enable Shardy (experimental)."
+    )
 
     return parser.parse_args(args)
 
@@ -330,10 +334,9 @@ class TestEncoder(unittest.TestCase):
     is_fp8_supported, fp8_reason = is_fp8_available(ScalingMode.DELAYED_TENSOR_SCALING)
     is_mxfp8_supported, mxfp8_reason = is_fp8_available(ScalingMode.MXFP8_1D_SCALING)
 
-    @classmethod
-    def setUpClass(cls):
-        """Run 4 epochs for testing"""
-        cls.args = encoder_parser(["--epochs", "3"])
+    def setUp(self):
+        """Run 3 epochs for testing"""
+        self.args = encoder_parser(["--epochs", "3"])
 
     @unittest.skipIf(not is_bf16_supported(), "Device compute capability 8.0+ is required for BF16")
     def test_te_bf16(self):
@@ -354,6 +357,31 @@ class TestEncoder(unittest.TestCase):
         """Test Transformer Engine with MXFP8"""
         self.args.use_fp8 = True
         self.args.fp8_recipe = "MXFP8BlockScaling"
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.455 and actual[1] > 0.79
+
+    @unittest.skipIf(not is_bf16_supported(), "Device compute capability 8.0+ is required for BF16")
+    def test_te_bf16_shardy(self):
+        """Test Transformer Engine with BF16"""
+        self.args.enable_shardy = True
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.45 and actual[1] > 0.79
+
+    @unittest.skipIf(not is_fp8_supported, fp8_reason)
+    def test_te_delayed_scaling_fp8_shardy(self):
+        """Test Transformer Engine with DelayedScaling FP8"""
+        self.args.use_fp8 = True
+        self.args.fp8_recipe = "DelayedScaling"
+        self.args.enable_shardy = True
+        actual = train_and_evaluate(self.args)
+        assert actual[0] < 0.455 and actual[1] > 0.79
+
+    @unittest.skipIf(not is_mxfp8_supported, mxfp8_reason)
+    def test_te_mxfp8_shardy(self):
+        """Test Transformer Engine with MXFP8"""
+        self.args.use_fp8 = True
+        self.args.fp8_recipe = "MXFP8BlockScaling"
+        self.args.enable_shardy = True
         actual = train_and_evaluate(self.args)
         assert actual[0] < 0.455 and actual[1] > 0.79
 

--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -203,7 +203,6 @@ def check_fp8(state, var_collect, inputs, masks, labels):
 def train_and_evaluate(args):
     """Execute model training and evaluation loop."""
     print(args)
-    jax.config.update("jax_use_shardy_partitioner", args.enable_shardy)
     train_ds, test_ds, num_embed = get_datasets(args.max_seq_len)
 
     rng = jax.random.PRNGKey(args.seed)
@@ -321,9 +320,6 @@ def encoder_parser(args):
         default="DelayedScaling",
         help="Use FP8 recipe (default: DelayedScaling)",
     )
-    parser.add_argument(
-        "--enable-shardy", action="store_true", default=False, help="Enable Shardy (experimental)."
-    )
 
     return parser.parse_args(args)
 
@@ -357,31 +353,6 @@ class TestEncoder(unittest.TestCase):
         """Test Transformer Engine with MXFP8"""
         self.args.use_fp8 = True
         self.args.fp8_recipe = "MXFP8BlockScaling"
-        actual = train_and_evaluate(self.args)
-        assert actual[0] < 0.455 and actual[1] > 0.79
-
-    @unittest.skipIf(not is_bf16_supported(), "Device compute capability 8.0+ is required for BF16")
-    def test_te_bf16_shardy(self):
-        """Test Transformer Engine with BF16"""
-        self.args.enable_shardy = True
-        actual = train_and_evaluate(self.args)
-        assert actual[0] < 0.45 and actual[1] > 0.79
-
-    @unittest.skipIf(not is_fp8_supported, fp8_reason)
-    def test_te_delayed_scaling_fp8_shardy(self):
-        """Test Transformer Engine with DelayedScaling FP8"""
-        self.args.use_fp8 = True
-        self.args.fp8_recipe = "DelayedScaling"
-        self.args.enable_shardy = True
-        actual = train_and_evaluate(self.args)
-        assert actual[0] < 0.455 and actual[1] > 0.79
-
-    @unittest.skipIf(not is_mxfp8_supported, mxfp8_reason)
-    def test_te_mxfp8_shardy(self):
-        """Test Transformer Engine with MXFP8"""
-        self.args.use_fp8 = True
-        self.args.fp8_recipe = "MXFP8BlockScaling"
-        self.args.enable_shardy = True
         actual = train_and_evaluate(self.args)
         assert actual[0] < 0.455 and actual[1] > 0.79
 

--- a/tests/jax/pytest.ini
+++ b/tests/jax/pytest.ini
@@ -25,3 +25,5 @@ filterwarnings=
     ignore:jax.experimental.maps and .* are deprecated.*:DeprecationWarning
     ignore:The host_callback APIs are deprecated .*:DeprecationWarning
     ignore:Scan loop is disabled for fused ring attention.*:UserWarning
+    ignore:jax.extend.ffi.register_ffi_target is deprecated
+    ignore:jax.extend.ffi.ffi_lowering is deprecated

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -172,7 +172,9 @@ class TestDistributedSelfAttn:
             pytest.param(AttnBiasType.PRE_SCALE_BIAS, BiasShape._1HSS, id="PRE_SCALE_BIAS-1HSS"),
         ],
     )
-    def test_self_attn_shardy(self, device_count, mesh_shape, mesh_axes, mesh_resource, attn_bias_type, bias_shape):
+    def test_self_attn_shardy(
+        self, device_count, mesh_shape, mesh_axes, mesh_resource, attn_bias_type, bias_shape
+    ):
         data_shape = (32, 512, 12, 64)
         self.impl_test_self_attn(
             device_count,
@@ -258,7 +260,9 @@ DISTRIBUTED_CONTEXT_SELF_ATTN_LAYOUTS_MASKS = [
     pytest.param(QKVLayout.BSHD_BSHD_BSHD, AttnMaskType.CAUSAL_MASK, id="BSHD_SEPARATE-CAUSAL"),
     pytest.param(QKVLayout.BSHD_BS2HD, AttnMaskType.NO_MASK, id="HD_KVPACKED-NO_MASK"),
     pytest.param(QKVLayout.BSHD_BSHD_BSHD, AttnMaskType.NO_MASK, id="BSHD_SEPARATE-NO_MASK"),
-    pytest.param(QKVLayout.THD_THD_THD, AttnMaskType.PADDING_CAUSAL_MASK, id="THD_SEPARATE-PADDING_CAUSAL"),
+    pytest.param(
+        QKVLayout.THD_THD_THD, AttnMaskType.PADDING_CAUSAL_MASK, id="THD_SEPARATE-PADDING_CAUSAL"
+    ),
 ]
 
 DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES = [
@@ -266,6 +270,7 @@ DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES = [
     pytest.param([2, 128, 8, 128], id="2-128xCP-8-128"),
     pytest.param([4, 256, 16, 64], id="4-256xCP-16-64"),
 ]
+
 
 class TestDistributedContextParallelSelfAttn:
 
@@ -498,7 +503,7 @@ class TestDistributedContextParallelSelfAttn:
             load_balanced,
             CPStrategy.RING,
             use_shardy=False,
-            use_scan_ring=use_scan
+            use_scan_ring=use_scan,
         )
 
     @pytest.mark.parametrize(
@@ -535,7 +540,7 @@ class TestDistributedContextParallelSelfAttn:
             load_balanced=True,
             cp_strategy=CPStrategy.RING,
             use_shardy=False,
-            use_scan_ring=True
+            use_scan_ring=True,
         )
 
 

--- a/tests/jax/test_distributed_layernorm.py
+++ b/tests/jax/test_distributed_layernorm.py
@@ -86,6 +86,7 @@ class TestDistributedLayernorm:
     @pytest_parametrize_wrapper("zero_centered_gamma", [False, True])
     @pytest_parametrize_wrapper("shard_weights", [False, True])
     @pytest_parametrize_wrapper("fp8_recipe", SUPPORTED_RECIPES)
+    @pytest_parametrize_wrapper("use_shardy", [False, True])
     def test_layernorm(
         self,
         device_count,
@@ -97,7 +98,9 @@ class TestDistributedLayernorm:
         zero_centered_gamma,
         shard_weights,
         fp8_recipe,
+        use_shardy,
     ):
+        jax.config.update("jax_use_shardy_partitioner", use_shardy)
         epsilon = 1e-6
         ln_type = "layernorm"
         q_dtype = jnp.float8_e4m3fn
@@ -168,6 +171,7 @@ class TestDistributedLayernorm:
     @pytest_parametrize_wrapper("dtype", DTYPES)
     @pytest_parametrize_wrapper("shard_weights", [False, True])
     @pytest_parametrize_wrapper("fp8_recipe", SUPPORTED_RECIPES)
+    @pytest_parametrize_wrapper("use_shardy", [False, True])
     def test_rmsnorm(
         self,
         device_count,
@@ -178,7 +182,9 @@ class TestDistributedLayernorm:
         dtype,
         shard_weights,
         fp8_recipe,
+        use_shardy,
     ):
+        jax.config.update("jax_use_shardy_partitioner", use_shardy)
         epsilon = 1e-6
         ln_type = "rmsnorm"
         q_dtype = jnp.float8_e4m3fn

--- a/tests/jax/test_distributed_layernorm_mlp.py
+++ b/tests/jax/test_distributed_layernorm_mlp.py
@@ -399,4 +399,5 @@ class TestDistributedLayernormMLP:
             dtype,
             use_fp8=True,
             fp8_recipe=fp8_recipe,
+            use_shardy=False,
         )

--- a/tests/jax/test_distributed_layernorm_mlp.py
+++ b/tests/jax/test_distributed_layernorm_mlp.py
@@ -334,9 +334,18 @@ class TestDistributedLayernormMLP:
     @pytest_parametrize_wrapper("dtype", DTYPES)
     @pytest_parametrize_wrapper("use_bias", [True, False])
     @pytest_parametrize_wrapper("use_shardy", [False, True])
-    def test_layernorm_mlp_layer(self, mesh_config, activation_type, use_bias, input_shape, dtype, use_shardy):
+    def test_layernorm_mlp_layer(
+        self, mesh_config, activation_type, use_bias, input_shape, dtype, use_shardy
+    ):
         self._test_layernorm_mlp(
-            mesh_config, activation_type, use_bias, input_shape, dtype, use_fp8=False, fp8_recipe=None, use_shardy=use_shardy
+            mesh_config,
+            activation_type,
+            use_bias,
+            input_shape,
+            dtype,
+            use_fp8=False,
+            fp8_recipe=None,
+            use_shardy=use_shardy,
         )
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)

--- a/tests/jax/test_distributed_layernorm_mlp.py
+++ b/tests/jax/test_distributed_layernorm_mlp.py
@@ -151,9 +151,11 @@ class TestDistributedLayernormMLP:
     @pytest_parametrize_wrapper("dtype", DTYPES)
     @pytest_parametrize_wrapper("use_bias", [True, False])
     @pytest_parametrize_wrapper("fp8_recipe", SUPPORTED_RECIPES)
+    @pytest_parametrize_wrapper("use_shardy", [True, False])
     def test_layernorm_mlp_grad(
-        self, mesh_config, activation_type, use_bias, input_shape, dtype, fp8_recipe
+        self, mesh_config, activation_type, use_bias, input_shape, dtype, fp8_recipe, use_shardy
     ):
+        jax.config.update("jax_use_shardy_partitioner", use_shardy)
         device_count, mesh_shape, mesh_axes, mesh_resource = mesh_config
         layernorm_type = "rmsnorm"
 
@@ -258,8 +260,17 @@ class TestDistributedLayernormMLP:
                     )
 
     def _test_layernorm_mlp(
-        self, mesh_config, activation_type, use_bias, input_shape, dtype, use_fp8, fp8_recipe=None
+        self,
+        mesh_config,
+        activation_type,
+        use_bias,
+        input_shape,
+        dtype,
+        use_fp8,
+        fp8_recipe,
+        use_shardy,
     ):
+        jax.config.update("jax_use_shardy_partitioner", use_shardy)
         batch, seqlen, hidden_in = input_shape
         layernorm_type = "rmsnorm"
 
@@ -322,9 +333,10 @@ class TestDistributedLayernormMLP:
     @pytest_parametrize_wrapper("activation_type", [("gelu",), ("silu", "linear")])
     @pytest_parametrize_wrapper("dtype", DTYPES)
     @pytest_parametrize_wrapper("use_bias", [True, False])
-    def test_layernorm_mlp_layer(self, mesh_config, activation_type, use_bias, input_shape, dtype):
+    @pytest_parametrize_wrapper("use_shardy", [False, True])
+    def test_layernorm_mlp_layer(self, mesh_config, activation_type, use_bias, input_shape, dtype, use_shardy):
         self._test_layernorm_mlp(
-            mesh_config, activation_type, use_bias, input_shape, dtype, use_fp8=False
+            mesh_config, activation_type, use_bias, input_shape, dtype, use_fp8=False, fp8_recipe=None, use_shardy=use_shardy
         )
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)

--- a/tests/jax/test_distributed_softmax.py
+++ b/tests/jax/test_distributed_softmax.py
@@ -28,14 +28,14 @@ class TestDistributedSoftmax:
         all_reduce_loss_bytes = 4  # 1 * FP32
         return generate_collectives_count(allreduce=all_reduce_loss_bytes, allgather=0, other=0)
 
-    def generate_inputs(self, shape, mesh_resource, softmax_type, dtype, bad_sharding):
+    def generate_inputs(self, shape, mesh_resource, softmax_type, dtype, bad_sharding, broadcast_batch_mask):
         batch, _, sqelen, _ = shape
 
         x = random.normal(random.PRNGKey(1124), shape, dtype=dtype)
         if softmax_type == SoftmaxType.SCALED_UPPER_TRIANG_MASKED:
             mask = make_causal_mask(batch, sqelen)
         else:
-            mask = make_self_mask(batch, sqelen)
+            mask = make_self_mask(1 if broadcast_batch_mask else batch, sqelen)
 
         if not bad_sharding:
             x_pspec = PartitionSpec(
@@ -45,7 +45,11 @@ class TestDistributedSoftmax:
             x_pspec = PartitionSpec(
                 mesh_resource.dp_resource, None, None, mesh_resource.tp_resource
             )
-        mask_pspec = PartitionSpec(mesh_resource.dp_resource, None, None, None)
+
+        if broadcast_batch_mask:
+            mask_pspec = PartitionSpec(None, None, None, None)
+        else:
+            mask_pspec = PartitionSpec(mesh_resource.dp_resource, None, None, None)
 
         return (x, mask), (x_pspec, mask_pspec)
 
@@ -76,6 +80,8 @@ class TestDistributedSoftmax:
     @pytest.mark.parametrize("scale_factor", [1.0, 3.0])
     @pytest.mark.parametrize("dtype", DTYPES)
     @pytest.mark.parametrize("bad_sharding", [False, True])
+    @pytest.mark.parametrize("broadcast_batch_mask", [False, True])
+    @pytest.mark.parametrize("use_shardy", [False, True])
     def test_softmax(
         self,
         device_count,
@@ -87,15 +93,20 @@ class TestDistributedSoftmax:
         scale_factor,
         dtype,
         bad_sharding,
+        broadcast_batch_mask,
+        use_shardy,
     ):
+        if broadcast_batch_mask and softmax_type != SoftmaxType.SCALED_MASKED:
+            pytest.skip("Softmax type has no mask.")
 
+        jax.config.update("jax_use_shardy_partitioner", use_shardy)
         target_func = partial(
             self.target_func, scale_factor=scale_factor, softmax_type=softmax_type
         )
         ref_func = partial(self.ref_func, scale_factor=scale_factor, dtype=dtype)
 
         (x, mask), (x_pspec, mask_pspec) = self.generate_inputs(
-            data_shape, mesh_resource, softmax_type, dtype, bad_sharding
+            data_shape, mesh_resource, softmax_type, dtype, bad_sharding, broadcast_batch_mask
         )
         collective_count_ref = self.generate_collectives_count_ref()
         devices = np.asarray(jax.devices()[:device_count]).reshape(*mesh_shape)
@@ -128,5 +139,5 @@ class TestDistributedSoftmax:
                     for w in warns:
                         assert "Sharding the hidden dimension is not supported" in str(w), (
                             "Softmax primitive did not raise the correct warning for "
-                            "unsupported sharding in the hidden dimension."
+                            "unsupported sharding in the hidden dimension." f"{str(w)}"
                         )

--- a/tests/jax/test_distributed_softmax.py
+++ b/tests/jax/test_distributed_softmax.py
@@ -28,7 +28,9 @@ class TestDistributedSoftmax:
         all_reduce_loss_bytes = 4  # 1 * FP32
         return generate_collectives_count(allreduce=all_reduce_loss_bytes, allgather=0, other=0)
 
-    def generate_inputs(self, shape, mesh_resource, softmax_type, dtype, bad_sharding, broadcast_batch_mask):
+    def generate_inputs(
+        self, shape, mesh_resource, softmax_type, dtype, bad_sharding, broadcast_batch_mask
+    ):
         batch, _, sqelen, _ = shape
 
         x = random.normal(random.PRNGKey(1124), shape, dtype=dtype)
@@ -139,5 +141,6 @@ class TestDistributedSoftmax:
                     for w in warns:
                         assert "Sharding the hidden dimension is not supported" in str(w), (
                             "Softmax primitive did not raise the correct warning for "
-                            "unsupported sharding in the hidden dimension." f"{str(w)}"
+                            "unsupported sharding in the hidden dimension."
+                            f"{str(w)}"
                         )

--- a/tests/jax/test_distributed_softmax.py
+++ b/tests/jax/test_distributed_softmax.py
@@ -168,7 +168,7 @@ class TestDistributedSoftmax:
             dtype,
             bad_sharding,
             broadcast_batch_mask,
-            use_shardy=False
+            use_shardy=False,
         )
 
     @pytest.mark.parametrize("device_count,mesh_shape,mesh_axes,mesh_resource", generate_configs())
@@ -196,5 +196,5 @@ class TestDistributedSoftmax:
             dtype=DTYPES[0],
             bad_sharding=bad_sharding,
             broadcast_batch_mask=broadcast_batch_mask,
-            use_shardy=True
+            use_shardy=True,
         )

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -429,7 +429,7 @@ class ActLuPrimitive(BasePrimitive):
         )
         x_axes = scale_rules.input_spec + (f"x{x_rank-1}",)
         out = (*x_axes[:-2], x_axes[-1])
-        if scaling_mode == ScalingMode.NVTE_MXFP8_1D_SCALING.value:
+        if scaling_mode == ScalingMode.MXFP8_1D_SCALING.value:
             scale_inv = scale_rules.rowwise_rule[:-1] + (scale_rules.rowwise_rule[-1],)
             colwise_scale_inv = scale_rules.colwise_rule[:-1] + (scale_rules.colwise_rule[-1],)
         else:
@@ -437,7 +437,7 @@ class ActLuPrimitive(BasePrimitive):
             colwise_scale_inv = scale_rules.colwise_rule
 
         if is_2x:
-            if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
+            if scaling_mode == ScalingMode.DELAYED_TENSOR_SCALING.value:
                 colwise_out = tuple(
                     multidim_transpose(x_axes, static_axis_boundary=-1, transpose_axis=-1)
                 )
@@ -894,7 +894,7 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
         x_axes = scale_rules.input_spec
         out = x_axes
         if is_2x:
-            if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
+            if scaling_mode == ScalingMode.DELAYED_TENSOR_SCALING.value:
                 colwise_out = tuple(multidim_transpose(x_axes, transpose_axis=-2))
             else:
                 colwise_out = tuple(x_axes)

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -439,7 +439,7 @@ class ActLuPrimitive(BasePrimitive):
         if is_2x:
             if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
                 colwise_out = tuple(
-                    multidim_transpose(x_axes, static_axis_boundary=-1, transpose_axis_boundary=-1)
+                    multidim_transpose(x_axes, static_axis_boundary=-1, transpose_axis=-1)
                 )
             else:
                 colwise_out = out

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -426,7 +426,7 @@ class ActLuPrimitive(BasePrimitive):
         x_rank = len(value_types[0].shape)
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(x_rank-1,
                                                                           unique_var='i')
-        x_axes = scale_rules.input + (f'x{x_rank-1}',)
+        x_axes = scale_rules.input_spec + (f'x{x_rank-1}',)
         out = (*x_axes[:-2], x_axes[-1])
         if scaling_mode == ScalingMode.NVTE_MXFP8_1D_SCALING.value:
             scale_inv = scale_rules.rowwise_rule[:-1] + (scale_rules.rowwise_rule[-1],)
@@ -887,7 +887,7 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
         x_rank = len(value_types[0].shape)
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(x_rank,
                                                                           unique_var='i')
-        x_axes = scale_rules.input
+        x_axes = scale_rules.input_spec
         out = x_axes
         if is_2x:
             if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -425,7 +425,7 @@ class ActLuPrimitive(BasePrimitive):
 
         x_rank = len(value_types[0].shape)
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(
-            x_rank - 1, unique_var="i", flatten_axis=-1
+            x_rank - 1, unique_var="i", flatten_axis=-2
         )
         x_axes = scale_rules.input_spec + (f"x{x_rank-1}",)
         out = (*x_axes[:-2], x_axes[-1])

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -10,6 +10,7 @@ from packaging import version
 import jax
 import jax.numpy as jnp
 from jax import dtypes
+from jax.experimental.custom_partitioning import SdyShardingRule
 from jax.sharding import PartitionSpec
 
 import transformer_engine_jax
@@ -405,6 +406,53 @@ class ActLuPrimitive(BasePrimitive):
             )
 
         return mesh, sharded_impl, out_shardings, arg_shardings
+
+    @staticmethod
+    def shardy_sharding_rule(
+        out_dtype,
+        act_enum,
+        act_len,
+        scaling_mode,
+        is_2x,
+        scale_dtype,
+        scale_shapes,
+        is_outer,
+        mesh,
+        value_types,
+        result_types
+    ):
+        del out_dtype, act_enum, act_len, scale_dtype, scale_shapes, is_outer, mesh, result_types
+
+        x_rank = len(value_types[0].shape)
+        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(x_rank-1,
+                                                                          unique_var='i')
+        x_axes = scale_rules.input + (f'x{x_rank-1}',)
+        out = (*x_axes[:-2], x_axes[-1])
+        if scaling_mode == ScalingMode.NVTE_MXFP8_1D_SCALING.value:
+            scale_inv = scale_rules.rowwise_rule[:-1] + (scale_rules.rowwise_rule[-1],)
+            colwise_scale_inv = scale_rules.colwise_rule[:-1] + (scale_rules.colwise_rule[-1],)
+        else:
+            scale_inv = scale_rules.rowwise_rule
+            colwise_scale_inv = scale_rules.colwise_rule
+
+        if is_2x:
+            if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
+                colwise_out = tuple(multidim_transpose(
+                    x_axes, static_axis_boundary=-1, transpose_axis_boundary=-1
+                ))
+            else:
+                colwise_out = out
+        else:
+            colwise_out = ('j',)
+
+        # amax is always a unit tensor.
+        amax = ('k',)
+
+        return SdyShardingRule(
+            (x_axes, ('…1'),),
+            (out, colwise_out, scale_inv, colwise_scale_inv, amax),
+            **scale_rules.factor_sizes
+        )
 
 
 register_primitive(ActLuPrimitive)
@@ -818,6 +866,45 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
             return out, colwise_out, scale_inv, colwise_scale_inv, global_updated_amax, global_dbias
 
         return mesh, sharded_impl, out_shardings, arg_shardings
+
+    @staticmethod
+    def shardy_sharding_rule(
+        out_dtype,
+        scaling_mode,
+        is_2x,
+        scale_dtype,
+        scale_shapes,
+        is_dbias,
+        act_enum,
+        act_len,
+        is_outer,
+        mesh,
+        value_types,
+        result_types,
+    ):
+        del out_dtype, scale_dtype, scale_shapes, act_enum, act_len, is_outer, mesh, result_types
+
+        x_rank = len(value_types[0].shape)
+        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(x_rank,
+                                                                          unique_var='i')
+        x_axes = scale_rules.input
+        out = x_axes
+        if is_2x:
+            if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
+                colwise_out = tuple(multidim_transpose(x_axes, transpose_axis=-2))
+            else:
+                colwise_out = tuple(x_axes)
+        else:
+            colwise_out = ('j',)
+
+        dbias = (x_axes[-1],) if is_dbias else ('k',)
+        amax = ('…4',)
+
+        return SdyShardingRule(
+            (('…0',), tuple(x_axes), ('…2',)),
+            (out, colwise_out, scale_rules.rowwise_rule, scale_rules.colwise_rule, amax, dbias),
+            **scale_rules.factor_sizes
+        )
 
 
 register_primitive(DActLuDBiasQuantizePrimitive)

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -445,9 +445,10 @@ class ActLuPrimitive(BasePrimitive):
                 colwise_out = out
         else:
             colwise_out = ("j",)
+            colwise_scale_inv = ("k",)
 
         # amax is always a unit tensor.
-        amax = ("k",)
+        amax = ("l",)
 
         return SdyShardingRule(
             (
@@ -888,7 +889,7 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
     ):
         del out_dtype, scale_dtype, scale_shapes, act_enum, act_len, is_outer, mesh, result_types
 
-        x_rank = len(value_types[0].shape)
+        x_rank = len(value_types[1].shape)
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(x_rank, unique_var="i")
         x_axes = scale_rules.input_spec
         out = x_axes
@@ -900,7 +901,7 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
         else:
             colwise_out = ("j",)
 
-        dbias = (x_axes[-1],) if is_dbias else ("k",)
+        dbias = x_axes[-2:] if is_dbias else ("k",)
         amax = ("…4",)
 
         return SdyShardingRule(

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -626,28 +626,29 @@ class FusedAttnFwdPrimitive(BasePrimitive):
 
         # Keep in sync with `infer_sharding_from_operands`.
         # We only need the first input. Fill up the rest with placeholders.
-        input_spec = [(f'…{x}',) for x in range(len(value_types))]
+        input_spec = [(f"…{x}",) for x in range(len(value_types))]
         # The RNG state sharding cannot be expressed as a Shardy rule. We use with_sharding_constraint
         # instead. This has to happen outside of the primitive, see `fused_attn_fwd`.
-        rng_sharding = (f'…{len(value_types)}',)
+        rng_sharding = (f"…{len(value_types)}",)
 
         if config.qkv_layout.is_qkvpacked():
-            input_spec[0] = ('…0', 'seqlen', 'three', 'head', 'hidden')
+            input_spec[0] = ("…0", "seqlen", "three", "head", "hidden")
         elif config.qkv_layout.is_kvpacked() or config.qkv_layout.is_separate():
-            input_spec[0] = ('…0', 'seqlen', 'head', 'hidden')
+            input_spec[0] = ("…0", "seqlen", "head", "hidden")
         else:
             raise ValueError(f"Unsupported {config.qkv_layout=}")
 
         is_packed_softmax = get_cudnn_version() >= (9, 6, 0) and config.qkv_layout.is_thd()
-        out_sharding = ('…0', 'seqlen', 'head', 'hidden')
+        out_sharding = ("…0", "seqlen", "head", "hidden")
         if is_packed_softmax:
-            softmax_aux_sharding = ('…0', 'seqlen', 'head', 'i')
+            softmax_aux_sharding = ("…0", "seqlen", "head", "i")
         else:
-            softmax_aux_sharding = ('…0', 'head', 'seqlen', 'i')
+            softmax_aux_sharding = ("…0", "head", "seqlen", "i")
 
         return SdyShardingRule(
-            tuple(input_spec),
-            (out_sharding, softmax_aux_sharding, rng_sharding))
+            tuple(input_spec), (out_sharding, softmax_aux_sharding, rng_sharding)
+        )
+
 
 register_primitive(FusedAttnFwdPrimitive)
 
@@ -1033,8 +1034,8 @@ class FusedAttnBwdPrimitive(BasePrimitive):
         del config, mesh
         # We only care about the four first arguments.
         # Keep in sync with `infer_sharding_from_operands`.
-        input_spec = tuple((f'…{x}',) for x in range(len(value_types)))
-        output_spec = tuple((f'…{x}',) for x in range(len(result_types)))
+        input_spec = tuple((f"…{x}",) for x in range(len(value_types)))
+        output_spec = tuple((f"…{x}",) for x in range(len(result_types)))
         return SdyShardingRule(input_spec, output_spec)
 
 

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -14,6 +14,7 @@ import jax
 import jax.numpy as jnp
 from jax import dtypes, lax
 from jax.sharding import PartitionSpec, NamedSharding
+from jax.experimental.custom_partitioning import SdyShardingRule
 
 import transformer_engine_jax
 from transformer_engine_jax import NVTE_Fused_Attn_Backend
@@ -42,6 +43,7 @@ from ..sharding import (
     get_mesh_axis_rank,
     get_all_mesh_axes,
     num_of_devices,
+    with_sharding_constraint,
 )
 
 
@@ -618,6 +620,28 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         impl = partial(FusedAttnFwdPrimitive.impl, config=config)
         return mesh, impl, out_shardings, arg_shardings
 
+    @staticmethod
+    def shardy_sharding_rule(config, mesh, value_types, result_types):
+        del mesh, result_types
+
+        # Keep in sync with `infer_sharding_from_operands`.
+        # We only need the first input. Fill up the rest with placeholders.
+        input_spec = [(f'…{x}',) for x in range(len(value_types))]
+        # The RNG state sharding cannot be expressed as a Shardy rule. We use with_sharding_constraint
+        # instead. This has to happen outside of the primitive, see `fused_attn_fwd`.
+        rng_sharding = (f'…{len(value_types)}',)
+
+        if config.qkv_layout.is_qkvpacked():
+            input_spec[0] = ('…0', 'i', 'j', 'k', 'l')
+            return SdyShardingRule(
+                tuple(input_spec),
+                (('…0', 'i', 'k', 'l'), ('…0', 'k', 'i', 'm'), rng_sharding))
+
+        # All other layouts.
+        input_spec[0] = ('…0', 'i', 'j', 'k')
+        return SdyShardingRule(
+            tuple(input_spec),
+            (('…0', 'i', 'j', 'k'), ('…0', 'j', 'i', 'l'), rng_sharding))
 
 register_primitive(FusedAttnFwdPrimitive)
 
@@ -997,6 +1021,15 @@ class FusedAttnBwdPrimitive(BasePrimitive):
             return local_dq, local_dk, local_dv, global_dbias
 
         return mesh, sharded_impl, out_shardings, arg_shardings
+
+    @staticmethod
+    def shardy_sharding_rule(config, mesh, value_types, result_types):
+        del config, mesh
+        # We only care about the four first arguments.
+        # Keep in sync with `infer_sharding_from_operands`.
+        input_spec = tuple((f'…{x}',) for x in range(len(value_types)))
+        output_spec = tuple((f'…{x}',) for x in range(len(result_types)))
+        return SdyShardingRule(input_spec, output_spec)
 
 
 register_primitive(FusedAttnBwdPrimitive)
@@ -2436,13 +2469,15 @@ def fused_attn_fwd(
                 primitive = FusedRingAttnFwdPrimitive.outer_primitive
 
     seq_desc_flatten, _ = jax.tree.flatten(sequence_descriptor)
-    return primitive.bind(
+    output, softmax_aux, rng_state = primitive.bind(
         *qkv_for_primitive,
         bias,
         seed,
         *seq_desc_flatten,
         config=fused_config,
     )
+    rng_state = with_sharding_constraint(rng_state, PartitionSpec(get_all_mesh_axes(), None))
+    return (output, softmax_aux, rng_state)
 
 
 def fused_attn_bwd(

--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -98,6 +98,12 @@ class BasePrimitive(metaclass=ABCMeta):
         """
         return NotImplemented
 
+    @staticmethod
+    @abstractmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '... -> ...'
+
 
 def register_primitive(cls):
     """
@@ -123,7 +129,8 @@ def register_primitive(cls):
     batching.primitive_batchers[outer_p] = cls.batcher
     outer_p_lower = custom_partitioning(cls.impl, static_argnums=cls.impl_static_args)
     outer_p_lower.def_partition(
-        infer_sharding_from_operands=cls.infer_sharding_from_operands, partition=cls.partition
+        infer_sharding_from_operands=cls.infer_sharding_from_operands, partition=cls.partition,
+        sharding_rule=cls.shardy_sharding_rule
     )
     mlir.register_lowering(
         outer_p, mlir.lower_fun(outer_p_lower, multiple_results=cls.multiple_results)

--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -105,7 +105,7 @@ class BasePrimitive(metaclass=ABCMeta):
         Returns the sharding rule for this primitive.
         """
         del args
-        return '... -> ...'
+        return "... -> ..."
 
 
 def register_primitive(cls):
@@ -132,8 +132,9 @@ def register_primitive(cls):
     batching.primitive_batchers[outer_p] = cls.batcher
     outer_p_lower = custom_partitioning(cls.impl, static_argnums=cls.impl_static_args)
     outer_p_lower.def_partition(
-        infer_sharding_from_operands=cls.infer_sharding_from_operands, partition=cls.partition,
-        sharding_rule=cls.shardy_sharding_rule
+        infer_sharding_from_operands=cls.infer_sharding_from_operands,
+        partition=cls.partition,
+        sharding_rule=cls.shardy_sharding_rule,
     )
     mlir.register_lowering(
         outer_p, mlir.lower_fun(outer_p_lower, multiple_results=cls.multiple_results)

--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -101,6 +101,9 @@ class BasePrimitive(metaclass=ABCMeta):
     @staticmethod
     @abstractmethod
     def shardy_sharding_rule(*args):
+        """
+        Returns the sharding rule for this primitive.
+        """
         del args
         return '... -> ...'
 

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -535,11 +535,11 @@ class NormFwdPrimitive(BasePrimitive):
         value_types,
         result_types,
     ):
-        del zero_centered_gamma, epsilon, out_dtype, scale_dtype, scale_shapes, is_outer, mesh
+        del zero_centered_gamma, epsilon, out_dtype, scale_dtype, scale_shapes, is_outer, mesh, result_types
 
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(len(value_types[0].shape),
                                                                           unique_var='i')
-        x_axes = scale_rules.input
+        x_axes = scale_rules.input_spec
 
         out = x_axes[:-1] + ('k',)
         if is_2x and norm_type != NVTE_Norm_Type.RMSNorm:

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -552,10 +552,7 @@ class NormFwdPrimitive(BasePrimitive):
         x_axes = scale_rules.input_spec
 
         out = x_axes[:-1] + ("k",)
-        if is_2x and norm_type != NVTE_Norm_Type.RMSNorm:
-            colwise_out = out
-        else:
-            colwise_out = ("…4",)
+        colwise_out = out if is_2x else ("…4",)
         rsigma = x_axes[:-1]
         mu = ("…5",) if norm_type == NVTE_Norm_Type.RMSNorm else rsigma
         amax = ("…6",)

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -547,7 +547,7 @@ class NormFwdPrimitive(BasePrimitive):
         )
 
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(
-            len(value_types[0].shape), unique_var="i"
+            len(value_types[0].shape), unique_var="i", flatten_axis=-1
         )
         x_axes = scale_rules.input_spec
 

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -535,26 +535,45 @@ class NormFwdPrimitive(BasePrimitive):
         value_types,
         result_types,
     ):
-        del zero_centered_gamma, epsilon, out_dtype, scale_dtype, scale_shapes, is_outer, mesh, result_types
+        del (
+            zero_centered_gamma,
+            epsilon,
+            out_dtype,
+            scale_dtype,
+            scale_shapes,
+            is_outer,
+            mesh,
+            result_types,
+        )
 
-        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(len(value_types[0].shape),
-                                                                          unique_var='i')
+        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(
+            len(value_types[0].shape), unique_var="i"
+        )
         x_axes = scale_rules.input_spec
 
-        out = x_axes[:-1] + ('k',)
+        out = x_axes[:-1] + ("k",)
         if is_2x and norm_type != NVTE_Norm_Type.RMSNorm:
             colwise_out = out
         else:
-            colwise_out = ('…4',)
+            colwise_out = ("…4",)
         rsigma = x_axes[:-1]
-        mu = ('…5',) if norm_type == NVTE_Norm_Type.RMSNorm else rsigma
-        amax = ('…6',)
+        mu = ("…5",) if norm_type == NVTE_Norm_Type.RMSNorm else rsigma
+        amax = ("…6",)
 
         return SdyShardingRule(
-            (x_axes, ('…1',), ('…2',), ('…3',)),
-            (out, colwise_out, scale_rules.rowwise_rule, scale_rules.colwise_rule, amax, mu, rsigma),
-            **scale_rules.factor_sizes
+            (x_axes, ("…1",), ("…2",), ("…3",)),
+            (
+                out,
+                colwise_out,
+                scale_rules.rowwise_rule,
+                scale_rules.colwise_rule,
+                amax,
+                mu,
+                rsigma,
+            ),
+            **scale_rules.factor_sizes,
         )
+
 
 register_primitive(NormFwdPrimitive)
 
@@ -761,7 +780,7 @@ class NormBwdPrimitive(BasePrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '...0, ...1 i, ...2, ...3, ...4 -> ...1 j, k, l'
+        return "...0, ...1 i, ...2, ...3, ...4 -> ...1 j, k, l"
 
 
 register_primitive(NormBwdPrimitive)

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -12,6 +12,7 @@ from packaging import version
 import jax
 import jax.numpy as jnp
 from jax import dtypes
+from jax.experimental.custom_partitioning import SdyShardingRule
 from jax.interpreters.mlir import ir
 from jax.sharding import PartitionSpec
 
@@ -519,6 +520,41 @@ class NormFwdPrimitive(BasePrimitive):
 
         return mesh, sharded_impl, out_shardings, arg_shardings
 
+    @staticmethod
+    def shardy_sharding_rule(
+        norm_type,
+        zero_centered_gamma,
+        epsilon,
+        out_dtype,
+        scaling_mode,
+        is_2x,
+        scale_dtype,
+        scale_shapes,
+        is_outer,
+        mesh,
+        value_types,
+        result_types,
+    ):
+        del zero_centered_gamma, epsilon, out_dtype, scale_dtype, scale_shapes, is_outer, mesh
+
+        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(len(value_types[0].shape),
+                                                                          unique_var='i')
+        x_axes = scale_rules.input
+
+        out = x_axes[:-1] + ('k',)
+        if is_2x and norm_type != NVTE_Norm_Type.RMSNorm:
+            colwise_out = out
+        else:
+            colwise_out = ('…4',)
+        rsigma = x_axes[:-1]
+        mu = ('…5',) if norm_type == NVTE_Norm_Type.RMSNorm else rsigma
+        amax = ('…6',)
+
+        return SdyShardingRule(
+            (x_axes, ('…1',), ('…2',), ('…3',)),
+            (out, colwise_out, scale_rules.rowwise_rule, scale_rules.colwise_rule, amax, mu, rsigma),
+            **scale_rules.factor_sizes
+        )
 
 register_primitive(NormFwdPrimitive)
 
@@ -721,6 +757,11 @@ class NormBwdPrimitive(BasePrimitive):
             return local_dx, global_dgamma, global_dbeta
 
         return mesh, sharded_impl, out_shardings, arg_shardings
+
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '...0, ...1 i, ...2, ...3, ...4 -> ...1 j, k, l'
 
 
 register_primitive(NormBwdPrimitive)

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -496,7 +496,7 @@ class DBiasQuantizePrimitive(BasePrimitive):
 
         out = x_axes
         if q_layout in (QuantizeLayout.COLWISE.value, QuantizeLayout.ROWWISE_COLWISE.value):
-            if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
+            if scaling_mode == ScalingMode.DELAYED_TENSOR_SCALING.value:
                 colwise_out = tuple(multidim_transpose(x_axes, transpose_axis=flatten_axis))
             else:
                 colwise_out = x_axes

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -509,7 +509,7 @@ class DBiasQuantizePrimitive(BasePrimitive):
 
         return SdyShardingRule(
             (x_axes, ("…1",)),
-            (out, colwise_out, scale_rules.rowwise_rule, scale_rules.colwise_rule, amax, dbias),
+            (out, colwise_out, scale_rules.rowwise_rule, colwise_scale_inv, amax, dbias),
             **scale_rules.factor_sizes,
         )
 

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -502,7 +502,7 @@ class DBiasQuantizePrimitive(BasePrimitive):
                 colwise_out = x_axes
         else:
             colwise_out = ("j",)
-            colwise_scale_inv =  ("k",)
+            colwise_scale_inv = ("k",)
 
         dbias = x_axes[flatten_axis:] if is_dbias else ("l",)
         amax = ("m",)

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -486,8 +486,9 @@ class DBiasQuantizePrimitive(BasePrimitive):
     ):
         del out_dtype, scale_dtype, scale_shapes, is_outer, mesh, result_types
 
-        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(len(value_types[0].shape),
-                                                                          unique_var='i')
+        scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(
+            len(value_types[0].shape), unique_var="i"
+        )
 
         x_axes = scale_rules.input_spec
         out = x_axes
@@ -497,15 +498,15 @@ class DBiasQuantizePrimitive(BasePrimitive):
             else:
                 colwise_out = x_axes
         else:
-            colwise_out = ('j',)
+            colwise_out = ("j",)
 
-        dbias = (x_axes[-1],) if is_dbias else ('k',)
-        amax = ('l',)
+        dbias = (x_axes[-1],) if is_dbias else ("k",)
+        amax = ("l",)
 
         return SdyShardingRule(
-            (x_axes, ('…1',)),
+            (x_axes, ("…1",)),
             (out, colwise_out, scale_rules.rowwise_rule, scale_rules.colwise_rule, amax, dbias),
-            **scale_rules.factor_sizes
+            **scale_rules.factor_sizes,
         )
 
 

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -488,7 +488,7 @@ class DBiasQuantizePrimitive(BasePrimitive):
         del out_dtype, scale_dtype, scale_shapes, is_outer, mesh, result_types
 
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(
-            len(value_types[0].shape), unique_var="i"
+            len(value_types[0].shape), unique_var="i", flatten_axis=flatten_axis
         )
 
         x_axes = scale_rules.input_spec

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -489,9 +489,9 @@ class DBiasQuantizePrimitive(BasePrimitive):
         scale_rules = ScalingMode(scaling_mode).get_shardy_sharding_rules(len(value_types[0].shape),
                                                                           unique_var='i')
 
-        x_axes = scale_rules.input
+        x_axes = scale_rules.input_spec
         out = x_axes
-        if q_axis == QuantizeAxis.COLWISE.value or q_axis == QuantizeAxis.ROWWISE_COLWISE.value:
+        if q_axis in (QuantizeAxis.COLWISE.value, QuantizeAxis.ROWWISE_COLWISE.value):
             if scaling_mode == ScalingMode.NVTE_DELAYED_TENSOR_SCALING.value:
                 colwise_out = tuple(multidim_transpose(x_axes))
             else:

--- a/transformer_engine/jax/cpp_extensions/softmax.py
+++ b/transformer_engine/jax/cpp_extensions/softmax.py
@@ -333,7 +333,7 @@ class ScaledSoftmaxFwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '... -> ...'
+        return "... -> ..."
 
 
 register_primitive(ScaledSoftmaxFwdPrimitive)
@@ -408,7 +408,7 @@ class ScaledSoftmaxBwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '..., ... -> ...'
+        return "..., ... -> ..."
 
 
 register_primitive(ScaledSoftmaxBwdPrimitive)
@@ -538,7 +538,7 @@ class ScaledMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '...1, ...2 -> ...1'
+        return "...1, ...2 -> ...1"
 
 
 register_primitive(ScaledMaskedSoftmaxFwdPrimitive)
@@ -614,7 +614,8 @@ class ScaledMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '..., ... -> ...'
+        return "..., ... -> ..."
+
 
 register_primitive(ScaledMaskedSoftmaxBwdPrimitive)
 
@@ -704,7 +705,8 @@ class ScaledUpperTriangMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '... -> ...'
+        return "... -> ..."
+
 
 register_primitive(ScaledUpperTriangMaskedSoftmaxFwdPrimitive)
 
@@ -787,7 +789,7 @@ class ScaledUpperTriangMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
     @staticmethod
     def shardy_sharding_rule(*args):
         del args
-        return '..., ... -> ...'
+        return "..., ... -> ..."
 
 
 register_primitive(ScaledUpperTriangMaskedSoftmaxBwdPrimitive)

--- a/transformer_engine/jax/cpp_extensions/softmax.py
+++ b/transformer_engine/jax/cpp_extensions/softmax.py
@@ -330,6 +330,11 @@ class ScaledSoftmaxFwdPrimitive(SoftmaxPrimitive):
             ScaledSoftmaxFwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
         )
 
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '... -> ...'
+
 
 register_primitive(ScaledSoftmaxFwdPrimitive)
 
@@ -399,6 +404,11 @@ class ScaledSoftmaxBwdPrimitive(SoftmaxPrimitive):
         return ScaledSoftmaxBwdPrimitive.backward_partition(
             ScaledSoftmaxBwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
         )
+
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '..., ... -> ...'
 
 
 register_primitive(ScaledSoftmaxBwdPrimitive)
@@ -525,6 +535,11 @@ class ScaledMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
             ScaledMaskedSoftmaxFwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
         )
 
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '...1, ...2 -> ...1'
+
 
 register_primitive(ScaledMaskedSoftmaxFwdPrimitive)
 
@@ -596,6 +611,10 @@ class ScaledMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
             ScaledMaskedSoftmaxBwdPrimitive.impl, scale_factor, mesh, arg_infos, result_infos
         )
 
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '..., ... -> ...'
 
 register_primitive(ScaledMaskedSoftmaxBwdPrimitive)
 
@@ -682,6 +701,10 @@ class ScaledUpperTriangMaskedSoftmaxFwdPrimitive(SoftmaxPrimitive):
             result_infos,
         )
 
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '... -> ...'
 
 register_primitive(ScaledUpperTriangMaskedSoftmaxFwdPrimitive)
 
@@ -760,6 +783,11 @@ class ScaledUpperTriangMaskedSoftmaxBwdPrimitive(SoftmaxPrimitive):
             arg_infos,
             result_infos,
         )
+
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        del args
+        return '..., ... -> ...'
 
 
 register_primitive(ScaledUpperTriangMaskedSoftmaxBwdPrimitive)

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -80,7 +80,9 @@ class ScalingModeMetadataImpl(ABC):
         """
 
     @abstractmethod
-    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis) -> QuantizeShardyRules:
+    def get_shardy_sharding_rules(
+        self, input_rank, unique_var, flatten_axis
+    ) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
@@ -128,7 +130,9 @@ class DelayedScalingModeMetadataImpl(ScalingModeMetadataImpl):
         del data_shape, is_colwise
         return (1,)
 
-    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis) -> QuantizeShardyRules:
+    def get_shardy_sharding_rules(
+        self, input_rank, unique_var, flatten_axis
+    ) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
@@ -265,7 +269,9 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
 
         return (*first_dim_scale_shape, *last_dim_scale_shape)
 
-    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis) -> QuantizeShardyRules:
+    def get_shardy_sharding_rules(
+        self, input_rank, unique_var, flatten_axis
+    ) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
@@ -375,7 +381,9 @@ class ScalingMode(Enum):
         """
         return self._get_impl().get_scale_shape(data_shape, is_colwise, is_padded, flatten_axis)
 
-    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis=-1) -> Tuple[Tuple[str]]:
+    def get_shardy_sharding_rules(
+        self, input_rank, unique_var, flatten_axis=-1
+    ) -> Tuple[Tuple[str]]:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -275,9 +275,11 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
         bx = unique_var
         by = f"{unique_var}_"
 
+        # We have to use two different factors in the two CompoundFactors because of Shardy
+        # verifier requirements, even though they are the same.
         input_spec = [f"x{i}" for i in range(input_rank - 2)] + [
-            CompoundFactor(bx, "block_size"),
-            CompoundFactor(by, "block_size"),
+            CompoundFactor(bx, "block_size_x"),
+            CompoundFactor(by, "block_size_y"),
         ]
 
         # The rowwise and colwise scale tensors should be sharded the same way as the input.
@@ -289,7 +291,10 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
         colwise[-2] = bx
 
         return QuantizeShardyRules(
-            tuple(input_spec), tuple(rowwise), tuple(colwise), {"block_size": 32}
+            tuple(input_spec),
+            tuple(rowwise),
+            tuple(colwise),
+            {"block_size_x": 32, "block_size_y": 32},
         )
 
 

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -31,15 +31,15 @@ class QuantizeShardyRules:
     """Information necessary to shard scale tensors with Shardy.
     
     Attributes:
-        input: Specification for the input axes
+        input_spec: Specification for the input axes
         rowwise_rule: Sharding rule for the row-wise scale tensor, depends on 
-          the axes in `input`
+          the axes in `input_spec`
         colwise_rule: Likewise for the column-wise scale tensor.
         factor_sizes: For block scaling, contains the block size factor, which is
-          used in `input`.
+          used in `input_spec`.
     """
 
-    input: Tuple[str]
+    input_spec: Tuple[str]
     rowwise_rule: Tuple[str]
     colwise_rule: Tuple[str]
     factor_sizes: Dict[str, int]
@@ -135,8 +135,8 @@ class DelayedScalingModeMetadataImpl(ScalingModeMetadataImpl):
         Returns:
             The Shardy rules for the scaling mode
         """
-        input = tuple(f'x{i}' for i in range(input_rank))
-        return QuantizeShardyRules(input, (unique_var,), (unique_var,), {})
+        input_spec = tuple(f'x{i}' for i in range(input_rank))
+        return QuantizeShardyRules(input_spec, (unique_var,), (unique_var,), {})
 
 
 class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
@@ -270,13 +270,13 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
         Returns:
             The Shardy rules for the scaling mode
         """
-        input = [f'x{i}' for i in range(input_rank)]
-        input[-2] = CompoundFactor(unique_var, 'block_size')
+        input_spec = [f'x{i}' for i in range(input_rank)]
+        input_spec[-2] = CompoundFactor(unique_var, 'block_size')
 
-        rowwise = input[:-1] + [f'{unique_var}_']
-        colwise = input[:-2] + [unique_var, f'{unique_var}__']
+        rowwise = input_spec[:-1] + [f'{unique_var}_']
+        colwise = input_spec[:-2] + [unique_var, f'{unique_var}__']
 
-        return QuantizeShardyRules(tuple(input), tuple(rowwise), tuple(colwise), {'block_size': 32})
+        return QuantizeShardyRules(tuple(input_spec), tuple(rowwise), tuple(colwise), {'block_size': 32})
 
 
 @dataclass(frozen=True)

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -29,10 +29,10 @@ __all__ = ["QuantizeShardyRules", "ScalingMode"]
 @dataclass
 class QuantizeShardyRules:
     """Information necessary to shard scale tensors with Shardy.
-    
+
     Attributes:
         input_spec: Specification for the input axes
-        rowwise_rule: Sharding rule for the row-wise scale tensor, depends on 
+        rowwise_rule: Sharding rule for the row-wise scale tensor, depends on
           the axes in `input_spec`
         colwise_rule: Likewise for the column-wise scale tensor.
         factor_sizes: For block scaling, contains the block size factor, which is
@@ -82,7 +82,7 @@ class ScalingModeMetadataImpl(ABC):
     @abstractmethod
     def get_shardy_sharding_rules(self, input_rank, unique_var) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
-        
+
         Args:
             input_rank: The rank of the input tensor (for which we produce the scale tensor)
             unique_var: An otherwise unused Shardy variable name prefix
@@ -129,7 +129,7 @@ class DelayedScalingModeMetadataImpl(ScalingModeMetadataImpl):
 
     def get_shardy_sharding_rules(self, input_rank, unique_var) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
-        
+
         Args:
             input_rank: The rank of the input tensor (for which we produce the scale tensor)
             unique_var: An otherwise unused Shardy variable name prefix
@@ -264,7 +264,7 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
 
     def get_shardy_sharding_rules(self, input_rank, unique_var) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
-        
+
         Args:
             input_rank: The rank of the input tensor (for which we produce the scale tensor)
             unique_var: An otherwise unused Shardy variable name prefix
@@ -367,7 +367,7 @@ class ScalingMode(Enum):
 
     def get_shardy_sharding_rules(self, input_rank, unique_var) -> Tuple[Tuple[str]]:
         """Sharding rules for the input and (row, col)wise scale tensors.
-        
+
         Args:
             input_rank: The rank of the input tensor (for which we produce the scale tensor)
             unique_var: An otherwise unused Shardy variable name prefix

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -80,12 +80,13 @@ class ScalingModeMetadataImpl(ABC):
         """
 
     @abstractmethod
-    def get_shardy_sharding_rules(self, input_rank, unique_var) -> QuantizeShardyRules:
+    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
             input_rank: The rank of the input tensor (for which we produce the scale tensor)
             unique_var: An otherwise unused Shardy variable name prefix
+            flatten_axis: Axis along which data can be flattened to 2D for quantization.
 
         Returns:
             The Shardy rules for the scaling mode
@@ -127,16 +128,18 @@ class DelayedScalingModeMetadataImpl(ScalingModeMetadataImpl):
         del data_shape, is_colwise
         return (1,)
 
-    def get_shardy_sharding_rules(self, input_rank, unique_var) -> QuantizeShardyRules:
+    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
             input_rank: The rank of the input tensor (for which we produce the scale tensor)
             unique_var: An otherwise unused Shardy variable name prefix
+            flatten_axis: Axis along which data can be flattened to 2D for quantization.
 
         Returns:
             The Shardy rules for the scaling mode
         """
+        del flatten_axis
         input_spec = tuple(f"x{i}" for i in range(input_rank))
         return QuantizeShardyRules(input_spec, (unique_var,), (unique_var,), {})
 
@@ -262,7 +265,7 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
 
         return (*first_dim_scale_shape, *last_dim_scale_shape)
 
-    def get_shardy_sharding_rules(self, input_rank, unique_var) -> QuantizeShardyRules:
+    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis) -> QuantizeShardyRules:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
@@ -272,29 +275,31 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
         Returns:
             The Shardy rules for the scaling mode
         """
-        bx = unique_var
-        by = f"{unique_var}_"
+        input_spec = [f"x{i}" for i in range(input_rank)]
 
         # We have to use two different factors in the two CompoundFactors because of Shardy
         # verifier requirements, even though they are the same.
-        input_spec = [f"x{i}" for i in range(input_rank - 2)] + [
-            CompoundFactor(bx, "block_size_x"),
-            CompoundFactor(by, "block_size_y"),
-        ]
+        rowwise_var = unique_var
+        colwise_var = f"{unique_var}_"
+        input_spec[flatten_axis - 1] = CompoundFactor(colwise_var, "block_size_colwise")
+        input_spec[-1] = CompoundFactor(rowwise_var, "block_size_rowwise")
 
         # The rowwise and colwise scale tensors should be sharded the same way as the input.
         # However, we need to adjust the dimensions where the block scaling factor applies.
         rowwise = input_spec.copy()
-        rowwise[-1] = by
+        rowwise[-1] = rowwise_var
 
         colwise = input_spec.copy()
-        colwise[-2] = bx
+        colwise[flatten_axis - 1] = colwise_var
+
+        # This implementation needs to be updated for different block dims.
+        assert self._block_dims == (1, 32)
 
         return QuantizeShardyRules(
             tuple(input_spec),
             tuple(rowwise),
             tuple(colwise),
-            {"block_size_x": 32, "block_size_y": 32},
+            {"block_size_rowwise": 32, "block_size_colwise": 32},
         )
 
 
@@ -370,7 +375,7 @@ class ScalingMode(Enum):
         """
         return self._get_impl().get_scale_shape(data_shape, is_colwise, is_padded, flatten_axis)
 
-    def get_shardy_sharding_rules(self, input_rank, unique_var) -> Tuple[Tuple[str]]:
+    def get_shardy_sharding_rules(self, input_rank, unique_var, flatten_axis=-1) -> Tuple[Tuple[str]]:
         """Sharding rules for the input and (row, col)wise scale tensors.
 
         Args:
@@ -380,7 +385,7 @@ class ScalingMode(Enum):
         Returns:
             The Shardy rules for the scaling mode
         """
-        return self._get_impl().get_shardy_sharding_rules(input_rank, unique_var)
+        return self._get_impl().get_shardy_sharding_rules(input_rank, unique_var, flatten_axis)
 
     def __eq__(self, other):
         """Compare this scaling mode with another.

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -44,6 +44,7 @@ class QuantizeShardyRules:
     colwise_rule: Tuple[str]
     factor_sizes: Dict[str, int]
 
+
 class ScalingModeMetadataImpl(ABC):
     """Base class for scaling mode implementations.
 
@@ -90,6 +91,7 @@ class ScalingModeMetadataImpl(ABC):
             The Shardy rules for the scaling mode
         """
 
+
 class DelayedScalingModeMetadataImpl(ScalingModeMetadataImpl):
     """Implementation for delayed scaling mode.
 
@@ -135,7 +137,7 @@ class DelayedScalingModeMetadataImpl(ScalingModeMetadataImpl):
         Returns:
             The Shardy rules for the scaling mode
         """
-        input_spec = tuple(f'x{i}' for i in range(input_rank))
+        input_spec = tuple(f"x{i}" for i in range(input_rank))
         return QuantizeShardyRules(input_spec, (unique_var,), (unique_var,), {})
 
 
@@ -270,13 +272,15 @@ class BlockScalingModeMetadataImpl(ScalingModeMetadataImpl):
         Returns:
             The Shardy rules for the scaling mode
         """
-        input_spec = [f'x{i}' for i in range(input_rank)]
-        input_spec[-2] = CompoundFactor(unique_var, 'block_size')
+        input_spec = [f"x{i}" for i in range(input_rank)]
+        input_spec[-2] = CompoundFactor(unique_var, "block_size")
 
-        rowwise = input_spec[:-1] + [f'{unique_var}_']
-        colwise = input_spec[:-2] + [unique_var, f'{unique_var}__']
+        rowwise = input_spec[:-1] + [f"{unique_var}_"]
+        colwise = input_spec[:-2] + [unique_var, f"{unique_var}__"]
 
-        return QuantizeShardyRules(tuple(input_spec), tuple(rowwise), tuple(colwise), {'block_size': 32})
+        return QuantizeShardyRules(
+            tuple(input_spec), tuple(rowwise), tuple(colwise), {"block_size": 32}
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This is experimental and not intended for production use. If you try this, please file issues for problems you encounter.

# Description

Shardy is a new partitioning system in JAX. It currently replaces the sharding propagation passes in GSPMD.

This PR adds Shardy support for TE's attention, normalization, quantization and softmax primitives.

To use this, simply enable Shardy:

```
jax.config.update("jax_use_shardy_partitioner", True)
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Adds functions to provide Shardy sharding rules to primitives. 