### PR TITLE
Fix #1524 and other softmax mask functionality

### DIFF
--- a/tests/jax/test_layer.py
+++ b/tests/jax/test_layer.py
@@ -218,7 +218,48 @@ ATTRS = [
     {
         _KEY_OF_TRANSPOSE_BS: False,
         _KEY_OF_RELATIVE_EMBEDDING: False,
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "causal",
+        _KEY_OF_WINDOW_SIZE: None,
+        _KEY_OF_FLOAT32_ATTENTION_LOGITS: True,
+    },
+    # attrs23
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "causal",
+        _KEY_OF_FLOAT32_ATTENTION_LOGITS: True,
+    },
+    # attrs24
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "no_mask",
+    },
+    # attrs25
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "no_mask",
+        _KEY_OF_WINDOW_SIZE: (2, 2),
+    },
+    # attrs26
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
         _KEY_OF_SELF_ATTN_MASK_TYPE: "padding",
+        _KEY_OF_WINDOW_SIZE: (2, 2),
+    },
+    # attrs27
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
+        _KEY_OF_SELF_ATTN_MASK_TYPE: "padding",
+        _KEY_OF_WINDOW_SIZE: None,
+    },
+    # attrs28
+    {
+        _KEY_OF_TRANSPOSE_BS: False,
+        _KEY_OF_RELATIVE_EMBEDDING: False,
         _KEY_OF_WINDOW_SIZE: (2, 2),
     },
 ]
@@ -370,13 +411,13 @@ class EncoderRunner(BaseRunner):
         data_rng = jax.random.PRNGKey(2024)
         inputs = (jax.random.normal(data_rng, data_shape, dtype),)
 
-        padded_mask = jnp.zeros((batch, 1, seqlen, seqlen), dtype=jnp.uint8)
-        causal_mask = jnp.triu(jnp.ones((batch, 1, seqlen, seqlen), dtype=jnp.uint8), k=1)
+        mask_shape = (batch, 1, seqlen, seqlen)
+        padded_mask = jnp.zeros(mask_shape, dtype=jnp.uint8)
+        causal_mask = jnp.triu(jnp.ones(mask_shape, dtype=jnp.uint8), k=1)
         if self.attrs[_KEY_OF_SELF_ATTN_MASK_TYPE] in ["causal", "padding_causal"]:
             mask = causal_mask
         else:
             mask = padded_mask
-
         ref_masks = (1 - mask,)
         test_masks = (None, mask)  # The second arg of Transformer is encoded tokens.
 

--- a/tests/jax/test_softmax.py
+++ b/tests/jax/test_softmax.py
@@ -139,6 +139,7 @@ class SoftmaxRunner:
         assert_allclose(primitive_out, reference_out, dtype=self.dtype)
         assert_allclose(primitive_grad_logits, reference_grad_logits, dtype=self.dtype)
 
+
 class SoftmaxPrimitivesRunner(SoftmaxRunner):
     """
     Jax Softmax Primitives runner
@@ -147,15 +148,17 @@ class SoftmaxPrimitivesRunner(SoftmaxRunner):
     @catch_unsupported
     def test_forward(self):
         return super().test_forward()
-    
+
     @catch_unsupported
     def test_backward(self):
         return super().test_backward()
+
 
 class SoftmaxModuleRunner:
     """
     Jax Softmax Modules runner
     """
+
     module_runner: SoftmaxRunner
     bias: None
 
@@ -169,12 +172,19 @@ class SoftmaxModuleRunner:
         """
         self.module_runner._setup_inputs()
         rng = jax.random.PRNGKey(0)
