### PR TITLE
[PyTorch Debug] Support log fp8 tensor stats for blockwise recipe

### DIFF
--- a/transformer_engine/debug/features/log_fp8_tensor_stats.py
+++ b/transformer_engine/debug/features/log_fp8_tensor_stats.py
@@ -15,8 +15,10 @@ from nvdlfw_inspect.registry import Registry, api_method
 from transformer_engine.debug.features.utils.stats_buffer import STATS_BUFFERS
 from transformer_engine.pytorch.tensor import QuantizedTensor
 from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor
+from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockwiseQTensor
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor
 from transformer_engine.pytorch.tensor._internal.float8_tensor_base import Float8TensorBase
+from transformer_engine.pytorch.tensor._internal.float8_blockwise_tensor_base import Float8BlockwiseQTensorBase
 from transformer_engine.pytorch.tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
 from transformer_engine.debug.pytorch.debug_state import TEDebugState
 
@@ -110,7 +112,7 @@ class LogFp8TensorStats(BaseLogTensorStats):
         API call used to collect the data about the tensor after process_tensor()/quantization.
         """
 
-        assert type(tensor) in [Float8Tensor, Float8TensorBase, MXFP8Tensor, MXFP8TensorBase], (
+        assert type(tensor) in [Float8Tensor, Float8TensorBase, MXFP8Tensor, MXFP8TensorBase, Float8BlockwiseQTensor, Float8BlockwiseQTensorBase], (
             f"[NVTORCH INSPECT ERROR] Tensor {tensor_name} must be a quantized tensor when using"
             " log_fp8_tensor_stats. Use log_tensor_stats for high precision tensors."
         )

--- a/transformer_engine/debug/features/log_fp8_tensor_stats.py
+++ b/transformer_engine/debug/features/log_fp8_tensor_stats.py
@@ -18,7 +18,9 @@ from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor
 from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockwiseQTensor
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Tensor
 from transformer_engine.pytorch.tensor._internal.float8_tensor_base import Float8TensorBase
-from transformer_engine.pytorch.tensor._internal.float8_blockwise_tensor_base import Float8BlockwiseQTensorBase
+from transformer_engine.pytorch.tensor._internal.float8_blockwise_tensor_base import (
+    Float8BlockwiseQTensorBase,
+)
 from transformer_engine.pytorch.tensor._internal.mxfp8_tensor_base import MXFP8TensorBase
 from transformer_engine.debug.pytorch.debug_state import TEDebugState
 
@@ -112,7 +114,14 @@ class LogFp8TensorStats(BaseLogTensorStats):
         API call used to collect the data about the tensor after process_tensor()/quantization.
         """
 
-        assert type(tensor) in [Float8Tensor, Float8TensorBase, MXFP8Tensor, MXFP8TensorBase, Float8BlockwiseQTensor, Float8BlockwiseQTensorBase], (
+        assert type(tensor) in [
+            Float8Tensor,
+            Float8TensorBase,
+            MXFP8Tensor,
+            MXFP8TensorBase,
+            Float8BlockwiseQTensor,
+            Float8BlockwiseQTensorBase,
+        ], (
             f"[NVTORCH INSPECT ERROR] Tensor {tensor_name} must be a quantized tensor when using"
             " log_fp8_tensor_stats. Use log_tensor_stats for high precision tensors."
         )


### PR DESCRIPTION
Support log fp8 tensor stats for fp8 blockwise recipe.
```
fp8_recipe: 'blockwise'
```

# Description
When enable fp8 underflow logging for blockwise recipe, it report the following exception:
```
[rank2]:   File "/TransformerEngine/transformer_engine/pytorch/module/layernorm_linear.py", line 283, in forward
[rank2]:     weightmat = module.get_weight_workspace(
[rank2]:   File "/TransformerEngine/transformer_engine/pytorch/module/base.py", line 1263, in get_weight_workspace
[rank2]:     out = quantizer.quantize(tensor, dtype=workspace_dtype)
[rank2]:   File "/TransformerEngine/transformer_engine/debug/pytorch/debug_quantization.py", line 332, in quantize
[rank2]:     self._call_inspect_tensor_api(tensor, rowwise_gemm_tensor, columnwise_gemm_tensor)
[rank2]:   File "/TransformerEngine/transformer_engine/debug/pytorch/debug_quantization.py", line 247, in _call_inspect_tensor_api
[rank2]:     debug_api.transformer_engine.inspect_tensor_postquantize(**args)
[rank2]:   File "nvidia-dlfw-inspect/nvdlfw_inspect/base.py", line 257, in route_api
[rank2]:     ret = getattr(self.namespace_features[feat_name], api_name)(
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/debug/features/log_fp8_tensor_stats.py", line 113, in inspect_tensor_postquantize
[rank2]:     assert type(tensor) in [Float8Tensor, Float8TensorBase, MXFP8Tensor, MXFP8TensorBase], (
[rank2]: AssertionError: [NVTORCH INSPECT ERROR] Tensor weight must be a quantized tensor when using log_fp8_tensor_stats. Use log_tensor_stats for high precision tensors.
```
Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)
Import the necessary Blockwise Tensor and Base.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
