### PR TITLE
[JAX] Resolve test conflict in JAX helper tests

### DIFF
--- a/tests/jax/test_helper.py
+++ b/tests/jax/test_helper.py
@@ -92,7 +92,7 @@ class TestFP8Functions(unittest.TestCase):
         self._check_default_state()
 
     @unittest.skipIf(not is_mxfp8_supported, reason=mxfp8_reason)
-    def test_fp8_autocast_mxfp8_scaling(self):
+    def test_fp8_autocast_mxfp8_current_scaling(self):
         QuantizeConfig.finalize()  # Ensure the testing not affect by previous tests.
         self._check_default_state()
 
@@ -116,7 +116,7 @@ class TestFP8Functions(unittest.TestCase):
         self._check_default_state()
 
     @unittest.skipIf(not is_mxfp8_supported, reason=mxfp8_reason)
-    def test_fp8_autocast_mxfp8_scaling(self):
+    def test_fp8_autocast_mxfp8_block_scaling(self):
         QuantizeConfig.finalize()  # Ensure the testing not affect by previous tests.
         self._check_default_state()
 

--- a/tests/jax/test_helper.py
+++ b/tests/jax/test_helper.py
@@ -92,7 +92,7 @@ class TestFP8Functions(unittest.TestCase):
         self._check_default_state()
 
     @unittest.skipIf(not is_mxfp8_supported, reason=mxfp8_reason)
-    def test_fp8_autocast_mxfp8_current_scaling(self):
+    def test_fp8_autocast_current_scaling(self):
         QuantizeConfig.finalize()  # Ensure the testing not affect by previous tests.
         self._check_default_state()
 


### PR DESCRIPTION
# Description
This small PR resolves a test method name conflict by renaming duplicated `test_fp8_autocast_mxfp8_scaling` methods to distinct names: `test_fp8_autocast_mxfp8_current_scaling` for `Float8CurrentScaling` tests and `test_fp8_autocast_mxfp8_block_scaling` for `MXFP8BlockScaling` tests.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
- Resolve test conflict in JAX helper tests

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