-        softmax_module = Softmax(scale_factor=self.module_runner.scale_factor, softmax_type=self.module_runner.softmax_type)
-        softmax_vars = softmax_module.init(rng,self.module_runner.logits, self.module_runner.mask)
-        module_out = softmax_module.apply(softmax_vars, self.module_runner.logits, self.module_runner.mask)#.astype(input_dtype)
-        reference_out = self.module_runner.reference_softmax(self.module_runner.logits, self.module_runner.mask, self.module_runner.scale_factor)
+        softmax_module = Softmax(
+            scale_factor=self.module_runner.scale_factor,
+            softmax_type=self.module_runner.softmax_type,
+        )
+        softmax_vars = softmax_module.init(rng, self.module_runner.logits, self.module_runner.mask)
+        module_out = softmax_module.apply(
+            softmax_vars, self.module_runner.logits, self.module_runner.mask
+        )  # .astype(input_dtype)
+        reference_out = self.module_runner.reference_softmax(
+            self.module_runner.logits, self.module_runner.mask, self.module_runner.scale_factor
+        )
         assert_allclose(module_out, reference_out, dtype=self.module_runner.dtype)
-        
+
 
 # Run softmax primitives test
 @pytest.mark.parametrize(
@@ -264,4 +274,3 @@ class TestSoftmaxModule:
         bias = None
         runner = SoftmaxModuleRunner(module_runner, bias)
         runner.test_forward()
-    

--- a/tests/jax/test_softmax.py
+++ b/tests/jax/test_softmax.py
@@ -18,6 +18,7 @@ from utils import assert_allclose
 
 from transformer_engine.jax.cpp_extensions import is_softmax_kernel_available
 from transformer_engine.jax.softmax import SoftmaxType, softmax
+from transformer_engine.jax.flax.module import Softmax
 
 
 def catch_unsupported(method):
@@ -94,7 +95,6 @@ class SoftmaxRunner:
             case _:
                 raise ValueError(f"Unknown {self.softmax_type=}")
 
-    @catch_unsupported
     def test_forward(self):
         """
         Test transformer_engine.jax.softmax.softmax fwd rule
@@ -104,7 +104,6 @@ class SoftmaxRunner:
         reference_out = __class__.reference_softmax(self.logits, self.mask, self.scale_factor)
         assert_allclose(primitive_out, reference_out, dtype=self.dtype)
 
-    @catch_unsupported
     def test_backward(self):
         """
         Test transformer_engine.jax.softmax.softmax bwd rule
@@ -140,7 +139,44 @@ class SoftmaxRunner:
         assert_allclose(primitive_out, reference_out, dtype=self.dtype)
         assert_allclose(primitive_grad_logits, reference_grad_logits, dtype=self.dtype)
 
+class SoftmaxPrimitivesRunner(SoftmaxRunner):
+    """
+    Jax Softmax Primitives runner
+    """
 
+    @catch_unsupported
+    def test_forward(self):
+        return super().test_forward()
+    
+    @catch_unsupported
+    def test_backward(self):
+        return super().test_backward()
+
+class SoftmaxModuleRunner:
+    """
+    Jax Softmax Modules runner
+    """
+    module_runner: SoftmaxRunner
+    bias: None
+
+    def __init__(self, module_runner, bias):
+        self.module_runner = module_runner
+        self.bias = bias
+
+    def test_forward(self):
+        """
+        Test transformer_engine.jax.flax.module.Softmax fwd rule
+        """
+        self.module_runner._setup_inputs()
+        rng = jax.random.PRNGKey(0)
+        softmax_module = Softmax(scale_factor=self.module_runner.scale_factor, softmax_type=self.module_runner.softmax_type)
+        softmax_vars = softmax_module.init(rng,self.module_runner.logits, self.module_runner.mask)
+        module_out = softmax_module.apply(softmax_vars, self.module_runner.logits, self.module_runner.mask)#.astype(input_dtype)
+        reference_out = self.module_runner.reference_softmax(self.module_runner.logits, self.module_runner.mask, self.module_runner.scale_factor)
+        assert_allclose(module_out, reference_out, dtype=self.module_runner.dtype)
+        
+
+# Run softmax primitives test
 @pytest.mark.parametrize(
     "b, s_q, s_kv, h",
     [
@@ -165,7 +201,7 @@ class SoftmaxRunner:
         pytest.param(jnp.float16, id="FP16"),
     ],
 )
-class TestSoftmax:
+class TestSoftmaxPrimitives:
     """
     Test transformer_engine.jax.softmax.softmax
     """
@@ -175,7 +211,7 @@ class TestSoftmax:
         """
         Test forward with parameterized configs
         """
-        runner = SoftmaxRunner(b, s_q, s_kv, h, scale_factor, softmax_type, dtype)
+        runner = SoftmaxPrimitivesRunner(b, s_q, s_kv, h, scale_factor, softmax_type, dtype)
         runner.test_forward()
 
     @staticmethod
@@ -183,5 +219,49 @@ class TestSoftmax:
         """
         Test forward with parameterized configs
         """
-        runner = SoftmaxRunner(b, s_q, s_kv, h, scale_factor, softmax_type, dtype)
+        runner = SoftmaxPrimitivesRunner(b, s_q, s_kv, h, scale_factor, softmax_type, dtype)
         runner.test_backward()
+
+
+# Run Softmax module test
+@pytest.mark.parametrize(
+    "b, s_q, s_kv, h",
+    [
+        pytest.param(8, 16, 16, 16, id="8-16-16-16"),
+        pytest.param(8, 512, 512, 16, id="8-512-512-16"),
+        pytest.param(2, 8, 16384, 8, id="2-8-16384-8"),
+        # triggers backup framework implementation due to (s_q % 4) != 0
+        pytest.param(8, 511, 512, 16, id="8-511-512-16"),
+    ],
+)
+@pytest.mark.parametrize("scale_factor", [0.125])
+@pytest.mark.parametrize(
+    "softmax_type",
+    [
+        pytest.param(SoftmaxType.SCALED, id="SCALED"),
+        pytest.param(SoftmaxType.SCALED_MASKED, id="SCALED_MASKED"),
+        pytest.param(SoftmaxType.SCALED_UPPER_TRIANG_MASKED, id="SCALED_UPPER_TRIANG_MASKED"),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(jnp.bfloat16, id="BF16"),
+        pytest.param(jnp.float16, id="FP16"),
+    ],
+)
+class TestSoftmaxModule:
+    """
+    Test transformer_engine.jax.flax.module.Softmax
+    """
+
+    @staticmethod
+    def test_forward(b, s_q, s_kv, h, scale_factor, softmax_type, dtype):
+        """
+        Test forward with parameterized configs
+        """
+        module_runner = SoftmaxRunner(b, s_q, s_kv, h, scale_factor, softmax_type, dtype)
+        bias = None
+        runner = SoftmaxModuleRunner(module_runner, bias)
+        runner.test_forward()
+    

--- a/tests/jax/test_softmax.py
+++ b/tests/jax/test_softmax.py
@@ -178,12 +178,8 @@ class SoftmaxModuleRunner:
             softmax_type=runner.softmax_type,
         )
         softmax_vars = softmax_module.init(rng, runner.logits, runner.mask)
