### PR TITLE
Introduce nvte_memset to provide a fill kernel that is faster than cudaMemsetAsync for small sizes

### DIFF
--- a/tests/cpp/operator/test_memset.cu
+++ b/tests/cpp/operator/test_memset.cu
@@ -1,0 +1,86 @@
+/*************************************************************************
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <type_traits>
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <transformer_engine/transformer_engine.h>
+#include "../test_common.h"
+
+using namespace transformer_engine;
+
+
+class MemsetTestSuite : public ::testing::TestWithParam<std::tuple<int,
+                                                                size_t>> {};
+
+TEST_P(MemsetTestSuite, TestMemset) {
+    using namespace transformer_engine;
+    using namespace test;
+
+    int value = std::get<0>(GetParam());
+    size_t size_in_bytes = std::get<1>(GetParam());
+
+    std::vector<uint8_t> h_buffer{};
+    h_buffer.resize(size_in_bytes);
+    for (size_t i = 0; i < size_in_bytes; ++i) {
+        h_buffer[i] = value + 1;  // Initialize host buffer to a different value than memset value to verify memset is working correctly
+    }
+
+    char* d_ptr;
+    NVTE_CHECK_CUDA(cudaMalloc(&d_ptr, size_in_bytes));
+
+    NVTE_CHECK_CUDA(cudaMemcpy(d_ptr, h_buffer.data(), size_in_bytes, cudaMemcpyHostToDevice));
+
+    nvte_memset(d_ptr, value, size_in_bytes, 0 /* stream */);
+
+    NVTE_CHECK_CUDA(cudaMemcpy(
+        h_buffer.data(), d_ptr, size_in_bytes, cudaMemcpyDeviceToHost));
+    NVTE_CHECK_CUDA(cudaFree(d_ptr));
+
+    NVTE_CHECK_CUDA(cudaDeviceSynchronize());
+
+    for (size_t i = 0; i < size_in_bytes; ++i) {
+        EXPECT_EQ(h_buffer[i], static_cast<uint8_t>(value))
+            << "Mismatch at index " << i << ": expected " << static_cast<int>(value)
+            << ", got " << static_cast<int>(h_buffer[i]);
+    }
+}
+
+namespace {
+
+std::vector<size_t> memset_test_sizes = {
+  1,
+  4,
+  9,
+  16,
+  128,
+  4096,
+  4097,
+  8192,
+};
+
+}  // namespace
+
+INSTANTIATE_TEST_SUITE_P(
+    OperatorTest,
+    MemsetTestSuite,
+    ::testing::Combine(
+        ::testing::Values(0, 6),
+        ::testing::ValuesIn(memset_test_sizes)),
+    [](const testing::TestParamInfo<MemsetTestSuite::ParamType>& info) {
+      std::string name = std::to_string(std::get<0>(info.param)) + "X" +
+                         std::to_string(std::get<1>(info.param));
+      return name;
+    });

--- a/transformer_engine/common/include/transformer_engine/transformer_engine.h
+++ b/transformer_engine/common/include/transformer_engine/transformer_engine.h
@@ -338,6 +338,17 @@ void nvte_destroy_quantization_config(NVTEQuantizationConfig config);
  */
 int nvte_is_non_tn_fp8_gemm_supported();
 
+/*! \brief Performs a memset of the data at the given pointer and size in bytes.
+ *
+ *  \param[in] ptr Pointer to the memory to be set.
+ *  \param[in] value Value to set the memory to.
+ *  \param[in] size_in_bytes Size of the memory in bytes.
+ *  \param[in] stream CUDA stream to use for the operation.
+ *
+ *  This function calls a fill kernel for small sizes and calls cudaMemsetAsync for larger sizes.
+*/
+void nvte_memset(void* ptr, int value, size_t size_in_bytes, cudaStream_t stream);
+
 #ifdef __cplusplus
 }  // extern "C"
 

--- a/transformer_engine/common/include/transformer_engine/transformer_engine.h
+++ b/transformer_engine/common/include/transformer_engine/transformer_engine.h
@@ -347,7 +347,7 @@ int nvte_is_non_tn_fp8_gemm_supported();
  *
  *  This function calls a fill kernel for small sizes and calls cudaMemsetAsync for larger sizes.
 */
