### PR TITLE
Remove `comm_gemm_overlap` doc

### DIFF
--- a/docs/api/c/comm_gemm_overlap.rst
+++ b/docs/api/c/comm_gemm_overlap.rst
@@ -1,9 +1,0 @@
-..
-    Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-
-    See LICENSE for license information.
-
-comm_gemm_overlap.h
-===================
-
-.. doxygenfile:: comm_gemm_overlap.h

--- a/docs/api/c/index.rst
+++ b/docs/api/c/index.rst
@@ -16,7 +16,6 @@ directly from C/C++, without Python.
    activation.h <activation>
    cast_transpose_noop.h <cast_transpose_noop>
    cast.h <cast>
-   comm_gemm_overlap.h <comm_gemm_overlap>
    cudnn.h <cudnn>
    fused_attn.h <fused_attn>
    fused_rope.h <fused_rope>


### PR DESCRIPTION
# Description

Remove `comm_gemm_overlap` doc.

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Remove `comm_gemm_overlap` doc.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
