### PR TITLE
[JAX] Expose recipes via get_te_recipe()

### DIFF
--- a/examples/jax/encoder/common.py
+++ b/examples/jax/encoder/common.py
@@ -28,16 +28,3 @@ def is_mxfp8_supported():
     """Return if FP8 has hardware supported"""
     gpu_arch = get_device_compute_capability(0)
     return gpu_arch >= 100
-
-
-def get_fp8_recipe_from_name_string(name: str):
-    """Query recipe from a given name string"""
-    match name:
-        case "DelayedScaling":
-            return recipe.DelayedScaling()
-        case "MXFP8BlockScaling":
-            return recipe.MXFP8BlockScaling()
-        case "Float8CurrentScaling":
-            return recipe.Float8CurrentScaling()
-        case _:
-            raise ValueError(f"Invalid fp8_recipe, got {name}")

--- a/examples/jax/encoder/test_model_parallel_encoder.py
+++ b/examples/jax/encoder/test_model_parallel_encoder.py
@@ -22,7 +22,7 @@ from jax.sharding import PartitionSpec, NamedSharding
 from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_fp8_recipe
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_te_recipe
 
 
 DEVICE_DP_AXIS = "data"
@@ -284,7 +284,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
+        fp8_recipe = get_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_model_parallel_encoder.py
+++ b/examples/jax/encoder/test_model_parallel_encoder.py
@@ -19,10 +19,10 @@ from flax.training import train_state
 from jax.experimental import mesh_utils
 from jax.sharding import PartitionSpec, NamedSharding
 
-from common import is_bf16_supported, get_fp8_recipe_from_name_string
+from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_fp8_recipe
 
 
 DEVICE_DP_AXIS = "data"
@@ -284,7 +284,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe_from_name_string(args.fp8_recipe)
+        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_model_parallel_encoder.py
+++ b/examples/jax/encoder/test_model_parallel_encoder.py
@@ -22,7 +22,7 @@ from jax.sharding import PartitionSpec, NamedSharding
 from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_te_recipe
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, create_te_recipe
 
 
 DEVICE_DP_AXIS = "data"
@@ -284,7 +284,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_te_recipe(args.fp8_recipe)
+        fp8_recipe = create_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -19,7 +19,7 @@ from flax.training import train_state
 from jax.experimental import mesh_utils
 from jax.sharding import PartitionSpec, NamedSharding
 
-from common import is_bf16_supported, get_fp8_recipe_from_name_string
+from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
 from transformer_engine.jax.quantize import is_fp8_available, ScalingMode
@@ -253,7 +253,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe_from_name_string(args.fp8_recipe)
+        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -253,7 +253,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_te_recipe(args.fp8_recipe)
+        fp8_recipe = create_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_multigpu_encoder.py
+++ b/examples/jax/encoder/test_multigpu_encoder.py
@@ -253,7 +253,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
+        fp8_recipe = get_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -28,7 +28,7 @@ from common import (
 )
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_fp8_recipe
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_te_recipe
 
 
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
@@ -371,7 +371,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
+        fp8_recipe = get_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -28,7 +28,7 @@ from common import (
 )
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_te_recipe
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, create_te_recipe
 
 
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
@@ -371,7 +371,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_te_recipe(args.fp8_recipe)
+        fp8_recipe = create_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -25,11 +25,10 @@ from common import (
     is_bf16_supported,
     is_fp8_supported,
     is_mxfp8_supported,
-    get_fp8_recipe_from_name_string,
 )
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_fp8_recipe
 
 
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
@@ -372,7 +371,7 @@ def train_and_evaluate(args):
         ), "Test batch size needs to be multiple of 32 for MXFP8"
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe_from_name_string(args.fp8_recipe)
+        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -16,10 +16,10 @@ from datasets import load_dataset
 from flax import linen as nn
 from flax.training import train_state
 
-from common import is_bf16_supported, get_fp8_recipe_from_name_string
+from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_fp8_recipe
 
 
 PARAMS_KEY = "params"
