### PR TITLE
[JAX] Enable TE GEMM custom call for all recipes

### DIFF
--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -34,7 +34,7 @@ class BasePrimitive(metaclass=ABCMeta):
     _is_enabled = True
 
     # Default list of primitives to disable for all recipes
-    _default_disable_names = ["GemmPrimitive"]
+    _default_disable_names = []
 
     @classmethod
     def enabled(cls):

--- a/transformer_engine/jax/layernorm_mlp.py
+++ b/transformer_engine/jax/layernorm_mlp.py
@@ -15,11 +15,11 @@ quantization, and distributed training through sharding constraints.
 
 from typing import List, Tuple, Sequence, Union, Callable
 from functools import partial
+import warnings
 
 import jax
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
-import warnings
 
 from . import cpp_extensions as tex
 from .layernorm import canonicalize_norm_type
@@ -105,7 +105,7 @@ def layernorm_mlp(
     if (
         inspect_axes is not None
         and len(inspect_axes) == x.ndim
-        and inspect_axes[-1] != None
+        and inspect_axes[-1] is not None
         and not is_mxfp8
     ):
         warnings.warn(

--- a/transformer_engine/jax/layernorm_mlp.py
+++ b/transformer_engine/jax/layernorm_mlp.py
@@ -19,6 +19,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 from jax.ad_checkpoint import checkpoint_name
+import warnings
 
 from . import cpp_extensions as tex
 from .layernorm import canonicalize_norm_type
@@ -91,6 +92,21 @@ def layernorm_mlp(
         - Checkpointing is applied to both feed-forward networks for memory efficiency
     """
     assert len(kernels) == 2
+
+    # For MaxText TP (= Megatron TP + sharding in hidden dimension of remaining unsharded
+    # activations), JAX dot_general may perform better then TE GEMM custom call
+    # This inspection only works if either norm_input_axes or dot_1_input_axes is set
+    is_mxfp8 = (
+        False if quantizer_sets[0] == noop_quantizer_set
+        else quantizer_sets[0].x.scaling_mode.is_1d_block_scaling()
+    )
+    inspect_axes = norm_input_axes or dot_1_input_axes
+    if (inspect_axes is not None
+        and len(inspect_axes) == x.ndim
+        and inspect_axes[-1] != None
+        and not is_mxfp8
+            ):
+        warnings.warn("Detected sharding in the hidden dimension of the MLP activation input. For improved performance, consider using JAX’s built-in `dot_general` implementation.  To try this, set the environment variable: `NVTE_JAX_CUSTOM_CALLS='GemmPrimitive=false'`", UserWarning)
 
     kernel_1 = kernels[0]
     kernel_2 = kernels[1]

--- a/transformer_engine/jax/layernorm_mlp.py
+++ b/transformer_engine/jax/layernorm_mlp.py
@@ -97,16 +97,23 @@ def layernorm_mlp(
     # activations), JAX dot_general may perform better then TE GEMM custom call
     # This inspection only works if either norm_input_axes or dot_1_input_axes is set
     is_mxfp8 = (
-        False if quantizer_sets[0] == noop_quantizer_set
+        False
+        if quantizer_sets[0] == noop_quantizer_set
         else quantizer_sets[0].x.scaling_mode.is_1d_block_scaling()
     )
     inspect_axes = norm_input_axes or dot_1_input_axes
-    if (inspect_axes is not None
+    if (
+        inspect_axes is not None
         and len(inspect_axes) == x.ndim
         and inspect_axes[-1] != None
         and not is_mxfp8
-            ):
-        warnings.warn("Detected sharding in the hidden dimension of the MLP activation input. For improved performance, consider using JAX’s built-in `dot_general` implementation.  To try this, set the environment variable: `NVTE_JAX_CUSTOM_CALLS='GemmPrimitive=false'`", UserWarning)
+    ):
+        warnings.warn(
+            "Detected sharding in the hidden dimension of the MLP activation input. For improved"
+            " performance, consider using JAX’s built-in `dot_general` implementation.  To try"
+            " this, set the environment variable: `NVTE_JAX_CUSTOM_CALLS='GemmPrimitive=false'`",
+            UserWarning,
+        )
 
     kernel_1 = kernels[0]
     kernel_2 = kernels[1]

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -352,9 +352,6 @@ class BlockScalingQuantizeConfig:
         cls.initialize(fp8_recipe)
         cls.AMAX_HISTORY_LEN = 0
 
-        # Use TE GEMM instead of JAX GEMM for better performance
-        tex.base.manage_primitives(enable_names=["GemmPrimitive"])
-
     @staticmethod
     def finalize() -> None:
         """Reset the block scaling configuration."""


### PR DESCRIPTION
# Description

With changes introduced in the GH-2023, the TE GEMM custom calls outperform the built-in JAX `dot_general` in most of the parallelism schemes (except TP + Sharding in the hidden dimension of remaining unsharded activations) for all recipes.
Hence, this PR enabled TE GEMM custom calls as the default. 
In addition, a warning is raised when sharding in the hidden dimension of the MLP activation input is detected.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
