### PR TITLE
Fixed cpu overhead when doing DS cast

### DIFF
--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -193,7 +193,7 @@ def _cast_master_weights_to_fp8_delayed_scaling(params, group, use_fsdp_shard_mo
         quantizer.update_quantized(master_weight.view(1, -1), shard_model_weight_fp8)
 
     if len(amaxes) > 0:
-        dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device=amaxes[0].device)
+        dummy_overflow_buf = torch.zeros(1, dtype=torch.int, device=amaxes[0].device)
 
         # Reduce amaxes.
         packed_amaxes = torch.empty(len(amaxes), dtype=torch.float32, device=amaxes[0].device)


### PR DESCRIPTION
Using torch.tensor([0]) induces a pageable memory copy from host to device causing a lot of CPU syncs. 

So changing it to torch.zeros to improve perf. 