### PR TITLE
[JAX] Support logical partitioning axes in TE Flax modules

### DIFF
--- a/examples/jax/encoder/test_multiprocessing_encoder.py
+++ b/examples/jax/encoder/test_multiprocessing_encoder.py
@@ -609,7 +609,7 @@ class TestEncoder(unittest.TestCase):
     def test_te_delayed_scaling_fp8(self):
         """Test Transformer Engine with DelayedScaling FP8"""
         result = self.exec(True, "DelayedScaling")
-        assert result[0] < 0.505 and result[1] > 0.754
+        assert result[0] < 0.505 and result[1] > 0.753
 
     @unittest.skipIf(
         not is_fp8_supported(), "Device compute capability 9.0+ is required for CurrentScaling FP8"

--- a/tests/jax/utils.py
+++ b/tests/jax/utils.py
@@ -13,7 +13,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from flax import linen as nn
-from flax.linen import partitioning as nn_partitioning
 from flax.linen.attention import combine_masks
 from jax import lax, vmap
 from jax import nn as jax_nn

--- a/transformer_engine/jax/dense.py
+++ b/transformer_engine/jax/dense.py
@@ -47,9 +47,9 @@ def dense(
     Returns:
         Transformed output tensor
     """
-    x = with_sharding_constraint_by_logical_axes(x, input_axes)
     # Remove when tex.quantize() can handle quantizer=None
     if quantizer_set == noop_quantizer_set:
+        x = with_sharding_constraint_by_logical_axes(x, input_axes)
         output = tex.gemm(x, kernel, contracting_dims)
         if bias is not None:
             bias_new_shape = (1,) * (output.ndim - bias.ndim) + bias.shape

--- a/transformer_engine/jax/dense.py
+++ b/transformer_engine/jax/dense.py
@@ -47,6 +47,7 @@ def dense(
     Returns:
         Transformed output tensor
     """
+    x = with_sharding_constraint_by_logical_axes(x, input_axes)
     # Remove when tex.quantize() can handle quantizer=None
     if quantizer_set == noop_quantizer_set:
         output = tex.gemm(x, kernel, contracting_dims)

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -1118,7 +1118,7 @@ class LayerNormMLP(TransformerEngineBase):
             ).astype(input_dtype)
 
             bias_2_shape = (hidden_size,)
-            bias_1 = self.param(
+            bias_2 = self.param(
                 "wo_bias",
                 nn.with_logical_partitioning(self.bias_init, self.bias_axes_2),
                 bias_2_shape,
@@ -1187,9 +1187,7 @@ class LayerNormMLP(TransformerEngineBase):
                         kernel_1.ndim, self.kernel_axes_1, contract_ind
                     ),
                 )
-            else:
-                dot_1_output_axes = None  # don't insert sharding constraint so default partitioning from previous ops will apply
-            x = with_sharding_constraint_by_logical_axes(x, dot_1_output_axes)
+                x = with_sharding_constraint_by_logical_axes(x, dot_1_output_axes)
 
             if self.enable_low_rank_adaptation:
                 wi_lora_a_kernel_each_shape = (

--- a/transformer_engine/jax/flax/module.py
+++ b/transformer_engine/jax/flax/module.py
@@ -65,6 +65,7 @@ def _obtain_default_layernorm_scale_init_if_need(original_init, zero_centered_ga
 
 
 def _create_layernorm_parameters(
+    module,
     norm_type,
     shape,
     scale_init,
@@ -74,13 +75,21 @@ def _create_layernorm_parameters(
     input_dtype,
     dtype,
 ):
-    scale = nn_partitioning.param_with_axes("scale", scale_init, shape, dtype, axes=scale_axes)
-    scale = scale.astype(input_dtype)
+    scale = module.param(
+        "scale",
+        nn.with_logical_partitioning(scale_init, scale_axes),
+        shape,
+        dtype,
+    ).astype(input_dtype)
 
     norm_type = canonicalize_norm_type(norm_type)
     if norm_type == "layernorm":
-        bias = nn_partitioning.param_with_axes("ln_bias", bias_init, shape, dtype, axes=bias_axes)
-        bias = jnp.asarray(bias, input_dtype)
+        bias = module.param(
+            "ln_bias",
+            nn.with_logical_partitioning(bias_init, bias_axes),
+            shape,
+            dtype,
+        ).astype(input_dtype)
     else:
         assert norm_type == "rmsnorm"
         bias = None
@@ -308,6 +317,7 @@ class LayerNorm(nn.Module):  # pylint: disable=too-few-public-methods
 
         features = x.shape[-1]
         scale, ln_bias = _create_layernorm_parameters(
+            self,
             self.layernorm_type,
             (features,),
             self.scale_init,
@@ -467,16 +477,22 @@ class DenseGeneral(TransformerEngineBase):
                 "Expected len(kernel_shape) to match len(kernel_axes),"
                 f"got kernel_shape {kernel_shape} and kernel_axes {self.kernel_axes}"
             )
-        kernel = nn_partitioning.param_with_axes(
-            "kernel", self.kernel_init, kernel_shape, self.dtype, axes=self.kernel_axes
+        kernel = self.param(
+            "kernel",
+            nn.with_logical_partitioning(self.kernel_init, self.kernel_axes),
+            kernel_shape,
+            self.dtype,
         )
 
         if not QuantizeConfig.is_fp8_enabled():
             kernel = kernel.astype(input_dtype)
 
         if self.use_bias:
-            bias = nn_partitioning.param_with_axes(
-                "bias", self.bias_init, features, self.dtype, axes=self.bias_axes
+            bias = self.param(
+                "bias",
+                nn.with_logical_partitioning(self.bias_init, self.bias_axes),
+                features,
+                self.dtype,
             ).astype(input_dtype)
         else:
             bias = None
@@ -499,25 +515,21 @@ class DenseGeneral(TransformerEngineBase):
                 self.low_rank_adaptation_dim,
             )
             lora_a_kernel_axes = (None,) * len(lora_a_kernel_shape)
-            lora_a_kernel = nn_partitioning.param_with_axes(
+            lora_a_kernel = self.param(
                 "lora_a_kernel",
-                self.kernel_init,
+                nn.with_logical_partitioning(self.kernel_init, lora_a_kernel_axes),
                 lora_a_kernel_shape,
                 self.dtype,
-                axes=lora_a_kernel_axes,
-            )
-            lora_a_kernel = lora_a_kernel.astype(input_dtype)
+            ).astype(input_dtype)
 
             lora_b_kernel_shape = (*features[:-1], self.low_rank_adaptation_dim, features[-1])
             lora_b_kernel_axes = (None,) * len(lora_b_kernel_shape)
-            lora_b_kernel = nn_partitioning.param_with_axes(
+            lora_b_kernel = self.param(
                 "lora_b_kernel",
-                nn.initializers.zeros,
+                nn.with_logical_partitioning(nn.initializers.zeros, lora_b_kernel_axes),
                 lora_b_kernel_shape,
                 self.dtype,
-                axes=lora_b_kernel_axes,
-            )
-            lora_b_kernel = lora_b_kernel.astype(input_dtype)
+            ).astype(input_dtype)
 
             y += _apply_low_rank_adaptation(
                 inputs, axis, features, lora_a_kernel, lora_b_kernel, self.low_rank_adaptation_alpha
@@ -695,6 +707,7 @@ class LayerNormDenseGeneral(TransformerEngineBase):
             inputs = with_sharding_constraint_by_logical_axes(inputs, self.layernorm_input_axes)
             features = inputs.shape[-1]
             scale, ln_bias = _create_layernorm_parameters(
+                self,
                 self.layernorm_type,
                 (features,),
                 self.scale_init,
@@ -730,8 +743,11 @@ class LayerNormDenseGeneral(TransformerEngineBase):
         axis = _normalize_axes(axis, y.ndim)
 
         kernel_shape = (np.prod([inputs.shape[ax] for ax in axis]),) + features
-        kernel = nn_partitioning.param_with_axes(
-            "kernel", self.kernel_init, kernel_shape, self.dtype, axes=self.kernel_axes
+        kernel = self.param(
+            "kernel",
+            nn.with_logical_partitioning(self.kernel_init, self.kernel_axes),
+            kernel_shape,
+            self.dtype,
         )
         if not QuantizeConfig.is_fp8_enabled():
             kernel = kernel.astype(input_dtype)
@@ -770,25 +786,21 @@ class LayerNormDenseGeneral(TransformerEngineBase):
                 self.low_rank_adaptation_dim,
             )
             lora_a_kernel_axes = (None,) * len(lora_a_kernel_shape)
-            lora_a_kernel = nn_partitioning.param_with_axes(
+            lora_a_kernel = self.param(
                 "lora_a_kernel",
-                self.kernel_init,
+                nn.with_logical_partitioning(self.kernel_init, lora_a_kernel_axes),
                 lora_a_kernel_shape,
                 self.dtype,
-                axes=lora_a_kernel_axes,
-            )
-            lora_a_kernel = lora_a_kernel.astype(input_dtype)
+            ).astype(input_dtype)
 
             lora_b_kernel_shape = (*features[:-1], self.low_rank_adaptation_dim, features[-1])
             lora_b_kernel_axes = (None,) * len(lora_b_kernel_shape)
-            lora_b_kernel = nn_partitioning.param_with_axes(
+            lora_b_kernel = self.param(
                 "lora_b_kernel",
-                nn.initializers.zeros,
+                nn.with_logical_partitioning(nn.initializers.zeros, lora_b_kernel_axes),
                 lora_b_kernel_shape,
                 self.dtype,
-                axes=lora_b_kernel_axes,
-            )
-            lora_b_kernel = lora_b_kernel.astype(input_dtype)
+            ).astype(input_dtype)
 
             z += _apply_low_rank_adaptation(
                 y, axis, features, lora_a_kernel, lora_b_kernel, self.low_rank_adaptation_alpha
@@ -796,8 +808,11 @@ class LayerNormDenseGeneral(TransformerEngineBase):
 
         bias = None
         if self.use_bias:
-            bias = nn_partitioning.param_with_axes(
-                "bias", self.bias_init, features, self.dtype, axes=self.bias_axes
+            bias = self.param(
+                "bias",
+                nn.with_logical_partitioning(self.bias_init, self.bias_axes),
+                features,
+                self.dtype,
             ).astype(input_dtype)
 
         if bias is not None:
@@ -1028,6 +1043,7 @@ class LayerNormMLP(TransformerEngineBase):
             features = inputs.shape[-1]
 
             scale, ln_bias = _create_layernorm_parameters(
+                self,
                 self.layernorm_type,
                 (features,),
                 self.scale_init,
@@ -1067,14 +1083,13 @@ class LayerNormMLP(TransformerEngineBase):
         axis = _canonicalize_tuple(self.axis)
         axis = _normalize_axes(axis, y.ndim)
         kernel_1_each_shape = (np.prod([inputs.shape[ax] for ax in axis]), self.intermediate_dim)
-        kernel_1 = nn_partitioning.param_with_axes(
+        kernel_1 = self.param(
             "wi_kernel",
-            kernel_1_init,
+            nn.with_logical_partitioning(kernel_1_init, self.kernel_axes_1),
             num_activations,
             -2,
             kernel_1_each_shape,
             self.dtype,
-            axes=self.kernel_axes_1,
         )
 
         if not QuantizeConfig.is_fp8_enabled():
@@ -1083,12 +1098,11 @@ class LayerNormMLP(TransformerEngineBase):
         hidden_size = inputs.shape[-1]
         hidden_size_tuple = _canonicalize_tuple(hidden_size)
         kernel_2_shape = (self.intermediate_dim,) + hidden_size_tuple
-        kernel_2 = nn_partitioning.param_with_axes(
+        kernel_2 = self.param(
             "wo_kernel",
-            self.kernel_init,
+            nn.with_logical_partitioning(self.kernel_init, self.kernel_axes_2),
             kernel_2_shape,
             self.dtype,
-            axes=self.kernel_axes_2,
         )
         if not QuantizeConfig.is_fp8_enabled():
             kernel_2 = kernel_2.astype(input_dtype)
@@ -1097,21 +1111,19 @@ class LayerNormMLP(TransformerEngineBase):
 
         if self.use_bias:
             bias_1_shape = (num_activations, self.intermediate_dim)
-            bias_1 = nn_partitioning.param_with_axes(
+            bias_1 = self.param(
                 "wi_bias",
-                self.bias_init,
+                nn.with_logical_partitioning(self.bias_init, self.bias_axes_1),
                 bias_1_shape,
                 self.dtype,
-                axes=self.bias_axes_1,
             ).astype(input_dtype)
 
             bias_2_shape = (hidden_size,)
-            bias_2 = nn_partitioning.param_with_axes(
+            bias_1 = self.param(
                 "wo_bias",
-                self.bias_init,
+                nn.with_logical_partitioning(self.bias_init, self.bias_axes_2),
                 bias_2_shape,
                 self.dtype,
-                axes=self.bias_axes_2,
             ).astype(input_dtype)
         else:
             bias_1 = None
@@ -1180,16 +1192,14 @@ class LayerNormMLP(TransformerEngineBase):
                     self.low_rank_adaptation_dim,
                 )
                 wi_lora_a_kernel_axes = (None,) * len(wi_lora_a_kernel_each_shape + 1)
-                wi_lora_a_kernel = nn_partitioning.param_with_axes(
+                wi_lora_a_kernel = self.param(
                     "wi_lora_a_kernel",
-                    kernel_1_init,
+                    nn.with_logical_partitioning(kernel_1_init, wi_lora_a_kernel_axes),
                     num_activations,
                     -2,
                     wi_lora_a_kernel_each_shape,
                     self.dtype,
-                    axes=wi_lora_a_kernel_axes,
-                )
-                wi_lora_a_kernel = wi_lora_a_kernel.astype(input_dtype)
+                ).astype(input_dtype)
 
                 wi_lora_b_kernel_shape = (
                     num_activations,
@@ -1197,14 +1207,12 @@ class LayerNormMLP(TransformerEngineBase):
                     self.intermediate_dim,
                 )
                 wi_lora_b_kernel_axes = (None,) * len(wi_lora_b_kernel_shape)
-                wi_lora_b_kernel = nn_partitioning.param_with_axes(
+                wi_lora_b_kernel = self.param(
                     "wi_lora_b_kernel",
-                    nn.initializers.zeros,
+                    nn.with_logical_partitioning(nn.initializers.zeros, wi_lora_b_kernel_axes),
                     wi_lora_b_kernel_shape,
                     self.dtype,
-                    axes=wi_lora_b_kernel_axes,
-                )
-                wi_lora_b_kernel = wi_lora_b_kernel.astype(input_dtype)
+                ).astype(input_dtype)
 
                 x += _apply_low_rank_adaptation(
                     y,
@@ -1253,25 +1261,21 @@ class LayerNormMLP(TransformerEngineBase):
             if self.enable_low_rank_adaptation:
                 wo_lora_a_kernel_shape = (self.intermediate_dim, self.low_rank_adaptation_dim)
                 wo_lora_a_kernel_axes = (None,) * len(wo_lora_a_kernel_shape)
-                wo_lora_a_kernel = nn_partitioning.param_with_axes(
+                wo_lora_a_kernel = self.param(
                     "wo_lora_a_kernel",
-                    self.kernel_init,
+                    nn.with_logical_partitioning(self.kernel_init, wo_lora_a_kernel_axes),
                     wo_lora_a_kernel_shape,
                     self.dtype,
-                    axes=wo_lora_a_kernel_axes,
-                )
-                wo_lora_a_kernel = wo_lora_a_kernel.astype(input_dtype)
+                ).astype(input_dtype)
 
                 wo_lora_b_kernel_shape = (self.low_rank_adaptation_dim, hidden_size)
                 wo_lora_b_kernel_axes = (None,) * len(wo_lora_b_kernel_shape)
-                wo_lora_b_kernel = nn_partitioning.param_with_axes(
+                wo_lora_b_kernel = self.param(
                     "wo_lora_b_kernel",
-                    nn.initializers.zeros,
+                    nn.with_logical_partitioning(nn.initializers.zeros, wo_lora_b_kernel_axes),
                     wo_lora_b_kernel_shape,
                     self.dtype,
-                    axes=wo_lora_b_kernel_axes,
-                )
-                wo_lora_b_kernel = wo_lora_b_kernel.astype(input_dtype)
+                ).astype(input_dtype)
 
                 out += _apply_low_rank_adaptation(
                     z,

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -15,7 +15,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from flax import linen as nn
-from flax.linen import partitioning as nn_partitioning
 from flax.linen.attention import combine_masks
 from jax import nn as jax_nn
 from jax import random as jax_random

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -1503,12 +1503,11 @@ class RelativePositionBiases(nn.Module):  # pylint: disable=too-few-public-metho
         rp_bucket += np.where(rpb_is_small, negative_rp, rpb_val_if_large)
 
         # Compute relative attention bias
-        relative_attention_bias = nn_partitioning.param_with_axes(
+        relative_attention_bias = self.param(
             "rel_embedding",
-            self.embedding_init,
+            nn.with_logical_partitioning(self.embedding_init, self.embedding_axes),
             (self.num_attention_heads, self.num_buckets),
             self.dtype,
-            axes=self.embedding_axes,
         )
 
         relative_attention_bias = jnp.asarray(relative_attention_bias, self.dtype)

--- a/transformer_engine/jax/layernorm_mlp.py
+++ b/transformer_engine/jax/layernorm_mlp.py
@@ -275,11 +275,12 @@ def _layernorm_mlp_fwd_rule(
         (x_contracting_dims, k_contracting_dims),
     )
 
-    dot_1_output_axes = (
-        *get_non_contracting_logical_axes(x.ndim, dot_1_input_axes, x_contracting_dims),
-        *get_non_contracting_logical_axes(kernel_1.ndim, kernel_1_axes, k_contracting_dims),
-    )
-    dot_1_output = with_sharding_constraint_by_logical_axes(dot_1_output, dot_1_output_axes)
+    if dot_1_input_axes is not None and kernel_1_axes is not None:
+        dot_1_output_axes = (
+            *get_non_contracting_logical_axes(x.ndim, dot_1_input_axes, x_contracting_dims),
+            *get_non_contracting_logical_axes(kernel_1.ndim, kernel_1_axes, k_contracting_dims),
+        )
+        dot_1_output = with_sharding_constraint_by_logical_axes(dot_1_output, dot_1_output_axes)
 
     if use_bias_1:
         bias_1_shape = bias_1.shape
@@ -302,12 +303,6 @@ def _layernorm_mlp_fwd_rule(
         casted_kernel_2.get_colwise_tensor(),
         (x_contracting_dims, k_contracting_dims),
     )
-
-    dot_2_output_axes = (
-        *get_non_contracting_logical_axes(x.ndim, dot_2_input_axes, x_contracting_dims),
-        *get_non_contracting_logical_axes(kernel_2.ndim, None, k_contracting_dims),
-    )
-    dot_2_output = with_sharding_constraint_by_logical_axes(dot_2_output, dot_2_output_axes)
 
     if use_bias_2:
         bias_2_shape = bias_2.shape

--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -334,7 +334,7 @@ def get_non_contracting_logical_axes(ndim, logical_axes, contracting_dims):
     """
     if not logical_axes:
         return None
-    elif len(logical_axes) < ndim:
+    if len(logical_axes) < ndim:
         logical_axes = logical_axes + (None,) * (ndim - len(logical_axes))
     assert len(logical_axes) == ndim
 

--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -333,7 +333,7 @@ def get_non_contracting_logical_axes(ndim, logical_axes, contracting_dims):
         Tuple of logical axes for non-contracting dimensions.
     """
     if not logical_axes:
-        logical_axes = (None,) * ndim
+        return None
     elif len(logical_axes) < ndim:
         logical_axes = logical_axes + (None,) * (ndim - len(logical_axes))
     assert len(logical_axes) == ndim

--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -10,11 +10,10 @@ parallelism (FSDP). It includes functions for sharding constraints, mesh managem
 and collective operations.
 """
 import os
-from typing import Optional
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable
+from typing import Callable, Optional
 from jax.interpreters import pxla
 import jax
 import jax.numpy as jnp
@@ -349,9 +348,7 @@ def get_non_contracting_logical_axes(
         Tuple of logical axes for non-contracting dimensions.
     """
     assert logical_axes is not None, "Logical axes must be a tuple and cannot be None."
-    if len(logical_axes) < ndim:
-        logical_axes = logical_axes + (None,) * (ndim - len(logical_axes))
-    assert len(logical_axes) == ndim
+    assert len(logical_axes) == ndim, "Logical axes must match the number of dimensions."
 
     non_contracting_dims = [i for i in range(ndim) if i not in contracting_dims]
     non_contracting_logical_axes = tuple(logical_axes[i] for i in non_contracting_dims)


### PR DESCRIPTION
# Description

TE/JAX Flax modules are using weight initialization that only supports physical mesh partitioning axes, not logical axes used in some frameworks, such as MaxText. To support partitioning in these frameworks weight initialization was updated to a newer way that supports logical axes.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Update Flax modules in `module.py` and `transformer.py` to replace usages of `nn_partitioning.param_with_axes` with `self.param(..., nn.with_logical_partitioning(...), ...)`
- Fix bug where ffn1 intermediate result in the LayerNormMLP layer incorrectly added a sharding constraint to replicate the tensor and following gemm, leading to OOM on some configs that normal MaxText did not have OOM on.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
