### PR TITLE
Fix miscellaneous bugs during library loading

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -136,12 +136,14 @@ def get_build_ext(
                 if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or framework_extension_only
                 else ""
             )
-            target_dir = install_dir / "transformer_engine" / lib_dir
-            target_dir.mkdir(exist_ok=True, parents=True)
 
-            for ext in Path(self.build_lib).glob("*.so"):
-                self.copy_file(ext, target_dir)
-                os.remove(ext)
+            if not self.inplace:
+                target_dir = install_dir / "transformer_engine" / lib_dir
+                target_dir.mkdir(exist_ok=True, parents=True)
+
+                for ext in Path(self.build_lib).glob("*.so"):
+                    self.copy_file(ext, target_dir)
+                    os.remove(ext)
 
         def build_extensions(self):
             # For core lib + JAX install, fix build_ext from pybind11.setup_helpers

--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -130,13 +130,17 @@ def get_build_ext(
             super().run()
             self.extensions = all_extensions
 
-            # Ensure that binaries are not in global package space.
+            # Ensure that shared objects files for source and PyPI installations live
+            # in separate directories to avoid conflicts during install and runtime.
             lib_dir = (
                 "wheel_lib"
                 if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or framework_extension_only
                 else ""
             )
 
+            # Ensure that binaries are not in global package space.
+            # For editable/inplace builds this is not a concern as
+            # the SOs will be in a local directory anyway.
             if not self.inplace:
                 target_dir = install_dir / "transformer_engine" / lib_dir
                 target_dir.mkdir(exist_ok=True, parents=True)

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ if __name__ == "__main__":
             int(os.getenv("NVTE_RELEASE_BUILD", "0"))
         ), "NVTE_RELEASE_BUILD env must be set for metapackage build."
         ext_modules = []
-        cmdclass = {}
         package_data = {}
         include_package_data = False
         setup_requires = []
@@ -156,7 +155,6 @@ if __name__ == "__main__":
     else:
         setup_requires, install_requires, test_requires = setup_requirements()
         ext_modules = [setup_common_extension()]
-        cmdclass = {"build_ext": CMakeBuildExtension, "bdist_wheel": TimedBdist}
         package_data = {"": ["VERSION.txt"]}
         include_package_data = True
         extras_require = {"test": test_requires}

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -11,12 +11,12 @@ import transformer_engine.common
 
 try:
     from . import pytorch
-except (ImportError, StopIteration) as e:
+except ImportError as e:
     pass
 
 try:
     from . import jax
-except (ImportError, StopIteration) as e:
+except ImportError as e:
     pass
 
 __version__ = str(metadata.version("transformer_engine"))

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -45,12 +45,17 @@ def _find_shared_object_in_te_dir(te_path: Path, prefix: str):
     if not te_path.exists() or not (te_path / "transformer_engine").exists():
         return None
 
-    # Search.
     files = []
+    search_paths = (
+        te_path,
+        te_path / "transformer_engine",
+        te_path / "transformer_engine/wheel_lib",
+        te_path / "wheel_lib",
+    )
+
+    # Search.
     for dirname, _, names in os.walk(te_path):
-        # Limit search paths.
-        current_directory = os.path.basename(dirname)
-        if current_directory in ("transformer_engine", "wheel_lib") or dirname == str(te_path):
+        if Path(dirname) in search_paths:
             for name in names:
                 if name.startswith(prefix) and name.endswith(f".{_get_sys_extension()}"):
                     files.append(Path(dirname, name))

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -121,7 +121,9 @@ def _get_shared_object_file(library: str) -> Path:
     if so_path_in_install_dir is not None and so_path_in_default_dir is not None:
         raise RuntimeError(
             f"Found multiple shared object files: {so_path_in_install_dir} and"
-            f" {so_path_in_default_dir}."
+            f" {so_path_in_default_dir}. Remove local shared objects installed"
+            f" here {so_path_in_install_dir} or change the working directory to"
+            "execute from outside TE."
         )
 
     # Case 3: Typical dev workflow: Editable install

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -41,7 +41,7 @@ def _find_shared_object_in_te_dir(te_path: Path, prefix: str):
     Raises an error if multiple shared object files are found.
     """
 
-    # Ensure top level dir exists and has the module. before searching.
+    # Before searching, ensure top level directory exists and has the module.
     if not te_path.exists() or not (te_path / "transformer_engine").exists():
         return None
 

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -22,6 +22,11 @@ model and support automatic differentiation.
 
 # pylint: disable=wrong-import-position
 
+# This unused import is needed because the top level `transformer_engine/__init__.py`
+# file catches an `ImportError` as a guard for cases where the given framework's
+# extensions are not available.
+import jax
+
 from transformer_engine.common import load_framework_extension
 
 load_framework_extension("jax")

--- a/transformer_engine/jax/__init__.py
+++ b/transformer_engine/jax/__init__.py
@@ -20,66 +20,12 @@ All operations are designed to work seamlessly with JAX's functional programming
 model and support automatic differentiation.
 """
 
