### PR TITLE
Fixes for JIT-able grouped_gemm

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -2,10 +2,8 @@
 #
 # See LICENSE for license information.
 
-import os
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 from jax import jit, value_and_grad
 from functools import reduce
@@ -14,7 +12,6 @@ import operator
 
 from utils import (
     assert_allclose,
-    assert_tree_like_allclose,
     pytest_parametrize_wrapper,
 )
 from transformer_engine.jax.layernorm import layernorm

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -682,9 +682,9 @@ class TestGroupedQuantize:
             n_groups=n_groups,
         )
 
-        scaled_tensor = tex.grouped_quantize(
-            x, group_sizes=group_sizes, flatten_axis=flatten_axis, quantizer=grouped_quantizer
-        )
+        scaled_tensor = jax.jit(tex.grouped_quantize, static_argnames=('flatten_axis',))(
+                x, group_sizes=group_sizes, flatten_axis=flatten_axis, quantizer=grouped_quantizer
+                )
 
         assert_dequantized_grouped_scaled_tensor(scaled_tensor, x)
 
@@ -1313,8 +1313,8 @@ class TestGroupedDense:
         )
         ref_out = self._ref_grouped_dense(lhs, rhs, None, group_sizes, contracting_dims)
         prim_out = tex.grouped_gemm(
-            lhs, rhs, group_sizes, contracting_dims, quantizer_set=quantizer_set
-        )
+                lhs, rhs, group_sizes, contracting_dims, quantizer_set=quantizer_set
+                )
 
         allclose_dtype = jnp.float8_e4m3fn
         if jnp.float8_e5m2 in fwd_bwd_dtype:

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -683,9 +683,9 @@ class TestGroupedQuantize:
             n_groups=n_groups,
         )
 
-        scaled_tensor = jax.jit(tex.grouped_quantize, static_argnames=('flatten_axis',))(
-                x, group_sizes=group_sizes, flatten_axis=flatten_axis, quantizer=grouped_quantizer
-                )
+        scaled_tensor = jax.jit(tex.grouped_quantize, static_argnames=("flatten_axis",))(
+            x, group_sizes=group_sizes, flatten_axis=flatten_axis, quantizer=grouped_quantizer
+        )
 
         assert_dequantized_grouped_scaled_tensor(scaled_tensor, x)
 
@@ -1282,9 +1282,12 @@ class TestGroupedDense:
             dtype, input_shape, layout
         )
         ref_out = self._ref_grouped_dense(lhs, rhs, None, group_sizes, contracting_dims)
-        prim_out = jax.jit(tex.grouped_gemm, static_argnames=('contracting_dims',))(
-                lhs, rhs, group_sizes, contracting_dims,
-                )
+        prim_out = jax.jit(tex.grouped_gemm, static_argnames=("contracting_dims",))(
+            lhs,
+            rhs,
+            group_sizes,
+            contracting_dims,
+        )
         self._assert_grouped_gemm_output(prim_out, group_sizes, ref_out, dtype)
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)
@@ -1324,8 +1327,8 @@ class TestGroupedDense:
         #         )
 
         prim_out = tex.grouped_gemm(
-                lhs, rhs, group_sizes, contracting_dims, quantizer_set=quantizer_set
-                )
+            lhs, rhs, group_sizes, contracting_dims, quantizer_set=quantizer_set
+        )
 
         allclose_dtype = jnp.float8_e4m3fn
         if jnp.float8_e5m2 in fwd_bwd_dtype:

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -685,8 +685,8 @@ class TestGroupedQuantize:
         # disable cudaGraph, then use the following jitted function
 
         scaled_tensor = tex.grouped_quantize(
-                x, group_sizes=group_sizes, flatten_axis=flatten_axis, quantizer=grouped_quantizer
-                )
+            x, group_sizes=group_sizes, flatten_axis=flatten_axis, quantizer=grouped_quantizer
+        )
 
         assert_dequantized_grouped_scaled_tensor(scaled_tensor, x)
 

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -1281,8 +1281,11 @@ class TestGroupedDense:
             dtype, input_shape, layout
         )
         ref_out = self._ref_grouped_dense(lhs, rhs, None, group_sizes, contracting_dims)
-        prim_out = tex.grouped_gemm(lhs, rhs, group_sizes, contracting_dims)
+        prim_out = jax.jit(tex.grouped_gemm, static_argnames=('contracting_dims',))(
+                lhs, rhs, group_sizes, contracting_dims,
+                )
         self._assert_grouped_gemm_output(prim_out, group_sizes, ref_out, dtype)
