### PR TITLE
[Minor] Update 1_getting_started.rst

### DIFF
--- a/docs/debug/1_getting_started.rst
+++ b/docs/debug/1_getting_started.rst
@@ -141,7 +141,7 @@ Adjusting Python file
 In the modified code above, the following changes were made:
 
 1. Added an import for ``nvdlfw_inspect.api``.
-2. Initialized the Nvidia-DL-Framework-Inspect by calling ``debug_api.initialize()`` with appropriate configuration, specifying the path to the config file, feature directories, and log directory.
+2. Initialized the Nvidia-DL-Framework-Inspect by calling ``debug_api.initialize()`` with appropriate configuration, specifying the path to the config file, feature directories, and log directory. The directory with Transformer Engine features is located `here <https://github.com/NVIDIA/TransformerEngine/tree/main/transformer_engine/debug/features>`_. The full parameters description could be found in the `documentation <https://github.com/NVIDIA/nvidia-dlfw-inspect/blob/main/docs/getting_started.md#2-initializing-the-tool>`_.
 3. Added ``debug_api.step()`` after each of the forward-backward pass.
 
 Inspecting the logs


### PR DESCRIPTION
# Description

I was following the [debugging tutorial](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/debug/1_getting_started.html), and during the testing I didn't find what is a feature directory and where to locate it for the TE. I've found answers in the docs of the `nvidia-dlfw-inspect`, so I've added a short description to the 1_getting_started.rst


## Type of change

- [x] Documentation change

## Changes

Description of the nvdlfw_inspect initialization is expanded with a description of the TE features location and the full `debug_api.initialize` parameters description

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