-void nvte_memset(void* ptr, int value, size_t size_in_bytes, cudaStream_t stream);
+void nvte_memset(void *ptr, int value, size_t size_in_bytes, cudaStream_t stream);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/transformer_engine/jax/csrc/extensions/activation.cpp
+++ b/transformer_engine/jax/csrc/extensions/activation.cpp
@@ -53,7 +53,7 @@ Error_Type ActLuFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type scal
     if (scaling_mode == JAXX_Scaling_Mode::DELAYED_TENSOR_SCALING) {
       NVTE_CHECK(scale != nullptr, "scale must be provided for delayed tensor scaling");
       NVTE_CHECK(amax != nullptr, "amax must be provided for delayed tensor scaling");
-      cudaMemsetAsync(amax, 0, sizeof(float), stream);
+      nvte_memset(amax, 0, sizeof(float), stream);
       output_tensor.set_scale(scale, DType::kFloat32, std::vector<size_t>{1});
       output_tensor.set_amax(amax, DType::kFloat32, std::vector<size_t>{1});
       output_tensor.set_rowwise_scale_inv(
@@ -266,7 +266,7 @@ Error_Type DActLuDBiasQuantizeFFI(cudaStream_t stream, Buffer_Type input_buf,
     if (scaling_mode == JAXX_Scaling_Mode::DELAYED_TENSOR_SCALING) {
       NVTE_CHECK(scale != nullptr, "scale must be provided for delayed tensor scaling");
       NVTE_CHECK(amax != nullptr, "amax must be provided for delayed tensor scaling");
-      cudaMemsetAsync(amax, 0, sizeof(float), stream);
+      nvte_memset(amax, 0, sizeof(float), stream);
       output_tensor.set_scale(scale, DType::kFloat32, std::vector<size_t>{1});
       output_tensor.set_amax(amax, DType::kFloat32, std::vector<size_t>{1});
       output_tensor.set_rowwise_scale_inv(

--- a/transformer_engine/jax/csrc/extensions/normalization.cpp
+++ b/transformer_engine/jax/csrc/extensions/normalization.cpp
@@ -123,7 +123,7 @@ Error_Type NormForwardFFI(cudaStream_t stream, Buffer_Type x_buf, Buffer_Type sc
 
   if (scaling_mode == JAXX_Scaling_Mode::DELAYED_TENSOR_SCALING && is_fp8_dtype(out_dtype)) {
     output_tensor.set_scale(scale, DType::kFloat32, std::vector<size_t>{1});
-    cudaMemsetAsync(amax, 0, sizeof(float), stream);
+    nvte_memset(amax, 0, sizeof(float), stream);
     output_tensor.set_amax(amax, DType::kFloat32, std::vector<size_t>{1});
   }
 

--- a/transformer_engine/jax/csrc/extensions/quantization.cpp
+++ b/transformer_engine/jax/csrc/extensions/quantization.cpp
@@ -122,7 +122,7 @@ Error_Type DBiasQuantizeFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_T
         NVTE_CHECK(scale != nullptr, "scale must be provided for delayed tensor scaling");
         NVTE_CHECK(amax != nullptr, "amax must be provided for delayed tensor scaling");
         output_tensor.set_scale(scale, DType::kFloat32, std::vector<size_t>{1});
-        cudaMemsetAsync(amax, 0, sizeof(float), stream);
+        nvte_memset(amax, 0, sizeof(float), stream);
         output_tensor.set_amax(amax, DType::kFloat32, std::vector<size_t>{1});
         output_tensor.set_rowwise_scale_inv(
             scale_inv_buf->untyped_data(),


### PR DESCRIPTION
# Description

Adds a new API call and kernel for `nvte_memset`, a drop-in replacement for `cudaMemsetAsync` which uses a fill kernel for small sizes and falls back to `cudaMemsetAsync` for larger sizes.

In profiling small 4B memsets in TE/JAX, this takes less time

`cudaMemsetAsync` + latency gap: ~3.2us
![image](https://github.com/user-attachments/assets/dd59408b-95d4-4355-80a1-ab437a4d9493)

`nvte_memset` + latency gap: 0.8us
![image](https://github.com/user-attachments/assets/2d4fe619-aed9-4b4e-9a27-304a10e655bc)


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Created a new API call and kernel for `nvte_memset` which runs on a fill kernel on small sizes and falls back to `cudaMemsetAsync` for larger sizes
- Add cpp tests for nvte_memset
- Update TE/JAX extension to use `nvte_memset` to reduce gaps in profiles from `cudaMemsetAsync` on 4B zero-ing out of amax buffers before TE common kernels

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
