### PR TITLE
Call `pre_(first_)forward` only when global state changes

### DIFF
--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -593,7 +593,7 @@ def save_fp8_tensors(
                     m.adjust_amax_history_length(fp8_recipe.amax_history_len)
                 module_tensors = m.get_fp8_meta_tensors()
             elif isinstance(m, BasicOperation):
-                m.pre_forward(fp8_enabled=True, fp8_recipe=fp8_recipe)
+                m.pre_first_forward(recipe=fp8_recipe)
                 module_tensors = m._save_fp8_metas()
             fp8_tensors.append(module_tensors)
     return fp8_tensors

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -19,7 +19,7 @@ from ...distributed import (
     gather_along_first_dim,
     reduce_scatter_along_first_dim,
 )
-from ...fp8 import FP8GlobalStateManager
+from ...fp8 import FP8GlobalStateManager, Recipe
 from ...module.base import _2X_ACC_FPROP, _2X_ACC_DGRAD, _2X_ACC_WGRAD
 from ...tensor import Quantizer
 from ...tensor.float8_tensor import Float8Quantizer, Float8CurrentScalingQuantizer
@@ -303,8 +303,12 @@ class BasicLinear(BasicOperation):
             weight = torch.nn.Parameter(weight)
         self.weight = weight
 
-    def pre_forward(self, *args, **kwargs) -> None:
-        super().pre_forward(*args, **kwargs)
+    def pre_first_forward(
+        self,
+        *,
+        recipe: Optional[Recipe],
+    ) -> None:
+        super().pre_first_forward(recipe=recipe)
 
         # Initialize weights if needed
         weight = self.weight
@@ -313,23 +317,17 @@ class BasicLinear(BasicOperation):
             weight = self.weight
 
         # Configure quantizers
-        if FP8GlobalStateManager.is_fp8_enabled():
+        if recipe is not None:
             input_quantizer = self.get_quantizer("forward", 0)
             weight_quantizer = self.get_quantizer("forward", 1)
             grad_output_quantizer = self.get_quantizer("backward", 0)
 
             # Specify required tensor formats
-            is_grad_enabled = torch.is_grad_enabled()
-            weight_requires_grad = is_grad_enabled and weight.requires_grad
-            input_quantizer.set_usage(rowwise=True, columnwise=weight_requires_grad)
-            weight_quantizer.set_usage(rowwise=True, columnwise=is_grad_enabled)
-            grad_output_quantizer.set_usage(rowwise=True, columnwise=weight_requires_grad)
             input_quantizer.internal = True
             weight_quantizer.internal = True
             grad_output_quantizer.internal = True
 
             # Recipe-specific configuration
-            recipe = FP8GlobalStateManager.get_fp8_recipe()
             if recipe.float8_current_scaling():
                 if any(
                     not isinstance(q, Float8CurrentScalingQuantizer)

--- a/transformer_engine/pytorch/ops/basic/bias.py
+++ b/transformer_engine/pytorch/ops/basic/bias.py
@@ -112,8 +112,8 @@ class Bias(BasicOperation):
             bias = torch.nn.Parameter(bias)
         self.bias = bias
 
-    def pre_forward(self, *args, **kwargs) -> None:
-        super().pre_forward(*args, **kwargs)
+    def pre_first_forward(self, *args, **kwargs) -> None:
+        super().pre_first_forward(*args, **kwargs)
         if self.bias.device.type == "meta":
             self.reset_parameters()
 

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -167,8 +167,8 @@ class LayerNorm(BasicOperation):
         self.weight = weight
         self.bias = bias
 
-    def pre_forward(self, *args, **kwargs) -> None:
-        super().pre_forward(*args, **kwargs)
+    def pre_first_forward(self, *args, **kwargs) -> None:
+        super().pre_first_forward(*args, **kwargs)
         if self.weight.device.type == "meta" or self.bias.device.type == "meta":
             self.reset_parameters()
 

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -150,8 +150,8 @@ class RMSNorm(BasicOperation):
             weight = torch.nn.Parameter(weight)
         self.weight = weight
 
-    def pre_forward(self, *args, **kwargs) -> None:
-        super().pre_forward(*args, **kwargs)
+    def pre_first_forward(self, *args, **kwargs) -> None:
+        super().pre_first_forward(*args, **kwargs)
         if self.weight.device.type == "meta":
             self.reset_parameters()
 

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -344,6 +344,9 @@ class OperationFuser:
         self._forward_ops = [(op, (idx,)) for idx, op in enumerate(self._basic_ops)]
         self._backward_ops = list(reversed(self._forward_ops))
 
+        # Flag for checking if this is the first iteration
+        self._is_first_forward = True
+
         # Fuse ops if needed
         if fuse_ops:
             self.fuse_ops()
@@ -391,8 +394,11 @@ class OperationFuser:
             )
 
         # Initialization before forward pass
-        for op in self._basic_ops:
-            op.pre_forward()
+        if self._is_first_forward:
+            recipe = FP8GlobalStateManager.get_fp8_recipe()
+            for op in self._basic_ops:
+                op.pre_first_forward(recipe=recipe)
+            self._is_first_forward = False
 
         # Canonicalize op kwargs
         if basic_op_kwargs is None:

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -395,7 +395,8 @@ class OperationFuser:
 
         # Initialization before forward pass
         if self._is_first_forward:
-            recipe = FP8GlobalStateManager.get_fp8_recipe()
+            with_quantized_compute = FP8GlobalStateManager.is_fp8_enabled()
+            recipe = FP8GlobalStateManager.get_fp8_recipe() if with_quantized_compute else None
             for op in self._basic_ops:
                 op.pre_first_forward(recipe=recipe)
             self._is_first_forward = False

--- a/transformer_engine/pytorch/ops/sequential.py
+++ b/transformer_engine/pytorch/ops/sequential.py
@@ -191,7 +191,7 @@ class Sequential(torch.nn.Module):
 
         # Get current global state
         fp8_enabled = FP8GlobalStateManager.is_fp8_enabled()
-        fp8_recipe = FP8GlobalStateManager.get_fp8_recipe()
+        fp8_recipe = FP8GlobalStateManager.get_fp8_recipe() if fp8_enabled else None
         global_state = (fp8_enabled, type(fp8_recipe))
 
         # Reset module groups is global state changed

--- a/transformer_engine/pytorch/ops/sequential.py
+++ b/transformer_engine/pytorch/ops/sequential.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import torch
 
+from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 from transformer_engine.pytorch.ops.op import FusibleOperation
 from transformer_engine.pytorch.ops.fuser import OperationFuser
 
@@ -36,6 +37,9 @@ class Sequential(torch.nn.Module):
         # List of modules, with fusible operations grouped together
         self._module_groups: Optional[list[OperationFuser | torch.nn.Module]]
         self._module_groups = None
+
+        # Global state of last iteration
+        self._last_global_state = None
 
         # Add modules
         if len(args) == 1 and isinstance(args[0], dict):
@@ -184,6 +188,16 @@ class Sequential(torch.nn.Module):
         *extra_inputs: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
         """Forward pass"""
+
+        # Get current global state
+        fp8_enabled = FP8GlobalStateManager.is_fp8_enabled()
+        fp8_recipe = FP8GlobalStateManager.get_fp8_recipe()
+        global_state = (fp8_enabled, type(fp8_recipe))
+
+        # Reset module groups is global state changed
+        if self._last_global_state != global_state:
+            self._module_groups = None
+            self._last_global_state = global_state
 
         # Create module groups if needed
         if self._module_groups is None:


### PR DESCRIPTION
# Description

Change `FusibleOperation.pre_forward` to `FusibleOperation.pre_first_forward` and call it only before the first forward iteration using a given recipe type in `OperationFuser.__call__`. Additionally, reset fusions on recipe type change to enable recipe-dependent fusions and retrigger a call to `pre_first_forward`. See removed calls in the visual comparison of forward pass below.

Resultant performance gain in benchmark scenario: +4% for FP8 Sequential.

## Visual comparison

![image](https://github.com/user-attachments/assets/b1184452-126d-49a5-a3f0-f8dd4ceead0a)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Rename `FusibleOperation.pre_forward` to `FusibleOperation.pre_first_forward`
- Call `pre_first_forward` only before the first forward in `OperationFuser` instead of calling it every iteration
- Pass `recipe: Optional[Recipe]` as argument to `pre_first_forward` instead of access via `FP8GlobalStateManager`
- Remove redundant `set_usage` calls in `BasicLinear.pre_first_forward`
- Cache `is_fp8_enabled` and `type(fp8_recipe)` in `Sequential` and reset `_module_groups` on change

## Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance data

Below is reported the running time of a GPT encoder transformer layer (averaged over 10k runs) using [my benchmark script](https://github.com/janekb04/transformer-engine-benchmark-sequential). Here, Fused refers to an implementation using the fused modules `LayerNormLinear` and `LayerNormMLP`, Sequential refers to an implementation implementing those two modules with `te.ops.Sequential`, and Builtin refers to using `te.TransformerLayer`.

### B100 results

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|6f4310d700f7445fd12d524c645b1e72fb8886f7|1.57ms|1.89ms|1.56ms|2.07ms|2.25ms|2.64ms|
|8bcdb796f2624aed331b167d53fb56e85d1f3478|1.60ms|1.92ms|1.53ms|1.99ms|2.24ms|2.64ms|

### H100 results

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|6f4310d700f7445fd12d524c645b1e72fb8886f7|1.16ms|1.54ms|1.08ms|1.70ms|1.85ms|2.37ms|
|8bcdb796f2624aed331b167d53fb56e85d1f3478|1.15ms|1.53ms|1.06ms|1.61ms|1.84ms|2.35ms|