@@ -215,7 +215,7 @@ def train_and_evaluate(args):
     label_shape = [args.batch_size]
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe_from_name_string(args.fp8_recipe)
+        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -19,7 +19,7 @@ from flax.training import train_state
 from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_te_recipe
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, create_te_recipe
 
 
 PARAMS_KEY = "params"
@@ -215,7 +215,7 @@ def train_and_evaluate(args):
     label_shape = [args.batch_size]
 
     if args.use_fp8:
-        fp8_recipe = get_te_recipe(args.fp8_recipe)
+        fp8_recipe = create_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/examples/jax/encoder/test_single_gpu_encoder.py
+++ b/examples/jax/encoder/test_single_gpu_encoder.py
@@ -19,7 +19,7 @@ from flax.training import train_state
 from common import is_bf16_supported
 import transformer_engine.jax as te
 import transformer_engine.jax.flax as te_flax
-from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_fp8_recipe
+from transformer_engine.jax.quantize import is_fp8_available, ScalingMode, get_te_recipe
 
 
 PARAMS_KEY = "params"
@@ -215,7 +215,7 @@ def train_and_evaluate(args):
     label_shape = [args.batch_size]
 
     if args.use_fp8:
-        fp8_recipe = get_fp8_recipe(args.fp8_recipe)
+        fp8_recipe = get_te_recipe(args.fp8_recipe)
     else:
         fp8_recipe = None
 

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -83,7 +83,7 @@ _load_library()
 from . import flax
 from . import quantize
 
-from .quantize import fp8_autocast, update_collections, get_delayed_scaling, get_fp8_recipe
+from .quantize import fp8_autocast, update_collections, get_delayed_scaling, get_te_recipe
 from .quantize import NVTE_FP8_COLLECTION_NAME
 
 from .sharding import MeshResource