+
 
     @pytest.mark.skipif(not is_fp8_supported, reason=reason)
     @pytest.mark.parametrize("fwd_bwd_dtype", fwd_bwd_dtypes)
@@ -1312,7 +1315,7 @@ class TestGroupedDense:
             out_dtype, input_shape, layout
         )
         ref_out = self._ref_grouped_dense(lhs, rhs, None, group_sizes, contracting_dims)
-        prim_out = tex.grouped_gemm(
+        prim_out = jax.jit(tex.grouped_gemm, static_argnames=('contracting_dims',))(
                 lhs, rhs, group_sizes, contracting_dims, quantizer_set=quantizer_set
                 )
 

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -1357,6 +1357,9 @@ class TestGroupedDense:
         )
 
         value_n_grad_ref_func = value_and_grad(self._ref_sum_grouped_dense, (0, 1, 2))
+        # jitting the grouped_dense
+        # value_n_grad_prim_func = jit(value_and_grad(self._primitive_sum_grouped_dense, (0, 1, 2)),
+        #                              static_argnums=(4,))
         value_n_grad_prim_func = value_and_grad(self._primitive_sum_grouped_dense, (0, 1, 2))
 
         ref_out_sum, (ref_dgrad, ref_wgrad, ref_dbias) = value_n_grad_ref_func(
@@ -1397,6 +1400,10 @@ class TestGroupedDense:
             n_groups=group_sizes.size,
         )
         value_n_grad_ref_func = value_and_grad(self._ref_sum_grouped_dense, (0, 1, 2))
