### PR TITLE
[PyTorch] Fix bug when reshaping norm output from LayerNormLinear

### DIFF
--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -467,7 +467,7 @@ class _LayerNormLinear(torch.autograd.Function):
                 shape = list(inp_shape)
                 shape[0] *= tp_size
                 return out, ln_out_return.view(shape)
-            return out, ln_out_return.view_as(inp)
+            return out, ln_out_return.view(inp_shape)
         return out
 
     @staticmethod

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -612,7 +612,7 @@ class _LayerNormMLP(torch.autograd.Function):
                 shape = list(inp_shape)
                 shape[0] *= tp_size
                 return fc2_out, ln_out_return.view(shape)
-            return fc2_out, ln_out_return.view_as(inp)
+            return fc2_out, ln_out_return.view(inp_shape)
         return fc2_out
 
     @staticmethod


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1686 introduced a bug when returning the norm output from `LayerNormLinear`/`LayerNormMLP`. In particular, this line breaks the logic for reshaping the norm output:
https://github.com/NVIDIA/TransformerEngine/blob/dac098d816cd6001a3dc4ce8f1b2f65e1fea5bc6/transformer_engine/pytorch/module/layernorm_linear.py#L142

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Fix bug when reshaping norm output from `LayerNormLinear`/`LayerNormMLP`

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
