### PR TITLE
[JAX] Fix 1x quantize kernel availability check on hopper

### DIFF
--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -183,6 +183,16 @@ def get_xla_flag(flag: str, default=None, cast=str):
     return default
 
 
+def get_max_device_compute_capability():
+    """
+    Returns the maximum compute capability of all local devices.
+    """
+    return max(
+        transformer_engine_jax.get_device_compute_capability(local_gpu_id)
+        for local_gpu_id in range(len(jax.local_devices()))
+    )
+
+
 def should_apply_1x_fused_dbias_war_for_arch_l_100(is_dbias: bool = False, quantizer=None):
     """
     Fused dbias is not supported for arch < 100 for 1x quantization, so we need to apply a workaround to

--- a/transformer_engine/jax/cpp_extensions/misc.py
+++ b/transformer_engine/jax/cpp_extensions/misc.py
@@ -183,11 +183,11 @@ def get_xla_flag(flag: str, default=None, cast=str):
     return default
 
 
-def get_max_device_compute_capability():
+def get_min_device_compute_capability():
     """
-    Returns the maximum compute capability of all local devices.
+    Returns the minimum compute capability of all local devices.
     """
-    return max(
+    return min(
         transformer_engine_jax.get_device_compute_capability(local_gpu_id)
         for local_gpu_id in range(len(jax.local_devices()))
     )

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -23,7 +23,7 @@ from .misc import (
     jax_dtype_to_te_dtype,
     multidim_transpose,
     should_apply_1x_fused_dbias_war_for_arch_l_100,
-    get_max_device_compute_capability,
+    get_min_device_compute_capability,
     NamedSharding,
 )
 from ..sharding import all_reduce_max_along_all_axes_except_PP, all_reduce_sum_along_dp_fsdp
@@ -630,7 +630,7 @@ def _quantize_dbias_impl(
     if isinstance(quantizer, DelayedScaleQuantizer):
         scale = quantizer.scale
 
-    is_1x_kernel_supported = not (is_dbias and get_max_device_compute_capability() < 100)
+    is_1x_kernel_supported = not (is_dbias and get_min_device_compute_capability() < 100)
     # It is faster to use 1x quantization for tensor scaling
     force_1x_quantization = (
         quantizer.scaling_mode.is_tensor_scaling()

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -23,6 +23,7 @@ from .misc import (
     jax_dtype_to_te_dtype,
     multidim_transpose,
     should_apply_1x_fused_dbias_war_for_arch_l_100,
+    get_max_device_compute_capability,
     NamedSharding,
 )
 from ..sharding import all_reduce_max_along_all_axes_except_PP, all_reduce_sum_along_dp_fsdp
@@ -629,8 +630,13 @@ def _quantize_dbias_impl(
     if isinstance(quantizer, DelayedScaleQuantizer):
         scale = quantizer.scale
 
+    is_1x_kernel_supported = not (is_dbias and get_max_device_compute_capability() < 100)
     # It is faster to use 1x quantization for tensor scaling
-    force_1x_quantization = quantizer.scaling_mode.is_tensor_scaling() and quantizer.is_2x2x()
+    force_1x_quantization = (
+        quantizer.scaling_mode.is_tensor_scaling()
+        and quantizer.is_2x2x()
+        and is_1x_kernel_supported
+    )
 
     q_layout = quantizer.q_layout
     if force_1x_quantization:


### PR DESCRIPTION
# Description

Fixes issue with #1830 that would attempt to call a 1x + fused dbias kernel that doesn't exist on Hopper, leading to the following error:
```
/opt/transformerengine/transformer_engine/common/util/cast_kernels.cuh:1164 in function fp8_quantize_arch_l_100: Not implemented scaling mode or fusion: NVTE_DELAYED_TENSOR_SCALING on GPU with compute capability < 10.0.
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Do not force 1x quantization if on Hopper and using dbias as a 1x fused quantize and dbias kernel does not exist for Hopper.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
