### PR TITLE
[PyTorch] Use FP16 tols for distributed tests with TF32 compute

### DIFF
--- a/tests/pytorch/distributed/run_numerics.py
+++ b/tests/pytorch/distributed/run_numerics.py
@@ -185,7 +185,8 @@ def _get_tolerances(dtype):
     if dtype == torch.bfloat16:
         return {"rtol": 1.6e-2, "atol": 1e-5}
     if dtype == torch.float32:
-        return {"rtol": 1e-4, "atol": 1e-4}
+        # TF32 has same mantissa bits as FP16
+        return {"rtol": 1e-3, "atol": 1e-5}
     raise ValueError(f"Unsupported dtype ({dtype})")
 
 

--- a/tests/pytorch/distributed/run_numerics.py
+++ b/tests/pytorch/distributed/run_numerics.py
@@ -161,8 +161,8 @@ def _gather(tensor, dim=0):
     return torch.cat(gathered, dim=dim)
 
 
-def _constant(tensor):
-    return nn.init.constant_(tensor, 0.5)
+def _init_uniform(tensor):
+    return nn.init.uniform_(tensor, a=0.0, b=0.05)
 
 
 def dist_print(msg, src=None, end="\n", error=False):
@@ -512,7 +512,7 @@ def test_linear():
     kwargs_list = [
         {},
         {"bias": False},
-        {"init_method": _constant},
+        {"init_method": _init_uniform},
         {"fuse_wgrad_accumulation": True},
         {"return_bias": True},
         {"params_dtype": torch.float16},
@@ -688,7 +688,7 @@ def test_layernorm_linear():
     kwargs_list = [
         {},
         {"bias": False},
-        {"init_method": _constant},
+        {"init_method": _init_uniform},
         {"fuse_wgrad_accumulation": True},
         {"return_bias": True},
         {"params_dtype": torch.float16},
@@ -792,8 +792,8 @@ def _test_layernorm_mlp(set_parallel_mode=None, sequence_parallel=False, **kwarg
 def test_layernorm_mlp():
     kwargs_list = [
         {},
-        {"init_method": _constant},
-        {"output_layer_init_method": _constant},
+        {"init_method": _init_uniform},
+        {"output_layer_init_method": _init_uniform},
         {"normalization": "RMSNorm"},
         {"zero_centered_gamma": True},
         {"bias": False},
@@ -882,8 +882,8 @@ def test_transformer_layer():
     kwargs_list = [
         {},
         {"num_gqa_groups": 4},
-        {"init_method": _constant},
-        {"output_layer_init_method": _constant},
+        {"init_method": _init_uniform},
+        {"output_layer_init_method": _init_uniform},
         {"apply_residual_connection_post_layernorm": True},
         {"output_layernorm": True},
         {"parallel_attention_mlp": True},

--- a/tests/pytorch/distributed/run_numerics.py
+++ b/tests/pytorch/distributed/run_numerics.py
@@ -47,11 +47,6 @@ if os.environ.get("NVTE_TEST_NVINSPECT_ENABLED", False):
     )
 
 
-# Disable TF32
-torch.backends.cuda.matmul.allow_tf32 = False
-torch.backends.cudnn.allow_tf32 = False
-
-
 # Quantization recipe setup
 def quantization_recipe() -> Recipe:
     if QUANTIZATION == "fp8":
@@ -161,8 +156,8 @@ def _gather(tensor, dim=0):
     return torch.cat(gathered, dim=dim)
 
 
-def _init_uniform(tensor):
-    return nn.init.uniform_(tensor, a=0.0, b=0.05)
+def _constant(tensor):
+    return nn.init.constant_(tensor, 0.05)
 
 
 def dist_print(msg, src=None, end="\n", error=False):
@@ -512,7 +507,7 @@ def test_linear():
     kwargs_list = [
         {},
         {"bias": False},
-        {"init_method": _init_uniform},
+        {"init_method": _constant},
         {"fuse_wgrad_accumulation": True},
         {"return_bias": True},
         {"params_dtype": torch.float16},
@@ -688,7 +683,7 @@ def test_layernorm_linear():
     kwargs_list = [
         {},
         {"bias": False},
-        {"init_method": _init_uniform},
+        {"init_method": _constant},
         {"fuse_wgrad_accumulation": True},
         {"return_bias": True},
         {"params_dtype": torch.float16},
@@ -792,8 +787,8 @@ def _test_layernorm_mlp(set_parallel_mode=None, sequence_parallel=False, **kwarg
 def test_layernorm_mlp():
     kwargs_list = [
         {},
-        {"init_method": _init_uniform},
-        {"output_layer_init_method": _init_uniform},
+        {"init_method": _constant},
+        {"output_layer_init_method": _constant},
         {"normalization": "RMSNorm"},
         {"zero_centered_gamma": True},
         {"bias": False},
@@ -882,8 +877,8 @@ def test_transformer_layer():
     kwargs_list = [
         {},
         {"num_gqa_groups": 4},
-        {"init_method": _init_uniform},
-        {"output_layer_init_method": _init_uniform},
+        {"init_method": _constant},
+        {"output_layer_init_method": _constant},
         {"apply_residual_connection_post_layernorm": True},
         {"output_layernorm": True},
         {"parallel_attention_mlp": True},

--- a/tests/pytorch/distributed/test_numerics.py
+++ b/tests/pytorch/distributed/test_numerics.py
@@ -56,7 +56,7 @@ def test_distributed(quantization):
     if quantization == "fp8" and not fp8_available:
         pytest.skip(reason_for_no_fp8)
     if quantization == "fp8_cs" and not fp8_available:
-        pytest.skip(fp8_available)
+        pytest.skip(reason_for_no_fp8)
     if quantization == "mxfp8" and not mxfp8_available:
         pytest.skip(reason_for_no_mxfp8)
     if quantization == "fp8_block_scaling" and not fp8_block_scaling_available:


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1806 relaxed the numerical tolerances for the distributed tests using FP32 because they are actually doing compute in TF32. However, it seems the tolerances are still too tight because we are still seeing test failures on some systems. Since TF32 has the same number of mantissa bits as FP16, this PR drops the FP32 tolerances to match the FP16 tolerances in [`torch.testing.assert_close`](https://docs.pytorch.org/docs/stable/testing.html#torch.testing.assert_close).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Use FP16 tols for distributed tests with TF32 compute

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
