### PR TITLE
Fix multi-framework runtime lib loading

### DIFF
--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -11,12 +11,12 @@ import transformer_engine.common
 
 try:
     from . import pytorch
-except (ImportError, RuntimeError):
+except (ImportError, AssertionError):
     pass
 
 try:
     from . import jax
-except (ImportError, RuntimeError):
+except (ImportError, AssertionError):
     pass
 
 __version__ = str(metadata.version("transformer_engine"))

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -11,12 +11,12 @@ import transformer_engine.common
 
 try:
     from . import pytorch
-except ImportError as e:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from . import jax
-except ImportError as e:
+except (ImportError, RuntimeError):
     pass
 
 __version__ = str(metadata.version("transformer_engine"))

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -108,9 +108,10 @@ def _get_shared_object_file(library: str) -> Path:
 
     # Case 1: Typical user workflow: Both locations are the same, return any result.
     if te_install_dir == site_packages_dir:
-        assert (
-            so_path_in_install_dir is not None
-        ), f"Could not find shared object file for Transformer Engine {library} lib."
+        if so_path_in_install_dir is None:
+            raise RuntimeError(
+                f"Could not find shared object file for Transformer Engine {library} lib."
+            )
         return so_path_in_install_dir
 
     # Case 2: ERR! Both locations are different but returned a valid result.


### PR DESCRIPTION
# Description

Fixes a runtime crash in TE when both frameworks are installed but only one of their extensions are built.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Catch `AssertionError`s in `transformer_engine/__init__.py` during `load_framework_extension`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
