### PR TITLE
[PyTorch] Avoid unnecessary tensor usages when caching for linear op backward

### DIFF
--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -533,7 +533,7 @@ class BasicLinear(BasicOperation):
             x_local = x_local.detach()
 
         # Configure input tensor for backward pass
-        if with_quantized_compute:
+        if with_quantized_compute and isinstance(x_local, QuantizedTensor):
             x_local.update_usage(rowwise_usage=False, columnwise_usage=True)
 
         return y, x_local, w

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -413,7 +413,6 @@ class BasicLinear(BasicOperation):
         x = None
         x_async = None
         with_x_all_gather = tensor_parallel_mode == "column" and sequence_parallel
-        own_quantized_x_local = False
         if with_quantized_compute:
             if input_quantizer is None:
                 raise ValueError("Missing quantizer for input tensor")
@@ -429,7 +428,6 @@ class BasicLinear(BasicOperation):
             else:
                 if not isinstance(x_local, QuantizedTensor):
                     x_local = input_quantizer(x_local)
-                    own_quantized_x_local = True
                 x = x_local
         else:
             if isinstance(x_local, QuantizedTensor):
@@ -528,15 +526,15 @@ class BasicLinear(BasicOperation):
             else:
                 torch.distributed.all_reduce(y, group=tensor_parallel_group)
 
-        # Configure input tensor for backward pass
-        if own_quantized_x_local:
-            x_local.update_usage(rowwise_usage=False, columnwise_usage=True)
-
         # Detach input tensor if needed
         # Note: PyTorch autograd produces esoteric errors if we save
         # input tensor as context for backward pass.
         if x_local is input:
             x_local = x_local.detach()
+
+        # Configure input tensor for backward pass
+        if with_quantized_compute:
+            x_local.update_usage(rowwise_usage=False, columnwise_usage=True)
 
         return y, x_local, w
 


### PR DESCRIPTION
# Description

The linear op avoids modifying its input tensor since it assumes it could be used elsewhere. This results in it caching unnecessary data for the backward pass since it cannot discard unneeded tensor usages. This PR modifies its behavior so that it detaches the input tensor, allowing it to freely change the tensor usages without any external impact.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Avoid unnecessary tensor usage when caching for linear op backward

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
