### PR TITLE
[JAX] Remove unneccessary MXFP8 scale_inv padding 

### DIFF
--- a/tests/jax/test_distributed_layernorm.py
+++ b/tests/jax/test_distributed_layernorm.py
@@ -75,8 +75,6 @@ class TestDistributedLayernorm:
             all_reduce_loss_bytes + weight_count * shape[-1] * jax_dtype.itemsize
         )
         other_bytes = 0
-        if fp8_recipe == recipe.MXFP8BlockScaling() and "dp" in mesh_axes:
-            other_bytes = 384  # required for small scale shapes that require padding
         if fp8_recipe == recipe.Float8CurrentScaling():
             allreduce_total_bytes += jax_dtype.itemsize  # 1 * dtype for the amax reduction
         return generate_collectives_count(

--- a/transformer_engine/jax/quantize/dequantizer.py
+++ b/transformer_engine/jax/quantize/dequantizer.py
@@ -121,9 +121,6 @@ class BlockScaleDequantizer(Dequantizer):
         scale_shape = scaling_mode.get_scale_shape(
             data_shape, is_colwise, is_padded=False, flatten_axis=flatten_axis
         )
-        scale_inv = jax.lax.slice(
-            scale_inv, [0] * len(scale_shape), scale_shape
-        )  # slice out the padding
 
         data = data.reshape(
             *data_shape[: flatten_axis - 1],
@@ -211,28 +208,35 @@ def _grouped_dequantize(grouped_scaled_tensor):
             f"math.prod({data_shape_i}) = {math.prod(data_shape_i)} which is not equal to"
             f" {data_i.size}"
         )
-        scale_shape_i = scaling_mode.get_scale_shape(
+        padded_scale_shape_i = scaling_mode.get_scale_shape(
             data_shape_i,
             grouped_scaled_tensor.is_colwise,
             is_padded=True,
             flatten_axis=flatten_axis,
         )
-        scale_shape_i_size = math.prod(scale_shape_i)
-        scale_inv_i = scale_inv[scale_inv_ptr : scale_inv_ptr + scale_shape_i_size]
+        unpadded_scale_shape_i = scaling_mode.get_scale_shape(
+            data_shape_i,
+            grouped_scaled_tensor.is_colwise,
+            is_padded=False,
+            flatten_axis=flatten_axis,
+        )
+        scale_inv_i = scale_inv[scale_inv_ptr: scale_inv_ptr +
+                                math.prod(padded_scale_shape_i)].reshape(padded_scale_shape_i)
+        scale_inv_i = jax.lax.slice(scale_inv_i, [0] * len(unpadded_scale_shape_i), unpadded_scale_shape_i)
         dequantizer_type = ScalingModeToDequantizerMap.get(grouped_scaled_tensor.scaling_mode)
         if len(data_i) == 0:
             out_i = []
         else:
             out_i = dequantizer_type._dequantize_func(
                 data_i.reshape(data_shape_i),
-                scale_inv_i.reshape(scale_shape_i),
+                scale_inv_i,
                 grouped_scaled_tensor.dq_dtype,
                 scaling_mode=grouped_scaled_tensor.scaling_mode,
                 is_colwise=grouped_scaled_tensor.is_colwise,
                 flatten_axis=grouped_scaled_tensor.flatten_axis,
             )
         output.append(out_i)
-        scale_inv_ptr += scale_shape_i_size
+        scale_inv_ptr += math.prod(padded_scale_shape_i)
 
     return output
 

--- a/transformer_engine/jax/quantize/dequantizer.py
+++ b/transformer_engine/jax/quantize/dequantizer.py
@@ -220,9 +220,12 @@ def _grouped_dequantize(grouped_scaled_tensor):
             is_padded=False,
             flatten_axis=flatten_axis,
         )
-        scale_inv_i = scale_inv[scale_inv_ptr: scale_inv_ptr +
-                                math.prod(padded_scale_shape_i)].reshape(padded_scale_shape_i)
-        scale_inv_i = jax.lax.slice(scale_inv_i, [0] * len(unpadded_scale_shape_i), unpadded_scale_shape_i)
+        scale_inv_i = scale_inv[
+            scale_inv_ptr : scale_inv_ptr + math.prod(padded_scale_shape_i)
+        ].reshape(padded_scale_shape_i)
+        scale_inv_i = jax.lax.slice(
+            scale_inv_i, [0] * len(unpadded_scale_shape_i), unpadded_scale_shape_i
+        )
         dequantizer_type = ScalingModeToDequantizerMap.get(grouped_scaled_tensor.scaling_mode)
         if len(data_i) == 0:
             out_i = []

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -199,8 +199,8 @@ class CurrentScalingModeMetadataImpl(ScalingModeMetadataImpl):
             The shape for scale tensors - (1,)
         """
         del is_colwise
-        if np.prod(data_shape) == 0:
-            return (0,)
+        # if np.prod(data_shape) == 0:
+        #     return (0,)
         return (1,)
 
     @lru_cache(maxsize=4)

--- a/transformer_engine/jax/quantize/scaling_modes.py
+++ b/transformer_engine/jax/quantize/scaling_modes.py
@@ -199,8 +199,8 @@ class CurrentScalingModeMetadataImpl(ScalingModeMetadataImpl):
             The shape for scale tensors - (1,)
         """
         del is_colwise
-        # if np.prod(data_shape) == 0:
-        #     return (0,)
+        if np.prod(data_shape) == 0:
+            return (0,)
         return (1,)
 
     @lru_cache(maxsize=4)

--- a/transformer_engine/jax/quantize/tensor.py
+++ b/transformer_engine/jax/quantize/tensor.py
@@ -17,7 +17,6 @@ from jax.tree_util import register_pytree_node_class
 
 from transformer_engine_jax import QuantizeLayout
 
-from .helper import apply_padding_to_scale_inv
 from .scaling_modes import ScalingMode, TensorUsage
 from .dequantizer import ScalingModeToDequantizerMap
 from ..sharding import (
@@ -135,15 +134,6 @@ class ScaledTensor1x(ScaledTensor):
 
         if self.scaling_mode == ScalingMode.NO_SCALING:
             self.scale_inv = jnp.empty((0,), dtype=jnp.float32)
-
-        else:
-            self.scale_inv = apply_padding_to_scale_inv(
-                self.scale_inv,
-                self.scaling_mode,
-                self.data.shape,
-                is_colwise=self.is_colwise,
-                flatten_axis=self.flatten_axis,
-            )
 
     def tree_flatten(self):
         """Flattens the tensor for JAX tree operations.

--- a/transformer_engine/jax/quantize/tensor.py
+++ b/transformer_engine/jax/quantize/tensor.py
@@ -134,6 +134,15 @@ class ScaledTensor1x(ScaledTensor):
 
         if self.scaling_mode == ScalingMode.NO_SCALING:
             self.scale_inv = jnp.empty((0,), dtype=jnp.float32)
+        else:
+            unpadded_scale_shape = self.scaling_mode.get_scale_shape(
+                    self.data.shape, is_colwise=self.is_colwise, is_padded=False,
+                    flatten_axis=self.flatten_axis
+                    )
+            assert self.scale_inv.shape == unpadded_scale_shape, (
+                    f"Unpadded inverse scale factor has wrong shape, expected {unpadded_scale_shape} but got "
+                    f"{self.scale_inv.shape}."
+                    )
 
     def tree_flatten(self):
         """Flattens the tensor for JAX tree operations.

--- a/transformer_engine/jax/quantize/tensor.py
+++ b/transformer_engine/jax/quantize/tensor.py
@@ -136,13 +136,15 @@ class ScaledTensor1x(ScaledTensor):
             self.scale_inv = jnp.empty((0,), dtype=jnp.float32)
         else:
             unpadded_scale_shape = self.scaling_mode.get_scale_shape(
-                    self.data.shape, is_colwise=self.is_colwise, is_padded=False,
-                    flatten_axis=self.flatten_axis
-                    )
+                self.data.shape,
+                is_colwise=self.is_colwise,
+                is_padded=False,
+                flatten_axis=self.flatten_axis,
+            )
             assert self.scale_inv.shape == unpadded_scale_shape, (
-                    f"Unpadded inverse scale factor has wrong shape, expected {unpadded_scale_shape} but got "
-                    f"{self.scale_inv.shape}."
-                    )
+                "Unpadded inverse scale factor has wrong shape, expected"
+                f" {unpadded_scale_shape} but got {self.scale_inv.shape}."
+            )
 
     def tree_flatten(self):
         """Flattens the tensor for JAX tree operations.


### PR DESCRIPTION
# Description

This PR removes unnecessary padding steps in the MXFP8 workflow, which should improve the recipe performance.

Right now, we do
```
# In layernorm/activation/quantization
1. Allocate padded scale in inner_primitive.abstract() 
2. Slice out the padding in Primitive.impl(), after calling the inner_primitve
3. Add padding in ScaledTensor.__post_init__()

# In GEMM custom call
4. Remove padding before calling the custom call
5. Adding padding in the Primitive.impl() before calling the inner_primitive
```

This PR removes unnecessary padding steps, the new workflow becomes:
```
# In layernorm/activation/quantization
1. Allocate padded scale in inner_primitive.abstract() 
2. Slice out the padding in Primitive.impl(), after calling the inner_primitve

# In GEMM custom call
5. Adding padding in the Primitive.impl() before calling the inner_primitive
```
(3) and (4) are removed.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
