### PR TITLE
[JAX] FP8 GEMM via dot_general + direct quant

### DIFF
--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -163,7 +163,7 @@ def __jitted_jax_gemm_tensor_scaling_fp8(lhs, rhs, lhs_dn, rhs_dn, precision):
         lhs_3d, rhs_3d, dim_nums, precision=precision, preferred_element_type=jnp.float32
     )
     scale_inv = (lhs.scale_inv * rhs.scale_inv).astype(jnp.float32)
-    
+
     return (out_fp8 * scale_inv).astype(lhs.dq_dtype)
 
 

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -163,9 +163,6 @@ def __jitted_jax_gemm_tensor_scaling_fp8(lhs, rhs, lhs_dn, rhs_dn, precision):
     rhs_3d = _shape_normalization(rhs.data, rhs_dn, rhs.data_layout == "T")
 
     dim_nums = (((2,), (2,)), ((0,), (0,)))
-    out_3d = jax.lax.dot_general(
-        lhs_3d, rhs_3d, dim_nums, precision=precision, preferred_element_type=lhs.dq_dtype
-    )
     out_fp8 = jax.lax.dot_general(
         lhs_3d, rhs_3d, dim_nums, precision=precision, preferred_element_type=lhs.dq_dtype
     )
@@ -177,7 +174,7 @@ def __jitted_jax_gemm_tensor_scaling_fp8(lhs, rhs, lhs_dn, rhs_dn, precision):
 def _jax_gemm_tensor_scaling_fp8(
     lhs: ScaledTensor, rhs: ScaledTensor, dim_nums: Tuple[Tuple[Sequence[int], Sequence[int]]]
 ):
-    """FP8 GEMM for XLA pattern match"""
+    """FP8 GEMM"""
     assert rhs.scaling_mode.is_tensor_scaling(), "rhs does not have tensor scaling mode"
 
     (lhs_contract, rhs_contract), (lhs_batch, rhs_batch) = dim_nums

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -159,10 +159,8 @@ def __jitted_jax_gemm_tensor_scaling_fp8(lhs, rhs, lhs_dn, rhs_dn, precision):
     rhs_3d = _shape_normalization(rhs.data, rhs_dn, rhs.data_layout == "T")
 
     dim_nums = (((2,), (2,)), ((0,), (0,)))
-    out_fp8 = jax.lax.dot_general(
-        lhs_3d, rhs_3d, dim_nums, preferred_element_type=jnp.float32
-    )
-    out_fp32 = (out_fp8 * (lhs.scale_inv * rhs.scale_inv).astype(jnp.float32))
+    out_fp8 = jax.lax.dot_general(lhs_3d, rhs_3d, dim_nums, preferred_element_type=jnp.float32)
+    out_fp32 = out_fp8 * (lhs.scale_inv * rhs.scale_inv).astype(jnp.float32)
 
     return out_fp32.astype(lhs.dq_dtype)
 

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -159,10 +159,12 @@ def __jitted_jax_gemm_tensor_scaling_fp8(lhs, rhs, lhs_dn, rhs_dn, precision):
     rhs_3d = _shape_normalization(rhs.data, rhs_dn, rhs.data_layout == "T")
 
     dim_nums = (((2,), (2,)), ((0,), (0,)))
-    out_fp8 = jax.lax.dot_general(lhs_3d, rhs_3d, dim_nums, preferred_element_type=jnp.float32)
-    out_fp32 = out_fp8 * (lhs.scale_inv * rhs.scale_inv).astype(jnp.float32)
-
-    return out_fp32.astype(lhs.dq_dtype)
+    out_fp8 = jax.lax.dot_general(
+        lhs_3d, rhs_3d, dim_nums, precision=precision, preferred_element_type=jnp.float32
+    )
+    scale_inv = (lhs.scale_inv * rhs.scale_inv).astype(jnp.float32)
+    
+    return (out_fp8 * scale_inv).astype(lhs.dq_dtype)
 
 
 def _jax_gemm_tensor_scaling_fp8(

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -156,20 +156,21 @@ def _dequantize(x, scale_inv, dq_dtype):
     ),
 )
 def __jitted_jax_gemm_tensor_scaling_fp8(lhs, rhs, lhs_dn, rhs_dn, precision):
-    # Need to hard-code the dequantize here instead of calling lhs.dequantize() for pattern matching
-    lhs_dq = _dequantize(lhs.data, lhs.scale_inv, lhs.dq_dtype)
-    rhs_dq = _dequantize(rhs.data, rhs.scale_inv, rhs.dq_dtype)
-
     # Reshape + Transpose
     # [..., M, K] -> [B, M, K]
     # [..., K, M] -> [B, M, K]
-    lhs_3d = _shape_normalization(lhs_dq, lhs_dn, lhs.data_layout == "N")
-    rhs_3d = _shape_normalization(rhs_dq, rhs_dn, rhs.data_layout == "T")
+    lhs_3d = _shape_normalization(lhs.data, lhs_dn, lhs.data_layout == "N")
+    rhs_3d = _shape_normalization(rhs.data, rhs_dn, rhs.data_layout == "T")
 
     dim_nums = (((2,), (2,)), ((0,), (0,)))
     out_3d = jax.lax.dot_general(
         lhs_3d, rhs_3d, dim_nums, precision=precision, preferred_element_type=lhs.dq_dtype
     )
+    out_fp8 = jax.lax.dot_general(
+        lhs_3d, rhs_3d, dim_nums, precision=precision, preferred_element_type=lhs.dq_dtype
+    )
+    out_3d = _dequantize(out_fp8, lhs.scale_inv * rhs.scale_inv, lhs.dq_dtype)
+
     return out_3d
 
 


### PR DESCRIPTION
# Description

XLA-FP8 feature that pattern-matched QDQ->dot is unstable and going to be [deprecated](https://flax-linen.readthedocs.io/en/latest/guides/quantization/fp8_basics.html#deprecated-apis).
Hence, we replace the pattern-matching GEMM with doing direct FP8 GEMM and dequantizing the output, as recommended by [the JAX guideline](https://flax-linen.readthedocs.io/en/latest/guides/quantization/fp8_basics.html#delayed-scaling).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
