### PR TITLE
correct weight quantizer for grouped_linear/layernorm_linear and layernorm_mlp

### DIFF
--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -719,6 +719,15 @@ class GroupedLinear(TransformerEngineBaseModule):
                     for i in range(self.num_gemms):
                         grad_output_quantizers[i].internal = True
 
+            # Make sure weight tensor has correct quantizer
+            # Note: Quantizer might have changed if quantization
+            # recipe changed
+            for i in range(self.num_gemms):
+                if weight_quantizers[i] is not None and isinstance(
+                    weight_tensors[i], QuantizedTensor
+                ):
+                    weight_tensors[i]._quantizer = weight_quantizers[i]
+
             if torch.is_grad_enabled():
                 linear_fn = _GroupedLinear.apply
                 args = []

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1429,6 +1429,12 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 grad_output_quantizer,
             ) = quantizers
 
+            # Make sure weight tensor has correct quantizer
+            # Note: Quantizer might have changed if quantization
+            # recipe changed
+            if weight_quantizer is not None and isinstance(weight_tensor, QuantizedTensor):
+                weight_tensor._quantizer = weight_quantizer
+
             if torch.is_grad_enabled():
                 fwd_fn = _LayerNormLinear.apply
                 args = []

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -1653,6 +1653,14 @@ class LayerNormMLP(TransformerEngineBaseModule):
             if self.bias_gelu_nvfusion and not use_reentrant_activation_recompute():
                 self.bias_gelu_nvfusion = False
 
+            # Make sure weight tensor has correct quantizer
+            # Note: Quantizer might have changed if quantization
+            # recipe changed
+            if fc1_weight_quantizer is not None and isinstance(fc1_weight, QuantizedTensor):
+                fc1_weight._quantizer = fc1_weight_quantizer
+            if fc2_weight_quantizer is not None and isinstance(fc2_weight, QuantizedTensor):
+                fc2_weight._quantizer = fc2_weight_quantizer
+
             if torch.is_grad_enabled():
                 fwd_fn = _LayerNormMLP.apply
                 args = []


### PR DESCRIPTION
# Description

In grouped_linear/layernorm_linear and layernorm_mlp, weight._quantizer is not the same with quantizer saved in global buffer, and resulting in the problem of scale always being 1.

After fixing the issue, the mean relative error of the loss for 200 steps of fp8 and bf16 decreased from 0.15% to 0.09% in the two-layer deepseek example.

Fixes 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:
refers to behaviour in linear.py: 1246-1250
```
1246            # Make sure weight tensor has correct quantizer
1247            # Note: Quantizer might have changed if quantization
1248            # recipe changed
1249            if weight_quantizer is not None and isinstance(weight_tensor, QuantizedTensor):
1250                weight_tensor._quantizer = weight_quantizer
```
- set weight_tensors[i]._quantizer = weight_quantizers[i] in grouped_linear.py
- set weight_tensor._quantizer = weight_quantizer in layernorm_linear.py
- set fc1/2_weight._quantizer = fc1/2_weight_quantizer layernorm_mlp.py

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
