### PR TITLE
Add backward fusions of dbias+quantize and dbias+dactivation+quantize to `te.Sequential`

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -1894,10 +1894,8 @@ class TestFusedOps:
         # Random data
         x_ref, x_test = make_reference_and_test_tensors(
             in_shape,
-            quantization=quantization,
             test_dtype=dtype,
             test_device=device,
-            test_is_quantized=with_quantization,
         )
         b_ref, b_test = make_reference_and_test_tensors(
             hidden_size,
@@ -1906,10 +1904,8 @@ class TestFusedOps:
         )
         dy_ref, dy_test = make_reference_and_test_tensors(
             in_shape,
-            quantization=quantization,
             test_dtype=dtype,
             test_device=device,
-            test_is_quantized=with_quantization,
             requires_grad=False,
         )
 

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -20,6 +20,7 @@ import transformer_engine.pytorch as te
 from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
 import transformer_engine.pytorch.ops as te_ops
 from transformer_engine.pytorch.ops.fused import (
+    BackwardBiasActivation,
     BackwardLinearAdd,
     ForwardLinearBiasActivation,
     ForwardLinearBiasAdd,
@@ -1864,6 +1865,102 @@ class TestFusedOps:
         if bias:
             db_test = model[0].bias.grad.to(dtype=torch.float64, device="cpu")
             torch.testing.assert_close(db_test, b_ref.grad, **tols)
+
+    @pytest.mark.parametrize("activation", ("relu", "gelu"))
+    @pytest.mark.parametrize("out_shape", ((32, 32), (32, 1, 32), (8, 2, 2, 32)))
+    @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("quantization", _quantization_list)
+    def test_backward_bias_activation(
+        self,
+        *,
+        activation: str,
+        out_shape: Iterable[int],
+        dtype: torch.dtype,
+        device: torch.device = "cuda",
+        quantization: Optional[str],
+    ) -> None:
+        """Backward dbias + dact + quantize"""
+
+        # Tensor dimensions
+        in_shape = list(out_shape)
+        hidden_size = in_shape[-1]
+
+        # Skip invalid configurations
+        with_quantization = quantization is not None
+        maybe_skip_quantization(quantization, device=device)
+        if quantization == "mxfp8" and (len(in_shape) < 2 or in_shape[-1] % 32 != 0):
+            pytest.skip("Unsupported tensor size for MXFP8")
+
+        # Random data
+        x_ref, x_test = make_reference_and_test_tensors(
+            in_shape,
+            quantization=quantization,
+            test_dtype=dtype,
+            test_device=device,
+            test_is_quantized=with_quantization,
+        )
+        b_ref, b_test = make_reference_and_test_tensors(
+            hidden_size,
+            test_dtype=dtype,
+            test_device=device,
+        )
+        dy_ref, dy_test = make_reference_and_test_tensors(
+            in_shape,
+            quantization=quantization,
+            test_dtype=dtype,
+            test_device=device,
+            test_is_quantized=with_quantization,
+            requires_grad=False,
+        )
+
+        # Plain PyTorch implementation
+        y_ref = x_ref + b_ref.reshape([1] * (len(in_shape) - 1) + [hidden_size])
+        if activation == "gelu":
+            y_ref = torch.nn.functional.gelu(y_ref, approximate="tanh")
+        elif activation == "relu":
+            y_ref = torch.nn.functional.relu(y_ref)
+        else:
+            raise ValueError(f"Unexpected activation function ({activation})")
+        y_ref.backward(dy_ref)
+
+        # Implementation with fusible operations
+        recipe = make_recipe(quantization)
+        act_type = te_ops.GELU if activation == "gelu" else te_ops.ReLU
+        model = te_ops.Sequential(
+            te_ops.Quantize(forward=False, backward=True),
+            te_ops.Bias(hidden_size, device=device, dtype=dtype),
+            act_type(),
+        )
+        with torch.no_grad():
+            model[1].bias.copy_(b_test)
+            del b_test
+        with te.fp8_autocast(enabled=with_quantization, fp8_recipe=recipe):
+            y_test = model(x_test)
+        y_test.backward(dy_test)
+
+        # Check that backward operations have been fused
+        backward_ops = model._module_groups[0]._backward_ops
+        if with_quantization and quantization in ["fp8_delayed_scaling", "mxfp8"]:
+            assert len(backward_ops) == 2
+            assert isinstance(backward_ops[0][0], BackwardBiasActivation)
+            assert isinstance(backward_ops[1][0], te_ops.Quantize)
+        else:
+            assert len(backward_ops) == 3
+            assert isinstance(backward_ops[0][0], act_type)
+            assert isinstance(backward_ops[1][0], te_ops.Bias)
+            assert isinstance(backward_ops[2][0], te_ops.Quantize)
+
+        # Expected numerical error
+        tols = dtype_tols(dtype)
+        if with_quantization:
+            tols = dtype_tols(tex.DType.kFloat8E4M3)
+
+        y_test = y_test.to(dtype=torch.float64, device="cpu")
+        dx_test = x_test.grad.to(dtype=torch.float64, device="cpu")
+        db_test = model[1].bias.grad.to(dtype=torch.float64, device="cpu")
+        torch.testing.assert_close(y_test, y_ref, **tols)
+        torch.testing.assert_close(dx_test, x_ref.grad, **tols)
+        torch.testing.assert_close(db_test, b_ref.grad, **tols)
 
     @pytest.mark.parametrize("dtype", _dtypes)
     @pytest.mark.parametrize("quantization", _quantization_list)

--- a/transformer_engine/common/util/cast_gated_kernels.cuh
+++ b/transformer_engine/common/util/cast_gated_kernels.cuh
@@ -926,8 +926,8 @@ void cast_gated(const Tensor &input, Tensor *output, cudaStream_t stream) {
              "Wrong output shape. Expected (after flattening) [", input.flat_first_dim(),
              ", *], got [", output->flat_first_dim(), ", ", output->flat_last_dim(), "].");
   NVTE_CHECK(input.flat_last_dim() % 2 == 0,
-             "Wrong input shape. Expected (after flattening) last dimension to be even, ",
-             "got [", input.flat_first_dim(), ", ", input.flat_last_dim(), "]."); 
+             "Wrong input shape. Expected (after flattening) last dimension to be even, ", "got [",
+             input.flat_first_dim(), ", ", input.flat_last_dim(), "].");
   NVTE_CHECK(output->flat_last_dim() == input.flat_last_dim() / 2,
              "Wrong output shape. Expected (after flattening) [*, ", input.flat_last_dim() / 2,
              "], got [", output->flat_first_dim(), ", ", output->flat_last_dim(), "].");

--- a/transformer_engine/common/util/cast_gated_kernels.cuh
+++ b/transformer_engine/common/util/cast_gated_kernels.cuh
@@ -922,17 +922,20 @@ template <typename ParamOP, float (*ActOP)(float, const ParamOP &)>
 void cast_gated(const Tensor &input, Tensor *output, cudaStream_t stream) {
   CheckInputTensor(input, "gated_act_input");
   CheckOutputTensor(*output, "gated_act_output");
-  NVTE_CHECK(input.data.shape.size() == 2, "Input must have 2 dimensions.");
-  NVTE_CHECK(output->data.shape.size() == 2, "Output must have 2 dimensions.");
-  NVTE_CHECK(input.data.shape[0] == output->data.shape[0],
-             "Input shape[0] must be equal to output shape[0].");
-  NVTE_CHECK(input.data.shape[1] == output->data.shape[1] * 2,
-             "Input shape[1] must be 2x larger than output shape[1].");
+  NVTE_CHECK(output->flat_first_dim() == input.flat_first_dim(),
+             "Wrong output shape. Expected (after flattening) [", input.flat_first_dim(),
+             ", *], got [", output->flat_first_dim(), ", ", output->flat_last_dim(), "].");
+  NVTE_CHECK(input.flat_last_dim() % 2 == 0,
+             "Wrong input shape. Expected (after flattening) last dimension to be even, ",
+             "got [", input.flat_first_dim(), ", ", input.flat_last_dim(), "]."); 
+  NVTE_CHECK(output->flat_last_dim() == input.flat_last_dim() / 2,
+             "Wrong output shape. Expected (after flattening) [*, ", input.flat_last_dim() / 2,
+             "], got [", output->flat_first_dim(), ", ", output->flat_last_dim(), "].");
 
   TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
-      input.data.dtype, IType,
+      input.dtype(), IType,
       TRANSFORMER_ENGINE_TYPE_SWITCH_OUTPUT(
-          output->data.dtype, OType,
+          output->dtype(), OType,
 
           if (!is_fp8_dtype(output->data.dtype) ||
               is_delayed_tensor_scaling(output->scaling_mode)) {
@@ -942,8 +945,8 @@ void cast_gated(const Tensor &input, Tensor *output, cudaStream_t stream) {
                 reinterpret_cast<OType *>(output->data.dptr),
                 reinterpret_cast<const fp32 *>(output->scale.dptr),
                 reinterpret_cast<fp32 *>(output->amax.dptr),
-                reinterpret_cast<fp32 *>(output->scale_inv.dptr), output->data.shape[0],
-                output->data.shape[1], {}, stream);
+                reinterpret_cast<fp32 *>(output->scale_inv.dptr), input.flat_first_dim(),
+                output->flat_last_dim(), {}, stream);
           } else {
             NVTE_ERROR("Not implemented scaling mode: " + to_string(output->scaling_mode) + ".");
           });  // NOLINT(*)

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -85,16 +85,16 @@ __all__ = ["LayerNormMLP"]
 
 def _get_act_func_supported_list(recipe: Optional[Recipe] = None):
     if recipe is None:
-        # bf16 (recipe is None): [tex.dbias_dgelu, tex.dbias_drelu, tex.dbias_dqgelu, tex.dbias_dsrelu]
+        # bf16 (recipe is None):
         return {
-            "gelu": (tex.gelu, tex.dgelu, tex.dbias_dgelu),
-            "relu": (tex.relu, tex.drelu, tex.dbias_drelu),
+            "gelu": (tex.gelu, tex.dgelu, None),
+            "relu": (tex.relu, tex.drelu, None),
             "geglu": (tex.geglu, tex.dgeglu, None),
             "reglu": (tex.reglu, tex.dreglu, None),
             "swiglu": (tex.swiglu, tex.dswiglu, None),
-            "qgelu": (tex.qgelu, tex.dqgelu, tex.dbias_dqgelu),
+            "qgelu": (tex.qgelu, tex.dqgelu, None),
             "qgeglu": (tex.qgeglu, tex.dqgeglu, None),
-            "srelu": (tex.srelu, tex.dsrelu, tex.dbias_dsrelu),
+            "srelu": (tex.srelu, tex.dsrelu, None),
         }
     if recipe.delayed() or recipe.mxfp8():
         # Delayed scaling, fusion supported list: [tex.dbias_dgelu, tex.dbias_drelu, tex.dbias_dqgelu, tex.dbias_dsrelu]

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -73,7 +73,6 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Compute dtype
@@ -114,7 +113,6 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         ctx.save_for_backward(x)
         ctx.with_quantized_compute = with_quantized_compute
         ctx.dtype = dtype
-        ctx.is_first_op = is_first_op
         ctx.prev_op_grad_input_quantizer = prev_op_grad_input_quantizer
 
         return y
@@ -151,8 +149,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
             dx = dx.view(x.size())
 
         # Clear input tensor if possible
-        if not ctx.is_first_op:
-            clear_tensor_data(x)
+        clear_tensor_data(x)
 
         return dx, ()
 

