### PR TITLE
add view/reshape to blockwise tensor

### DIFF
--- a/tests/pytorch/test_float8blockwisetensor.py
+++ b/tests/pytorch/test_float8blockwisetensor.py
@@ -373,17 +373,22 @@ class TestFloat8BlockwiseTensor:
 
     @pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2], ids=str)
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=str)
-    @pytest.mark.parametrize("dims", [[16, 16, 512], [16, 16, 512, 16], [12,7,11],[13,14,16],[2,3,5]])
-    def test_view_and_reshape_1D(self, fp8_dtype: tex.DType, dtype: torch.dtype, dims: List[int]) -> None:
+    @pytest.mark.parametrize(
+        "dims", [[16, 16, 512], [16, 16, 512, 16], [12, 7, 11], [13, 14, 16], [2, 3, 5]]
+    )
+    def test_view_and_reshape_1D(
+        self, fp8_dtype: tex.DType, dtype: torch.dtype, dims: List[int]
+    ) -> None:
         """Test view operations that preserve tensor shape"""
         device = "cuda"
+
         def is_bitwise_equal(a, b):
             if a.numel() != b.numel():
                 return False
             a_flat = a.reshape(-1).view(torch.uint8)
             b_flat = b.reshape(-1).view(torch.uint8)
             return torch.all((a_flat ^ b_flat) == 0)
-        
+
         x_hp = torch.rand(dims, dtype=dtype, device=device)
         quantizer = Float8BlockQuantizer(
             fp8_dtype=fp8_dtype,
@@ -419,20 +424,22 @@ class TestFloat8BlockwiseTensor:
         assert is_bitwise_equal(x_fp8_reshape._rowwise_data, x_fp8._rowwise_data)
         assert is_bitwise_equal(x_fp8_reshape._rowwise_scale_inv, x_fp8._rowwise_scale_inv)
 
-
     @pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2], ids=str)
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=str)
-    @pytest.mark.parametrize("dims", [[16, 16, 512, 16], [2,512,512,128], [3,13,14,16]])
-    def test_view_and_reshape_2D(self, fp8_dtype: tex.DType, dtype: torch.dtype, dims: List[int]) -> None:
+    @pytest.mark.parametrize("dims", [[16, 16, 512, 16], [2, 512, 512, 128], [3, 13, 14, 16]])
+    def test_view_and_reshape_2D(
+        self, fp8_dtype: tex.DType, dtype: torch.dtype, dims: List[int]
+    ) -> None:
         """Test view operations that preserve tensor shape"""
         device = "cuda"
+
         def is_bitwise_equal(a, b):
             if a.numel() != b.numel():
                 return False
             a_flat = a.reshape(-1).view(torch.uint8)
             b_flat = b.reshape(-1).view(torch.uint8)
             return torch.all((a_flat ^ b_flat) == 0)
-        
+
         x_hp = torch.rand(dims, dtype=dtype, device=device)
         quantizer = Float8BlockQuantizer(
             fp8_dtype=fp8_dtype,
@@ -467,8 +474,6 @@ class TestFloat8BlockwiseTensor:
         # Check the bitwise equality of the inner data
         assert is_bitwise_equal(x_fp8_reshape._rowwise_data, x_fp8._rowwise_data)
         assert is_bitwise_equal(x_fp8_reshape._rowwise_scale_inv, x_fp8._rowwise_scale_inv)
-
-
 
     @pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3], ids=str)
     @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=str)

--- a/tests/pytorch/test_float8blockwisetensor.py
+++ b/tests/pytorch/test_float8blockwisetensor.py
@@ -371,6 +371,105 @@ class TestFloat8BlockwiseTensor:
         with pytest.raises(AssertionError):
             torch.testing.assert_close(x_view.dequantize(), -x_hp, **_tols[fp8_dtype])
 
