### PR TITLE
Set sequence_parallel before super().__init__() in norm modules

### DIFF
--- a/transformer_engine/pytorch/module/layernorm.py
+++ b/transformer_engine/pytorch/module/layernorm.py
@@ -133,7 +133,7 @@ class LayerNorm(_LayerNormOp):
         super().reset_parameters()
 
         # Set flag for sequence parallelism (custom Megatron-LM integration)
-        if getattr(self, "sequence_parallel", None) is not None:
+        if self.sequence_parallel is not None:
             self.weight.sequence_parallel = self.sequence_parallel
             self.bias.sequence_parallel = self.sequence_parallel
 

--- a/transformer_engine/pytorch/module/layernorm.py
+++ b/transformer_engine/pytorch/module/layernorm.py
@@ -94,6 +94,9 @@ class LayerNorm(_LayerNormOp):
                 )
             kwargs["dtype"] = params_dtype
 
+        # Flag for sequence parallelism (custom Megatron-LM integration)
+        self.sequence_parallel: Optional[bool] = sequence_parallel
+
         # Initialize layer norm operation
         super().__init__(
             normalized_shape,
@@ -101,12 +104,6 @@ class LayerNorm(_LayerNormOp):
             zero_centered_gamma=zero_centered_gamma,
             **kwargs,
         )
-
-        # Flag for sequence parallelism (custom Megatron-LM integration)
-        self.sequence_parallel: Optional[bool] = sequence_parallel
-        if sequence_parallel is not None:
-            self.weight.sequence_parallel = sequence_parallel
-            self.bias.sequence_parallel = sequence_parallel
 
     def reset_layer_norm_parameters(self) -> None:
         """Init LN params"""

--- a/transformer_engine/pytorch/module/rmsnorm.py
+++ b/transformer_engine/pytorch/module/rmsnorm.py
@@ -137,7 +137,7 @@ class RMSNorm(_RMSNormOp):
         super().reset_parameters()
 
         # Flag for sequence parallelism (custom Megatron-LM integration)
-        if getattr(self, "sequence_parallel", None) is not None:
+        if self.sequence_parallel is not None:
             self.weight.sequence_parallel = self.sequence_parallel
 
     @property

--- a/transformer_engine/pytorch/module/rmsnorm.py
+++ b/transformer_engine/pytorch/module/rmsnorm.py
@@ -98,6 +98,9 @@ class RMSNorm(_RMSNormOp):
                 )
             kwargs["dtype"] = params_dtype
 
+        # Flag for sequence parallelism (custom Megatron-LM integration)
+        self.sequence_parallel: Optional[bool] = sequence_parallel
+
         # Initialize RMSNorm operation
         super().__init__(
             normalized_shape,
@@ -105,11 +108,6 @@ class RMSNorm(_RMSNormOp):
             zero_centered_gamma=zero_centered_gamma,
             **kwargs,
         )
-
-        # Flag for sequence parallelism (custom Megatron-LM integration)
-        self.sequence_parallel: Optional[bool] = sequence_parallel
-        if sequence_parallel is not None:
-            self.weight.sequence_parallel = sequence_parallel
 
     def reset_rms_norm_parameters(self) -> None:
         """Deprecated"""


### PR DESCRIPTION
# Description

The current implementation has a problematic ordering:

- In `__init__`, `super().__init__()` is called first
- Then `self.sequence_parallel` is set
- If `reset_parameters()` gets called during the parent's initialization, it will try to use `self.sequence_parallel` before it's been set.

This could lead to the `sequence_parallel` not being properly applied to the parameters during initialization.

Currently, this is fixed with (in `__init__`):
https://github.com/NVIDIA/TransformerEngine/blob/51cd441501e8e6dee18c00056f008e1b53b89ebd/transformer_engine/pytorch/module/layernorm.py#L107-L109
but this does not seem right

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [X] Code refactoring

## Changes

Please list the changes introduced in this PR:

Set sequence_parallel before super().__init__() in norm modules

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
