### PR TITLE
[PyTorch] Recipe heuristics for initializing quantized weights

### DIFF
--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -1358,10 +1358,7 @@ def test_quantized_weight_heuristics(
     """Test heuristics for initializing quantized weights"""
 
     # Skip invalid configurations
-    if (
-        quantization in ("fp8_delayed_scaling", "fp8_current_scaling")
-        and not fp8_available
-    ):
+    if quantization in ("fp8_delayed_scaling", "fp8_current_scaling") and not fp8_available:
         pytest.skip(reason_for_no_fp8)
     if quantization == "mxfp8" and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)

--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -61,10 +61,12 @@ class QParams:
     amax_epsilon: float = 0.0
 
 
+@dataclass
 class Recipe:
-    """
-    Base recipe class.
-    """
+    """Configuration for quantization scheme."""
+
+    # Recipe-specific heuristics (options: "performance", "inference")
+    heuristic: str = "performance"
 
     def mxfp8(self):
         """Whether the given recipe is MXFP8 block scaling."""
@@ -185,7 +187,8 @@ class DelayedScaling(Recipe):
             f"format={str(self.fp8_format).split('.')[1]}, "
             f"amax_history_len={self.amax_history_len}, "
             f"fp8_dpa={self.fp8_dpa}, "
-            f"fp8_mha={self.fp8_mha}"
+            f"fp8_mha={self.fp8_mha}, "
+            f"heuristic={self.heuristic}"
         )
 
 
@@ -228,7 +231,8 @@ class Float8CurrentScaling(Recipe):
             f"fp8_gemm_dgrad={self.fp8_gemm_dgrad}, "
             f"fp8_gemm_wgrad={self.fp8_gemm_wgrad}, "
             f"fp8_dpa={self.fp8_dpa}, "
-            f"fp8_mha={self.fp8_mha}"
+            f"fp8_mha={self.fp8_mha}, "
+            f"heuristic={self.heuristic}"
         )
 
 
@@ -269,7 +273,8 @@ class MXFP8BlockScaling(Recipe):
         return (
             f"recipe_type={self.__class__.__name__}, "
             f"margin={self.margin}, "
-            f"format={str(self.fp8_format).split('.')[1]}"
+            f"format={str(self.fp8_format).split('.')[1]}, "
+            f"heuristic={self.heuristic}"
         )
 
 
@@ -349,5 +354,6 @@ class Float8BlockScaling(Recipe):
             f"fp8_gemm_dgrad={self.fp8_gemm_dgrad}, "
             f"fp8_gemm_wgrad={self.fp8_gemm_wgrad}, "
             f"fp8_dpa={self.fp8_dpa}, "
-            f"fp8_mha={self.fp8_mha}"
+            f"fp8_mha={self.fp8_mha}, "
+            f"heuristic={self.heuristic}"
         )

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -384,6 +384,7 @@ class MXFP8Tensor(MXFP8TensorBase, QuantizedTensor):
 
         # Quantize to FP8
         assert self._quantizer is not None, "Can't quantize without a quantizer"
+        self._quantizer.internal = False
         self.data = self._quantizer.quantize(tensor)
         if self.requires_grad != tensor.requires_grad:
             self.requires_grad_(requires_grad=tensor.requires_grad)


### PR DESCRIPTION
# Description

When initializing a model with quantized weights, the required data is different for training and inference (training requires row-wise data for forward GEMM and column-wise data for dgrad GEMM, inference only requires column-wise). This PR adds a `heuristic` option to the quantization recipes, with support for `"performance"` and `"inference"`. In the future, we may want to consider a `"memory"` heuristic that prioritizes memory usage over performance.

This is similar to the heuristic API in https://github.com/NVIDIA/TransformerEngine/pull/1300.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add recipe heuristics for initializing quantized weights

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
