### PR TITLE
[Common] Optimize KV cache related kernels

### DIFF
--- a/transformer_engine/common/fused_attn/kv_cache.cu
+++ b/transformer_engine/common/fused_attn/kv_cache.cu
@@ -27,7 +27,8 @@ __global__ void reindex_kv_cache_kernel(dtype *k_cache, dtype *v_cache, int *bat
   bool flag = (batch_indices[0] != 0);
   for (int batch_idx = 0; batch_idx < actual_b; batch_idx++) {
     if (flag || ((batch_indices[batch_idx] - batch_indices[0]) != batch_idx)) {
-      int num_tokens = (cu_cached_lens[batch_idx + 1] - cu_cached_lens[batch_idx]) - (cu_new_lens[batch_idx + 1] - cu_new_lens[batch_idx]);
+      int num_tokens = (cu_cached_lens[batch_idx + 1] - cu_cached_lens[batch_idx]) -
+                       (cu_new_lens[batch_idx + 1] - cu_new_lens[batch_idx]);
       int num_elts_k = h_kv * d_k;
       int num_elts_v = h_kv * d_v;
       int num_elts = max(num_elts_k, num_elts_v);
@@ -73,15 +74,17 @@ __global__ void copy_to_kv_cache_kernel(dtype *new_k, dtype *new_v, dtype *k_cac
         int page_idx = is_non_paged ? batch_idx : page_list[(cached_len - new_len + i) / page_size];
         dtype *new_token_id_k = new_k + (batch_idx * max_ctx_len + i) * num_elts_k;
         dtype *new_token_id_v = new_v + (batch_idx * max_ctx_len + i) * num_elts_v;
-        dtype *token_id_k = k_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_k;
-        dtype *token_id_v = v_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_v;
-        for (int j = threadIdx.x; j < hd; j+=blockDim.x) {
+        dtype *token_id_k =
+            k_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_k;
+        dtype *token_id_v =
+            v_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_v;
+        for (int j = threadIdx.x; j < hd; j += blockDim.x) {
           if (j < num_elts_k) {
             *(token_id_k + j) = *(new_token_id_k + j);
-	  }
+          }
           if (j < num_elts_v) {
             *(token_id_v + j) = *(new_token_id_v + j);
-	  }
+          }
         }
       }
     }
@@ -97,13 +100,15 @@ __global__ void copy_to_kv_cache_kernel(dtype *new_k, dtype *new_v, dtype *k_cac
         int page_idx = is_non_paged ? batch_idx : page_list[(cached_len - new_len + i) / page_size];
         dtype *new_token_id_k = new_k + (i * b + batch_idx) * num_elts_k;
         dtype *new_token_id_v = new_v + (i * b + batch_idx) * num_elts_v;
-        dtype *token_id_k = k_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_k;
-        dtype *token_id_v = v_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_v;
-        for (int j = threadIdx.x; j < hd; j+=blockDim.x) {
-	  if (j < num_elts_k) {
+        dtype *token_id_k =
+            k_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_k;
+        dtype *token_id_v =
+            v_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_v;
+        for (int j = threadIdx.x; j < hd; j += blockDim.x) {
+          if (j < num_elts_k) {
             *(token_id_k + j) = *(new_token_id_k + j);
           }
-	  if (j < num_elts_v) {
+          if (j < num_elts_v) {
             *(token_id_v + j) = *(new_token_id_v + j);
           }
         }
@@ -121,15 +126,17 @@ __global__ void copy_to_kv_cache_kernel(dtype *new_k, dtype *new_v, dtype *k_cac
         int page_idx = is_non_paged ? batch_idx : page_list[(cached_len - new_len + i) / page_size];
         dtype *new_token_id_k = new_k + (cu_new_lens[batch_idx] + i) * num_elts_k;
         dtype *new_token_id_v = new_v + (cu_new_lens[batch_idx] + i) * num_elts_v;
-        dtype *token_id_k = k_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_k;
-        dtype *token_id_v = v_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_v;
-        for (int j = threadIdx.x; j < hd; j+=blockDim.x) {
-	  if (j < num_elts_k) {
+        dtype *token_id_k =
+            k_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_k;
+        dtype *token_id_v =
+            v_cache + (page_idx * page_size + (cached_len - new_len + i) % page_size) * num_elts_v;
+        for (int j = threadIdx.x; j < hd; j += blockDim.x) {
+          if (j < num_elts_k) {
             *(token_id_k + j) = *(new_token_id_k + j);
-	  }
-	  if (j < num_elts_v) {
+          }
+          if (j < num_elts_v) {
             *(token_id_v + j) = *(new_token_id_v + j);
-	  }
+          }
         }
       }
     }

--- a/transformer_engine/pytorch/attention/inference.py
+++ b/transformer_engine/pytorch/attention/inference.py
@@ -421,7 +421,7 @@ class NonPagedKVCacheManager(KVCacheManager):
             device=torch.cuda.current_device(),
         )
         # whether reindexing is needed, i.e. when batch seq_ids have changed
-        self.need_reindex = False
+        self.need_reindex = True
 
     def allocate_memory(self, layer_number):
         """Allocate memory for the cache"""
@@ -453,7 +453,7 @@ class NonPagedKVCacheManager(KVCacheManager):
         # step() re-indexes k_cache and v_cache using batch_indices = [0, 2, 3, 1] so that
         # they are contiguous and match the indexing in q
         prev_batch_size = len(self.sequences)
-        prev_seq_ids = self.sequences.keys()
+        prev_seq_ids = set(self.sequences.keys())
         unfinished_seqs = self.sequences.keys() & step_dict.keys()
         finished_seqs = self.sequences.keys() - unfinished_seqs
         unfinished_indices = [i for i, j in enumerate(self.sequences) if j in unfinished_seqs]
@@ -482,7 +482,7 @@ class NonPagedKVCacheManager(KVCacheManager):
             self.sequences[i] = step_dict[i]
 
         # Whether reindexing is needed
-        self.need_reindex = self.sequences.keys() != prev_seq_ids
+        self.need_reindex = set(self.sequences.keys()) != prev_seq_ids
 
         return self.sequences
 

--- a/transformer_engine/pytorch/attention/inference.py
+++ b/transformer_engine/pytorch/attention/inference.py
@@ -482,7 +482,7 @@ class NonPagedKVCacheManager(KVCacheManager):
             self.sequences[i] = step_dict[i]
 
         # Whether reindexing is needed
-        self.need_reindex = self.sequences.keys() != pre_seq_ids
+        self.need_reindex = self.sequences.keys() != prev_seq_ids
 
         return self.sequences
 


### PR DESCRIPTION
# Description

This PR improves the runtime performance of the `reindex_kv_cache` and `copy_to_kv_cache` kernels, by remapping CUDA blocks/threads to different `b`, `s`, `hxd` dimensions, parallelizing one loop that was previously serial, and skipping reindexing if there are no new sequences added to the batch.

Example problem size: b=64, max_s=1024, current_s=128, new_s=8, h=12, d=256, on Hopper
Before: reindex: 4.8ms, copy: 1.3ms
After: reindex: 46us, copy: 13us

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Optimize reindex and copy kernels in KV caching

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