-        module_out = softmax_module.apply(
-            softmax_vars, runner.logits, runner.mask
-        )
-        reference_out = runner.reference_softmax(
-            runner.logits, runner.mask, runner.scale_factor
-        )
+        module_out = softmax_module.apply(softmax_vars, runner.logits, runner.mask)
+        reference_out = runner.reference_softmax(runner.logits, runner.mask, runner.scale_factor)
         assert_allclose(module_out, reference_out, dtype=runner.dtype)
 
 

--- a/tests/jax/test_softmax.py
+++ b/tests/jax/test_softmax.py
@@ -156,7 +156,7 @@ class SoftmaxPrimitivesRunner(SoftmaxRunner):
 
 class SoftmaxModuleRunner:
     """
-    Jax Softmax Modules runner
+    Jax Softmax Module runner
     """
 
     module_runner: SoftmaxRunner
@@ -170,20 +170,21 @@ class SoftmaxModuleRunner:
         """
         Test transformer_engine.jax.flax.module.Softmax fwd rule
         """
-        self.module_runner._setup_inputs()
+        runner = self.module_runner
+        runner._setup_inputs()
         rng = jax.random.PRNGKey(0)
         softmax_module = Softmax(
-            scale_factor=self.module_runner.scale_factor,
-            softmax_type=self.module_runner.softmax_type,
+            scale_factor=runner.scale_factor,
+            softmax_type=runner.softmax_type,
         )
