### PR TITLE
[JAX] Update distributed LayerNormMLP test tolerance for L40

### DIFF
--- a/tests/jax/test_distributed_layernorm_mlp.py
+++ b/tests/jax/test_distributed_layernorm_mlp.py
@@ -33,6 +33,7 @@ from transformer_engine.jax.sharding import (
 )
 from transformer_engine.jax.sharding import MeshResource
 from transformer_engine.jax.quantize import QuantizerFactory
+from transformer_engine.jax.cpp_extensions.misc import get_min_device_compute_capability
 
 
 is_fp8_supported, reason = is_fp8_available()
@@ -333,7 +334,21 @@ class TestDistributedLayernormMLP:
         # Make sure params values are the same
         assert_tree_like_allclose(params_sharded["params"], params_single["params"])
         assert_allclose(ln_out_sharded, ln_out_single, dtype=dtype)
-        assert_allclose(mlp_out_sharded, mlp_out_single, dtype=dtype)
+
+        atol = None
+        rtol = None
+        l40_tolerance_update = (
+            get_min_device_compute_capability() == 89
+            and fp8_recipe == recipe.DelayedScaling()
+            and use_fp8
+            and dtype == jnp.float16
+            and activation_type == ("gelu",)
+        )
+        if l40_tolerance_update:
+            atol = 0.04
+            rtol = 11
+
+        assert_allclose(mlp_out_sharded, mlp_out_single, dtype=dtype, atol=atol, rtol=rtol)
 
     @pytest_parametrize_wrapper("input_shape", INPUT_SHAPE)
     @pytest_parametrize_wrapper("mesh_config", generate_fsdp_and_tp_configs())


### PR DESCRIPTION
# Description

Fixes a failure in TE/JAX tests on dual L40s that is new in v2.5 and not occurring in v2.4. The summary is that we were incorrectly running a FP16 gemm in these tests in v2.4 due to failed pattern matching, but now are correctly running an FP8 gemm in v2.5, leading to a test tolerance issue.

Tested in the v2.5 container on L40Sx2 and the tests now pass with the tolerance update.

Tracking down the issue to our GEMM calls:
* In the 2.4 container, TE 2.5 still fails with the same issues indicating it was a TE change that affected this issue.
* Disabling all TE custom kernels with NVTE_JAX_CUSTOM_CALLS_RE="", the same tests still fail. This means it's likely not a TE kernel or custom call issue
* Disabling the FP8 gemm in LayerNormMLP, the tests now pass.
* Got cublas log from v2.4 TE and v2.5 TE, both in the v2.4 container. TE v2.4 doesn't actually trigger FP8 gemms due to failed XLA pattern matching. That was fixed in this [PR ](https://github.com/NVIDIA/TransformerEngine/pull/1819)which was in v2.5, as we switched to direct quant instead of pattern matching 

Since we were incorrectly running a higher-precision gemm here in v2.4, I think it is okay to update to test tolerances as we're now running an FP8 gemm as intended in v2.5

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Update test tolerance for specific test configuration on L40Sx2

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