+
+        # jitting the grouped_dense
+        # value_n_grad_prim_func = jit(value_and_grad(self._primitive_sum_grouped_dense, (0, 1, 2)),
+        #                              static_argnums=(4,))
         value_n_grad_prim_func = value_and_grad(self._primitive_sum_grouped_dense, (0, 1, 2))
 
         ref_out_sum, (ref_dgrad, ref_wgrad, ref_dbias) = value_n_grad_ref_func(

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -103,8 +103,10 @@ class GroupedGemmPrimitive(BasePrimitive):
         """
         del lhs_data_aval, rhs_data_aval, bias_aval, group_offset_aval
         del K, lhs_is_trans, rhs_is_trans, scaling_mode, has_bias
+        del lhs_scale_inv_aval, rhs_scale_inv_aval
         # TODO(Phuong): move some shape checks from Cpp to here
         workspace_size = get_cublas_workspace_size_bytes() * num_cublas_streams
+        # JAX buffer pointers are 128-aligned
         # 255 is added to the workspace size to ensure workspace ptr is 256-aligned
         workspace_size += 255
         workspace_aval = jax.core.ShapedArray(shape=(workspace_size,), dtype=jnp.uint8)

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -973,8 +973,9 @@ def grouped_quantize(
 
     if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
         row_amax = jnp.max(jnp.abs(x), axis=range(group_axis + 1, x.ndim))
-        segment_ids = jnp.repeat(jnp.arange(n_groups), group_sizes,
-                                 total_repeat_length=x.shape[group_axis])
+        segment_ids = jnp.repeat(
+            jnp.arange(n_groups), group_sizes, total_repeat_length=x.shape[group_axis]
+        )
         grouped_amax = jax.ops.segment_max(row_amax, segment_ids, num_segments=n_groups)
         for i in range(n_groups):
             tmp_scale = compute_scale_from_amax(grouped_amax[i], quantizer.q_dtype)

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -1048,8 +1048,9 @@ def grouped_dbias(grad: jnp.ndarray, group_sizes: jnp.ndarray) -> jnp.ndarray:
     assert grad.ndim == 2, "Input grad must be a 2D tensor."
     assert group_sizes.ndim == 1, "group_sizes must be a 1D tensor."
 
-    segment_ids = jnp.repeat(jnp.arange(group_sizes.size), group_sizes,
-                             total_repeat_length=grad.shape[0])
+    segment_ids = jnp.repeat(
+        jnp.arange(group_sizes.size), group_sizes, total_repeat_length=grad.shape[0]
+    )
     grad_fp32 = grad.astype(jnp.float32)
     dbias_fp32 = jax.ops.segment_sum(grad_fp32, segment_ids, num_segments=group_sizes.shape[0])
     dbias = dbias_fp32.astype(grad.dtype)

--- a/transformer_engine/jax/cpp_extensions/quantization.py
+++ b/transformer_engine/jax/cpp_extensions/quantization.py
@@ -1048,7 +1048,8 @@ def grouped_dbias(grad: jnp.ndarray, group_sizes: jnp.ndarray) -> jnp.ndarray:
     assert grad.ndim == 2, "Input grad must be a 2D tensor."
     assert group_sizes.ndim == 1, "group_sizes must be a 1D tensor."
 
-    segment_ids = jnp.repeat(jnp.arange(group_sizes.shape[0]), group_sizes)
+    segment_ids = jnp.repeat(jnp.arange(group_sizes.size), group_sizes,
+                             total_repeat_length=grad.shape[0])
     grad_fp32 = grad.astype(jnp.float32)
     dbias_fp32 = jax.ops.segment_sum(grad_fp32, segment_ids, num_segments=group_sizes.shape[0])
     dbias = dbias_fp32.astype(grad.dtype)

--- a/transformer_engine/jax/csrc/extensions.h
+++ b/transformer_engine/jax/csrc/extensions.h
@@ -13,6 +13,8 @@
 #include <cudnn.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <transformer_engine/normalization.h>
+#include <transformer_engine/transformer_engine.h>
 
 #include <cassert>
 #include <cstddef>
@@ -27,11 +29,8 @@
 #include "extensions/ffi.h"
 #include "extensions/misc.h"
 #include "extensions/utils.h"
-#include <transformer_engine/transformer_engine.h>
 #include "transformer_engine/activation.h"
 #include "transformer_engine/multi_stream.h"
-#include <transformer_engine/normalization.h>
-
 
 // ENUM_ATTR and DICT_ATTR recoding need to be registered in the global namespace
 XLA_FFI_REGISTER_ENUM_ATTR_DECODING(transformer_engine::jax::JAXX_Scaling_Mode);

--- a/transformer_engine/jax/csrc/extensions.h
+++ b/transformer_engine/jax/csrc/extensions.h
@@ -13,8 +13,6 @@
 #include <cudnn.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <transformer_engine/normalization.h>
-#include <transformer_engine/transformer_engine.h>
 
 #include <cassert>
 #include <cstddef>
@@ -29,7 +27,11 @@
 #include "extensions/ffi.h"
 #include "extensions/misc.h"
 #include "extensions/utils.h"
+#include <transformer_engine/transformer_engine.h>
 #include "transformer_engine/activation.h"
+#include "transformer_engine/multi_stream.h"
+#include <transformer_engine/normalization.h>
+
 
 // ENUM_ATTR and DICT_ATTR recoding need to be registered in the global namespace
 XLA_FFI_REGISTER_ENUM_ATTR_DECODING(transformer_engine::jax::JAXX_Scaling_Mode);

--- a/transformer_engine/jax/csrc/extensions/gemm.cpp
+++ b/transformer_engine/jax/csrc/extensions/gemm.cpp
@@ -58,12 +58,11 @@ Error_Type GroupedGemmFFI(cudaStream_t stream, Buffer_Type lhs_data, Buffer_Type
   auto out_ptr = reinterpret_cast<uint8_t *>(output->untyped_data());
   auto out_dtype = convert_ffi_datatype_to_te_dtype(output->element_type());
   // Here we clear the lower 8 bits of the buffer address to ensure the buffer is 256-aligned
-  auto workspace_ptr = reinterpret_cast<uint8_t*>(
-      (reinterpret_cast<uintptr_t>(workspace->untyped_data()) + 255)
-      & ~static_cast<uintptr_t>(255)
-      );
+  auto workspace_ptr =
+      reinterpret_cast<uint8_t *>((reinterpret_cast<uintptr_t>(workspace->untyped_data()) + 255) &
+                                  ~static_cast<uintptr_t>(255));
   auto workspace_total_size = product(workspace->dimensions()) - 255;
-  auto workspace_size = workspace_total_size/ num_streams;
+  auto workspace_size = workspace_total_size / num_streams;
 
   size_t lhs_dtype_bytes = te_dtype_bytes(lhs_dtype);
   size_t rhs_dtype_bytes = te_dtype_bytes(rhs_dtype);

--- a/transformer_engine/jax/csrc/extensions/pybind.cpp
+++ b/transformer_engine/jax/csrc/extensions/pybind.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(transformer_engine_jax, m) {
   m.def("get_cuda_version", &GetCudaRuntimeVersion);
   m.def("get_cudnn_version", &GetCudnnRuntimeVersion);
   m.def("get_device_compute_capability", &GetDeviceComputeCapability);
+  m.def("get_num_compute_streams", &nvte_get_num_compute_streams);
   m.def("get_cublasLt_version", &cublasLtGetVersion);
   m.def("get_dact_dbias_quantize_workspace_sizes", &GetDActDBiasQuantizeWorkspaceSizes);
   m.def("get_dbias_quantize_workspace_sizes", &GetDBiasQuantizeWorkspaceSizes);

--- a/transformer_engine/jax/dense.py
+++ b/transformer_engine/jax/dense.py
@@ -389,7 +389,7 @@ def _grouped_dense_bwd_rule(
         # after the extra transpose for FP8 in grouped_gemm
         # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
         g_contracting_dim = (0,)
-        x_contracting_dim = (1,)
+        x_contracting_dim = (0,)
         wgrad_contracting_dims = (x_contracting_dim, g_contracting_dim)
         wgrad_x_T = ctx_x
         wgrad_grad = casted_grad.get_colwise_tensor()

--- a/transformer_engine/jax/quantize/dequantizer.py
+++ b/transformer_engine/jax/quantize/dequantizer.py
@@ -188,7 +188,7 @@ def _grouped_dequantize(grouped_scaled_tensor):
         data_shape_i = (
             *original_shape[:group_axis],
             group_sizes[i],
-            *original_shape[group_axis + 1:],
+            *original_shape[group_axis + 1 :],
         )
         assert math.prod(data_shape_i) == data_i.size, (
             f"math.prod({data_shape_i}) = {math.prod(data_shape_i)} which is not equal to"

--- a/transformer_engine/jax/quantize/dequantizer.py
+++ b/transformer_engine/jax/quantize/dequantizer.py
@@ -188,7 +188,7 @@ def _grouped_dequantize(grouped_scaled_tensor):
         data_shape_i = (
             *original_shape[:group_axis],
             group_sizes[i],
-            *original_shape[group_axis + 1 :],
+            *original_shape[group_axis + 1:],
         )
         assert math.prod(data_shape_i) == data_i.size, (
             f"math.prod({data_shape_i}) = {math.prod(data_shape_i)} which is not equal to"

--- a/transformer_engine/jax/quantize/tensor.py
+++ b/transformer_engine/jax/quantize/tensor.py
@@ -455,9 +455,9 @@ class ScaledTensorFactory:
             A ScaledTensor1x or GroupedScaledTensor1x instance depending on whether group_sizes is provided
         """
         dequantizer = ScalingModeToDequantizerMap.get(scaling_mode)
-        flatten_axis = len(original_shape) + flatten_axis if flatten_axis < 0 else flatten_axis
 
         if group_sizes is not None:
+            flatten_axis = len(original_shape) + flatten_axis if flatten_axis < 0 else flatten_axis
             assert (
                 original_shape is not None
             ), "original_shape is not given for GroupedScaledTensor1x"
@@ -495,6 +495,7 @@ class ScaledTensorFactory:
             )
 
         # Handling attrs of transposed tensors