-        softmax_vars = softmax_module.init(rng, self.module_runner.logits, self.module_runner.mask)
+        softmax_vars = softmax_module.init(rng, runner.logits, runner.mask)
         module_out = softmax_module.apply(
-            softmax_vars, self.module_runner.logits, self.module_runner.mask
-        )  # .astype(input_dtype)
-        reference_out = self.module_runner.reference_softmax(
-            self.module_runner.logits, self.module_runner.mask, self.module_runner.scale_factor
+            softmax_vars, runner.logits, runner.mask
         )
-        assert_allclose(module_out, reference_out, dtype=self.module_runner.dtype)
+        reference_out = runner.reference_softmax(
+            runner.logits, runner.mask, runner.scale_factor
+        )
+        assert_allclose(module_out, reference_out, dtype=runner.dtype)
 
 
 # Run softmax primitives test

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -26,7 +26,11 @@ from ..layernorm_mlp import layernorm_mlp
 from ..activation import activation
 from ..softmax import softmax, SoftmaxType
 from ..sharding import with_sharding_constraint_by_logical_axes
-from ..cpp_extensions import is_softmax_kernel_available, jax_scaled_softmax, jax_scaled_upper_triang_masked_softmax
+from ..cpp_extensions import (
+    is_softmax_kernel_available,
+    jax_scaled_softmax,
+    jax_scaled_upper_triang_masked_softmax,
+)
 from ..quantize import QuantizerFactory, QuantizeConfig, QuantizeMeta, QuantizeMetaSet, ScalingMode
 from ..sharding import get_non_contracting_logical_axes
 
@@ -183,7 +187,7 @@ class Softmax(nn.Module):  # pylint: disable=too-few-public-methods
         # use default jax based implementation
         else:
             attention_bias = None
