### PR TITLE
[JAX BUILD] Fixes for JAX 0.7.0

### DIFF
--- a/build_tools/jax.py
+++ b/build_tools/jax.py
@@ -29,6 +29,7 @@ def xla_path() -> str:
 
     try:
         import jax
+
         if version.parse(jax.__version__) >= version.parse("0.5.0"):
             from jax import ffi  # pylint: disable=ungrouped-imports
         else:


### PR DESCRIPTION
# Description

`jax.extend.ffi` is deprecated in JAX 0.7.0, so it breaks the JAX build.
This PR replaces `jax.extend.ffi` with `jax.ffi` in `build_tools/jax.py`

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
