### PR TITLE
[BUILD] Exclude ninja from required packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ System Requirements
   * Compiler: GCC 9+ or Clang 10+ with C++17 support
   * Python: 3.12 recommended
 
-* **Source Build Requirements:** CMake 3.18+, Ninja, Git 2.17+, pybind11 2.6.0+
+* **Source Build Requirements:** CMake 3.18+, Git 2.17+, pybind11 2.6.0+
 
 * **Notes:** FP8 features require Compute Capability 8.9+ (Ada/Hopper/Blackwell)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # See LICENSE for license information.
 
 [build-system]
-requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "ninja", "pip", "torch>=2.1", "jax[cuda12]", "flax>=0.7.1"]
+requires = ["setuptools>=61.0", "cmake>=3.21", "wheel", "pybind11[global]", "pip", "torch>=2.1", "jax[cuda12]", "flax>=0.7.1"]
 
 # Use legacy backend to import local packages in setup.py
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
# Description

JAX images do not come with `ninja` by default; hence, one should not enforce ninja as a required package.
Enforcing ninja as a required package causes build failures when ninja is absent.
In fact, when `ninja` is absent, our `build_ext.py` could fall back to use `MakeFile`. 

This PR removes `ninja` from the required package list in `pyproject.toml`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