-            #change mask in testing too to not be a causal mask
+            # change mask in testing too to not be a causal mask
             if mask is not None:
                 attention_bias = lax.select(
                     mask > 0,
@@ -204,6 +208,8 @@ class Softmax(nn.Module):  # pylint: disable=too-few-public-methods
                 outputs = jax_scaled_upper_triang_masked_softmax(logits, self.scale_factor)
         assert input_dtype == outputs.dtype
         return outputs
+
+
 """         if self.softmax_type is not SoftmaxType.SCALED and is_softmax_kernel_available(
             self.softmax_type, batch, heads, q_seqlen, k_seqlen, input_dtype
         ):

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -13,7 +13,6 @@ import jax.numpy as jnp
 from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
 from jax import lax
-from jax import nn as jax_nn
 from jax import random as jax_random
 from jax.ad_checkpoint import checkpoint_name
 

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -168,7 +168,43 @@ class Softmax(nn.Module):  # pylint: disable=too-few-public-methods
         input_dtype = inputs.dtype
         logits = inputs
 
-        if self.softmax_type is not SoftmaxType.SCALED and is_softmax_kernel_available(
+        # use primitives
+        if is_softmax_kernel_available(
+            self.softmax_type, batch, heads, q_seqlen, k_seqlen, input_dtype
+        ):
+            if bias is not None:
+                logits = logits + bias.astype(input_dtype)
+
+            mask_ = mask
+            if self.softmax_type is not SoftmaxType.SCALED_MASKED:
+                mask_ = None
+
+            outputs = softmax(logits, mask_, self.scale_factor, self.softmax_type)
+        # use default jax based implementation
+        else:
+            attention_bias = None
+            #change mask in testing too to not be a causal mask
+            if mask is not None:
+                attention_bias = lax.select(
+                    mask > 0,
+                    jnp.full(mask.shape, -1e10),
+                    jnp.full(mask.shape, 0.0),
+                )
+                attention_bias = attention_bias.astype(input_dtype)
+
+            if bias is not None:
+                attention_bias = _combine_biases(attention_bias, bias)
+
+            if attention_bias is not None:
+                logits = logits + attention_bias.astype(input_dtype)
+
+            if self.softmax_type is not SoftmaxType.SCALED_UPPER_TRIANG_MASKED:
+                outputs = jax_scaled_softmax(logits, self.scale_factor)
+            else:
+                outputs = jax_scaled_upper_triang_masked_softmax(logits, self.scale_factor)
+        assert input_dtype == outputs.dtype
+        return outputs
+"""         if self.softmax_type is not SoftmaxType.SCALED and is_softmax_kernel_available(
             self.softmax_type, batch, heads, q_seqlen, k_seqlen, input_dtype
         ):
 
@@ -210,7 +246,7 @@ class Softmax(nn.Module):  # pylint: disable=too-few-public-methods
                     outputs = jax_scaled_upper_triang_masked_softmax(logits, self.scale_factor)
 
         assert input_dtype == outputs.dtype
-        return outputs
+        return outputs"""
 
 
 class LayerNorm(nn.Module):  # pylint: disable=too-few-public-methods

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -197,7 +197,10 @@ class Softmax(nn.Module):  # pylint: disable=too-few-public-methods
             elif self.softmax_type is SoftmaxType.SCALED_UPPER_TRIANG_MASKED:
                 outputs = jax_scaled_upper_triang_masked_softmax(logits, self.scale_factor)
             else:
-                raise ValueError(f"Unsupported softmax type: {self.softmax_type}. softmax_type must be [SCALED, SCALED_MASKED, SCALED_UPPER_TRIANG_MASKED]")
+                raise ValueError(
+                    f"Unsupported softmax type: {self.softmax_type}. softmax_type must be [SCALED,"
+                    " SCALED_MASKED, SCALED_UPPER_TRIANG_MASKED]"
+                )
         assert input_dtype == outputs.dtype
         return outputs
 

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -202,51 +202,6 @@ class Softmax(nn.Module):  # pylint: disable=too-few-public-methods
         return outputs
 
 
-"""         if self.softmax_type is not SoftmaxType.SCALED and is_softmax_kernel_available(
-            self.softmax_type, batch, heads, q_seqlen, k_seqlen, input_dtype
-        ):
-
-            if bias is not None:
-                logits = logits + bias.astype(input_dtype)
-
-            mask_ = mask
-            if self.softmax_type is not SoftmaxType.SCALED_MASKED:
-                mask_ = None
-
-            outputs = softmax(logits, mask_, self.scale_factor, self.softmax_type)
-        else:
-            attention_bias = None
-            #change mask in testing too to not be a causal mask
-            if mask is not None:
-                attention_bias = lax.select(
-                    mask > 0,
-                    jnp.full(mask.shape, -1e10),
-                    jnp.full(mask.shape, 0.0),
-                )
-                attention_bias = attention_bias.astype(input_dtype)
-
-            if bias is not None:
-                attention_bias = _combine_biases(attention_bias, bias)
-
-            if attention_bias is not None:
-                logits = logits + attention_bias.astype(input_dtype)
-
-            # For the case that self.softmax == SoftmaxType.SCALED_UPPER_TRIANG_MASKED
-            # and kernel is unavailable, then try on pure scaled softmax custom calls.
-            if is_softmax_kernel_available(
-                SoftmaxType.SCALED, batch, heads, q_seqlen, k_seqlen, input_dtype
-            ):
-                outputs = softmax(logits, None, self.scale_factor, SoftmaxType.SCALED)
-            else:
-                if self.softmax_type is not SoftmaxType.SCALED_UPPER_TRIANG_MASKED:
-                    outputs = jax_scaled_softmax(logits, self.scale_factor)
-                else:
-                    outputs = jax_scaled_upper_triang_masked_softmax(logits, self.scale_factor)
-
-        assert input_dtype == outputs.dtype
-        return outputs"""
-
-
 class LayerNorm(nn.Module):  # pylint: disable=too-few-public-methods
     r"""
     Applies layer normalization over a mini-batch of inputs.

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -446,7 +446,7 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         .. note:: :attr:`mask` in :attr:`__call__` is ignored for 'no_mask' and 'causal'.
 
         .. note:: THD format only supports 'padding' or 'causal_padding' mask type.
-    
+
        attn_mask_type       mask/sequence_descriptor       SW         softmax type
        --------------------------------------------------------------------------------------------
        no_mask              None                           None       SCALED

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -446,14 +446,14 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         .. note:: :attr:`mask` in :attr:`__call__` is ignored for 'no_mask' and 'causal'.
 
         .. note:: THD format only supports 'padding' or 'causal_padding' mask type.
-
-       attn_mask_type       mask/sequence_descriptor       SW         softmax type
+    
+       attn_mask_type       mask/sequence_descriptor       SWA               softmax type
        --------------------------------------------------------------------------------------------
-       no_mask              None                           None       SCALED
-       causal               None                           None       SCALED_UPPER_TRIANG_MASKED
-       causal               None                           Yes        SCALED_MASKED
-       padding              Required                       X          SCALED_MASKED
-       padding_causal       Required                       X          SCALED_MASKED
+       no_mask              None                           None              SCALED
+       causal               None                           None              SCALED_UPPER_TRIANG_MASKED
+       causal               None                           Yes               SCALED_MASKED
+       padding              Required                       Yes/No/None       SCALED_MASKED
+       padding_causal       Required                       Yes/No/None       SCALED_MASKED
 
     attn_bias_type: Optional[str], default = None
         Type of the attention bias passed in the attention.

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -446,7 +446,7 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         .. note:: :attr:`mask` in :attr:`__call__` is ignored for 'no_mask' and 'causal'.
 
         .. note:: THD format only supports 'padding' or 'causal_padding' mask type.
-    
+
        attn_mask_type       mask/sequence_descriptor       SWA               softmax type
        --------------------------------------------------------------------------------------------
        no_mask              None                           None              SCALED

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -446,7 +446,7 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         .. note:: :attr:`mask` in :attr:`__call__` is ignored for 'no_mask' and 'causal'.
 
         .. note:: THD format only supports 'padding' or 'causal_padding' mask type.
-    
+
        attn_mask_type       mask/sequence_descriptor       SWA          softmax type
        --------------------------------------------------------------------------------------------
        no_mask              None                           None         SCALED

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -446,14 +446,14 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         .. note:: :attr:`mask` in :attr:`__call__` is ignored for 'no_mask' and 'causal'.
 
         .. note:: THD format only supports 'padding' or 'causal_padding' mask type.
-
-       attn_mask_type       mask/sequence_descriptor       SWA               softmax type
+    
+       attn_mask_type       mask/sequence_descriptor       SWA          softmax type
        --------------------------------------------------------------------------------------------
-       no_mask              None                           None              SCALED
-       causal               None                           None              SCALED_UPPER_TRIANG_MASKED
-       causal               None                           Yes               SCALED_MASKED
-       padding              Required                       Yes/No/None       SCALED_MASKED
-       padding_causal       Required                       Yes/No/None       SCALED_MASKED
+       no_mask              None                           None         SCALED
+       causal               None                           None         SCALED_UPPER_TRIANG_MASKED
+       causal               None                           Yes          SCALED_MASKED
+       padding              Required                       Yes/No       SCALED_MASKED
+       padding_causal       Required                       Yes/No       SCALED_MASKED
 
     attn_bias_type: Optional[str], default = None
         Type of the attention bias passed in the attention.


### PR DESCRIPTION
# Description

Fixes #1524 
Simplifies and corrects logic around mapping attn mask to softmax mask, while adding additional testing capabilities

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

1. Add test cases for better coverage in `test_layer.py`

- causal and window size None
- causal and window size default (-1,1)
- no_mask and window size default (-1,1)
- no_mask and window size default (2,2)
- padding and window size None
- padding_causal and window_size (2,2)

2. Correctly map `padding_causal` to `scaled_masked` instead of `scaled_upper_triangle`
3. Add fallback jax implementation for `scaled_upper_triangle` (#1524 )
4. Add tests for `Softmax` wrapper/module in `jax.flax.module.Softmax`
5. Simplify logic for jax based softmax
6. Add support table in comments for attn mask, SWA and softmax type

## TODO:
Add support for `causal_bottom_right` and `padding_causal_bottom_right` as well. 

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
