### PR TITLE
[JAX] Fix for contracting dim specs in GEMM custom calls

### DIFF
--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -522,8 +522,8 @@ class GemmPrimitive(BasePrimitive):
         # Non-batch leading dimension specs
         lspecs = tuple(specs[i] for i in range(ndims) if i not in cdims + bdims)
 
-        # Non-batch contracting dimension specs
-        cspecs = tuple(specs[i] for i in range(ndims) if i in cdims and i not in bdims)
+        # contracting dimension specs
+        cspecs = tuple(specs[i] for i in range(ndims) if i in cdims)
 
         return bspecs, lspecs, cspecs
 


### PR DESCRIPTION
# Description
In Data Parallism, we have 
```
Wgrad =  input[B{X}, S, D]^T * dY [B{X}, S, H]
``` 
, both the lhs and rhs are sharded in the X mesh axis. 

The [current `_decompose_operand_specs`](https://github.com/phu0ngng/TransformerEngine/blob/main/transformer_engine/jax/cpp_extensions/gemm.py#L525-L526) does not infer the contracting spec correctly when the contracting specs are the batch dimension as it excludes the contracting dimension if the dimension is already in `bdims`. 

This results `None` for both `lhs_cspec` and `rhs_cspec`, leading to `reduce_output=False`, followed by overwriting `lhs_spec` and `rhs_specs`. This removes the `data` axis in the batch dimension for both lhs and rhs. As a result, `AllGather`-s are triggers to gather both the lhs and rhs before the GEMM.

This PR fixes the `_decompose_operand_specs`. The fix was verified in MaxText E2E runs with `tensor_parallelsim`, `tensor_sequence_parallelism`, and `data_parallelism`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
