### PR TITLE
[PyTorch] Limit max time for distributed PyTorch tests

### DIFF
--- a/qa/L1_pytorch_distributed_unittest/test.sh
+++ b/qa/L1_pytorch_distributed_unittest/test.sh
@@ -23,13 +23,41 @@ mkdir -p "$XML_LOG_DIR"
 
 pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/distributed/test_numerics.py || test_fail "test_numerics.py"
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_fusible_ops.xml $TE_PATH/tests/pytorch/distributed/test_fusible_ops.py || test_fail "test_fusible_ops.py"
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_torch_fsdp2.xml $TE_PATH/tests/pytorch/distributed/test_torch_fsdp2.py || test_fail "test_torch_fsdp2.py"
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_comm_gemm_overlap.xml $TE_PATH/tests/pytorch/distributed/test_comm_gemm_overlap.py || test_fail "test_comm_gemm_overlap.py"
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_fusible_ops_with_userbuffers.xml $TE_PATH/tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py || test_fail "test_fusible_ops_with_userbuffers.py"
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_fused_attn_with_cp.xml $TE_PATH/tests/pytorch/fused_attn/test_fused_attn_with_cp.py || test_fail "test_fused_attn_with_cp.py"
-python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_cast_master_weights_to_fp8.xml $TE_PATH/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py || test_fail "test_cast_master_weights_to_fp8.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml \
+    $TE_PATH/tests/pytorch/distributed/test_numerics.py \
+  || test_fail "test_numerics.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_fusible_ops.xml \
+    $TE_PATH/tests/pytorch/distributed/test_fusible_ops.py \
+  || test_fail "test_fusible_ops.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_torch_fsdp2.xml \
+    $TE_PATH/tests/pytorch/distributed/test_torch_fsdp2.py \
+  || test_fail "test_torch_fsdp2.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_comm_gemm_overlap.xml \
+    $TE_PATH/tests/pytorch/distributed/test_comm_gemm_overlap.py \
+  || test_fail "test_comm_gemm_overlap.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_fusible_ops_with_userbuffers.xml \
+    $TE_PATH/tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py \
+  || test_fail "test_fusible_ops_with_userbuffers.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_fused_attn_with_cp.xml \
+    $TE_PATH/tests/pytorch/fused_attn/test_fused_attn_with_cp.py \
+  || test_fail "test_fused_attn_with_cp.py"
+timeout 30m \
+    python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_cast_master_weights_to_fp8.xml \
+    $TE_PATH/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py \
+  || test_fail "test_cast_master_weights_to_fp8.py"
 
 
 # debug tests
@@ -40,9 +68,19 @@ python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_cast_master_weights_
 : ${NVTE_TEST_NVINSPECT_DUMMY_CONFIG_FILE:=$TE_PATH/tests/pytorch/debug/test_configs/dummy_feature.yaml}
 : ${NVTE_TEST_NVINSPECT_FEATURE_DIRS:=$TE_PATH/transformer_engine/debug/features}
 
-pytest -v -s $TE_PATH/tests/pytorch/debug/test_distributed.py --feature_dirs=$NVTE_TEST_NVINSPECT_FEATURE_DIRS || test_fail "debug test_distributed.py"
+timeout 30m \
+    pytest -v -s \
+    $TE_PATH/tests/pytorch/debug/test_distributed.py \
+    --feature_dirs=$NVTE_TEST_NVINSPECT_FEATURE_DIRS \
+  || test_fail "debug test_distributed.py"
 # standard numerics tests with initialized debug
-NVTE_TEST_NVINSPECT_ENABLED=True NVTE_TEST_NVINSPECT_CONFIG_FILE=$NVTE_TEST_NVINSPECT_DUMMY_CONFIG_FILE NVTE_TEST_NVINSPECT_FEATURE_DIRS=$NVTE_TEST_NVINSPECT_FEATURE_DIRS pytest -v -s $TE_PATH/tests/pytorch/distributed/test_numerics.py || test_fail "debug test_numerics.py"
+NVTE_TEST_NVINSPECT_ENABLED=True \
+    NVTE_TEST_NVINSPECT_CONFIG_FILE=$NVTE_TEST_NVINSPECT_DUMMY_CONFIG_FILE \
+    NVTE_TEST_NVINSPECT_FEATURE_DIRS=$NVTE_TEST_NVINSPECT_FEATURE_DIRS \
+    timeout 30m \
+    pytest -v -s \
+    $TE_PATH/tests/pytorch/distributed/test_numerics.py \
+  || test_fail "debug test_numerics.py"
 
 if [ "$RET" -ne 0 ]; then
     echo "Error in the following test cases:$FAILED_CASES"


### PR DESCRIPTION
# Description

We have recently experienced test failures due to allocation timeouts. The main culprit is `test_fused_attn_with_cp.py`, which takes over 90 min to run on B200. This PR attempts to impose discipline by giving each distributed PyTorch test script a maximum of 30 minutes to run.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [x] Testing 

## Changes

- Limit PyTorch distributed tests to 30 min each.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes