### PR TITLE
[JAX] Fix partitioning issues in LayerNorm and LayerNormMLP layers

### DIFF
--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -501,6 +501,9 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
         ir_hidden_size = dz_aval.shape[-1]
         gi_hidden_size = act_len * x_aval.shape[-1]
         assert act_len * ir_hidden_size == gi_hidden_size
+        assert (
+            x_aval.shape[:-2] == dz_aval.shape[:-1]
+        ), "dz and x should have the same leading dimensions"
         out_shape = x_aval.shape
         out_aval = x_aval.update(shape=out_shape, dtype=out_dtype)
 

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -821,8 +821,12 @@ class DActLuDBiasQuantizePrimitive(BasePrimitive):
             mesh, PartitionSpec(*colwise_scale_inv_spec), desc="ActLuPrimitive.colwise_scale_inv"
         )
 
-        arg_shardings = tuple(arg_i.sharding for arg_i in arg_infos)
-
+        arg_shardings = list(arg_i.sharding for arg_i in arg_infos)
+        # Ensure dz and x are partitioned the same way.
+        arg_shardings[0] = NamedSharding(
+            mesh, PartitionSpec(*x_spec[:-2], x_spec[-1]), desc="DActLuDBiasQuantizePrimitive.dz"
+        )
+        arg_shardings = tuple(arg_shardings)
         out_shardings = (
             out_sharding,
             colwise_out_sharding,

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -502,7 +502,16 @@ class NormFwdPrimitive(BasePrimitive):
         )
         amax_sharding = NamedSharding(mesh, PartitionSpec(*amax_spec), desc="NormFwdPrimitive.amax")
 
