### PR TITLE
[PyTorch] Make `MXFP8Tensor` unpickling function backward compatible

### DIFF
--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -328,7 +328,7 @@ class MXFP8Tensor(MXFP8TensorBase, QuantizedTensor):
         fp8_dtype: TE_DType,
         dtype: torch.dtype,
         shape: torch.shape,
-        quantizer: Quantizer,
+        quantizer: Optional[Quantizer] = None,
     ) -> MXFP8Tensor:
         """Build MXFP8Tensor, for use in __reduce__
 


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1934 changed the pickling logic for `MXFP8Tensor` (see [Python docs for `__reduce__` and `__reduce_ex__`](https://docs.python.org/3/library/pickle.html#object.__reduce__)) so that it stores its quantizer:
https://github.com/NVIDIA/TransformerEngine/blob/62acae05993c9132e20b2d25c387203a04bcd56f/transformer_engine/pytorch/tensor/mxfp8_tensor.py#L362

However, this breaks older checkpoints because it changes the signature of the unpickling function ([`_make_in_reduce_ex`](https://github.com/NVIDIA/TransformerEngine/blob/62acae05993c9132e20b2d25c387203a04bcd56f/transformer_engine/pytorch/tensor/mxfp8_tensor.py#L322). This PR makes the quantizer an optional arg to `_make_in_reduce_ex`, restoring backward compatibility.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Make `MXFP8Tensor` unpickling function backward compatible

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
