### PR TITLE
fix(grouped_gemm): fix error when at::from_blob pass zero shape

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/gemm.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/gemm.cpp
@@ -337,7 +337,9 @@ std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
         pytorch::detail::getGemmOutputShape(te_A.shape(), transa, te_B.shape(), transb);
     bool D_numel_is_zero = false;
     std::vector<int64_t> D_shape;
+    bool D_shape_zero = false;
     for (size_t t : size_t_shape) {
+      D_shape_zero = t == 0 || D_shape_zero;
       D_shape.push_back(t);
       if (t == 0) {
         D_numel_is_zero = true;
@@ -346,7 +348,7 @@ std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
     auto dtype = GetATenDType(D_type);
     auto opts = torch::TensorOptions().dtype(dtype).device(torch::kCUDA);
     if (single_output) {
-      if (output_data_ptr == nullptr) {
+      if (output_data_ptr == nullptr || D_shape_zero) {
         out_tensor = at::empty(D_shape, opts);
       } else {
         // We need to check !D_numel_is_zero because if the final input portion has zero elements,


### PR DESCRIPTION
# Description

In grouped gemm, when shape of D is zero, will raise `The specified pointer resides on host memory and is not registered with any CUDA device.`

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Add zero shape check.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