-        arg_shardings = tuple(arg_i.sharding for arg_i in arg_infos)
+        arg_shardings = list(arg_i.sharding for arg_i in arg_infos)
+        # Enforce no sharding of hidden dim for x, gamma and beta
+        arg_shardings[0] = NamedSharding(mesh, PartitionSpec(*out_spec), desc="NormFwdPrimitive.x")
+        arg_shardings[2] = NamedSharding(
+            mesh, PartitionSpec(*g_spec[:-1], None), desc="NormFwdPrimitive.gamma"
+        )
+        arg_shardings[3] = NamedSharding(
+            mesh, PartitionSpec(*b_spec[:-1], None), desc="NormFwdPrimitive.beta"
+        )
+        arg_shardings = tuple(arg_shardings)
         out_shardings = (
             out_sharding,
             colwise_out_sharding,

--- a/transformer_engine/jax/csrc/extensions/activation.cpp
+++ b/transformer_engine/jax/csrc/extensions/activation.cpp
@@ -210,6 +210,36 @@ pybind11::tuple GetDActDBiasQuantizeWorkspaceSizes(size_t batch_size, size_t hid
   return pybind11::make_tuple(std::make_pair(work_shape, dummy_workspace.dtype()));
 }
 
+void checkDActShapes(Buffer_Type input_buf, Buffer_Type act_input_buf, Result_Type output_buf) {
+  auto const &input_dims = input_buf.dimensions();
+  auto const &act_input_dims = act_input_buf.dimensions();
+  auto const &output_dims = output_buf->dimensions();
+
+  // Check act_input_buf and output_buf have the same shape
+  NVTE_CHECK(act_input_dims.size() == output_dims.size(),
+             "act_input_buf must have the same number of dimensions as output_buf, got ",
+             act_input_dims.size(), " and ", output_dims.size());
+  for (size_t i = 0; i < act_input_dims.size() - 2; ++i) {
+    NVTE_CHECK(act_input_dims[i] == output_dims[i], "act_input_dims[", i,
+               "] must have the same shape as output_dims[", i, "], got ", act_input_dims[i],
+               " and ", output_dims[i]);
+  }
+
+  // Check act_input_buf shape matches input_buf shape except for the activation dimension
+  NVTE_CHECK(act_input_dims.size() - 1 == input_dims.size(),
+             "act_input_buf must have the same number of dimensions as output_buf, except for the "
+             "activation dim, got ",
+             act_input_dims.size() - 1, " and ", input_dims.size());
+  for (size_t i = 0; i < input_dims.size() - 2; ++i) {
+    NVTE_CHECK(act_input_dims[i] == input_dims[i], "act_input_dims[", i,
+               "] must have the same shape as input_dims[", i, "], got ", act_input_dims[i],
+               " and ", input_dims[i]);
+  }
+  NVTE_CHECK(act_input_dims[act_input_dims.size() - 1] == input_dims[input_dims.size() - 1],
+             "act_input_buf must have the same last dimension as input_buf, got ",
+             act_input_dims[act_input_dims.size() - 1], " and ", input_dims[input_dims.size() - 1]);
+}
+
 Error_Type DActLuDBiasQuantizeFFI(cudaStream_t stream, Buffer_Type input_buf,
                                   Buffer_Type act_input_buf, Buffer_Type scale_buf,
                                   Result_Type output_buf, Result_Type colwise_output_buf,
@@ -245,8 +275,12 @@ Error_Type DActLuDBiasQuantizeFFI(cudaStream_t stream, Buffer_Type input_buf,
   // m = x_batch_size = reduce(operator.mul, x_shape[:-2]), x_shape == act_input_dims
   // n = ir_dz_shape[-1] * act_len, ir_dz_shape == input_dims
   auto act_len = act_input_dims[act_input_dims.size() - 2];
-  NVTE_CHECK(act_input_dims.back() == input_dims.back(),
-             "Shape mismatch between activation input and gradient input");
+  NVTE_CHECK(act_len == 1 || act_len == 2,
+             "The value of the activation dimension (axis=-2) must be 1 for non-gated or 2 for "
+             "gated activation, got ",
+             act_len);
+  checkDActShapes(input_buf, act_input_buf, output_buf);
+
   auto m = product(act_input_dims, 0, act_input_dims.size() - 2);
   auto n = input_dims.back();
 
@@ -257,8 +291,10 @@ Error_Type DActLuDBiasQuantizeFFI(cudaStream_t stream, Buffer_Type input_buf,
   auto dbias_shape = std::vector<size_t>{n * act_len};
   std::vector<size_t> workspace_shape(workspace_dims.begin(), workspace_dims.end());
 
-  auto input_tensor = TensorWrapper(input, input_shape, in_dtype);
-  auto act_input_tensor = TensorWrapper(act_input, act_input_shape, in_dtype);
+  auto input_tensor =
+      TensorWrapper(input, input_shape, convert_ffi_datatype_to_te_dtype(input_buf.element_type()));
+  auto act_input_tensor = TensorWrapper(
+      act_input, act_input_shape, convert_ffi_datatype_to_te_dtype(act_input_buf.element_type()));
 
   auto output_tensor = TensorWrapper(get_nvte_scaling_mode(scaling_mode));
   output_tensor.set_rowwise_data(output, out_dtype, output_shape);


### PR DESCRIPTION
# Description

Fixes two issues occurring in MaxText integration with TE. 1) NaNs caused on multi-gpu usage of the LayerNormMLP layer 2) Partitioning shape mismatch errors caused by using TE's LayerNorm layer with TP>1

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add additional shape checks on TE/JAX cpp extension for dact to ensure we pass the correct shapes after partitioning and don't implicitly assume `dz` and `x` are the same shape.
- In the dact primitive, make `dz` always use the same partitioning as `x`. In combination with the checks above, this prevents NaNs from running dact on `dz` and `x` partitioned differently leading to out of bounds reads.
- In the norm primitive, make the input `x` not partition along the TP axis. This prevents partitioning shape errors we were encountering where `x` was partitioned along TP but the norm output wasn't.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
