### PR TITLE
Enable use of internal tensors in Sequential

### DIFF
--- a/tests/pytorch/distributed/test_fusible_ops.py
+++ b/tests/pytorch/distributed/test_fusible_ops.py
@@ -28,7 +28,6 @@ from transformer_engine.pytorch.tensor.float8_tensor import (
 )
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 import transformer_engine.pytorch.ops as te_ops
-from transformer_engine.pytorch.ops._common import is_float8_tensor
 from transformer_engine.pytorch.utils import is_bf16_compatible
 import transformer_engine_torch as tex
 

--- a/tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py
+++ b/tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py
@@ -21,7 +21,6 @@ import transformer_engine.pytorch as te
 import transformer_engine.pytorch.cpp_extensions as tex
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 import transformer_engine.pytorch.ops as te_ops
-from transformer_engine.pytorch.ops._common import is_float8_tensor
 from transformer_engine.pytorch.ops.fused import (
     UserbuffersBackwardLinear,
     UserbuffersForwardLinear,
@@ -32,6 +31,7 @@ from transformer_engine.pytorch.tensor.float8_tensor import (
 )
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.tensor.quantized_tensor import QuantizedTensor
+from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor
 from transformer_engine.pytorch.utils import is_bf16_compatible
 
 # Import utility functions
@@ -370,7 +370,7 @@ def _test_linear(
     if quantized_compute:
         tols = dtype_tols(
             model[0].weight._fp8_dtype
-            if is_float8_tensor(model[0].weight)
+            if isinstance(model[0].weight, Float8Tensor)
             else tex.DType.kFloat8E4M3
         )
 

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -19,7 +19,6 @@ import transformer_engine.common.recipe
 import transformer_engine.pytorch as te
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 import transformer_engine.pytorch.ops as te_ops
-from transformer_engine.pytorch.ops._common import is_float8_tensor
 from transformer_engine.pytorch.ops.fused import (
     BackwardLinearAdd,
     ForwardLinearBiasActivation,

--- a/transformer_engine/pytorch/ops/_common.py
+++ b/transformer_engine/pytorch/ops/_common.py
@@ -17,7 +17,7 @@ from ..tensor.quantized_tensor import QuantizedTensorBase
 from ..utils import canonicalize_dtype
 
 
-def is_quantized_tensor(tensor: torch.Tensor | QuantizedTensorBase):
+def is_quantized_tensor(tensor: torch.Tensor | QuantizedTensorBase) -> bool:
     """Check if tensor is a quantized tensor"""
     return isinstance(tensor, QuantizedTensorBase)
 

--- a/transformer_engine/pytorch/ops/_common.py
+++ b/transformer_engine/pytorch/ops/_common.py
@@ -5,7 +5,7 @@
 """Helper functions used in fusible operations."""
 
 from __future__ import annotations
-from typing import Any, Optional
+from typing import Optional
 
 import torch
 
@@ -17,16 +17,16 @@ from ..tensor.quantized_tensor import QuantizedTensorBase
 from ..utils import canonicalize_dtype
 
 
-def is_float8_tensor(tensor: Any) -> bool:
-    """Check if object is a `Float8Tensor`"""
-    return isinstance(tensor, Float8Tensor)
+def is_quantized_tensor(tensor: torch.Tensor | QuantizedTensorBase):
+    """Check if tensor is a quantized tensor"""
+    return isinstance(tensor, QuantizedTensorBase)
 
 
 def maybe_dequantize(
     tensor: torch.Tensor | QuantizedTensorBase, dtype: torch.dtype | None = None
 ) -> torch.Tensor:
     """Dequantize tensor to given dtype or just convert if not a quantized tensor"""
-    if isinstance(tensor, QuantizedTensorBase):
+    if is_quantized_tensor(tensor):
         return tensor.dequantize(dtype=dtype)
     if dtype is not None and tensor.dtype != dtype:
         return tensor.to(dtype)

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -111,7 +111,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
             x = input_quantizer(x)
 
         # Save state for backward pass
-        ctx.save_for_backward(x.detach())
+        ctx.save_for_backward(x)
         ctx.with_quantized_compute = with_quantized_compute
         ctx.dtype = dtype
         ctx.is_first_op = is_first_op

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -12,7 +12,7 @@ import torch
 
 import transformer_engine_torch as tex
 from ...fp8 import FP8GlobalStateManager
-from ...tensor.float8_tensor import Float8CurrentScalingQuantizer
+from ...tensor.float8_tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
 from .._common import maybe_dequantize
@@ -71,8 +71,9 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Compute dtype
@@ -88,14 +89,10 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         x = maybe_dequantize(input_.contiguous(), dtype)
 
         # Check if quantized compute is enabled
-        quantized_compute_enabled = FP8GlobalStateManager.is_fp8_enabled()
+        with_quantized_compute = FP8GlobalStateManager.is_fp8_enabled()
         quantizer = None
-        if (
-            quantized_compute_enabled
-            and next_op is not None
-            and next_op.num_quantizers("forward") > 0
-        ):
-            quantizer = next_op.get_quantizer("forward", 0)
+        if with_quantized_compute:
+            quantizer = next_op_input_quantizer
 
         # Launch kernel
         y = self._activation_forward_impl(
@@ -115,9 +112,10 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
 
         # Save state for backward pass
         ctx.save_for_backward(x.detach())
-        ctx.quantized_compute_enabled = quantized_compute_enabled
+        ctx.with_quantized_compute = with_quantized_compute
         ctx.dtype = dtype
-        ctx.prev_op = prev_op
+        ctx.is_first_op = is_first_op
+        ctx.prev_op_grad_input_quantizer = prev_op_grad_input_quantizer
 
         return y
 
@@ -138,12 +136,8 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
 
         # Check if quantized compute is enabled
         quantizer = None
-        if (
-            ctx.quantized_compute_enabled
-            and ctx.prev_op is not None
-            and ctx.prev_op.num_quantizers("backward") > 0
-        ):
-            quantizer = ctx.prev_op.get_quantizer("backward", 0)
+        if ctx.with_quantized_compute:
+            quantizer = ctx.prev_op_grad_input_quantizer
 
         # Launch kernel
         dx = self._activation_backward_impl(
@@ -157,7 +151,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
             dx = dx.view(x.size())
 
         # Clear input tensor if possible
-        if ctx.prev_op is not None:
+        if not ctx.is_first_op:
             clear_tensor_data(x)
 
         return dx, ()

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -101,7 +101,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         )
 
         # Check output tensor
-        if y.dim() != x.dim():
+        if len(y.size()) != x.dim():
             y = y.view(list(x.shape[:-1]) + [-1])
 
         # Quantize input to FP8 before caching if needed

--- a/transformer_engine/pytorch/ops/basic/add_in_place.py
+++ b/transformer_engine/pytorch/ops/basic/add_in_place.py
@@ -15,6 +15,8 @@ from transformer_engine.pytorch.ops.op import (
     OperationContext,
 )
 
+from transformer_engine.pytorch.tensor import Quantizer
+
 
 class AddInPlace(BasicOperation):
     """Add in-place
@@ -57,8 +59,9 @@ class AddInPlace(BasicOperation):
         input_: torch.Tensor,
         *,
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
-        basic_op_prev_ops: list[Optional[BasicOperation]],
-        basic_op_next_ops: list[Optional[BasicOperation]],
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         output = basic_op_extra_inputs[0][0].detach()

--- a/transformer_engine/pytorch/ops/basic/all_gather.py
+++ b/transformer_engine/pytorch/ops/basic/all_gather.py
@@ -12,6 +12,7 @@ import torch
 from ...distributed import gather_along_first_dim
 from .._common import maybe_dequantize
 from ..op import BasicOperation, OperationContext
+from ...tensor import Quantizer
 
 
 class AllGather(BasicOperation):
@@ -39,8 +40,9 @@ class AllGather(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
         out: torch.Tensor
         if self.process_group_size == 1:

--- a/transformer_engine/pytorch/ops/basic/all_reduce.py
+++ b/transformer_engine/pytorch/ops/basic/all_reduce.py
@@ -11,6 +11,7 @@ import torch
 
 from .._common import maybe_dequantize
 from ..op import BasicOperation, OperationContext
+from ...tensor import Quantizer
 
 
 class AllReduce(BasicOperation):
@@ -41,8 +42,9 @@ class AllReduce(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Trivial case

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -324,6 +324,9 @@ class BasicLinear(BasicOperation):
             input_quantizer.set_usage(rowwise=True, columnwise=weight_requires_grad)
             weight_quantizer.set_usage(rowwise=True, columnwise=is_grad_enabled)
             grad_output_quantizer.set_usage(rowwise=True, columnwise=weight_requires_grad)
+            input_quantizer.internal = True
+            weight_quantizer.internal = True
+            grad_output_quantizer.internal = True
 
             # Recipe-specific configuration
             recipe = FP8GlobalStateManager.get_fp8_recipe()
@@ -660,7 +663,7 @@ class BasicLinear(BasicOperation):
 
         # Check datatype
         if dtype is None:
-            if weight is not None:
+            if weight is not None and not is_quantized_tensor(weight):
                 dtype = weight.dtype
             else:
                 dtype = grad_output.dtype
@@ -888,7 +891,7 @@ class BasicLinear(BasicOperation):
     ) -> torch.Tensor:
 
         # Check which grads are required
-        input_requires_grad = ctx.requires_grad and input_.requires_grad
+        input_requires_grad = ctx.requires_grad
         weight_requires_grad = ctx.requires_grad and self.weight.requires_grad
 
         # FP8 metadata

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -567,10 +567,6 @@ class BasicLinear(BasicOperation):
 
         # Prepare input tensor for backward pass
         if weight_requires_grad:
-            if x_local is input:
-                # PyTorch autograd produces esoteric errors if we
-                # cache input tensor directly.
-                x_local = x_local.detach()
             if with_quantized_compute and is_quantized_tensor(x_local):
                 if not (isinstance(x_local, Float8TensorBase) and with_x_all_gather):
                     # FP8 does not support all-gather of transpose data

--- a/transformer_engine/pytorch/ops/basic/bias.py
+++ b/transformer_engine/pytorch/ops/basic/bias.py
@@ -17,6 +17,7 @@ from ...utils import (
     canonicalize_device,
     canonicalize_dtype,
 )
+from ...tensor import Quantizer
 
 
 class Bias(BasicOperation):
@@ -120,8 +121,9 @@ class Bias(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
         x = input_
         b = self.bias.view([1] * (x.dim() - 1) + [self.local_size])

--- a/transformer_engine/pytorch/ops/basic/identity.py
+++ b/transformer_engine/pytorch/ops/basic/identity.py
@@ -13,7 +13,7 @@ from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
 )
-from transformer_engine.pytorch.tensor import Quantizer
+from ...tensor import Quantizer
 
 
 class Identity(BasicOperation):

--- a/transformer_engine/pytorch/ops/basic/identity.py
+++ b/transformer_engine/pytorch/ops/basic/identity.py
@@ -13,6 +13,7 @@ from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
 )
+from transformer_engine.pytorch.tensor import Quantizer
 
 
 class Identity(BasicOperation):
@@ -22,8 +23,9 @@ class Identity(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
         return input_
 

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -19,6 +19,7 @@ from ...jit import (
     set_jit_fusion_options,
     warmup_jit_l2normalization_all_dtypes,
 )
+from ...tensor import Quantizer
 
 
 class L2Normalization(BasicOperation):
@@ -73,8 +74,9 @@ class L2Normalization(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
         # Use input directly - torch.compile can handle multi-dimensional tensors
         x = maybe_dequantize(input_)
@@ -95,7 +97,7 @@ class L2Normalization(BasicOperation):
         # Save state for backward pass
         if requires_grad:
             ctx.save_for_backward(x, rsqrt_norm)
-            ctx.has_prev_op = prev_op is not None
+            ctx.has_prev_op = not is_first_op
 
         return y
 

--- a/transformer_engine/pytorch/ops/basic/make_extra_output.py
+++ b/transformer_engine/pytorch/ops/basic/make_extra_output.py
@@ -14,6 +14,7 @@ from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
 )
+from transformer_engine.pytorch.tensor import Quantizer
 
 
 class MakeExtraOutput(BasicOperation):
@@ -58,8 +59,9 @@ class MakeExtraOutput(BasicOperation):
         input_: torch.Tensor,
         *,
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
-        basic_op_prev_ops: list[Optional[BasicOperation]],
-        basic_op_next_ops: list[Optional[BasicOperation]],
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         return input_, [(input_,)]

--- a/transformer_engine/pytorch/ops/basic/make_extra_output.py
+++ b/transformer_engine/pytorch/ops/basic/make_extra_output.py
@@ -14,7 +14,7 @@ from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
 )
-from transformer_engine.pytorch.tensor import Quantizer
+from ...tensor import Quantizer
 
 
 class MakeExtraOutput(BasicOperation):

--- a/transformer_engine/pytorch/ops/basic/quantize.py
+++ b/transformer_engine/pytorch/ops/basic/quantize.py
@@ -10,7 +10,7 @@ from typing import Optional
 import torch
 
 from ...fp8 import FP8GlobalStateManager
-from ...tensor import QuantizedTensor
+from .._common import is_quantized_tensor
 from ..op import BasicOperation, OperationContext
 
 
@@ -60,7 +60,7 @@ class Quantize(BasicOperation):
 
         # Quantize if needed
         out = input_
-        if quantize_forward and not isinstance(out, QuantizedTensor):
+        if quantize_forward and not is_quantized_tensor(out):
             out = self.get_quantizer("forward", 0)(out)
 
         ctx.quantize_backward = quantize_backward
@@ -72,6 +72,6 @@ class Quantize(BasicOperation):
         grad_output: torch.Tensor,
     ) -> tuple[torch.Tensor, tuple[()]]:
         grad_input = grad_output
-        if ctx.quantize_backward and not isinstance(grad_input, QuantizedTensor):
+        if ctx.quantize_backward and not is_quantized_tensor(grad_input):
             grad_input = self.get_quantizer("backward", 0)(grad_input)
         return grad_input, ()

--- a/transformer_engine/pytorch/ops/basic/quantize.py
+++ b/transformer_engine/pytorch/ops/basic/quantize.py
@@ -12,6 +12,7 @@ import torch
 from ...fp8 import FP8GlobalStateManager
 from .._common import is_quantized_tensor
 from ..op import BasicOperation, OperationContext
+from ...tensor import Quantizer
 
 
 class Quantize(BasicOperation):
@@ -49,8 +50,9 @@ class Quantize(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Check if FP8 is enabled

--- a/transformer_engine/pytorch/ops/basic/reduce_scatter.py
+++ b/transformer_engine/pytorch/ops/basic/reduce_scatter.py
@@ -12,6 +12,7 @@ import torch
 from ...distributed import gather_along_first_dim
 from .._common import maybe_dequantize
 from ..op import BasicOperation, OperationContext
+from ...tensor import Quantizer
 
 
 class ReduceScatter(BasicOperation):
@@ -39,8 +40,9 @@ class ReduceScatter(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Trivial case

--- a/transformer_engine/pytorch/ops/basic/reshape.py
+++ b/transformer_engine/pytorch/ops/basic/reshape.py
@@ -14,7 +14,7 @@ from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
 )
-from transformer_engine.pytorch.tensor import Quantizer
+from ...tensor import Quantizer
 
 
 class Reshape(BasicOperation):

--- a/transformer_engine/pytorch/ops/basic/reshape.py
+++ b/transformer_engine/pytorch/ops/basic/reshape.py
@@ -14,6 +14,7 @@ from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
 )
+from transformer_engine.pytorch.tensor import Quantizer
 
 
 class Reshape(BasicOperation):
@@ -37,8 +38,9 @@ class Reshape(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
         ctx.input_shape = input_.size()
         return input_.reshape(*self._shape)

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -23,6 +23,7 @@ from ...utils import (
 )
 from ..op import BasicOperation, OperationContext
 from .._common import maybe_autocast_dtype, maybe_dequantize
+from ...tensor import Quantizer
 
 
 class RMSNorm(BasicOperation):
@@ -158,8 +159,9 @@ class RMSNorm(BasicOperation):
         self,
         ctx: OperationContext,
         input_: torch.Tensor,
-        prev_op: Optional[BasicOperation] = None,
-        next_op: Optional[BasicOperation] = None,
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Check tensor dims
@@ -183,12 +185,9 @@ class RMSNorm(BasicOperation):
 
         # Check if output is quantized
         output_quantizer = None
-        if (
-            FP8GlobalStateManager.is_fp8_enabled()
-            and next_op is not None
-            and next_op.num_quantizers("forward") > 0
-        ):
-            output_quantizer = next_op.get_quantizer("forward", 0)
+        with_quantized_compute = FP8GlobalStateManager.is_fp8_enabled()
+        if with_quantized_compute:
+            output_quantizer = next_op_input_quantizer
 
         # Compute RMSNorm
         sm_margin = self._sm_margins["forward" if requires_grad else "inference"]
@@ -207,7 +206,7 @@ class RMSNorm(BasicOperation):
         if requires_grad:
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
-            ctx.has_prev_op = prev_op is not None
+            ctx.has_prev_op = not is_first_op
 
         # Reshape output tensor
         out = y.view(input_dims)

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -17,7 +17,7 @@ from transformer_engine.pytorch.ops.op import (
     FusibleOperation,
     OperationContext,
 )
-from transformer_engine.pytorch.tensor import Quantizer
+from ...tensor import Quantizer
 
 
 class ForwardLinearBiasActivation(FusedOperation):

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -13,11 +13,11 @@ import torch
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 from transformer_engine.pytorch.ops.basic import BasicLinear, Bias
 from transformer_engine.pytorch.ops.op import (
-    BasicOperation,
     FusedOperation,
     FusibleOperation,
     OperationContext,
 )
+from transformer_engine.pytorch.tensor import Quantizer
 
 
 class ForwardLinearBiasActivation(FusedOperation):
@@ -59,8 +59,9 @@ class ForwardLinearBiasActivation(FusedOperation):
         input_: torch.Tensor,
         *,
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
-        basic_op_prev_ops: list[Optional[BasicOperation]],
-        basic_op_next_ops: list[Optional[BasicOperation]],
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
 
@@ -96,13 +97,9 @@ class ForwardLinearBiasActivation(FusedOperation):
         if with_quantized_compute:
             input_quantizer = linear_op.get_quantizer("forward", 0)
             weight_quantizer = linear_op.get_quantizer("forward", 1)
-            next_op = basic_op_next_ops[-1]
-            if next_op is not None and next_op.num_quantizers("forward") > 0:
-                output_quantizer = next_op.get_quantizer("forward", 0)
+            output_quantizer = next_op_input_quantizer
             grad_output_quantizer = linear_op.get_quantizer("backward", 0)
-            prev_op = basic_op_prev_ops[0]
-            if prev_op is not None and prev_op.num_quantizers("backward") > 0:
-                grad_input_quantizer = prev_op.get_quantizer("backward", 0)
+            grad_input_quantizer = prev_op_grad_input_quantizer
 
         # Get autocast dtype if needed
         dtype = None
@@ -136,7 +133,7 @@ class ForwardLinearBiasActivation(FusedOperation):
         linear_op_ctx.dtype = dtype
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
-        linear_op_ctx.has_prev_op = basic_op_prev_ops[0] is not None
+        linear_op_ctx.has_prev_op = not is_first_op
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -84,7 +84,7 @@ class ForwardLinearBiasActivation(FusedOperation):
             raise NotImplementedError("Activations are not yet supported")
 
         # Check which grads are required
-        input_requires_grad = linear_op_ctx.requires_grad and input_.requires_grad
+        input_requires_grad = linear_op_ctx.requires_grad
         weight_requires_grad = linear_op_ctx.requires_grad and linear_op.weight.requires_grad
 
         # FP8 metadata

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -78,7 +78,7 @@ class ForwardLinearBiasAdd(FusedOperation):
                 raise ValueError("Bias operation forward does not expect keyword arguments")
 
         # Check which grads are required
-        input_requires_grad = linear_op_ctx.requires_grad and input_.requires_grad
+        input_requires_grad = linear_op_ctx.requires_grad
         weight_requires_grad = linear_op_ctx.requires_grad and linear_op.weight.requires_grad
 
         # FP8 metadata

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -13,11 +13,11 @@ import torch
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 from transformer_engine.pytorch.ops.basic import AddInPlace, BasicLinear, Bias
 from transformer_engine.pytorch.ops.op import (
-    BasicOperation,
     FusedOperation,
     FusibleOperation,
     OperationContext,
 )
+from transformer_engine.pytorch.tensor import Quantizer
 
 
 class ForwardLinearBiasAdd(FusedOperation):
@@ -57,8 +57,9 @@ class ForwardLinearBiasAdd(FusedOperation):
         input_: torch.Tensor,
         *,
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
-        basic_op_prev_ops: list[Optional[BasicOperation]],
-        basic_op_next_ops: list[Optional[BasicOperation]],
+        prev_op_grad_input_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
 
@@ -91,9 +92,7 @@ class ForwardLinearBiasAdd(FusedOperation):
             input_quantizer = linear_op.get_quantizer("forward", 0)
             weight_quantizer = linear_op.get_quantizer("forward", 1)
             grad_output_quantizer = linear_op.get_quantizer("backward", 0)
-            prev_op = basic_op_prev_ops[0]
-            if prev_op is not None and prev_op.num_quantizers("backward") > 0:
-                grad_input_quantizer = prev_op.get_quantizer("backward", 0)
+            grad_input_quantizer = prev_op_grad_input_quantizer
 
         # Get autocast dtype if needed
         dtype = None
@@ -129,7 +128,7 @@ class ForwardLinearBiasAdd(FusedOperation):
         linear_op_ctx.dtype = dtype
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
-        linear_op_ctx.has_prev_op = basic_op_prev_ops[0] is not None
+        linear_op_ctx.has_prev_op = not is_first_op
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -272,10 +272,6 @@ class UserbuffersForwardLinear(FusedOperation):
 
         # Prepare input tensor for backward pass
         if weight_requires_grad:
-            if x_local is input:
-                # PyTorch autograd produces esoteric errors if we
-                # cache input tensor directly.
-                x_local = x_local.detach()
             if with_quantized_compute and is_quantized_tensor(x_local):
                 if not (isinstance(x_local, Float8TensorBase) and with_ub_all_gather):
                     # FP8 does not support all-gather of transpose data

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -309,7 +309,7 @@ class UserbuffersForwardLinear(FusedOperation):
                 raise ValueError("Bias operation forward does not expect keyword arguments")
 
         # Check which grads are required
-        input_requires_grad = linear_op_ctx.requires_grad and input_.requires_grad
+        input_requires_grad = linear_op_ctx.requires_grad
         weight_requires_grad = linear_op_ctx.requires_grad and linear_op.weight.requires_grad
 
         # Quantization metadata

--- a/transformer_engine/pytorch/tensor/_internal/float8_tensor_base.py
+++ b/transformer_engine/pytorch/tensor/_internal/float8_tensor_base.py
@@ -143,6 +143,19 @@ class Float8TensorBase(QuantizedTensorBase):
         size = self._transpose.size(*args, **kwargs)
         return torch.Size([size[-1], math.prod(size[:-1])])
 
+    def view(self, shape: torch.Size):
+        # pylint: disable=missing-function-docstring
+        data = self._data
+        if data is not None:
+            return Float8TensorBase(
+                data=data.view(shape),
+                fp8_scale_inv=self._scale_inv,
+                fp8_dtype=self._fp8_dtype,
+                data_transpose=None,
+                quantizer=self._quantizer,
+            )
+        raise RuntimeError("No data available to view")
+
     def __repr__(self):
         return (
             "Float8TensorBase("


### PR DESCRIPTION
# Description

Enable use of internal tensors (ex. `Float8TensorBase`) instead of regular quantized tensor (ex. `Float8Tensor`) in `te.Sequential`. Essentially, this removes calls to `Float8Tensor.__new__` and to `detach` (see visual comparison of forward pass below).

Expected performance gain: E2E FP8 GPT encoder Transformer layer implemented using Sequential: +15% over `main`.

## Visual comparison

![image](https://github.com/user-attachments/assets/e7add595-2b0e-4f5c-8b5e-590d17ac86e6)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

1. (39ea63da05c23565201e2270626afbcc8672155a) Replace free function `is_float8_tensor` with `is_quantized_tensor` in `_common.py` and use it throughout the `ops` codebase to check if a tensor is a (possibly internal) quantized tensor
2. (9e5acd94af7ceaa3a94598474bbebac162b5dcdd) Change interface of `fuser_forward` and `op_forward` to no longer take preceding and following ops and instead take the following op's input quantizer and preceding op's input gradient's quantizer directly
3. (c226033f5c292ee07b952716e40f8148eefe7736) Remove use of `detach` on input tensors saved for backward (enabled by not passing `prev_op` to backward)
4. (69e8cd564b8fbd403c03d414f337e29b5c70d99b) Handle saving internal tensors in `_OperationFuserAutogradFunction` using `prepare_for_saving` and `restore_from_saved`
5. (563d8b9cced7ab19ffe4f2be3e29325d67e046e3) Enable use of internal tensors in `BasicLinear` quantizers and fix issues resulting from internal tensors not having methods that regular tensors have

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance data

Below is reported the running time of a GPT encoder transformer layer (averaged over 10k runs) using [my benchmark script](https://github.com/janekb04/transformer-engine-benchmark-sequential). Here, Fused refers to an implementation using the fused modules `LayerNormLinear` and `LayerNormMLP`, Sequential refers to an implementation implementing those two modules with `te.ops.Sequential`, and Builtin refers to using `te.TransformerLayer`.

### B100 results

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|cc0cb35d4cb516669e1f166add37ccdc30f71488|1.60ms|1.90ms|1.55ms|2.39ms|2.21ms|2.61ms|
|39ea63da05c23565201e2270626afbcc8672155a|1.60ms|1.90ms|1.55ms|2.39ms|2.21ms|2.60ms|
|9e5acd94af7ceaa3a94598474bbebac162b5dcdd|1.62ms|1.92ms|1.56ms|2.39ms|2.21ms|2.60ms|
|c226033f5c292ee07b952716e40f8148eefe7736|1.57ms|1.89ms|1.54ms|2.34ms|2.22ms|2.58ms|
|69e8cd564b8fbd403c03d414f337e29b5c70d99b|1.58ms|1.92ms|1.55ms|2.36ms|2.22ms|2.59ms|
|563d8b9cced7ab19ffe4f2be3e29325d67e046e3|1.58ms|1.93ms|1.55ms|2.05ms|2.22ms|2.61ms|

### H100 results

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|cc0cb35d4cb516669e1f166add37ccdc30f71488|1.99ms|2.56ms|2.08ms|3.33ms|2.83ms|3.42ms|
|39ea63da05c23565201e2270626afbcc8672155a|2.02ms|2.61ms|2.09ms|3.35ms|2.78ms|3.40ms|
|9e5acd94af7ceaa3a94598474bbebac162b5dcdd|2.11ms|2.67ms|2.11ms|3.33ms|2.79ms|3.31ms|
|c226033f5c292ee07b952716e40f8148eefe7736|2.07ms|2.64ms|2.09ms|3.27ms|2.80ms|3.41ms|
|69e8cd564b8fbd403c03d414f337e29b5c70d99b|2.10ms|2.65ms|2.10ms|3.27ms|2.81ms|3.41ms|
|563d8b9cced7ab19ffe4f2be3e29325d67e046e3|2.09ms|2.64ms|2.09ms|2.85ms|2.83ms|3.41ms|