### PR TITLE
[JAX] Fixes for the grouped_gemm with MXFP8

### DIFF
--- a/transformer_engine/jax/csrc/extensions/quantization.cpp
+++ b/transformer_engine/jax/csrc/extensions/quantization.cpp
@@ -385,7 +385,7 @@ Error_Type GroupedQuantizeFFI(cudaStream_t stream, Buffer_Type inputs, Buffer_Ty
     total_rowwise_sinv_size += sinv_size;
     total_colwise_sinv_size += colwise_sinv_size;
   }
-  if (is_mxfp8_scaling){
+  if (is_mxfp8_scaling) {
     nvte_memset(scale_invs->untyped_data(), 0, total_rowwise_sinv_size, stream);
     nvte_memset(colwise_scale_invs->untyped_data(), 0, total_colwise_sinv_size, stream);
   }


### PR DESCRIPTION
# Description

This PR adds `memset` for the `scale_inv` in the `grouped_quantize` custom call so that the paddings are initialized with zeros. This fixes the NaN issue in the `grouped_dense_grad_fp8` tests in the nightly CI.


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
