### PR TITLE
[PyTorch] Fix zero initialization in permute kernel for padded slots

### DIFF
--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -359,7 +359,7 @@ def _permute_kernel(
             if prob == 0.0:
                 # for routing_map padding
                 # dst_row != -1 and prob == 0.0 means that this slot is padded
-                tl.store(output_ptr + output_off, 0, mask=mask)
+                tl.store(output_ptr + output_off, 0.0, mask=mask)
             else:
                 tl.store(output_ptr + output_off, inp, mask=mask)
         else:


### PR DESCRIPTION
# Description

Fix zero initialization in permute kernel for padded slots.

Reason for the bug fix：
When the data flow is float8_e4m3, the following error will be reported:
[default0]:[rank0]:   File "/opt/ac2/lib/python3.12/site-packages/triton/language/semantic.py", line 945, in cast
[default0]:[rank0]:     assert False, f'cannot cast {input} to {dst_ty}'
[default0]:[rank0]:            ^^^^^
[default0]:[rank0]: AssertionError: cannot cast int32[constexpr[64]] to <['64'], fp8e4nv>
[default0]:
[default0]:[rank0]: The above exception was the direct cause of the following exception:

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change  zero initialization from int 0 to float 0.0 when dst_row != -1 and prob == 0.0 means that this slot is padded

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
