### PR TITLE
[PyTorch] Register weight and bias params in linear op

### DIFF
--- a/transformer_engine/pytorch/ops/linear.py
+++ b/transformer_engine/pytorch/ops/linear.py
@@ -154,18 +154,16 @@ class Linear(FusedOperation):
         Also updates the basic operation that owns the parameter.
 
         """
+        if name == "bias" and self._bias_idx is None and param is not None:
+            raise ValueError(
+                "Attempted to set bias parameter in Linear operation "
+                "that does not have bias enabled"
+            )
         super().register_parameter(name, param)
         if name == "weight":
             self.basic_ops[self._linear_idx].weight = param
-        elif name == "bias":
-            if self._bias_idx is None:
-                if param is not None:
-                    raise ValueError(
-                        "Attempted to set bias parameter in Linear operation "
-                        "that does not have bias enabled"
-                    )
-            else:
-                self.basic_ops[self._bias_idx].bias = param
+        elif name == "bias" and self._bias_idx is not None:
+            self.basic_ops[self._bias_idx].bias = param
 
     def state_dict(self, *, prefix: str = "", **kwargs) -> dict[str, Any]:
         """Save state"""


### PR DESCRIPTION
# Description

The [`Linear` op](https://github.com/NVIDIA/TransformerEngine/blob/06947e87b5511f8ad69ccd00286de9227f0fad24/transformer_engine/pytorch/ops/linear.py#L23) is a fused op with an interface similar to [`torch.nn.Linear`](https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear.html). However, the param setters (for `weight` and `bias`) are buggy due to a bad interaction with [`torch.nn.Module.__setattr__`](https://github.com/pytorch/pytorch/blob/50eac811a68e63e96ad56c11c983bfe298a0bb8a/torch/nn/modules/module.py#L1968).

<details>

I would like to be able to replace the linear weight with something like:
```python
op = te.Linear(...)
op.weight = torch.nn.Parameter(...)
```

However, [when `torch.nn.Module.__setattr__` receives a `torch.nn.Parameter`](https://github.com/pytorch/pytorch/blob/50eac811a68e63e96ad56c11c983bfe298a0bb8a/torch/nn/modules/module.py#L1989), it calls [`torch.nn.Module.register_parameter`](https://github.com/pytorch/pytorch/blob/50eac811a68e63e96ad56c11c983bfe298a0bb8a/torch/nn/modules/module.py#L589).  This failed [here](https://github.com/pytorch/pytorch/blob/50eac811a68e63e96ad56c11c983bfe298a0bb8a/torch/nn/modules/module.py#L616) because the property names (`"weight"` and `"bias"`) were already taken by class properties.

</details>

This PR fixes the issue by changing the param logic in `Linear` from using class properties to directly registering params.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Register weight and bias params in linear op

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
