### PR TITLE
[PyTorch] Debug linear layer when saving original input and using debug quantizer

### DIFF
--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -595,7 +595,7 @@ class _Linear(torch.autograd.Function):
                             # All-gather is not supported with FP8 column-wise data
                             quantizer.set_usage(rowwise=True, columnwise=False)
                         else:
-                            quantizer.set_usage(rowwise=False, columnwise=True)
+                            quantizer.set_usage(rowwise=True, columnwise=True)
                         inputmat = quantizer(inputmat)
                 else:
                     if isinstance(inputmat, QuantizedTensorBase):


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1865 introduced a failure in the distributed debug tests. ~The root cause is because we only all-gather the row-wise data for `DebugQuantizedTensor`:~
https://github.com/NVIDIA/TransformerEngine/blob/f8933bbf6cac743d193ff730e6c61331635e38c1/transformer_engine/pytorch/distributed.py#L1394
~However, if the linear layer is caching its original input tensor and requantizing in the backward pass, the correct behavior is to only quantize the column-wise data.~ This PR is a hacky workaround that only applies the debug quantizer to the gathered input tensor.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Modify linear backward to avoid all-gathering debug tensor with only column-wise data

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
