### PR TITLE
Warn when using fp8 weights + non-fp8 computation

### DIFF
--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -677,8 +677,10 @@ class GroupedLinear(TransformerEngineBaseModule):
             weight_tensors = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
             bias_tensors = [getattr(self, f"bias{i}") for i in range(self.num_gemms)]
             if not self.fp8:
-                warnings.warn("You are using quantized weights without quantized compute. "
-                              "Please make sure this is intentional.")
+                warnings.warn(
+                    "You are using quantized weights without quantized compute. "
+                    "Please make sure this is intentional."
+                )
                 weight_tensors = [
                     w.dequantize() if isinstance(w, QuantizedTensor) else w for w in weight_tensors
                 ]

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -4,6 +4,7 @@
 
 """GroupedLinear API"""
 from typing import Union, Optional, Callable, Tuple, List
+import warnings
 
 import functools
 import torch
@@ -676,7 +677,8 @@ class GroupedLinear(TransformerEngineBaseModule):
             weight_tensors = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
             bias_tensors = [getattr(self, f"bias{i}") for i in range(self.num_gemms)]
             if not self.fp8 and any(isinstance(w, QuantizedTensor) for w in weight_tensors):
-                raise RuntimeError("FP8 weights without FP8 computation is not supported")
+                warnings.warn("You are using quantized weights without quantized compute. "
+                              "Please make sure this is intentional.")
 
             input_quantizers, weight_quantizers, output_quantizers = (
                 [None] * self.num_gemms,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -676,9 +676,12 @@ class GroupedLinear(TransformerEngineBaseModule):
 
             weight_tensors = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
             bias_tensors = [getattr(self, f"bias{i}") for i in range(self.num_gemms)]
-            if not self.fp8 and any(isinstance(w, QuantizedTensor) for w in weight_tensors):
+            if not self.fp8:
                 warnings.warn("You are using quantized weights without quantized compute. "
                               "Please make sure this is intentional.")
+                weight_tensors = [
+                    w.dequantize() if isinstance(w, QuantizedTensor) else w for w in weight_tensors
+                ]
 
             input_quantizers, weight_quantizers, output_quantizers = (
                 [None] * self.num_gemms,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -675,10 +675,8 @@ class GroupedLinear(TransformerEngineBaseModule):
 
             weight_tensors = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
             bias_tensors = [getattr(self, f"bias{i}") for i in range(self.num_gemms)]
-            if not self.fp8:
-                weight_tensors = [
-                    w.dequantize() if isinstance(w, QuantizedTensor) else w for w in weight_tensors
-                ]
+            if not self.fp8 and any(isinstance(w, QuantizedTensor) for w in weight_tensors):
+                raise RuntimeError("FP8 weights without FP8 computation is not supported")
 
             input_quantizers, weight_quantizers, output_quantizers = (
                 [None] * self.num_gemms,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1394,8 +1394,10 @@ class LayerNormLinear(TransformerEngineBaseModule):
                             "Splitting QuantizedTensor into multiple params is not supported"
                         )
                 else:
-                    warnings.warn("You are using quantized weights without quantized compute. "
-                                  "Please make sure this is intentional.")
+                    warnings.warn(
+                        "You are using quantized weights without quantized compute. "
+                        "Please make sure this is intentional."
+                    )
                     unfused_weights = [w.dequantize() for w in unfused_weights]
 
             weight_tensor = noop_cat(unfused_weights)

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1394,7 +1394,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
                             "Splitting QuantizedTensor into multiple params is not supported"
                         )
                 else:
-                    raise RuntimeError("FP8 weights without FP8 computation is not supported")
+                    warnings.warn("You are using quantized weights without quantized compute. "
+                                  "Please make sure this is intentional.")
 
             weight_tensor = noop_cat(unfused_weights)
             if self.use_bias:

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1394,7 +1394,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                             "Splitting QuantizedTensor into multiple params is not supported"
                         )
                 else:
-                    unfused_weights = [w.dequantize() for w in unfused_weights]
+                    raise RuntimeError("FP8 weights without FP8 computation is not supported")
 
             weight_tensor = noop_cat(unfused_weights)
             if self.use_bias:

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1396,6 +1396,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 else:
                     warnings.warn("You are using quantized weights without quantized compute. "
                                   "Please make sure this is intentional.")
+                    unfused_weights = [w.dequantize() for w in unfused_weights]
 
             weight_tensor = noop_cat(unfused_weights)
             if self.use_bias:

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -6,6 +6,7 @@
 from typing import Callable, Dict, Optional, Tuple, Union
 from functools import reduce
 from operator import mul as multiply_op
+import warnings
 
 import functools
 import torch
@@ -1207,7 +1208,8 @@ class Linear(TransformerEngineBaseModule):
                             "Splitting QuantizedTensor into multiple params is not supported"
                         )
                 else:
-                    raise RuntimeError("FP8 weights without FP8 computation is not supported")
+                    warnings.warn("You are using quantized weights without quantized compute. "
+                                  "Please make sure this is intentional.")
             weight_tensor = noop_cat(unfused_weights)
             if self.use_bias:
                 bias_tensor = noop_cat([getattr(self, name) for name in self.bias_names])

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1208,8 +1208,10 @@ class Linear(TransformerEngineBaseModule):
                             "Splitting QuantizedTensor into multiple params is not supported"
                         )
                 else:
-                    warnings.warn("You are using quantized weights without quantized compute. "
-                                  "Please make sure this is intentional.")
+                    warnings.warn(
+                        "You are using quantized weights without quantized compute. "
+                        "Please make sure this is intentional."
+                    )
                     unfused_weights = [w.dequantize() for w in unfused_weights]
 
             weight_tensor = noop_cat(unfused_weights)

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1207,7 +1207,7 @@ class Linear(TransformerEngineBaseModule):
                             "Splitting QuantizedTensor into multiple params is not supported"
                         )
                 else:
-                    unfused_weights = [w.dequantize() for w in unfused_weights]
+                    raise RuntimeError("FP8 weights without FP8 computation is not supported")
             weight_tensor = noop_cat(unfused_weights)
             if self.use_bias:
                 bias_tensor = noop_cat([getattr(self, name) for name in self.bias_names])

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1210,6 +1210,8 @@ class Linear(TransformerEngineBaseModule):
                 else:
                     warnings.warn("You are using quantized weights without quantized compute. "
                                   "Please make sure this is intentional.")
+                    unfused_weights = [w.dequantize() for w in unfused_weights]
+
             weight_tensor = noop_cat(unfused_weights)
             if self.use_bias:
                 bias_tensor = noop_cat([getattr(self, name) for name in self.bias_names])


### PR DESCRIPTION
# Description

Currently, TE's `Linear`, `LayerNormLinear` and `GroupedLinear` de-quantized the fp8 weights to bf16 when self.fp8 is False. This MR changes the de-quantization to raising an error, to prevent fp8 weights + non-fp8 computation.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
