### PR TITLE
[PyTorch] Fix setting `align_size` when FP8 is not initialized

### DIFF
--- a/transformer_engine/pytorch/module/fp8_padding.py
+++ b/transformer_engine/pytorch/module/fp8_padding.py
@@ -89,10 +89,7 @@ class Fp8Padding(torch.nn.Module):
         super().__init__()
 
         self.num_gemms = num_gemms
-        if align_size is None:
-            self.align_size = 32 if FP8GlobalStateManager.get_fp8_recipe().mxfp8() else 16
-        else:
-            self.align_size = align_size
+        self.align_size = align_size
 
     @no_torch_dynamo()
     def forward(
@@ -112,6 +109,8 @@ class Fp8Padding(torch.nn.Module):
         """
 
         assert len(m_splits) == self.num_gemms, "Number of splits should match number of GEMMs."
+        if self.align_size is None:
+            self.align_size = 32 if FP8GlobalStateManager.get_fp8_recipe().mxfp8() else 16
 
         # FP8 padding calculate
         padded_m_splits = [

--- a/transformer_engine/pytorch/module/fp8_padding.py
+++ b/transformer_engine/pytorch/module/fp8_padding.py
@@ -74,11 +74,12 @@ class Fp8Padding(torch.nn.Module):
 
     Parameters
     ----------
-    num_gemms: int
-               number of GEMMs to be performed simutaneously.
-    align_size: int, optional
-                the alignment size for the input tensor. If not provided, the alignment size  will
-                be determined by the FP8 recipe, 32 for MXFP8 and 16 for others.
+    num_gemms : int
+                number of GEMMs to be performed simultaneously.
+    align_size : int, optional
+                 the alignment size for the input tensor. If not provided, the alignment size will
+                 be determined by the FP8 recipe (32 for MXFP8 and 16 for others) in the first
+                 forward pass.
     """
 
     def __init__(

--- a/transformer_engine/pytorch/module/fp8_unpadding.py
+++ b/transformer_engine/pytorch/module/fp8_unpadding.py
@@ -72,11 +72,12 @@ class Fp8Unpadding(torch.nn.Module):
 
     Parameters
     ----------
-    num_gemms: int
-               number of GEMMs to be performed simutaneously.
-    align_size: int, optional
-                the alignment size for the input tensor. If not provided, the alignment size  will
-                be determined by the FP8 recipe, 32 for MXFP8 and 16 for others.
+    num_gemms : int
+                number of GEMMs to be performed simultaneously.
+    align_size : int, optional
+                 the alignment size for the input tensor. If not provided, the alignment size will
+                 be determined by the FP8 recipe (32 for MXFP8 and 16 for others) in the first
+                 forward pass.
     """
 
     def __init__(

--- a/transformer_engine/pytorch/module/fp8_unpadding.py
+++ b/transformer_engine/pytorch/module/fp8_unpadding.py
@@ -87,10 +87,7 @@ class Fp8Unpadding(torch.nn.Module):
         super().__init__()
 
         self.num_gemms = num_gemms
-        if align_size is None:
-            self.align_size = 32 if FP8GlobalStateManager.get_fp8_recipe().mxfp8() else 16
-        else:
-            self.align_size = align_size
+        self.align_size = align_size
 
     @no_torch_dynamo()
     def forward(
@@ -110,6 +107,8 @@ class Fp8Unpadding(torch.nn.Module):
         """
 
         assert len(m_splits) == self.num_gemms, "Number of splits should match number of GEMMs."
+        if self.align_size is None:
+            self.align_size = 32 if FP8GlobalStateManager.get_fp8_recipe().mxfp8() else 16
 
         # FP8 padding calculate
         padded_m_splits = [


### PR DESCRIPTION
# Description

The `Fp8Padding`/`Fp8Unpadding` module could be initialized before FP8 is initialized, so `FP8GlobalStateManager.get_fp8_recipe()` would just return the default fp8 recipe instead of the real one.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