+    @pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2], ids=str)
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=str)
+    @pytest.mark.parametrize("dims", [[16, 16, 512], [16, 16, 512, 16], [12,7,11],[13,14,16],[2,3,5]])
+    def test_view_and_reshape_1D(self, fp8_dtype: tex.DType, dtype: torch.dtype, dims: List[int]) -> None:
+        """Test view operations that preserve tensor shape"""
+        device = "cuda"
+        def is_bitwise_equal(a, b):
+            if a.numel() != b.numel():
+                return False
+            a_flat = a.reshape(-1).view(torch.uint8)
+            b_flat = b.reshape(-1).view(torch.uint8)
+            return torch.all((a_flat ^ b_flat) == 0)
+        
+        x_hp = torch.rand(dims, dtype=dtype, device=device)
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=fp8_dtype,
+            rowwise=True,
+            columnwise=True,
+            block_scaling_dim=1,
+        )
+        x_fp8 = quantizer.make_empty(x_hp.shape, dtype=dtype, device=device)
+        quantizer.update_quantized(x_hp.clone(), x_fp8)
+
+        # Test view, high dimension tensor -> 2D tensor
+        x_hp_view = x_hp.view(-1, dims[-1]).contiguous()
+        x_fp8_view = x_fp8.view(-1, dims[-1])
+        # Check the dequantized result
+        torch.testing.assert_close(
+            x_fp8_view.dequantize().contiguous(), x_hp_view, **_tols[fp8_dtype]
+        )
+        # Check the bitwise equality of the inner data
+        assert is_bitwise_equal(x_fp8_view._rowwise_data, x_fp8._rowwise_data)
+        assert is_bitwise_equal(x_fp8_view._rowwise_scale_inv, x_fp8._rowwise_scale_inv)
+        # Check the data ptr
+        assert x_fp8_view._rowwise_data.data_ptr() == x_fp8._rowwise_data.data_ptr()
+        assert x_fp8_view._rowwise_scale_inv.data_ptr() == x_fp8._rowwise_scale_inv.data_ptr()
+
+        # Test reshape high dimension tensor -> 2D tensor
+        x_hp_reshape = x_hp.reshape(-1, dims[-1]).contiguous()
+        x_fp8_reshape = x_fp8.reshape(-1, dims[-1])
+        # Check the dequantized result
+        torch.testing.assert_close(
+            x_fp8_reshape.dequantize().contiguous(), x_hp_reshape, **_tols[fp8_dtype]
+        )
+        # Check the bitwise equality of the inner data
+        assert is_bitwise_equal(x_fp8_reshape._rowwise_data, x_fp8._rowwise_data)
+        assert is_bitwise_equal(x_fp8_reshape._rowwise_scale_inv, x_fp8._rowwise_scale_inv)
+
+
+    @pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3, tex.DType.kFloat8E5M2], ids=str)
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=str)
+    @pytest.mark.parametrize("dims", [[16, 16, 512, 16], [2,512,512,128], [3,13,14,16]])
+    def test_view_and_reshape_2D(self, fp8_dtype: tex.DType, dtype: torch.dtype, dims: List[int]) -> None:
+        """Test view operations that preserve tensor shape"""
+        device = "cuda"
+        def is_bitwise_equal(a, b):
+            if a.numel() != b.numel():
+                return False
+            a_flat = a.reshape(-1).view(torch.uint8)
+            b_flat = b.reshape(-1).view(torch.uint8)
+            return torch.all((a_flat ^ b_flat) == 0)
+        
+        x_hp = torch.rand(dims, dtype=dtype, device=device)
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=fp8_dtype,
+            rowwise=True,
+            columnwise=True,
+            block_scaling_dim=2,
+        )
+        x_fp8 = quantizer.make_empty(x_hp.shape, dtype=dtype, device=device)
+        quantizer.update_quantized(x_hp.clone(), x_fp8)
+
+        # Test view, high dimension tensor -> 2D tensor
+        x_hp_view = x_hp.view(-1, dims[-2], dims[-1]).contiguous()
+        x_fp8_view = x_fp8.view(-1, dims[-2], dims[-1])
+        # Check the dequantized result
+        torch.testing.assert_close(
+            x_fp8_view.dequantize().contiguous(), x_hp_view, **_tols[fp8_dtype]
+        )
+        # Check the bitwise equality of the inner data
+        assert is_bitwise_equal(x_fp8_view._rowwise_data, x_fp8._rowwise_data)
+        assert is_bitwise_equal(x_fp8_view._rowwise_scale_inv, x_fp8._rowwise_scale_inv)
+        # Check the data ptr
+        assert x_fp8_view._rowwise_data.data_ptr() == x_fp8._rowwise_data.data_ptr()
+        assert x_fp8_view._rowwise_scale_inv.data_ptr() == x_fp8._rowwise_scale_inv.data_ptr()
+
+        # Test reshape high dimension tensor -> 2D tensor
+        x_hp_reshape = x_hp.reshape(-1, dims[-2], dims[-1]).contiguous()
+        x_fp8_reshape = x_fp8.reshape(-1, dims[-2], dims[-1])
+        # Check the dequantized result
+        torch.testing.assert_close(
+            x_fp8_reshape.dequantize().contiguous(), x_hp_reshape, **_tols[fp8_dtype]
+        )
+        # Check the bitwise equality of the inner data
+        assert is_bitwise_equal(x_fp8_reshape._rowwise_data, x_fp8._rowwise_data)
+        assert is_bitwise_equal(x_fp8_reshape._rowwise_scale_inv, x_fp8._rowwise_scale_inv)
+
+
+
     @pytest.mark.parametrize("fp8_dtype", [tex.DType.kFloat8E4M3], ids=str)
     @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=str)
     @pytest.mark.parametrize("dims", [[256, 512], [250, 500]])

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -581,11 +581,7 @@ class _ViewFunc(torch.autograd.Function):
         if tensor._rowwise_data is not None:
             new_rowwise_data = tensor._rowwise_data.view(*shape)
         if tensor._columnwise_data is not None:
