### PR TITLE
Make shape cache invalidation more conservative.

### DIFF
--- a/transformer_engine/common/common.h
+++ b/transformer_engine/common/common.h
@@ -195,7 +195,18 @@ struct Tensor {
   }
 
   const std::vector<size_t> &rowwise_shape_ref() const {
-    rowwise_shape_cache = shape();
+    auto shape_queried = shape();
+    // This method is primarily designed for nvte_shape.
+    // An unfortunate consequence of unconditionally assigning
+    // values to rowwise_shape_cache without a check is that
+    // repeated calls to rowwise_shape_ref are likely to
+    // invalidate the data pointers from previous calls.
+    // If the shape has changed, then invalidating is necessary
+    // in at least some cases, but we want to keep the data
+    // valid otherwise.
+    if (rowwise_shape_cache != shape_queried) {
+      rowwise_shape_cache = std::move(shape_queried);
+    }
     return rowwise_shape_cache;
   }
 


### PR DESCRIPTION
Repeated calls to nvte_shape should not invalidate previous data pointers.

It would be possible to avoid unnecessary comparisons by duplicating some of the logic from shape() so that the cache is only relevant when columnwise shapes are involved. Whether this code duplication is preferable to the comparisons that arise from by value semantics of reusing shape is a judgment call.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Change is self explanatory. Unclear what the scope of existing pointer invalidations are in causing bugs.
NVTEShape is perilous.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

Prevent some classes of data pointer invalidation from nvte_shape use.
1bbeab1c563e7b8551804cb5af0847d277e22951 made a code change that
increased the number of cases where pointer invalidation could occur.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
