### PR TITLE
[PyTorch] Add option in activation ops to cache input in FP8

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -1415,6 +1415,8 @@ class TestBasicOps:
         # Skip invalid configurations
         quantized_compute = quantization is not None
         maybe_skip_quantization(quantization, dims=in_shape, device=device)
+        if cache_quantized_input:
+            maybe_skip_quantization("fp8", device=device)
 
         # Random data
         x_ref, x_test = make_reference_and_test_tensors(

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -43,7 +43,8 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
     cache_quantized_input: bool, default = False
         Quantize input tensor when caching for use in the backward
         pass. This will typically reduce memory usage but require
-        extra compute and increase numerical error.
+        extra compute and increase numerical error. This feature is
+        highly experimental.
 
     """
 

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -115,6 +115,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         # Quantize input to FP8 before caching if needed
         if self.cache_quantized_input:
             quantizer = Float8CurrentScalingQuantizer(tex.DType.kFloat8E4M3, x.device)
+            quantizer.set_usage(rowwise=True, columnwise=False)
             x = quantizer(x)
 
         # Save state for backward pass


### PR DESCRIPTION
# Description

This PR adds experimental support in the activation fusible ops to cache input tensors in FP8. This reduces memory usage, at the expense of extra quantize/dequantize kernels and increased numerical error.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add option in activation ops to cache input in FP8

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
