### PR TITLE
[JAX] Use 1x quantization + jax transpose for performance for tensor-scaling

### DIFF
--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -183,6 +183,16 @@ def get_xla_flag(flag: str, default=None, cast=str):
     return default
 
 
+def get_max_device_compute_capability():
+    """
+    Returns the maximum compute capability of all local devices.
+    """
+    return max(
+        transformer_engine_jax.get_device_compute_capability(local_gpu_id)
+        for local_gpu_id in range(len(jax.local_devices()))
+    )
+
+
 def should_apply_1x_fused_dbias_war_for_arch_l_100(is_dbias: bool = False, quantizer=None):
     """
     Fused dbias is not supported for arch < 100 for 1x quantization, so we need to apply a workaround to

--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -183,16 +183,6 @@ def get_xla_flag(flag: str, default=None, cast=str):
     return default
 
 
-def get_max_device_compute_capability():
-    """
-    Returns the maximum compute capability of all local devices.
-    """
-    return max(
-        transformer_engine_jax.get_device_compute_capability(local_gpu_id)
-        for local_gpu_id in range(len(jax.local_devices()))
-    )
-
-
 def should_apply_1x_fused_dbias_war_for_arch_l_100(is_dbias: bool = False, quantizer=None):
     """
     Fused dbias is not supported for arch < 100 for 1x quantization, so we need to apply a workaround to

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -23,7 +23,6 @@ from .misc import (
     jax_dtype_to_te_dtype,
     multidim_transpose,
     should_apply_1x_fused_dbias_war_for_arch_l_100,
-    get_max_device_compute_capability,
     NamedSharding,
 )
 from ..sharding import all_reduce_max_along_all_axes_except_PP, all_reduce_sum_along_dp_fsdp
@@ -631,10 +630,7 @@ def _quantize_dbias_impl(
         scale = quantizer.scale
 
     # It is faster to use 1x quantization for tensor scaling
-    force_1x_quantization = (
-        quantizer.scaling_mode.is_tensor_scaling()
-        and quantizer.is_2x2x()
-    )
+    force_1x_quantization = quantizer.scaling_mode.is_tensor_scaling() and quantizer.is_2x2x()
 
     q_layout = quantizer.q_layout
     if force_1x_quantization:

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -630,10 +630,9 @@ def _quantize_dbias_impl(
     if isinstance(quantizer, DelayedScaleQuantizer):
         scale = quantizer.scale
 
-    # On arch >= 100, it is faster to use 1x quantization for tensor scaling
+    # It is faster to use 1x quantization for tensor scaling
     force_1x_quantization = (
-        get_max_device_compute_capability() >= 100
-        and quantizer.scaling_mode.is_tensor_scaling()
+        quantizer.scaling_mode.is_tensor_scaling()
         and quantizer.is_2x2x()
     )
 


### PR DESCRIPTION
# Description

Use 1x quantization with `QuantizePrimitive` and transpose in JAX instead of 2x fused transpose + quantization as it performed better on Blackwell and on Hopper.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Update `_quantize_dbias_impl` to use 1x quantization and a JAX transpose instead of 2x fused transpose + quantization.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
