### PR TITLE
Revert "[JAX] Disable TE Norm Custom Calls"

### DIFF
--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -34,7 +34,7 @@ class BasePrimitive(metaclass=ABCMeta):
     _is_enabled = True
 
     # Default list of primitives to disable for all recipes
-    _default_disable_names = ["GemmPrimitive", "NormFwdPrimitive", "NormBwdPrimitive"]
+    _default_disable_names = ["GemmPrimitive"]
 
     @classmethod
     def enabled(cls):


### PR DESCRIPTION
Reverts NVIDIA/TransformerEngine#1993 as byte-count in the L1 test_distributed_layernorm.py needs to be adapted.