### PR TITLE
Reduce framework extensions' binary size and fix debug builds

### DIFF
--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -59,6 +59,7 @@ def setup_jax_extension(
     cxx_flags = ["-O3"]
     if debug_build_enabled():
         cxx_flags.append("-g")
+        cxx_flags.append("-UNDEBUG")
     else:
         cxx_flags.append("-g0")
 

--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import setuptools
 
-from .utils import get_cuda_include_dirs, all_files_in_dir
+from .utils import get_cuda_include_dirs, all_files_in_dir, debug_build_enabled
 from typing import List
 
 
@@ -57,6 +57,10 @@ def setup_jax_extension(
 
     # Compile flags
     cxx_flags = ["-O3"]
+    if debug_build_enabled():
+        cxx_flags.append("-g")
+    else:
+        cxx_flags.append("-g0")
 
     # Define TE/JAX as a Pybind11Extension
     from pybind11.setup_helpers import Pybind11Extension

--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -40,6 +40,7 @@ def setup_pytorch_extension(
     cxx_flags = ["-O3", "-fvisibility=hidden"]
     if debug_build_enabled():
         cxx_flags.append("-g")
+        cxx_flags.append("-UNDEBUG")
     else:
         cxx_flags.append("-g0")
 

--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import setuptools
 
-from .utils import all_files_in_dir, cuda_version, get_cuda_include_dirs
+from .utils import all_files_in_dir, cuda_version, get_cuda_include_dirs, debug_build_enabled
 
 
 def setup_pytorch_extension(
@@ -37,10 +37,11 @@ def setup_pytorch_extension(
     )
 
     # Compiler flags
-    cxx_flags = [
-        "-O3",
-        "-fvisibility=hidden",
-    ]
+    cxx_flags = ["-O3", "-fvisibility=hidden"]
+    if debug_build_enabled():
+        cxx_flags.append("-g")
+    else:
+        cxx_flags.append("-g0")
 
     # Version-dependent CUDA options
     try:


### PR DESCRIPTION
# Description

Size of TE torch `.so` before fix: 116MB
Size of TE torch `.so` after fix: 2MB

Root cause: distutils adds debug info `-g` by default to compilation flags.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Use debug flags only when necessary.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
