### PR TITLE
[PyTorch] Fix numeric overflow caused by int-type parameters and return value in the roundup function

### DIFF
--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -286,7 +286,7 @@ std::vector<size_t> convertShape(const NVTEShape& shape) {
   return std::vector<size_t>(shape.data, shape.data + shape.ndim);
 }
 
-int roundup(const int value, const int multiple) {
+size_t roundup(const size_t value, const size_t multiple) {
   assert(multiple > 0);
   return ((value + multiple - 1) / multiple) * multiple;
 }

--- a/transformer_engine/pytorch/csrc/common.h
+++ b/transformer_engine/pytorch/csrc/common.h
@@ -417,7 +417,7 @@ void* getDataPtr(at::Tensor tensor, int offset = 0);
 
 std::vector<size_t> convertShape(const NVTEShape& shape);
 
-int roundup(const int value, const int multiple);
+size_t roundup(const size_t value, const size_t multiple);
 
 NVTEShape convertTorchShape(const c10::IntArrayRef torch_shape);
 }  // namespace transformer_engine::pytorch


### PR DESCRIPTION
# Description

Fixed potential integer overflow in buffer allocation when handling large tensor groups. This addresses a critical edge case where buffer_size calculations could overflow due to incorrect type usage in roundup function.

Anyone can reproduce the bug using the following code:
```
import torch
from transformer_engine.pytorch.module import GroupedLinear
from transformer_engine.pytorch.fp8 import fp8_autocast
from transformer_engine.common.recipe import Float8BlockScaling, Format


def test_grouped_linear_fp8():
    local_experts = 4
    hidden_size = 6144 
    total_tokens = 398016
    out_features = hidden_size

    x = torch.randn(total_tokens, hidden_size, dtype=torch.bfloat16, device='cuda')  

    m_splits = [total_tokens // local_experts] * local_experts
    m_splits[-1] += total_tokens % local_experts

    layer = GroupedLinear(
        num_gemms=local_experts,
        in_features=hidden_size,
        out_features=out_features,
        bias=True,
        params_dtype=torch.bfloat16,
        device='cuda'
    )

    # FP8 recipe
    fp8_recipe = Float8BlockScaling(
        fp8_format=Format.HYBRID,    
        x_block_scaling_dim=1,
        w_block_scaling_dim=2,
        grad_block_scaling_dim=1
    )

    print(f"x shape: {x.shape}")
    print(f"m_splits: {m_splits}")

    with fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
        output = layer.forward(x, m_splits, is_first_microbatch=True)

if __name__ == "__main__":
    test_grouped_linear_fp8()
```
The error message is as follows:
```
x shape: torch.Size([398016, 6144])
m_splits: [99504, 99504, 99504, 99504]
[W805 12:56:18.711012815 Module.cpp:186] symbolizing C++ stack trace for exception; if this hangs, rerun with TORCH_DISABLE_ADDR2LINE=1...

Traceback (most recent call last):
  File "/workspace/test.py", line 46, in <module>
    test_grouped_linear_fp8()
  File "/workspace/test.py", line 42, in test_grouped_linear_fp8
    output = layer.forward(x, m_splits, is_first_microbatch=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 850, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/module/grouped_linear.py", line 809, in forward
    out = linear_fn(*args)
          ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 575, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/module/grouped_linear.py", line 127, in forward
    inputmats = tex.split_quantize(inp_view, m_splits, input_quantizers)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Trying to create tensor with negative dimension -1773137856: [-1773137856]
```

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Changed roundup function parameters from int to size_t to prevent integer overflow

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
