### PR TITLE
[PyTorch] Fix bug with clearing op outputs during backward

### DIFF
--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -199,7 +199,7 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
 
         # Mark output tensors as not deletable in backward
         for tensor in [x] + extra_outputs_flat:
-            tensor.do_not_clear = True
+            tensor._do_not_clear = True
 
         x.requires_grad_(fuser.first_op_requiring_backward < fuser._num_basic_ops)
 


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/1977 renamed a tensor attr from `do_not_clear` to `_do_not_clear`, but it missed one usage from https://github.com/NVIDIA/TransformerEngine/pull/1983.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Fix bug with clearing op outputs during backward

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
