### PR TITLE
Fix MXFP8-training related issue

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -1242,7 +1242,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
 
         # FP8 primary weights
         if isinstance(tensor, QuantizedTensor):
-            if update_workspace and quantizer is not None:
+            if update_workspace and quantizer is not None and quantizer.columnwise_usage:
                 tensor.update_usage(
                     rowwise_usage=quantizer.rowwise_usage,
                     columnwise_usage=quantizer.columnwise_usage,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -117,6 +117,7 @@ class _Linear(torch.autograd.Function):
         skip_fp8_weight_update: bool,
         symmetric_ar_type: str,
         debug: Optional[bool] = False,
+        needs_columnwise_after_validation: bool = True,
     ) -> torch.Tensor:
         # pylint: disable=missing-function-docstring
 
@@ -229,7 +230,7 @@ class _Linear(torch.autograd.Function):
                     columnwise_usage = (
                         is_fp8_activation_recompute_enabled()
                         and not in_fp8_activation_recompute_phase()
-                    )
+                    ) or needs_columnwise_after_validation
                 weight_quantizer.set_usage(rowwise=True, columnwise=columnwise_usage)
 
             # Get quantized weight

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -117,7 +117,6 @@ class _Linear(torch.autograd.Function):
         skip_fp8_weight_update: bool,
         symmetric_ar_type: str,
         debug: Optional[bool] = False,
-        needs_columnwise_after_validation: bool = True,
     ) -> torch.Tensor:
         # pylint: disable=missing-function-docstring
 
@@ -230,7 +229,7 @@ class _Linear(torch.autograd.Function):
                     columnwise_usage = (
                         is_fp8_activation_recompute_enabled()
                         and not in_fp8_activation_recompute_phase()
-                    ) or needs_columnwise_after_validation
+                    )
                 weight_quantizer.set_usage(rowwise=True, columnwise=columnwise_usage)
 
             # Get quantized weight

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -346,7 +346,8 @@ class MXFP8Tensor(MXFP8TensorBase, QuantizedTensor):
         casts to FP8.
 
         """
-
+        if isinstance(tensor, MXFP8TensorBase):
+            return
         # Tensor device
         new_device = tensor.device if tensor.is_cuda else self.device
         if not devices_match(new_device, tensor.device):


### PR DESCRIPTION
# Description

Fix 2 bugs in mxfp8 training.

(1) The following error happened after validation since colwise data is cleared by update_usage() during validation.

```
0: [rank0]:   File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/tensor/_internal/mxfp8_tensor_base.py", line 192, in update_usage
0: [rank0]:     raise RuntimeError(
0: [rank0]: RuntimeError: Requested column-wise usage, but MXFP8Tensor is missing column-scaled FP8 data
```

(2) This happened after training completes and copying tensor to CPU:

```
1: [rank1]:   File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/tensor/mxfp8_tensor.py", line 394, in _set_data                                                                           1: [rank1]:     new_device = tensor.device if tensor.is_cuda else self.device
1: [rank1]:                                   ^^^^^^^^^^^^^^
1: [rank1]: AttributeError: 'MXFP8TensorBase' object has no attribute 'is_cuda'
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
[ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
