### PR TITLE
Fix test case that assumes char is signed

### DIFF
--- a/tests/cpp/util/test_string.cpp
+++ b/tests/cpp/util/test_string.cpp
@@ -38,7 +38,7 @@ TEST(UtilTest, ToStringLike) {  // to_string_like
 
   // Non-zero integer types
   EXPECT_EQ(to_string_like(static_cast<char>(1)), "1");
-  EXPECT_EQ(to_string_like(static_cast<char>(-1)), "-1");
+  EXPECT_EQ(to_string_like(static_cast<signed char>(-1)), "-1");
   EXPECT_EQ(to_string_like(static_cast<unsigned char>(2)), "2");
   EXPECT_EQ(to_string_like(static_cast<short>(3)), "3");
   EXPECT_EQ(to_string_like(static_cast<short>(-5)), "-5");


### PR DESCRIPTION
# Description

One test case for our string utility functions assumes that `char` is signed, but ARM64 systems usually use an unsigned type. This PR explicitly specifies `signed char` for this case.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

-Fix test case that assumes `char` is signed

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