-            # Maybe changed in the future
-            if tensor._is_2D_scaled:
-                columnwise_shape = list(shape[-2:]) + list(shape[:-2])
-            else:
-                columnwise_shape = [shape[-1]] + list(shape[:-1])
+            columnwise_shape = [shape[-1]] + list(shape[:-1])
             new_columnwise_data = tensor._columnwise_data.view(columnwise_shape)
 
         return Float8BlockwiseQTensor(
@@ -612,10 +608,7 @@ class _ViewFunc(torch.autograd.Function):
                 grad._rowwise_data.view(*ctx.shape) if grad._rowwise_data is not None else None
             )
             if grad._columnwise_data is not None:
-                if grad._is_2D_scaled:
-                    columnwise_shape = list(ctx.shape[-2:]) + list(ctx.shape[:-2])
-                else:
-                    columnwise_shape = [ctx.shape[-1]] + list(ctx.shape[:-1])
+                columnwise_shape = [ctx.shape[-1]] + list(ctx.shape[:-1])
                 new_columnwise_data = grad._columnwise_data.view(columnwise_shape)
             else:
                 new_columnwise_data = None
@@ -693,11 +686,7 @@ class _ReshapeFunc(torch.autograd.Function):
         if tensor._rowwise_data is not None:
             new_rowwise_data = tensor._rowwise_data.reshape(*shape)
         if tensor._columnwise_data is not None:
-            # Maybe changed in the future
-            if tensor._is_2D_scaled:
-                columnwise_shape = list(shape[-2:]) + list(shape[:-2])
-            else:
-                columnwise_shape = [shape[-1]] + list(shape[:-1])
+            columnwise_shape = [shape[-1]] + list(shape[:-1])
             new_columnwise_data = tensor._columnwise_data.view(columnwise_shape)
 
         return Float8BlockwiseQTensor(
@@ -726,10 +715,7 @@ class _ReshapeFunc(torch.autograd.Function):
             if grad._rowwise_data is not None:
                 new_rowwise_data = grad._rowwise_data.view(*ctx.shape)
             if grad._columnwise_data is not None:
-                if grad._is_2D_scaled:
-                    columnwise_shape = list(ctx.shape[-2:]) + list(ctx.shape[:-2])
-                else:
-                    columnwise_shape = [ctx.shape[-1]] + list(ctx.shape[:-1])
+                columnwise_shape = [ctx.shape[-1]] + list(ctx.shape[:-1])
                 new_columnwise_data = grad._columnwise_data.view(columnwise_shape)
             dgrad = Float8BlockwiseQTensor(
                 shape=ctx.shape,

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -563,7 +563,7 @@ class _ViewFunc(torch.autograd.Function):
                     "the last 2 dimensions "
                     f"(attempted to view dims={tuple(tensor.shape)} to {tuple(shape)})"
                 )
-        else:  
+        else:
             # For the case of 1D scaled tensor, the last dimension should not change
             if shape[-1] != ctx.shape[-1]:
                 raise RuntimeError(
@@ -574,7 +574,7 @@ class _ViewFunc(torch.autograd.Function):
 
         if list(shape) == list(tensor.shape):
             return tensor
-        
+
         # Construct new tensor if shape is provided
         new_rowwise_data = None
         new_columnwise_data = None
@@ -583,7 +583,7 @@ class _ViewFunc(torch.autograd.Function):
         if tensor._columnwise_data is not None:
             # Maybe changed in the future
             if tensor._is_2D_scaled:
-                columnwise_shape = list(shape[-2:])+ list(shape[:-2])
+                columnwise_shape = list(shape[-2:]) + list(shape[:-2])
             else:
                 columnwise_shape = [shape[-1]] + list(shape[:-1])
             new_columnwise_data = tensor._columnwise_data.view(columnwise_shape)
@@ -676,7 +676,7 @@ class _ReshapeFunc(torch.autograd.Function):
                     "the last 2 dimensions "
                     f"(attempted to reshape dims={tuple(tensor.shape)} to {tuple(shape)})"
                 )
-        else:  
+        else:
             # For the case of 1D scaled tensor, the last dimension should not change
             if shape[-1] != ctx.shape[-1]:
                 raise RuntimeError(
@@ -695,7 +695,7 @@ class _ReshapeFunc(torch.autograd.Function):
         if tensor._columnwise_data is not None:
             # Maybe changed in the future
             if tensor._is_2D_scaled:
-                columnwise_shape = list(shape[-2:])+ list(shape[:-2])
+                columnwise_shape = list(shape[-2:]) + list(shape[:-2])
             else:
                 columnwise_shape = [shape[-1]] + list(shape[:-1])
             new_columnwise_data = tensor._columnwise_data.view(columnwise_shape)


### PR DESCRIPTION
# Description

Based on the MXFP8 implementation, this PR implemented view and reshape methods for the 1x128 scaling tensor in the sub-channel recipe, and added corresponding unit tests

Merged In https://github.com/NVIDIA/TransformerEngine/pull/1641

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
