### PR TITLE
Make quantize_ respect the usages of the quantizer

### DIFF
--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -397,6 +397,7 @@ def _test_sanity_common(
 
     # now try eval with weight caching
     block.eval()
+    te_inp.requires_grad = False
 
     with fp8_autocast(enabled=use_fp8, fp8_recipe=fp8_recipe):
         te_out = block(te_inp, is_first_microbatch=True)
@@ -406,6 +407,7 @@ def _test_sanity_common(
 
     # now try regular execution again with weight caching
     block.train()
+    te_inp.requires_grad = True
 
     with fp8_autocast(enabled=use_fp8, fp8_recipe=fp8_recipe):
         te_out = block(te_inp, is_first_microbatch=True)

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -286,9 +286,4 @@ std::vector<size_t> convertShape(const NVTEShape& shape) {
   return std::vector<size_t>(shape.data, shape.data + shape.ndim);
 }
 
-int roundup(const int value, const int multiple) {
-  assert(multiple > 0);
-  return ((value + multiple - 1) / multiple) * multiple;
-}
-
 }  // namespace transformer_engine::pytorch

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -355,7 +355,16 @@ void* getDataPtr(at::Tensor tensor, int offset = 0);
 
 std::vector<size_t> convertShape(const NVTEShape& shape);
 
-int roundup(const int value, const int multiple);
+template <typename T>
+T divup(const T value, const T multiple) {
+  assert(multiple > 0);
+  return ((value + multiple - 1) / multiple);
+}
+
+template <typename T>
+T roundup(const T value, const T multiple) {
+  return divup(value, multiple) * multiple;
+}
 
 NVTEShape convertTorchShape(const c10::IntArrayRef torch_shape);
 }  // namespace transformer_engine::pytorch

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -98,6 +98,7 @@ class Quantizer {
 
   virtual std::pair<TensorWrapper, py::object> create_tensor(
       const std::vector<size_t>& shape, DType dtype,
+      const py::object& output = py::none(),
       std::optional<at::Tensor> rowwise_data = std::nullopt) const = 0;
 
   virtual ~Quantizer() = default;
@@ -121,6 +122,7 @@ class NoneQuantizer : public Quantizer {
 
   std::pair<TensorWrapper, py::object> create_tensor(
       const std::vector<size_t>& shape, DType dtype,
+      const py::object& output = py::none(),
       std::optional<at::Tensor> rowwise_data = std::nullopt) const override;
 };
 
@@ -139,6 +141,7 @@ class Float8Quantizer : public Quantizer {
 
   std::pair<TensorWrapper, py::object> create_tensor(
       const std::vector<size_t>& shape, DType dtype,
+      const py::object& output = py::none(),
       std::optional<at::Tensor> rowwise_data = std::nullopt) const override;
 };
 
@@ -161,6 +164,7 @@ class Float8CurrentScalingQuantizer : public Quantizer {
 
   std::pair<TensorWrapper, py::object> create_tensor(
       const std::vector<size_t>& shape, DType dtype,
+      const py::object& output = py::none(),
       std::optional<at::Tensor> rowwise_data = std::nullopt) const override;
 };
 
@@ -193,6 +197,7 @@ class Float8BlockQuantizer : public Quantizer {
   // and optionally columnwise usage.
   std::pair<TensorWrapper, py::object> create_tensor(
       const std::vector<size_t>& shape, DType dtype,
+      const py::object& output = py::none(),
       std::optional<at::Tensor> rowwise_data = std::nullopt) const override;
 };
 
@@ -208,6 +213,7 @@ class MXFP8Quantizer : public Quantizer {
 
   std::pair<TensorWrapper, py::object> create_tensor(
       const std::vector<size_t>& shape, DType dtype,
+      const py::object& output = py::none(),
       std::optional<at::Tensor> rowwise_data = std::nullopt) const override;
 };
 

--- a/transformer_engine/pytorch/csrc/extensions/attention.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/attention.cpp
@@ -374,9 +374,9 @@ std::vector<py::object> fused_attn_bwd(
     default:
       NVTE_ERROR("QKV layout not supported!");
   }
-  std::tie(te_dQ, py_dQ) = dQKV_quantizer->create_tensor(q_shape, fake_dtype_te, dQ);
-  std::tie(te_dK, py_dK) = dQKV_quantizer->create_tensor(k_shape, fake_dtype_te, dK);
-  std::tie(te_dV, py_dV) = dQKV_quantizer->create_tensor(v_shape, fake_dtype_te, dV);
+  std::tie(te_dQ, py_dQ) = dQKV_quantizer->create_tensor(q_shape, fake_dtype_te, py::none(), dQ);
+  std::tie(te_dK, py_dK) = dQKV_quantizer->create_tensor(k_shape, fake_dtype_te, py::none(), dK);
+  std::tie(te_dV, py_dV) = dQKV_quantizer->create_tensor(v_shape, fake_dtype_te, py::none(), dV);
 
   // construct NVTE tensors
   if (qkv_type == DType::kFloat8E4M3 || qkv_type == DType::kFloat8E5M2) {

--- a/transformer_engine/pytorch/csrc/quantizer.cpp
+++ b/transformer_engine/pytorch/csrc/quantizer.cpp
@@ -17,11 +17,11 @@ bool tensor_is_reusable(const at::Tensor& tensor,
                         const std::vector<int64_t>& shape,
                         const at::TensorOptions& opts) {
   const auto& tensor_shape = tensor.sizes();
-  if (tensor_shape.equals(shape)) return false;
+  if (!tensor_shape.equals(shape)) return false;
   const at::TensorOptions& tensor_opts = tensor.options();
-  if (opts.dtype() == tensor_opts.dtype()) return false;
-  if (opts.device() == tensor_opts.device()) return false;
-  if (opts.device_index() == tensor_opts.device_index()) return false;
+  if (opts.dtype() != tensor_opts.dtype()) return false;
+  if (opts.device() != tensor_opts.device()) return false;
+  if (opts.device_index() != tensor_opts.device_index()) return false;
   return true;
 }
 

--- a/transformer_engine/pytorch/csrc/quantizer.cpp
+++ b/transformer_engine/pytorch/csrc/quantizer.cpp
@@ -20,8 +20,8 @@ bool tensor_is_reusable(const at::Tensor& tensor,
   if (!tensor_shape.equals(shape)) return false;
   const at::TensorOptions& tensor_opts = tensor.options();
   if (opts.dtype() != tensor_opts.dtype()) return false;
-  if (opts.device() != tensor_opts.device()) return false;
-  if (opts.device_index() != tensor_opts.device_index()) return false;
+  if (opts.device().type() != tensor_opts.device().type()) return false;
+  if (opts.device_index() != tensor_opts.device_index() && opts.device_index() != -1) return false;
   return true;
 }
 

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -1280,13 +1280,6 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
 
         if cache_name is not None:
             out = self._fp8_workspaces.get(cache_name, None)
-            if quantizer is not None and isinstance(out, MXFP8TensorBase):
-                if quantizer.rowwise_usage and out._rowwise_data is None:
-                    out = None
-                    del self._fp8_workspaces[cache_name]
-                elif quantizer.columnwise_usage and out._columnwise_data is None:
-                    out = None
-                    del self._fp8_workspaces[cache_name]
 
             is_debug = isinstance(quantizer, DebugQuantizer)
             is_out_debug_tensor = out is not None and isinstance(out, DebugQuantizedTensor)


### PR DESCRIPTION
# Description

This PR changes the create_tensor function to accept an optional `out` parameter - a tensor that can be reused. It also changes the tex.quantize function to always try to recreate the tensor (potentially reusing the provided `out`) rather than blindly believing that `out` is already prepared properly. This ensures that the quantizer settings are going to be preserved and enables us to drop the workaround in `get_weight_workspaces` to ignore the cached MXFP8 weight tensor when the usages are incompatible. See https://github.com/NVIDIA/TransformerEngine/pull/1593#issuecomment-2741229675 for more details.

Adding @guyueh1 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