--- a/transformer_engine/pytorch/ops/basic/add_in_place.py
+++ b/transformer_engine/pytorch/ops/basic/add_in_place.py
@@ -78,4 +78,4 @@ class AddInPlace(BasicOperation):
         Iterable[Iterable[Optional[torch.Tensor]]],
         Iterable[Iterable[Optional[torch.Tensor]]],
     ]:
-        return grad_output, [], [(grad_output,)]
+        return grad_output, [()], [(grad_output,)]

--- a/transformer_engine/pytorch/ops/basic/add_in_place.py
+++ b/transformer_engine/pytorch/ops/basic/add_in_place.py
@@ -61,7 +61,6 @@ class AddInPlace(BasicOperation):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         output = basic_op_extra_inputs[0][0].detach()

--- a/transformer_engine/pytorch/ops/basic/all_gather.py
+++ b/transformer_engine/pytorch/ops/basic/all_gather.py
@@ -42,7 +42,6 @@ class AllGather(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
         out: torch.Tensor
         if self.process_group_size == 1:

--- a/transformer_engine/pytorch/ops/basic/all_reduce.py
+++ b/transformer_engine/pytorch/ops/basic/all_reduce.py
@@ -44,7 +44,6 @@ class AllReduce(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Trivial case

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -890,7 +890,6 @@ class BasicLinear(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Check which grads are required
@@ -950,7 +949,6 @@ class BasicLinear(BasicOperation):
         ctx.dtype = dtype
         ctx.input_requires_grad = input_requires_grad
         ctx.weight_requires_grad = weight_requires_grad
-        ctx.has_prev_op = not is_first_op
 
         return output
 
@@ -1001,8 +999,7 @@ class BasicLinear(BasicOperation):
         )
 
         # Clear input tensor if possible
-        if ctx.has_prev_op:
-            clear_tensor_data(x_local)
+        clear_tensor_data(x_local)
 
         if accumulate_into_main_grad:
             grad_weight = None

--- a/transformer_engine/pytorch/ops/basic/bias.py
+++ b/transformer_engine/pytorch/ops/basic/bias.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import torch
 
+import transformer_engine_torch as tex
 from transformer_engine.pytorch.ops.op import (
     BasicOperation,
     OperationContext,
@@ -17,6 +18,7 @@ from ...utils import (
     canonicalize_device,
     canonicalize_dtype,
 )
+from ...fp8 import FP8GlobalStateManager
 from ...tensor import Quantizer
 
 
@@ -126,6 +128,20 @@ class Bias(BasicOperation):
     ) -> torch.Tensor:
         x = input_
         b = self.bias.view([1] * (x.dim() - 1) + [self.local_size])
+
+        # Check if backward pass is needed
+        requires_grad = ctx.requires_grad
+
+        # Check if output is quantized
+        grad_output_quantizer = None
+        with_quantized_compute = FP8GlobalStateManager.is_fp8_enabled()
+        if with_quantized_compute:
+            grad_output_quantizer = prev_op_grad_input_quantizer
+
+        if requires_grad:
+            ctx.with_quantized_compute = with_quantized_compute
+            ctx.grad_output_quantizer = grad_output_quantizer
+
         return x + b
 
     def op_backward(
@@ -135,7 +151,11 @@ class Bias(BasicOperation):
     ) -> tuple[torch.Tensor, tuple[()]]:
         dy = grad_output
         if dy.dim() > 1:
-            db = dy.sum(tuple(range(dy.dim() - 1)))
+            quantizer = ctx.grad_output_quantizer
+            if ctx.with_quantized_compute and quantizer is not None:
+                db, dy = tex.bgrad_quantize(dy, quantizer)
+            else:
+                db = dy.sum(tuple(range(dy.dim() - 1)))
         else:
             db = dy
         return dy, (db,)

--- a/transformer_engine/pytorch/ops/basic/bias.py
+++ b/transformer_engine/pytorch/ops/basic/bias.py
@@ -123,7 +123,6 @@ class Bias(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
         x = input_
         b = self.bias.view([1] * (x.dim() - 1) + [self.local_size])

--- a/transformer_engine/pytorch/ops/basic/identity.py
+++ b/transformer_engine/pytorch/ops/basic/identity.py
@@ -25,7 +25,6 @@ class Identity(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
         return input_
 

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -76,7 +76,6 @@ class L2Normalization(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
         # Use input directly - torch.compile can handle multi-dimensional tensors
         x = maybe_dequantize(input_)
@@ -97,7 +96,6 @@ class L2Normalization(BasicOperation):
         # Save state for backward pass
         if requires_grad:
             ctx.save_for_backward(x, rsqrt_norm)
-            ctx.has_prev_op = not is_first_op
 
         return y
 
@@ -116,8 +114,7 @@ class L2Normalization(BasicOperation):
         dx = l2normalization_backward_fused(dy, x, rsqrt_norm, self.eps)
 
         # Clear saved tensors if possible
-        if ctx.has_prev_op:
-            clear_tensor_data(x)
+        clear_tensor_data(x)
         clear_tensor_data(rsqrt_norm)
 
         # No parameters, so empty tuple for param grads

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -178,7 +178,6 @@ class LayerNorm(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Check tensor dims
@@ -225,7 +224,6 @@ class LayerNorm(BasicOperation):
         if requires_grad:
             ctx.save_for_backward(x, means, rstdevs)
             ctx.dtype = dtype
-            ctx.has_prev_op = not is_first_op
 
         # Reshape output tensor
         out = y.view(input_dims)
@@ -261,8 +259,7 @@ class LayerNorm(BasicOperation):
         )
 
         # Clear saved tensors if possible
-        if ctx.has_prev_op:
-            clear_tensor_data(x)
+        clear_tensor_data(x)
         clear_tensor_data(means)
         clear_tensor_data(rstdevs)
 

--- a/transformer_engine/pytorch/ops/basic/make_extra_output.py
+++ b/transformer_engine/pytorch/ops/basic/make_extra_output.py
@@ -78,4 +78,4 @@ class MakeExtraOutput(BasicOperation):
     ]:
         grad_input = basic_op_grad_extra_outputs[0][0]
         grad_input += grad_output
-        return grad_input, [], [()]
+        return grad_input, [()], [()]

--- a/transformer_engine/pytorch/ops/basic/make_extra_output.py
+++ b/transformer_engine/pytorch/ops/basic/make_extra_output.py
@@ -61,7 +61,6 @@ class MakeExtraOutput(BasicOperation):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         return input_, [(input_,)]

--- a/transformer_engine/pytorch/ops/basic/quantize.py
+++ b/transformer_engine/pytorch/ops/basic/quantize.py
@@ -52,7 +52,6 @@ class Quantize(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Check if FP8 is enabled

--- a/transformer_engine/pytorch/ops/basic/reduce_scatter.py
+++ b/transformer_engine/pytorch/ops/basic/reduce_scatter.py
@@ -42,7 +42,6 @@ class ReduceScatter(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Trivial case

--- a/transformer_engine/pytorch/ops/basic/reshape.py
+++ b/transformer_engine/pytorch/ops/basic/reshape.py
@@ -40,7 +40,6 @@ class Reshape(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
         ctx.input_shape = input_.size()
         return input_.reshape(*self._shape)

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -161,7 +161,6 @@ class RMSNorm(BasicOperation):
         input_: torch.Tensor,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
     ) -> torch.Tensor:
 
         # Check tensor dims
@@ -206,7 +205,6 @@ class RMSNorm(BasicOperation):
         if requires_grad:
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
-            ctx.has_prev_op = not is_first_op
 
         # Reshape output tensor
         out = y.view(input_dims)
@@ -241,8 +239,7 @@ class RMSNorm(BasicOperation):
         )
 
         # Clear saved tensors if possible
-        if ctx.has_prev_op:
-            clear_tensor_data(x)
+        clear_tensor_data(x)
         clear_tensor_data(rstdevs)
 
         # Reshape results

--- a/transformer_engine/pytorch/ops/fused/__init__.py
+++ b/transformer_engine/pytorch/ops/fused/__init__.py
@@ -4,6 +4,10 @@
 
 """Compound tensor operation supported by the operation fuser."""
 
+from .backward_bias_activation import (
+    BackwardBiasActivation,
+    fuse_backward_bias_activation,
+)
 from .backward_linear_add import (
     BackwardLinearAdd,
     fuse_backward_linear_add,

--- a/transformer_engine/pytorch/ops/fused/backward_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/backward_bias_activation.py
@@ -71,15 +71,14 @@ class BackwardBiasActivation(FusedOperation):
                 "BackwardBiasActivation requires quantized compute, "
                 "but Bias context has it disabled"
             )
-        quantizer = bias_op_ctx.grad_output_quantizer
+        quantizer = bias_op_ctx.grad_input_quantizer
         if quantizer is None:
             raise RuntimeError(
-                "BackwardBiasActivation requires previous op's grad input quantizer, "
+                "BackwardBiasActivation requires previous op's grad output quantizer, "
                 "but Bias context has no quantizer"
             )
 
         # Launch kernel
-        # Note: input doesn't need view as gated activation fusions are not currently supported
         db, dx = self._fused_function(dy, act_input, quantizer)
 
         # Clear activation input tensor

--- a/transformer_engine/pytorch/ops/fused/backward_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/backward_bias_activation.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Fused backward dbias + dact + quantize."""
+
+from __future__ import annotations
+from typing import Optional
+
+import torch
+
+import transformer_engine_torch as tex
+from transformer_engine.pytorch.fp8 import Recipe
+from transformer_engine.pytorch.ops.basic import Bias
+from transformer_engine.pytorch.ops.basic.activation import (
+    _ActivationOperation,
+    GELU,
+    ReLU,
+)
+from transformer_engine.pytorch.ops.op import (
+    FusedOperation,
+    FusibleOperation,
+    OperationContext,
+)
+from ...utils import clear_tensor_data
+from .._common import maybe_dequantize
+
+_fused_activations = {GELU: tex.dbias_dgelu, ReLU: tex.dbias_drelu}
+_fusible_activations = tuple(_fused_activations.keys())
+
+
+class BackwardBiasActivation(FusedOperation):
+    """Fused backward dbias + dact + quantize
+
+    Uses the next operation's input quantizer.
+
+    """
+
+    def __init__(self, *, bias: Bias, activation: _ActivationOperation):
+        super().__init__((bias, activation))
+        self._fused_function = _fused_activations[type(activation)]
+
+    def fuser_backward(
+        self,
+        basic_op_ctxs: list[OperationContext],
+        grad_output: torch.Tensor,
+        *,
+        basic_op_grad_extra_outputs: list[tuple[torch.Tensor, ...]],
+    ) -> tuple[
+        torch.Tensor,
+        list[tuple[Optional[torch.Tensor], ...]],
+        list[tuple[()]],
+    ]:
+
+        # Get basic operation contexts
+        activation_op_ctx = basic_op_ctxs[0]
+        bias_op_ctx = basic_op_ctxs[1]
+
+        # Saved tensors from forward pass
+        (act_input,) = activation_op_ctx.saved_tensors
+
+        # Check activation input tensor
+        act_input = maybe_dequantize(act_input.contiguous(), activation_op_ctx.dtype)
+
+        # Check grad output tensor
+        dy = maybe_dequantize(grad_output.contiguous(), act_input.dtype)
+
+        # Get previous op quantizer
+        if not bias_op_ctx.with_quantized_compute:
+            raise RuntimeError(
+                "BackwardBiasActivation requires quantized compute, "
+                "but Bias context has it disabled"
+            )
+        quantizer = bias_op_ctx.grad_output_quantizer
+        if quantizer is None:
+            raise RuntimeError(
+                "BackwardBiasActivation requires previous op's grad input quantizer, "
+                "but Bias context has no quantizer"
+            )
+
+        # Launch kernel
+        # Note: input doesn't need view as gated activation fusions are not currently supported
+        db, dx = self._fused_function(dy, act_input, quantizer)
+
+        # Clear activation input tensor
+        clear_tensor_data(act_input)
+
+        return dx, [(), (db,)], [(), ()]
+
+
+def fuse_backward_bias_activation(
+    ops: list[tuple[FusibleOperation, list[int]]],
+    recipe: Optional[Recipe],
+) -> list[tuple[FusibleOperation, list[int]]]:
+    """Fused backward dbias + dact + quantize
+
+    Parameters
+    ----------
+    ops: list of tuples
+        Backward pass operations and the indices of the corresponding
+        basic operations.
+    recipe: Recipe, optional
+        Used quantization recipe
+
+    Returns
+    -------
+    ops: list of tuples
+        Updated backward pass operations
+
+    """
+
+    # Check if recipe supports bias activation fusion
+    if recipe is None or not (recipe.delayed() or recipe.mxfp8()):
+        return ops
+
+    # Scan through ops, fusing if possible
+    out = []
+    window = []
+    while len(ops) >= 3:
+        out.extend(window)
+
+        # Check if first op is a supported activation
+        window, ops = ops[:1], ops[1:]
+        op, _ = window[0]
+        if not isinstance(op, _fusible_activations):
+            continue
+
+        # Check if second op is bias
+        op, _ = ops[0]
+        if not isinstance(op, Bias):
+            continue
+
+        # Check if third op has a grad input quantizer
+        op, _ = ops[1]
+        if not op.num_quantizers("backward") > 0:
+            continue
+
+        window.extend(ops[:1])
+        ops = ops[1:]
+
+        # Replace window with fused op
+        op = BackwardBiasActivation(
+            activation=window[0][0],
+            bias=window[1][0],
+        )
+        basic_op_idxs = [basic_op_idxs[0] for _, basic_op_idxs in window]
+        window = [(op, basic_op_idxs)]
+
+    # Return list of ops
+    out.extend(window)
+    out.extend(ops)
+    return out

--- a/transformer_engine/pytorch/ops/fused/backward_linear_add.py
+++ b/transformer_engine/pytorch/ops/fused/backward_linear_add.py
@@ -109,13 +109,13 @@ def fuse_backward_linear_add(
     Parameters
     ----------
     ops: list of tuples
-        Forward pass operations and the indices of the corresponding
+        Backward pass operations and the indices of the corresponding
         basic operations.
 
     Returns
     -------
     ops: list of tuples
-        Updated forward pass operations
+        Updated backward pass operations
 
     """
 

--- a/transformer_engine/pytorch/ops/fused/backward_linear_add.py
+++ b/transformer_engine/pytorch/ops/fused/backward_linear_add.py
@@ -96,8 +96,7 @@ class BackwardLinearAdd(FusedOperation):
             grad_weight = None
 
         # Clear input tensor if possible
-        if linear_op_ctx.has_prev_op:
-            clear_tensor_data(x_local)
+        clear_tensor_data(x_local)
 
         return grad_input, [(grad_weight,), ()], [(), ()]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -61,7 +61,6 @@ class ForwardLinearBiasActivation(FusedOperation):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
 
@@ -133,7 +132,6 @@ class ForwardLinearBiasActivation(FusedOperation):
         linear_op_ctx.dtype = dtype
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
-        linear_op_ctx.has_prev_op = not is_first_op
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -70,10 +70,12 @@ class ForwardLinearBiasActivation(FusedOperation):
         linear_op_ctx = basic_op_ctxs[idx]
         if self._op_idxs["bias"] is None:
             bias_op = None
+            bias_op_ctx = None
             bias = None
         else:
             idx = self._op_idxs["bias"]
             bias_op = self.basic_ops[idx]
+            bias_op_ctx = basic_op_ctxs[idx]
             bias = bias_op.bias
             if basic_op_kwargs[idx]:
                 raise ValueError("Bias operation forward does not expect keyword arguments")
@@ -133,6 +135,9 @@ class ForwardLinearBiasActivation(FusedOperation):
         linear_op_ctx.dtype = dtype
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
+        if bias_op is not None:
+            bias_op_ctx.with_quantized_compute = with_quantized_compute
+            bias_op_ctx.grad_output_quantizer = linear_op.get_grad_input_quantizer()
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -137,7 +137,7 @@ class ForwardLinearBiasActivation(FusedOperation):
         linear_op_ctx.weight_requires_grad = weight_requires_grad
         if bias_op is not None:
             bias_op_ctx.with_quantized_compute = with_quantized_compute
-            bias_op_ctx.grad_output_quantizer = linear_op.get_grad_input_quantizer()
+            bias_op_ctx.grad_input_quantizer = linear_op.get_grad_input_quantizer()
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -101,9 +101,10 @@ class ForwardLinearBiasActivation(FusedOperation):
             grad_input_quantizer = prev_op_grad_input_quantizer
 
         # Get autocast dtype if needed
-        dtype = None
         if torch.is_autocast_enabled():
             dtype = torch.get_autocast_dtype("cuda")
+        else:
+            dtype = linear_op.weight.dtype
 
         # Linear forward
         output, x_local, w = BasicLinear._functional_forward(

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -94,9 +94,10 @@ class ForwardLinearBiasAdd(FusedOperation):
             grad_input_quantizer = prev_op_grad_input_quantizer
 
         # Get autocast dtype if needed
-        dtype = None
         if torch.is_autocast_enabled():
             dtype = torch.get_autocast_dtype("cuda")
+        else:
+            dtype = linear_op.weight.dtype
 
         # Linear forward
         output = basic_op_extra_inputs[self._op_idxs["add"]][0]
@@ -104,6 +105,7 @@ class ForwardLinearBiasAdd(FusedOperation):
             input=input_,
             weight=linear_op.weight,
             bias=bias,
+            dtype=output.dtype,
             out=output,
             accumulate_into_out=True,
             tensor_parallel_mode=linear_op.tensor_parallel_mode,

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -68,10 +68,12 @@ class ForwardLinearBiasAdd(FusedOperation):
         linear_op_ctx = basic_op_ctxs[idx]
         if self._op_idxs["bias"] is None:
             bias_op = None
+            bias_op_ctx = None
             bias = None
         else:
             idx = self._op_idxs["bias"]
             bias_op = self.basic_ops[idx]
+            bias_op_ctx = basic_op_ctxs[idx]
             bias = bias_op.bias
             if basic_op_kwargs[idx]:
                 raise ValueError("Bias operation forward does not expect keyword arguments")
@@ -129,6 +131,9 @@ class ForwardLinearBiasAdd(FusedOperation):
         linear_op_ctx.dtype = dtype
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
+        if bias_op is not None:
+            bias_op_ctx.with_quantized_compute = with_quantized_compute
+            bias_op_ctx.grad_output_quantizer = linear_op.get_grad_input_quantizer()
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -133,7 +133,7 @@ class ForwardLinearBiasAdd(FusedOperation):
         linear_op_ctx.weight_requires_grad = weight_requires_grad
         if bias_op is not None:
             bias_op_ctx.with_quantized_compute = with_quantized_compute
-            bias_op_ctx.grad_output_quantizer = linear_op.get_grad_input_quantizer()
+            bias_op_ctx.grad_input_quantizer = linear_op.get_grad_input_quantizer()
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -59,7 +59,6 @@ class ForwardLinearBiasAdd(FusedOperation):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
 
@@ -128,7 +127,6 @@ class ForwardLinearBiasAdd(FusedOperation):
         linear_op_ctx.dtype = dtype
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
-        linear_op_ctx.has_prev_op = not is_first_op
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/userbuffers_backward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_backward_linear.py
@@ -568,13 +568,13 @@ def fuse_userbuffers_backward_linear(
     Parameters
     ----------
     ops: list of tuples
-        Forward pass operations and the indices of the corresponding
+        Backward pass operations and the indices of the corresponding
         basic operations.
 
     Returns
     -------
     ops: list of tuples
-        Updated forward pass operations
+        Updated backward pass operations
 
     """
 

--- a/transformer_engine/pytorch/ops/fused/userbuffers_backward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_backward_linear.py
@@ -547,8 +547,7 @@ class UserbuffersBackwardLinear(FusedOperation):
             grad_bias = extra_outputs["grad_bias"]
 
         # Clear input tensor if possible
-        if linear_op_ctx.has_prev_op:
-            clear_tensor_data(x_local)
+        clear_tensor_data(x_local)
 
         # Return gradients
         grad_params = [() for _ in range(len(self.basic_ops))]

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -292,10 +292,12 @@ class UserbuffersForwardLinear(FusedOperation):
         linear_op = self.basic_ops[idx]
         linear_op_ctx = basic_op_ctxs[idx]
         bias_op = None
+        bias_op_ctx = None
         bias = None
         if self._op_idxs["bias"] is not None:
             idx = self._op_idxs["bias"]
             bias_op = self.basic_ops[idx]
+            bias_op_ctx = basic_op_ctxs[idx]
             bias = bias_op.bias
             if basic_op_kwargs[idx]:
                 raise ValueError("Bias operation forward does not expect keyword arguments")
@@ -364,6 +366,9 @@ class UserbuffersForwardLinear(FusedOperation):
         linear_op_ctx.input_dims = input_.size()
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
+        if bias_op is not None:
+            bias_op_ctx.with_quantized_compute = with_quantized_compute
+            bias_op_ctx.grad_output_quantizer = linear_op.get_grad_input_quantizer()
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -291,7 +291,6 @@ class UserbuffersForwardLinear(FusedOperation):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
 
@@ -370,7 +369,6 @@ class UserbuffersForwardLinear(FusedOperation):
         linear_op_ctx.input_dims = input_.size()
         linear_op_ctx.input_requires_grad = input_requires_grad
         linear_op_ctx.weight_requires_grad = weight_requires_grad
-        linear_op_ctx.has_prev_op = not is_first_op
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -368,7 +368,7 @@ class UserbuffersForwardLinear(FusedOperation):
         linear_op_ctx.weight_requires_grad = weight_requires_grad
         if bias_op is not None:
             bias_op_ctx.with_quantized_compute = with_quantized_compute
-            bias_op_ctx.grad_output_quantizer = linear_op.get_grad_input_quantizer()
+            bias_op_ctx.grad_input_quantizer = linear_op.get_grad_input_quantizer()
 
         return output, [() for _ in range(len(self.basic_ops))]
 

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -101,10 +101,9 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
         # Operation autograd contexts
         basic_op_ctxs = [OperationContext() for _ in range(fuser._num_basic_ops)]
 
-        # Mark input tensors requiring grad as not deletable in backward
+        # Mark input tensors as not deletable in backward
         for tensor in (input_,) + params_and_extra_inputs:
-            if tensor.requires_grad:
-                tensor.do_not_clear = True
+            tensor.do_not_clear = True
 
         # Unflatten list of parameters and extra tensor inputs
         extra_inputs = params_and_extra_inputs[-fuser._num_extra_inputs :]

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -17,6 +17,7 @@ from transformer_engine.pytorch.ops.op import (
     OperationContext,
 )
 from transformer_engine.pytorch.ops.fused import (
+    fuse_backward_bias_activation,
     fuse_backward_linear_add,
     fuse_forward_linear_bias_activation,
     fuse_forward_linear_bias_add,
@@ -379,11 +380,12 @@ class OperationFuser:
     def _fuse_backward_ops(
         cls,
         ops: list[tuple[FusibleOperation, list[int]]],
-        recipe: Optional[Recipe],  # pylint: disable=unused-argument
+        recipe: Optional[Recipe],
     ) -> list[tuple[FusibleOperation, list[int]]]:
         """Attempt to fuse operations in backward pass"""
         ops = fuse_userbuffers_backward_linear(ops)
         ops = fuse_backward_linear_add(ops)
+        ops = fuse_backward_bias_activation(ops, recipe)
         return ops
 
     def fuse_ops(self) -> None:

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -518,7 +518,9 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         """Apply operation"""
         from .fuser import OperationFuser
 
-        return OperationFuser([self], fuse_ops=False)(
+        with_quantized_compute = FP8GlobalStateManager.is_fp8_enabled()
+        recipe = FP8GlobalStateManager.get_fp8_recipe() if with_quantized_compute else None
+        return OperationFuser([self], fuse_ops=False, recipe=recipe)(
             input,
             *extra_inputs,
             basic_op_kwargs=[kwargs],
@@ -725,7 +727,9 @@ class FusedOperation(FusibleOperation):
             basic_op_kwargs = [{} for _ in range(len(self.basic_ops))]
         from .fuser import OperationFuser
 
-        return OperationFuser([self], fuse_ops=False)(
+        with_quantized_compute = FP8GlobalStateManager.is_fp8_enabled()
+        recipe = FP8GlobalStateManager.get_fp8_recipe() if with_quantized_compute else None
+        return OperationFuser([self], fuse_ops=False, recipe=recipe)(
             input,
             *extra_inputs,
             basic_op_kwargs=basic_op_kwargs,

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -86,7 +86,6 @@ class FusibleOperation(torch.nn.Module, metaclass=abc.ABCMeta):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         """Forward pass
@@ -109,10 +108,6 @@ class FusibleOperation(torch.nn.Module, metaclass=abc.ABCMeta):
             The grad_input_quantizer of the preceeding operation
         next_op_input_quantizer: Quantizer, optional
             The input_quantizer of the following operation
-        is_first_op: bool
-            Does this op have a preceeding op or is it the first one in the
-            fuser. Used in the backward pass to safely delete the saved input
-            tensor when no longer needed and there is a preceeding op.
         basic_op_kwargs: list of dict
             Keyword arguments to forward functions of basic
             operations.
@@ -421,7 +416,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         *,
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         **kwargs: Any,
     ) -> torch.Tensor:
         """Forward pass
@@ -436,10 +430,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             The grad_input_quantizer of the preceeding operation
         next_op_input_quantizer: Quantizer, optional
             The input_quantizer of the following operation
-        is_first_op: bool
-            Does this op have a preceeding op or is it the first one in the
-            fuser. Used in the backward pass to safely delete the saved input
-            tensor when no longer needed and there is a preceeding op.
 
         Returns
         -------
@@ -480,7 +470,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         basic_op_extra_inputs: list[tuple[torch.Tensor, ...]],
         prev_op_grad_input_quantizer: Optional[Quantizer],
         next_op_input_quantizer: Optional[Quantizer],
-        is_first_op: bool,
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, list[tuple[()]]]:
         if self.num_extra_inputs > 0 or self.num_extra_outputs > 0:
@@ -495,7 +484,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             input_,
             prev_op_grad_input_quantizer=prev_op_grad_input_quantizer,
             next_op_input_quantizer=next_op_input_quantizer,
-            is_first_op=is_first_op,
             **basic_op_kwargs[0],
         )
         return output, [()]


### PR DESCRIPTION
# Description

Adds two backward fusions to `te.ops.Sequential`: dbias+quantize and dbias+dactivation+quantize. See fusions in the visual comparison of backward pass below.

Resultant performance gain in small model CPU-bound benchmark scenario: +4% on B100, +7% on H100 for FP8 Sequential.
Resultant performance gain in large model GPU-bound benchmark scenario: +5% on B100 for FP8 Sequential.

## Visual comparison

[<img width="1843" height="765" alt="image" src="https://github.com/user-attachments/assets/92990d7f-65f8-4eb5-bbf3-76385ec0604a" />](https://github.com/user-attachments/assets/92990d7f-65f8-4eb5-bbf3-76385ec0604a)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- (5befeb456974e0bdb225ccfab00aaf4b93e227f0) Mark inputs to `OperationFuser` which `require_grad` as `do_not_clear` to prevent backward from deleting them with `clear_tensor_data`. Remove `is_first_op` parameter as no longer necessary.
- (8d819c21c9c24c1c48eaeef28e7774425ee67550) Miscellaneous fixes not affecting execution, but changing misleading code and documentation.
- (371523f944523a62920719b560dcf7f80884bcc8) Pass `dtype` to `_functional_forward` instead of trying to infer it inside the function, which may fail if all the tensors are internal quantized tensors.
- (d074ad626fe60b88ee7159d81d5895bf737ba095) Add fusion of dbias+quantize by peeking at the previous operation's `grad_input_quantizer` (similarly to `LayerNorm`, except it does it in the forward) and use `bgrad_quantize` if possible.
- (53111a486091cda728380a2d9091dcb721ed6c62) Pass `recipe` as argument to `OperationFuser.__init__` to allow for recipe-dependent fusions.
- (09f330e81aefd130591ccf3e86e9ce94140b238f) Remove redundant use of `view` in activations. Instead, use `view` only when the input has more than two dimensions and the activation is gated.
- (0918ab4a6e61dca82c0725d84667b28b04d28437) Add fused operation `BackwardBiasActivation`, fusing function `fuse_backward_bias_activation`, and test `test_backward_bias_activation`. The fused operation is used if the recipe type allows and the operation preceding the `Bias` has a `grad_input_quantizer`. The fusion uses `dbias_d(activation)`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance data

Below is reported the running time of a GPT encoder transformer layer (averaged over 10k runs) using [my benchmark script](https://github.com/janekb04/transformer-engine-benchmark-sequential). Here, Fused refers to an implementation using the fused modules `LayerNormLinear` and `LayerNormMLP`, Sequential refers to an implementation implementing those two modules with `te.ops.Sequential`, and Builtin refers to using `te.TransformerLayer`.

### B100 results (small model, CPU bound)

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|1dd8f62d800da999563c4954ccfe54a5cc34f7f5|1.51ms|1.85ms|1.47ms|1.93ms|2.17ms|2.57ms|
|9769336bcf885ada8f2f524869038e136269f618|1.54ms|1.86ms|1.48ms|1.95ms|2.19ms|2.58ms|
|015879380dde36adcd3bd7e44da029c3603accdf|1.53ms|1.85ms|1.47ms|1.94ms|2.17ms|2.57ms|
|8bc106e47700e3141bc82281a5abe8513208c4dd|1.53ms|1.86ms|1.48ms|1.95ms|2.17ms|2.56ms|
|1a286d8e5d86e3cb0e069a9c5873ddd365308d2b|1.55ms|1.88ms|1.50ms|1.93ms|2.19ms|2.58ms|
|4eb66096117ec98f8ff7cf71aea47ecbe22eff5b|1.54ms|1.87ms|1.49ms|1.92ms|2.19ms|2.59ms|
|51b00a42b277125c4459dbe7cf0570331e142125|1.54ms|1.87ms|1.46ms|1.89ms|2.18ms|2.55ms|
|7aafa34aee6479e59899f4ef800a3f66052d8517|1.53ms|1.86ms|1.45ms|1.87ms|2.16ms|2.57ms|

### H100 results (small model, CPU bound)

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|1dd8f62d800da999563c4954ccfe54a5cc34f7f5|1.12ms|1.49ms|1.03ms|1.59ms|1.83ms|2.35ms|
|9769336bcf885ada8f2f524869038e136269f618|1.11ms|1.49ms|1.02ms|1.59ms|1.82ms|2.33ms|
|015879380dde36adcd3bd7e44da029c3603accdf|1.11ms|1.50ms|1.03ms|1.60ms|1.83ms|2.35ms|
|8bc106e47700e3141bc82281a5abe8513208c4dd|1.09ms|1.47ms|1.01ms|1.57ms|1.81ms|2.30ms|
|1a286d8e5d86e3cb0e069a9c5873ddd365308d2b|1.12ms|1.51ms|1.03ms|1.57ms|1.82ms|2.31ms|
|4eb66096117ec98f8ff7cf71aea47ecbe22eff5b|1.13ms|1.52ms|1.05ms|1.59ms|1.84ms|2.35ms|
|51b00a42b277125c4459dbe7cf0570331e142125|1.11ms|1.48ms|1.00ms|1.53ms|1.82ms|2.32ms|
|7aafa34aee6479e59899f4ef800a3f66052d8517|1.10ms|1.47ms|0.99ms|1.49ms|1.80ms|2.28ms|

### B100 results (large model, GPU bound)

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|64891899687dacb8293f8dc4ee786e16a47e1c02|31.44ms|24.01ms|30.66ms|23.51ms|20.43ms|13.00ms|
|8a6f43cd6f915dcb81dac8a4f4bfea50d722b568|31.50ms|23.97ms|30.66ms|23.54ms|20.45ms|12.99ms|
|b094e034d95b1763e47514e7be2c63567f3108bf|30.66ms|23.13ms|29.81ms|22.66ms|19.99ms|12.78ms|
|646d5381f0e7f8eba0c50abe8a1ef4b62c3a60d2|30.22ms|22.87ms|29.94ms|23.20ms|20.26ms|12.92ms|
|14fdc5509211f56598745df70747aa22edb835f4|30.66ms|23.08ms|30.01ms|22.87ms|20.21ms|12.88ms|
|9a4b351bc2f2614a1c57024fdd1b89c43248ef8d|30.66ms|23.12ms|29.96ms|22.80ms|20.19ms|12.89ms|
|a3f8de4e254c3d8940035c8cbc70347aa9512cf4|30.66ms|23.10ms|30.04ms|22.81ms|20.19ms|12.88ms|
|980904f38a702e7cd558b13c62212fdb1c90b4c6|30.66ms|23.05ms|29.92ms|22.55ms|20.14ms|12.88ms|

### H100 results (large model, GPU bound)

|Commit|Fused BF16|Fused FP8|Sequential BF16|Sequential FP8|Builtin BF16|Builtin FP8|
|-|-|-|-|-|-|-|
|64891899687dacb8293f8dc4ee786e16a47e1c02|41.36ms|31.97ms|41.82ms|31.99ms|31.55ms|21.04ms|
|8a6f43cd6f915dcb81dac8a4f4bfea50d722b568|43.14ms|32.00ms|42.65ms|32.22ms|32.02ms|21.04ms|
|b094e034d95b1763e47514e7be2c63567f3108bf|42.94ms|32.00ms|42.30ms|31.99ms|31.64ms|21.00ms|
|646d5381f0e7f8eba0c50abe8a1ef4b62c3a60d2|43.08ms|32.00ms|42.22ms|31.99ms|31.98ms|21.16ms|
|14fdc5509211f56598745df70747aa22edb835f4|43.11ms|31.99ms|42.54ms|31.99ms|32.06ms|21.19ms|
|9a4b351bc2f2614a1c57024fdd1b89c43248ef8d|43.17ms|32.00ms|42.26ms|32.00ms|31.73ms|20.95ms|
|a3f8de4e254c3d8940035c8cbc70347aa9512cf4|43.04ms|32.00ms|42.34ms|32.00ms|31.70ms|20.93ms|
|980904f38a702e7cd558b13c62212fdb1c90b4c6|42.98ms|32.00ms|42.37ms|32.00ms|31.62ms|20.97ms|