### PR TITLE
[JAX] Capped HuggingFace datasets version for TE/JAX encoder examples

### DIFF
--- a/examples/jax/encoder/requirements.txt
+++ b/examples/jax/encoder/requirements.txt
@@ -1,4 +1,4 @@
-datasets
+datasets<4.0.0
 flax>=0.7.1
 nltk>=3.8.2
 optax

--- a/examples/jax/mnist/requirements.txt
+++ b/examples/jax/mnist/requirements.txt
@@ -1,4 +1,4 @@
-datasets
+datasets<4.0.0
 flax>=0.7.1
 optax
 Pillow


### PR DESCRIPTION
# Description

HuggingFace datasets version 4.0 update broke the encoder examples. Capping version to keep using previous 3.6 instead.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
