### PR TITLE
[JAX] Fix NVTETensor leak in attention.cpp

### DIFF
--- a/transformer_engine/jax/csrc/extensions/attention.cpp
+++ b/transformer_engine/jax/csrc/extensions/attention.cpp
@@ -199,6 +199,8 @@ pybind11::tuple GetFusedAttnForwardWorkspaceSizes(
     }
   }
 
+  nvte_tensor_pack_destroy(&aux_output_tensors);
+
   auto workspace_shape = MakeShapeVector(query_workspace_tensor.shape());
   return pybind11::make_tuple(workspace_shape, query_workspace_tensor.dtype());
 }
@@ -484,6 +486,8 @@ pybind11::tuple GetFusedAttnBackwardWorkspaceSizes(
       NVTE_ERROR("Unsupported qkv_layout.");
     }
   }
+
+  nvte_tensor_pack_destroy(&aux_input_tensors);
 
   auto work_shape = MakeShapeVector(query_workspace_tensor.shape());
   return pybind11::make_tuple(work_shape, query_workspace_tensor.dtype());


### PR DESCRIPTION
# Description

Fixed leaking NVTETensors in `attention.cpp` created with `nvte_tensor_pack_create` but were missing frees with `nvte_tensor_pack_destory`.

Reproduced issue locally with `pytest tests/jax/test_distributed_fused_attn.py`. Confirmed with local testing with this fix PR and debug info enabled on `TensorAllocator` in `transformer_engine.cpp` that the capacity of the pool did not exceed `256`. Previously the tests failed due to exceeding `81920` unfreed NVTETensors.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Added two missing `nvte_tensor_pack_destory` calls in `attention.cpp`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