@@ -106,7 +106,7 @@ __all__ = [
     "fp8_autocast",
     "update_collections",
     "get_delayed_scaling",
-    "get_fp8_recipe",
+    "get_te_recipe",
     "MeshResource",
     "MajorShardingType",
     "ShardingResource",

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -83,7 +83,7 @@ _load_library()
 from . import flax
 from . import quantize
 
-from .quantize import fp8_autocast, update_collections, get_delayed_scaling
+from .quantize import fp8_autocast, update_collections, get_delayed_scaling, get_fp8_recipe
 from .quantize import NVTE_FP8_COLLECTION_NAME
 
 from .sharding import MeshResource
@@ -106,6 +106,7 @@ __all__ = [
     "fp8_autocast",
     "update_collections",
     "get_delayed_scaling",
+    "get_fp8_recipe",
     "MeshResource",
     "MajorShardingType",
     "ShardingResource",

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -83,7 +83,7 @@ _load_library()
 from . import flax
 from . import quantize
 
-from .quantize import fp8_autocast, update_collections, get_delayed_scaling, get_te_recipe
+from .quantize import fp8_autocast, update_collections, get_delayed_scaling, create_te_recipe
 from .quantize import NVTE_FP8_COLLECTION_NAME
 
 from .sharding import MeshResource
@@ -106,7 +106,7 @@ __all__ = [
     "fp8_autocast",
     "update_collections",
     "get_delayed_scaling",
-    "get_te_recipe",
+    "create_te_recipe",
     "MeshResource",
     "MajorShardingType",
     "ShardingResource",

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -34,7 +34,7 @@ __all__ = [
     "is_fp8_available",
     "update_collections",
     "get_delayed_scaling",
-    "get_te_recipe",
+    "create_te_recipe",
     "NVTE_FP8_COLLECTION_NAME",
 ]
 
@@ -443,8 +443,8 @@ def get_delayed_scaling():
         an instance of  DelayedScaling which is set via fp8_autocast.
     """
     warnings.warn(
-        "This function will be deprecated in the future, please use get_te_recipe() instead"
-    )
+            "This function will be deprecated in the future, please use create_te_recipe() instead"
+            )
     amax_compute_algo = (
         "max" if QuantizeConfig.AMAX_COMPUTE_ALGO is AmaxComputeAlgo.MAX else "most_recent"
     )
@@ -456,7 +456,7 @@ def get_delayed_scaling():
     )
 
 
-def get_te_recipe(recipe_name: str = "DelayedScaling"):
+def create_te_recipe(recipe_name: str = "DelayedScaling"):
     r"""
     Obtain an instance of  TE recipe which is used subsequently in fp8_autocast.
 

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -34,7 +34,7 @@ __all__ = [
     "is_fp8_available",
     "update_collections",
     "get_delayed_scaling",
-    "get_fp8_recipe",
+    "get_te_recipe",
     "NVTE_FP8_COLLECTION_NAME",
 ]
 
@@ -442,7 +442,7 @@ def get_delayed_scaling():
     delay_scaling : DelayedScaling
         an instance of  DelayedScaling which is set via fp8_autocast.
     """
-    warnings.warn("This function will be deprecated in the future, please use get_fp8_recipe() instead")
+    warnings.warn("This function will be deprecated in the future, please use get_te_recipe() instead")
     amax_compute_algo = (
         "max" if QuantizeConfig.AMAX_COMPUTE_ALGO is AmaxComputeAlgo.MAX else "most_recent"
     )
@@ -454,7 +454,7 @@ def get_delayed_scaling():
     )
 
 
-def get_fp8_recipe(recipe_name: str = "DelayedScaling"):
+def get_te_recipe(recipe_name: str = "DelayedScaling"):
     r"""
     Obtain an instance of  TE recipe which is used subsequently in fp8_autocast.
 

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -443,8 +443,8 @@ def get_delayed_scaling():
         an instance of  DelayedScaling which is set via fp8_autocast.
     """
     warnings.warn(
-            "This function will be deprecated in the future, please use create_te_recipe() instead"
-            )
+        "This function will be deprecated in the future, please use create_te_recipe() instead"
+    )
     amax_compute_algo = (
         "max" if QuantizeConfig.AMAX_COMPUTE_ALGO is AmaxComputeAlgo.MAX else "most_recent"
     )

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -442,7 +442,9 @@ def get_delayed_scaling():
     delay_scaling : DelayedScaling
         an instance of  DelayedScaling which is set via fp8_autocast.
     """
-    warnings.warn("This function will be deprecated in the future, please use get_te_recipe() instead")
+    warnings.warn(
+        "This function will be deprecated in the future, please use get_te_recipe() instead"
+    )
     amax_compute_algo = (
         "max" if QuantizeConfig.AMAX_COMPUTE_ALGO is AmaxComputeAlgo.MAX else "most_recent"
     )

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -43,7 +43,7 @@ _reason_for_no_fp8 = ""
 Collection = Union[Dict, FrozenDict]
 
 
-def _check_delayed_scaling_fp8_support(gpu_arch) -> Tuple[bool, str]:
+def _check_tensor_scaling_fp8_support(gpu_arch) -> Tuple[bool, str]:
     """Check if delayed scaling FP8 is supported on the given GPU architecture.
 
     Args:
@@ -97,7 +97,7 @@ def _check_fp8_support(scaling_mode, gpu_id) -> Tuple[bool, str]:
     """
     gpu_arch = get_device_compute_capability(gpu_id)
     if scaling_mode.is_tensor_scaling():
-        return _check_delayed_scaling_fp8_support(gpu_arch)
+        return _check_tensor_scaling_fp8_support(gpu_arch)
     if scaling_mode == ScalingMode.MXFP8_1D_SCALING:
         return _check_block_scaling_fp8_support(gpu_arch)
     return (False, "Unsupported scaling_mode!")


### PR DESCRIPTION
# Description

Provide a new API so that users can query the recipe and use it subsequently in the `fp8_autocast`.
Example usage:

```
fp8_recipe = create_te_recipe("MXFP8BlockScaling")
with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
   ... 
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