+        flatten_axis = data.ndim + flatten_axis if flatten_axis < 0 else flatten_axis
         if data_layout == "T":
             flatten_axis = data.ndim - flatten_axis
 

--- a/transformer_engine/jax/quantize/tensor.py
+++ b/transformer_engine/jax/quantize/tensor.py
@@ -131,22 +131,16 @@ class ScaledTensor1x(ScaledTensor):
         Ensures the scale_inv shape matches the expected shape based on the scaling mode
         and quantization direction. Pads the scale_inv if necessary.
         """
-        flatten_axis = (
-            len(self.data.shape) + self.flatten_axis if self.flatten_axis < 0 else self.flatten_axis
-        )
+        assert self.flatten_axis > 0
         assert (
-            0 < flatten_axis < len(self.data.shape)
-        ), f"flatten_axis {flatten_axis} is out of bounds for shape {self.data.shape}"
-
-        if self.data_layout == "T":
-            flatten_axis = self.data.ndim - flatten_axis
-        self.flatten_axis = flatten_axis
+            0 < self.flatten_axis < len(self.data.shape)
+        ), f"flatten_axis {self.flatten_axis} is out of bounds for shape {self.data.shape}"
 
         expected_scale_shape = self.scaling_mode.get_scale_shape(
-            self.data.shape, self.is_colwise, is_padded=True, flatten_axis=flatten_axis
+            self.data.shape, self.is_colwise, is_padded=True, flatten_axis=self.flatten_axis
         )
         expected_unpadded_scale_shape = self.scaling_mode.get_scale_shape(
-            self.data.shape, self.is_colwise, is_padded=False, flatten_axis=flatten_axis
+            self.data.shape, self.is_colwise, is_padded=False, flatten_axis=self.flatten_axis
         )
         if self.scale_inv.shape != expected_scale_shape:
             assert self.scale_inv.shape == expected_unpadded_scale_shape, (
@@ -291,6 +285,7 @@ class GroupedScaledTensor1x(ScaledTensor1x):
         original_shape,
         group_axis=0,
     ):
+        self.flatten_axis = flatten_axis
         self.group_sizes = group_sizes
         self.original_shape = original_shape
         self.group_axis = group_axis
@@ -301,44 +296,25 @@ class GroupedScaledTensor1x(ScaledTensor1x):
     def __post_init__(self):
         assert self.scale_inv.ndim == 1, "Only support flattened scale_inv"
         assert self.data.ndim == 1, "Only support flattened data"
+        assert self.group_axis >= 0
+        assert self.flatten_axis > 0
 
         data_ndim = len(self.original_shape)
-        flatten_axis = data_ndim + self.flatten_axis if self.flatten_axis < 0 else self.flatten_axis
         assert (
-            0 < flatten_axis < data_ndim
-        ), f"flatten_axis {flatten_axis} is out of bounds for data.ndim = {data_ndim}"
+            0 < self.flatten_axis < data_ndim
+        ), f"flatten_axis {self.flatten_axis} is out of bounds for data.ndim = {data_ndim}"
 
-        group_axis = (
-            len(self.original_shape) + self.group_axis if self.group_axis < 0 else self.group_axis
-        )
         assert (
-            0 <= group_axis < data_ndim
-        ), f"group_axis {group_axis} is out of bounds for shape {self.original_shape}"
+            0 <= self.group_axis < data_ndim
+        ), f"group_axis {self.group_axis} is out of bounds for shape {self.original_shape}"
 
-        if self.data_layout == "T":
-            if self.original_shape[0] == self.group_sizes.size:
-                self.original_shape = (
-                    self.original_shape[0],
-                    *self.original_shape[flatten_axis:],
-                    *self.original_shape[1:flatten_axis],
-                )
-                flatten_axis = len(self.original_shape) - flatten_axis + 1
-            else:
-                self.original_shape = (
-                    *self.original_shape[flatten_axis:],
-                    *self.original_shape[:flatten_axis],
-                )
-                self.group_axis = flatten_axis
-                flatten_axis = len(self.original_shape) - flatten_axis
-
-        self.flatten_axis = flatten_axis
         expected_scale_shape = self.scaling_mode.get_grouped_scale_shape(
             self.original_shape,
             self.group_sizes.size,
             self.group_axis,
             self.is_colwise,
             is_padded=True,
-            flatten_axis=flatten_axis,
+            flatten_axis=self.flatten_axis,
         )
 
         assert self.scale_inv.shape == expected_scale_shape, (
@@ -479,10 +455,31 @@ class ScaledTensorFactory:
             A ScaledTensor1x or GroupedScaledTensor1x instance depending on whether group_sizes is provided
         """
         dequantizer = ScalingModeToDequantizerMap.get(scaling_mode)
