### PR TITLE
[PyTorch] check and try to generate fp8 weight transpose cache before dgrad backward

### DIFF
--- a/tests/pytorch/distributed/run_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/run_cast_master_weights_to_fp8.py
@@ -380,17 +380,11 @@ class MiniFSDP:
         # Step 3: Cast master weights to FP8 or BF16 precision
         if isinstance(self.weights[0], Float8Tensor):
             local_weights = []
-            for model_weight, local_weight in zip(self.weights, self.local_weights):
+            for local_weight in self.local_weights:
                 if local_weight is None:
                     local_weights.append(None)
                     continue
 
-                quantizer = model_weight._get_quantizer()
-                if isinstance(quantizer, Float8CurrentScalingQuantizer):
-                    local_weight = quantizer.create_tensor_from_data(
-                        local_weight.view(-1),
-                        model_weight.dtype,
-                    )
                 local_weights.append(local_weight)
 
             cast_master_weights_to_fp8(

--- a/tests/pytorch/distributed/run_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/run_cast_master_weights_to_fp8.py
@@ -243,10 +243,10 @@ class MiniFSDP:
 
         # Flatten the weights and pad to align with world size
         raw_data_list = [
-            _get_raw_data(w).view(-1) if isinstance(w, Float8Tensor) else w.view(-1)
+            _get_raw_data(w).view(-1) if isinstance(w, QuantizedTensor) else w.view(-1)
             for w in weights
         ]
-        if isinstance(weights[0], Float8Tensor):
+        if isinstance(weights[0], QuantizedTensor):
             raw_data_list = [_get_raw_data(w).view(-1) for w in weights]
         else:
             raw_data_list = [w.view(-1) for w in weights]
@@ -282,7 +282,7 @@ class MiniFSDP:
                 self.weight_indices.append((None, None))
                 self.shard_indices.append((None, None))
 
-            if isinstance(weights[idx], Float8Tensor):
+            if isinstance(weights[idx], QuantizedTensor):
                 replace_raw_data(
                     weights[idx], self.flatten_weight[start:end].view(weights[idx].shape)
                 )
@@ -378,7 +378,7 @@ class MiniFSDP:
             master_weight -= grad * self.lr
 
         # Step 3: Cast master weights to FP8 or BF16 precision
-        if isinstance(self.weights[0], Float8Tensor):
+        if isinstance(self.weights[0], QuantizedTensor):
             local_weights = []
             for local_weight in self.local_weights:
                 if local_weight is None:

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -277,7 +277,7 @@ class _GroupedLinear(torch.autograd.Function):
                 )
 
                 for weight, quantizer in zip(weights, ctx.weight_quantizers):