-# pylint: disable=wrong-import-position,wrong-import-order
+# pylint: disable=wrong-import-position
 
-import logging
-import importlib
-import importlib.util
-from importlib.metadata import version
-import sys
+from transformer_engine.common import load_framework_extension
 
-from transformer_engine.common import get_te_path, is_package_installed
-from transformer_engine.common import _get_sys_extension
+load_framework_extension("jax")
 
-
-def _load_library():
-    """Load shared library with Transformer Engine C extensions"""
-    module_name = "transformer_engine_jax"
-
-    if is_package_installed(module_name):
-        assert is_package_installed("transformer_engine"), "Could not find `transformer-engine`."
-        assert is_package_installed(
-            "transformer_engine_cu12"
-        ), "Could not find `transformer-engine-cu12`."
-        assert (
-            version(module_name)
-            == version("transformer-engine")
-            == version("transformer-engine-cu12")
-        ), (
-            "TransformerEngine package version mismatch. Found"
-            f" {module_name} v{version(module_name)}, transformer-engine"
-            f" v{version('transformer-engine')}, and transformer-engine-cu12"
-            f" v{version('transformer-engine-cu12')}. Install transformer-engine using "
-            "'pip3 install transformer-engine[jax]==VERSION'"
-        )
-
-    if is_package_installed("transformer-engine-cu12"):
-        if not is_package_installed(module_name):
-            logging.info(
-                "Could not find package %s. Install transformer-engine using "
-                "'pip3 install transformer-engine[jax]==VERSION'",
-                module_name,
-            )
-
-    extension = _get_sys_extension()
-    try:
-        so_dir = get_te_path() / "transformer_engine"
-        so_path = next(so_dir.glob(f"{module_name}.*.{extension}"))
-    except StopIteration:
-        try:
-            so_dir = get_te_path() / "transformer_engine" / "wheel_lib"
-            so_path = next(so_dir.glob(f"{module_name}.*.{extension}"))
-        except StopIteration:
-            so_dir = get_te_path()
-            so_path = next(so_dir.glob(f"{module_name}.*.{extension}"))
-
-    spec = importlib.util.spec_from_file_location(module_name, so_path)
-    solib = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = solib
-    spec.loader.exec_module(solib)
-
-
-_load_library()
 from . import flax
 from . import quantize
 


### PR DESCRIPTION
# Description

A cleanup and minor refactor of the runtime library loading infrastructure during TE import, along with miscellaneous bug fixes.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [x] Code refactoring

## Changes

- Avoid use of `subprocess` to run python/pip, this is leading to esoteric failures during library loading in various environments.
- Consolidate logic for finding TE's shared object files in a single function based on various cases.
- Cleanup the framework's `__init__.py` files.
- Fix various cases of library loading after editable/source/wheel install and catch errors in case of any discrepancies.
- Remove a few unused lines in main `setup.py`.
- Fix duplication of shared object file during editable installation.

## Testing checklist (local)

- [x] Verified correct working of all 4 "cases" as mentioned in the comments for the `_get_shared_object_file` function in `transformer_engine/common/__init__.py` for both frameworks.
- [x] Tested wheel for core and sdist for both frameworks, including catching all errors during in the `load_framework_extension` function in `transformer_engine/common/__init__.py`.

## Future work

Create robust build testing suite to check for above cases in the CI.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