+        flatten_axis = len(original_shape) + flatten_axis if flatten_axis < 0 else flatten_axis
+
         if group_sizes is not None:
             assert (
                 original_shape is not None
             ), "original_shape is not given for GroupedScaledTensor1x"
+
+            # Handling attrs of transposed tensors
+            group_axis = len(original_shape) + group_axis if group_axis < 0 else group_axis
+            if data_layout == "T":
+                if original_shape[0] == group_sizes.size:
+                    original_shape = (
+                        original_shape[0],
+                        *original_shape[flatten_axis:],
+                        *original_shape[1: flatten_axis],
+                    )
+                    flatten_axis = len(original_shape) - flatten_axis + 1
+                else:
+                    original_shape = (
+                        *original_shape[flatten_axis:],
+                        *original_shape[:flatten_axis],
+                    )
+                    group_axis = flatten_axis
+                    flatten_axis = len(original_shape) - flatten_axis
+
             return GroupedScaledTensor1x(
                 data=data,
                 scale_inv=scale_inv,
@@ -496,6 +493,10 @@ class ScaledTensorFactory:
                 original_shape=original_shape,
                 group_axis=group_axis,
             )
+
+        # Handling attrs of transposed tensors
+        if data_layout == "T":
+            flatten_axis = data.ndim - flatten_axis
 
         return ScaledTensor1x(
             data,

--- a/transformer_engine/jax/quantize/tensor.py
+++ b/transformer_engine/jax/quantize/tensor.py
@@ -469,7 +469,7 @@ class ScaledTensorFactory:
                     original_shape = (
                         original_shape[0],
                         *original_shape[flatten_axis:],
-                        *original_shape[1: flatten_axis],
+                        *original_shape[1:flatten_axis],
                     )
                     flatten_axis = len(original_shape) - flatten_axis + 1
                 else:


### PR DESCRIPTION
# Description

- Fixes for JIT-able grouped_gemm and grouped_quantize
- Enforcing workspace to be aligned by 256.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
