### PR TITLE
Handle dtypes more carefully in multi-tensor Adam

### DIFF
--- a/transformer_engine/common/multi_tensor/adam.cu
+++ b/transformer_engine/common/multi_tensor/adam.cu
@@ -592,30 +592,29 @@ void multi_tensor_adam_cuda(int chunk_size, Tensor noop_flag,
              "Expected 4 or 5 tensor lists, but found ", num_tensor_lists);
   const size_t num_tensors_per_list = tensor_lists[0].size();
   for (size_t i = 1; i < num_tensor_lists; i++) {
-    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list,
-               "Tensor list ", i, " has size=", tensor_lists[i].size(),
-               ", but expected size=", num_tensors_per_list);
+    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list, "Tensor list ", i,
+               " has size=", tensor_lists[i].size(), ", but expected size=", num_tensors_per_list);
   }
 
   // Check tensor dtypes
   const auto g_in_type_te = tensor_lists[0][0]->dtype();
   const auto p_in_type_te = tensor_lists[1][0]->dtype();
   for (size_t j = 0; j < num_tensors_per_list; j++) {
-    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te,
-               "Grad tensor ", j, " has dtype=", to_string(tensor_lists[0][j]->dtype()),
+    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te, "Grad tensor ", j,
+               " has dtype=", to_string(tensor_lists[0][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[1][j]->dtype() == p_in_type_te,
-               "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
+    NVTE_CHECK(tensor_lists[1][j]->dtype() == p_in_type_te, "Param tensor ", j,
+               " has dtype=", to_string(tensor_lists[1][j]->dtype()),
                ", but expected dtype=", to_string(p_in_type_te));
-    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32,
-               "First moment tensor ", j, " has dtype=", to_string(tensor_lists[2][j]->dtype()),
+    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32, "First moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[2][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32,
-               "Second moment tensor ", j, " has dtype=", to_string(tensor_lists[3][j]->dtype()),
+    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32, "Second moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[3][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
     if (num_tensor_lists == 5) {
-      NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kFloat32,
-                 "Master param tensor ", j, " has dtype=", to_string(tensor_lists[4][j]->dtype()),
+      NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kFloat32, "Master param tensor ", j,
+                 " has dtype=", to_string(tensor_lists[4][j]->dtype()),
                  ", but expected dtype=", to_string(DType::kFloat32));
     }
   }
@@ -705,28 +704,27 @@ void multi_tensor_adam_param_remainder_cuda(int chunk_size, Tensor noop_flag,
   NVTE_CHECK(num_tensor_lists == 5, "Expected 5 tensor lists, but found ", num_tensor_lists);
   const size_t num_tensors_per_list = tensor_lists[0].size();
   for (size_t i = 1; i < num_tensor_lists; i++) {
-    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list,
-               "Tensor list ", i, " has size=", tensor_lists[i].size(),
-               ", but expected size=", num_tensors_per_list);
+    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list, "Tensor list ", i,
+               " has size=", tensor_lists[i].size(), ", but expected size=", num_tensors_per_list);
   }
 
   // Check tensor dtypes
   const auto g_in_type_te = tensor_lists[0][0]->dtype();
   for (size_t j = 0; j < num_tensors_per_list; j++) {
-    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te,
-               "Grad tensor ", j, " has dtype=", to_string(tensor_lists[0][j]->dtype()),
+    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te, "Grad tensor ", j,
+               " has dtype=", to_string(tensor_lists[0][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[1][j]->dtype() == DType::kBFloat16,
-               "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
+    NVTE_CHECK(tensor_lists[1][j]->dtype() == DType::kBFloat16, "Param tensor ", j,
+               " has dtype=", to_string(tensor_lists[1][j]->dtype()),
                ", but expected dtype=", to_string(DType::kBFloat16));
-    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32,
-               "First moment tensor ", j, " has dtype=", to_string(tensor_lists[2][j]->dtype()),
+    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32, "First moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[2][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32,
-               "Second moment tensor ", j, " has dtype=", to_string(tensor_lists[3][j]->dtype()),
+    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32, "Second moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[3][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kInt16,
-               "Param remainder tensor ", j, " has dtype=", to_string(tensor_lists[4][j]->dtype()),
+    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kInt16, "Param remainder tensor ", j,
+               " has dtype=", to_string(tensor_lists[4][j]->dtype()),
                ", but expected dtype=", to_string(DType::kInt16));
   }
 
@@ -759,38 +757,37 @@ void multi_tensor_adam_fp8_cuda(int chunk_size, Tensor noop_flag,
   NVTE_CHECK(num_tensor_lists == 8, "Expected 8 tensor lists, but found ", num_tensor_lists);
   const size_t num_tensors_per_list = tensor_lists[0].size();
   for (size_t i = 1; i < num_tensor_lists; i++) {
-    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list,
-               "Tensor list ", i, " has size=", tensor_lists[i].size(),
-               ", but expected size=", num_tensors_per_list);
+    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list, "Tensor list ", i,
+               " has size=", tensor_lists[i].size(), ", but expected size=", num_tensors_per_list);
   }
 
   // Check tensor dtypes
   const auto g_in_type_te = tensor_lists[0][0]->dtype();
   for (size_t j = 0; j < num_tensors_per_list; j++) {
-    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te,
-               "Grad tensor ", j, " has dtype=", to_string(tensor_lists[0][j]->dtype()),
+    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te, "Grad tensor ", j,
+               " has dtype=", to_string(tensor_lists[0][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[1][j]->dtype() == fp8_dtype
-               || tensor_lists[1][j]->dtype() == DType::kByte,
-               "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
-               ", but expected dtype=", to_string(fp8_dtype));
-    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32,
-               "First moment tensor ", j, " has dtype=", to_string(tensor_lists[2][j]->dtype()),
+    NVTE_CHECK(
+        tensor_lists[1][j]->dtype() == fp8_dtype || tensor_lists[1][j]->dtype() == DType::kByte,
+        "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
+        ", but expected dtype=", to_string(fp8_dtype));
+    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32, "First moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[2][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32,
-               "Second moment tensor ", j, " has dtype=", to_string(tensor_lists[3][j]->dtype()),
+    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32, "Second moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[3][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kFloat32,
-               "Master param tensor ", j, " has dtype=", to_string(tensor_lists[4][j]->dtype()),
+    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kFloat32, "Master param tensor ", j,
+               " has dtype=", to_string(tensor_lists[4][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[5][j]->dtype() == DType::kFloat32,
-               "Scale tensor ", j, " has dtype=", to_string(tensor_lists[5][j]->dtype()),
+    NVTE_CHECK(tensor_lists[5][j]->dtype() == DType::kFloat32, "Scale tensor ", j,
+               " has dtype=", to_string(tensor_lists[5][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[6][j]->dtype() == DType::kFloat32,
-               "Absmax tensor ", j, " has dtype=", to_string(tensor_lists[6][j]->dtype()),
+    NVTE_CHECK(tensor_lists[6][j]->dtype() == DType::kFloat32, "Absmax tensor ", j,
+               " has dtype=", to_string(tensor_lists[6][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[7][j]->dtype() == DType::kFloat32,
-               "Scale-inverse tensor ", j, " has dtype=", to_string(tensor_lists[7][j]->dtype()),
+    NVTE_CHECK(tensor_lists[7][j]->dtype() == DType::kFloat32, "Scale-inverse tensor ", j,
+               " has dtype=", to_string(tensor_lists[7][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
   }
 
@@ -845,25 +842,24 @@ void multi_tensor_adam_capturable_cuda(int chunk_size, Tensor noop_flag,
   NVTE_CHECK(num_tensor_lists == 4, "Expected 4 tensor lists, but found ", num_tensor_lists);
   const size_t num_tensors_per_list = tensor_lists[0].size();
   for (size_t i = 1; i < num_tensor_lists; i++) {
-    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list,
-               "Tensor list ", i, " has size=", tensor_lists[i].size(),
-               ", but expected size=", num_tensors_per_list);
+    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list, "Tensor list ", i,
+               " has size=", tensor_lists[i].size(), ", but expected size=", num_tensors_per_list);
   }
 
   // Check tensor dtypes
   const auto g_in_type_te = tensor_lists[0][0]->dtype();
   for (size_t j = 0; j < num_tensors_per_list; j++) {
-    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te,
-               "Grad tensor ", j, " has dtype=", to_string(tensor_lists[0][j]->dtype()),
+    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te, "Grad tensor ", j,
+               " has dtype=", to_string(tensor_lists[0][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[1][j]->dtype() == g_in_type_te,
-               "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
+    NVTE_CHECK(tensor_lists[1][j]->dtype() == g_in_type_te, "Param tensor ", j,
+               " has dtype=", to_string(tensor_lists[1][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32,
-               "First moment tensor ", j, " has dtype=", to_string(tensor_lists[2][j]->dtype()),
+    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32, "First moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[2][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32,
-               "Second moment tensor ", j, " has dtype=", to_string(tensor_lists[3][j]->dtype()),
+    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32, "Second moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[3][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
   }
 
@@ -892,28 +888,27 @@ void multi_tensor_adam_capturable_master_cuda(int chunk_size, Tensor noop_flag,
   NVTE_CHECK(num_tensor_lists == 5, "Expected 4 tensor lists, but found ", num_tensor_lists);
   const size_t num_tensors_per_list = tensor_lists[0].size();
   for (size_t i = 1; i < num_tensor_lists; i++) {
-    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list,
-               "Tensor list ", i, " has size=", tensor_lists[i].size(),
-               ", but expected size=", num_tensors_per_list);
+    NVTE_CHECK(tensor_lists[i].size() == num_tensors_per_list, "Tensor list ", i,
+               " has size=", tensor_lists[i].size(), ", but expected size=", num_tensors_per_list);
   }
 
   // Check tensor dtypes
   const auto g_in_type_te = tensor_lists[0][0]->dtype();
   for (size_t j = 0; j < num_tensors_per_list; j++) {
-    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te,
-               "Grad tensor ", j, " has dtype=", to_string(tensor_lists[0][j]->dtype()),
+    NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te, "Grad tensor ", j,
+               " has dtype=", to_string(tensor_lists[0][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[1][j]->dtype() == g_in_type_te,
-               "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
+    NVTE_CHECK(tensor_lists[1][j]->dtype() == g_in_type_te, "Param tensor ", j,
+               " has dtype=", to_string(tensor_lists[1][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32,
-               "First moment tensor ", j, " has dtype=", to_string(tensor_lists[2][j]->dtype()),
+    NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32, "First moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[2][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32,
-               "Second moment tensor ", j, " has dtype=", to_string(tensor_lists[3][j]->dtype()),
+    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32, "Second moment tensor ", j,
+               " has dtype=", to_string(tensor_lists[3][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kFloat32,
-               "Master param tensor ", j, " has dtype=", to_string(tensor_lists[4][j]->dtype()),
+    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kFloat32, "Master param tensor ", j,
+               " has dtype=", to_string(tensor_lists[4][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
   }
 

--- a/transformer_engine/common/multi_tensor/adam.cu
+++ b/transformer_engine/common/multi_tensor/adam.cu
@@ -725,7 +725,7 @@ void multi_tensor_adam_param_remainder_cuda(int chunk_size, Tensor noop_flag,
     NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kFloat32,
                "Second moment tensor ", j, " has dtype=", to_string(tensor_lists[3][j]->dtype()),
                ", but expected dtype=", to_string(DType::kFloat32));
-    NVTE_CHECK(tensor_lists[3][j]->dtype() == DType::kInt16,
+    NVTE_CHECK(tensor_lists[4][j]->dtype() == DType::kInt16,
                "Param remainder tensor ", j, " has dtype=", to_string(tensor_lists[4][j]->dtype()),
                ", but expected dtype=", to_string(DType::kInt16));
   }
@@ -770,7 +770,8 @@ void multi_tensor_adam_fp8_cuda(int chunk_size, Tensor noop_flag,
     NVTE_CHECK(tensor_lists[0][j]->dtype() == g_in_type_te,
                "Grad tensor ", j, " has dtype=", to_string(tensor_lists[0][j]->dtype()),
                ", but expected dtype=", to_string(g_in_type_te));
-    NVTE_CHECK(tensor_lists[1][j]->dtype() == fp8_dtype,
+    NVTE_CHECK(tensor_lists[1][j]->dtype() == fp8_dtype
+               || tensor_lists[1][j]->dtype() == DType::kByte,
                "Param tensor ", j, " has dtype=", to_string(tensor_lists[1][j]->dtype()),
                ", but expected dtype=", to_string(fp8_dtype));
     NVTE_CHECK(tensor_lists[2][j]->dtype() == DType::kFloat32,

--- a/transformer_engine/common/multi_tensor/multi_tensor_apply.cuh
+++ b/transformer_engine/common/multi_tensor/multi_tensor_apply.cuh
@@ -52,7 +52,7 @@ class OptionalCUDAGuard {
 
   ~OptionalCUDAGuard() {
     if (device_changed_) {
-      NVTE_CHECK_CUDA(cudaSetDevice(prev_device_));
+      cudaSetDevice(prev_device_);
     }
   }
 

--- a/transformer_engine/common/transformer_engine.cpp
+++ b/transformer_engine/common/transformer_engine.cpp
@@ -46,6 +46,8 @@ std::string to_string(const DType type) {
       return "Float8E8M0";
     case DType::kFloat4E2M1:
       return "Float4E2M1";
+    case DType::kInt16:
+      return "Int16";
     case DType::kInt32:
       return "Int32";
     case DType::kInt64:


### PR DESCRIPTION
# Description

One of our multi-tensor Adam kernels incorrectly downcasts an FP32 tensor to BF16 (https://github.com/NVIDIA/TransformerEngine/issues/1863). This PR fixes that bug. I've also taken the opportunity to add more safety checks.

Closes #1863.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Fix unnecessary cast in capturable Adam kernel
- Add safety checks to multi-tensor Adam functions

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