-                    if quantizer is not None:
+                    if quantizer is not None and isinstance(weight, QuantizedTensor):
                         weight.update_usage(
                             rowwise_usage=quantizer.rowwise_usage,
                             columnwise_usage=quantizer.columnwise_usage,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -126,7 +126,6 @@ class _GroupedLinear(torch.autograd.Function):
             for output_quantizer in output_quantizers:
                 output_quantizer.set_usage(rowwise=True, columnwise=False)
 
-        ctx.weight_quantizers = weight_quantizers
         if fp8:
             inputmats = tex.fused_multi_quantize(
                 inputmats_no_fp8, None, input_quantizers, TE_DType[activation_dtype]
@@ -180,7 +179,7 @@ class _GroupedLinear(torch.autograd.Function):
                     weight_quantizers[i].calibrate(weights[i])
 
         if is_grad_enabled:
-
+            ctx.weight_quantizers = weight_quantizers
             ctx.weights_shape_1 = weights[0].shape[1]
 
             tensors_to_save, tensor_objects = prepare_for_saving(

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -652,7 +652,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 if hasattr(recipe, "fp8_gemm_dgrad"):
                     dgrad_gemm_use_split_accumulator = recipe.fp8_gemm_dgrad.use_split_accumulator
 
-            if ctx.weight_quantizer is not None:
+            if ctx.weight_quantizer is not None and isinstance(weight, QuantizedTensor):
                 weight.update_usage(
                     rowwise_usage=ctx.weight_quantizer.rowwise_usage,
                     columnwise_usage=ctx.weight_quantizer.columnwise_usage,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -242,7 +242,6 @@ class _LayerNormLinear(torch.autograd.Function):
         nvtx_range_pop(f"{nvtx_label}.gemm_input_cast_comm")
 
         # Cast weight to expected dtype
-        ctx.weight_quantizer = weight_quantizer
         if not fp8:
             quantized_weight = False
             weightmat = cast_if_needed(weight, activation_dtype)
@@ -324,6 +323,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 clear_tensor_data(ln_out, ln_out_total)
 
         if is_grad_enabled:
+            ctx.weight_quantizer = weight_quantizer
             ctx.ln_out_needs_gather = (
                 weight.requires_grad and parallel_mode == "column" and sequence_parallel
             )

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -301,8 +301,6 @@ class _LayerNormMLP(torch.autograd.Function):
             ln_out_total = ln_out
 
         # Cast weights to expected dtype
-        ctx.fc1_weight_quantizer = fc1_weight_quantizer
-        ctx.fc2_weight_quantizer = fc2_weight_quantizer
         if not fp8:
             fc1_weight_final = cast_if_needed(fc1_weight, activation_dtype)
             fc2_weight_final = cast_if_needed(fc2_weight, activation_dtype)
@@ -480,6 +478,8 @@ class _LayerNormMLP(torch.autograd.Function):
                 fc2_weight_final if fp8 and not isinstance(fc2_weight, Float8Tensor) else None,
             )
 
+            ctx.fc1_weight_quantizer = fc1_weight_quantizer
+            ctx.fc2_weight_quantizer = fc2_weight_quantizer
             if not fc1_weight.requires_grad:
                 if not return_layernorm_output:
                     clear_tensor_data(ln_out)

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -751,7 +751,7 @@ class _LayerNormMLP(torch.autograd.Function):
             )
 
             # FC2 DGRAD; Unconditional
-            if ctx.fc2_weight_quantizer is not None:
+            if ctx.fc2_weight_quantizer is not None and isinstance(ctx.fc2_weight, QuantizedTensor):
                 ctx.fc2_weight.update_usage(
                     rowwise_usage=ctx.fc2_weight_quantizer.rowwise_usage,
                     columnwise_usage=ctx.fc2_weight_quantizer.columnwise_usage,
@@ -902,7 +902,7 @@ class _LayerNormMLP(torch.autograd.Function):
                     fc1_dgrad_bulk = ub_obj_fc1_wgrad.get_buffer(None)
 
             # FC1 DGRAD: Unconditional
-            if ctx.fc1_weight_quantizer is not None:
+            if ctx.fc1_weight_quantizer is not None and isinstance(ctx.fc1_weight_quantizer, QuantizedTensor):
                 ctx.fc1_weight.update_usage(
                     rowwise_usage=ctx.fc1_weight_quantizer.rowwise_usage,
                     columnwise_usage=ctx.fc1_weight_quantizer.columnwise_usage,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -902,7 +902,9 @@ class _LayerNormMLP(torch.autograd.Function):
                     fc1_dgrad_bulk = ub_obj_fc1_wgrad.get_buffer(None)
 
             # FC1 DGRAD: Unconditional
-            if ctx.fc1_weight_quantizer is not None and isinstance(ctx.fc1_weight_quantizer, QuantizedTensor):
+            if ctx.fc1_weight_quantizer is not None and isinstance(
+                ctx.fc1_weight_quantizer, QuantizedTensor
+            ):
                 ctx.fc1_weight.update_usage(
                     rowwise_usage=ctx.fc1_weight_quantizer.rowwise_usage,
                     columnwise_usage=ctx.fc1_weight_quantizer.columnwise_usage,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -196,7 +196,6 @@ class _Linear(torch.autograd.Function):
         nvtx_range_pop(f"{nvtx_label}.input_cast_comm")
 
         # Cast weight to expected dtype
-        ctx.weight_quantizer = weight_quantizer
         if not fp8:
             weightmat = cast_if_needed(weight, activation_dtype)
         else:
@@ -278,6 +277,7 @@ class _Linear(torch.autograd.Function):
         nvtx_range_pop(f"{nvtx_label}.gemm")
 
         if is_grad_enabled:
+            ctx.weight_quantizer = weight_quantizer
             saved_inputmat = None
 
             ctx.backward_input_needs_gather = (

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -575,7 +575,7 @@ class _Linear(torch.autograd.Function):
                             recipe.fp8_gemm_dgrad.use_split_accumulator
                         )
 
-                if ctx.weight_quantizer is not None:
+                if ctx.weight_quantizer is not None and isinstance(weight_fp8, QuantizedTensor):
                     weight_fp8.update_usage(
                         rowwise_usage=ctx.weight_quantizer.rowwise_usage,
                         columnwise_usage=ctx.weight_quantizer.columnwise_usage,

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -305,4 +305,11 @@ def _cast_master_weights_to_fp8_current_scaling(params, group, use_fsdp_shard_mo
             amax=torch.Tensor(),
             fp8_dtype=model_weight._fp8_dtype,
         )
+        if use_fsdp_shard_model_weights and not isinstance(model_weight_fragment, Float8Tensor):
+            # NOTE: The fsdp shard model weight may be a unit8 tensor instead of
+            # a float8 tensor. We should handle this situation properly.
+            model_weight_fragment = quantizer.create_tensor_from_data(
+                model_weight_fragment.view(-1),
+                model_weight.dtype,
+            )
         quantizer.update_quantized(master_weight, model_weight_fragment)


### PR DESCRIPTION
# Description

Added a check for fp8 weight transpose cache in backward, and regenerated it if it does not exist. In FSDP, we may delete the FP8 transpose cache and then regenerate it in backward. This MR ensures that this function works properly.

In addition, this MR comes with an edge case treatment for FSDP + FP8 current scaling. The FSDP shard model weight may be a unit8 tensor instead of a float8 tensor. This situation is specially handled in the cast_master_weight_to_fp8 function.

Error stacktrace:
```
[rank2]: Traceback (most recent call last):
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/pretrain_gpt.py", line 316, in <module>
[rank2]:     pretrain(
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/megatron/training/training.py", line 726, in pretrain
[rank2]:     iteration, num_floating_point_operations_so_far = train(
[rank2]:                                                       ^^^^^^
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/megatron/training/training.py", line 1901, in train
[rank2]:     train_step(forward_step_func,
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/megatron/training/training.py", line 1164, in train_step
[rank2]:     losses_reduced = forward_backward_func(
[rank2]:                      ^^^^^^^^^^^^^^^^^^^^^^
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 491, in forward_backward_no_pipelining
[rank2]:     backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config)
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 390, in backward_step
[rank2]:     custom_backward(output_tensor[0], output_tensor_grad[0])
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 151, in custom_backward
[rank2]:     Variable._execution_engine.run_backward(
[rank2]:   File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 307, in apply
[rank2]:     return user_fn(self, *args)
[rank2]:            ^^^^^^^^^^^^^^^^^^^^
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/TransformerEngine/transformer_engine/pytorch/module/linear.py", line 559, in backward
[rank2]:     dgrad, *_, rs_out = general_gemm(
[rank2]:                         ^^^^^^^^^^^^^
[rank2]:   File "/lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/TransformerEngine/transformer_engine/pytorch/cpp_extensions/gemm.py", line 141, in general_gemm
[rank2]:     out, bias_grad, gelu_input, extra_output = tex.generic_gemm(*args, **kwargs)
[rank2]:                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank2]: RuntimeError: /lustre/fsw/portfolios/coreai/users/jianbinc/playground/fp8_TE2.2/TransformerEngine/transformer_engine/common/gemm/cublaslt_gemm.cu:104 in function CanonicalizeGemmInput: Assertion failed: A.has_columnwise_data(). Input A is not suitable for columnwise usage!
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
