### PR TITLE
[JAX] Trim dist fused attn tests in L1 

### DIFF
--- a/qa/L2_jax_unittest/test.sh
+++ b/qa/L2_jax_unittest/test.sh
@@ -26,6 +26,15 @@ pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 mkdir -p "$XML_LOG_DIR"
 
 NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_jax_not_distributed.xml $TE_PATH/tests/jax -k 'not distributed' || test_fail "tests/jax/*not_distributed_*"
+# Run left over distributed fused attn tests
+# TestReorderCausalLoadBalancing: Run only one (non symmetric) BSHD/SBHD data shape combination
+NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestReorderCausalLoadBalancing and ( 4-32-12-32 or 1-16-1-1 )"
+# TestDistributedSelfAttn: Run only one (smaller) BSHD type data shape combination
+NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedSelfAttn and 32-512-12-64"
+# TestDistributedCrossAttn: Run only one (smaller) BSHD type data shape combination
+NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedCrossAttn and data_shape0"
+# TestDistributedContextParallelSelfAttn: Run only cp1 combinations
+NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedContextParallelSelfAttn and cp1"
 
 pip3 install -r $TE_PATH/examples/jax/mnist/requirements.txt || error_exit "Failed to install mnist requirements"
 NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_mnist.xml $TE_PATH/examples/jax/mnist || test_fail "mnist"

--- a/qa/L2_jax_unittest/test.sh
+++ b/qa/L2_jax_unittest/test.sh
@@ -25,16 +25,16 @@ pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 : ${XML_LOG_DIR:=/logs}
 mkdir -p "$XML_LOG_DIR"
 
-NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_jax_not_distributed.xml $TE_PATH/tests/jax -k 'not distributed' || test_fail "tests/jax/*not_distributed_*"
-# Run left over distributed fused attn tests
-# TestReorderCausalLoadBalancing: Run only one (non symmetric) BSHD/SBHD data shape combination
-NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestReorderCausalLoadBalancing and ( 4-32-12-32 or 1-16-1-1 )"
-# TestDistributedSelfAttn: Run only one (smaller) BSHD type data shape combination
-NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedSelfAttn and 32-512-12-64"
-# TestDistributedCrossAttn: Run only one (smaller) BSHD type data shape combination
-NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedCrossAttn and data_shape0"
-# TestDistributedContextParallelSelfAttn: Run only cp1 combinations
-NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedContextParallelSelfAttn and cp1"
+# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_jax_not_distributed.xml $TE_PATH/tests/jax -k 'not distributed' || test_fail "tests/jax/*not_distributed_*"
+# # Run left over distributed fused attn tests
+# # TestReorderCausalLoadBalancing: Run only one (non symmetric) BSHD/SBHD data shape combination
+# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestReorderCausalLoadBalancing and ( 4-32-12-32 or 1-16-1-1 )"
+# # TestDistributedSelfAttn: Run only one (smaller) BSHD type data shape combination
+# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedSelfAttn and 32-512-12-64"
+# # TestDistributedCrossAttn: Run only one (smaller) BSHD type data shape combination
+# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedCrossAttn and data_shape0"
+# # TestDistributedContextParallelSelfAttn: Run only cp1 combinations
+# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedContextParallelSelfAttn and cp1"
 
 pip3 install -r $TE_PATH/examples/jax/mnist/requirements.txt || error_exit "Failed to install mnist requirements"
 NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_mnist.xml $TE_PATH/examples/jax/mnist || test_fail "mnist"

--- a/qa/L2_jax_unittest/test.sh
+++ b/qa/L2_jax_unittest/test.sh
@@ -25,16 +25,7 @@ pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 : ${XML_LOG_DIR:=/logs}
 mkdir -p "$XML_LOG_DIR"
 
-# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_jax_not_distributed.xml $TE_PATH/tests/jax -k 'not distributed' || test_fail "tests/jax/*not_distributed_*"
-# # Run left over distributed fused attn tests
-# # TestReorderCausalLoadBalancing: Run only one (non symmetric) BSHD/SBHD data shape combination
-# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestReorderCausalLoadBalancing and ( 4-32-12-32 or 1-16-1-1 )"
-# # TestDistributedSelfAttn: Run only one (smaller) BSHD type data shape combination
-# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedSelfAttn and 32-512-12-64"
-# # TestDistributedCrossAttn: Run only one (smaller) BSHD type data shape combination
-# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedCrossAttn and data_shape0"
-# # TestDistributedContextParallelSelfAttn: Run only cp1 combinations
-# NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py -k "TestDistributedContextParallelSelfAttn and cp1"
+NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_jax_not_distributed.xml $TE_PATH/tests/jax -k 'not distributed' || test_fail "tests/jax/*not_distributed_*"
 
 pip3 install -r $TE_PATH/examples/jax/mnist/requirements.txt || error_exit "Failed to install mnist requirements"
 NVTE_JAX_UNITTEST_LEVEL="L2" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_mnist.xml $TE_PATH/examples/jax/mnist || test_fail "mnist"

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -40,6 +40,7 @@ def generate_configs():
 
 
 def generate_context_parallel_configs():
+    '''Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only'''
     configsL1 = []
     configsL2 = []
     mr = MeshResource(dp_resource="dp", cp_resource="cp", tp_resource="tp")
@@ -50,6 +51,7 @@ def generate_context_parallel_configs():
     for dp, cp, tp in product(DP_sizes, CP_sizes, TP_sizes):
         ndev = cp * tp * dp
         if is_devices_enough(ndev):
+            # Do not run cp1 case in L1 as that is already covered in TestDistributedSelfAttn and TestDistributedCrossAttn (as these do not have any cp combinations)
             if cp != 1:
                 configsL1.append(
                     pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}")

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -51,9 +51,13 @@ def generate_context_parallel_configs():
         ndev = cp * tp * dp
         if is_devices_enough(ndev):
             if cp != 1:
-                configsL1.append(pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}"))
+                configsL1.append(
+                    pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}")
+                )
             else:
-                configsL2.append(pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}"))
+                configsL2.append(
+                    pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}")
+                )
     configs = {"L1": configsL1, "L2": configsL2}
     return configs
 

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -39,8 +39,8 @@ def generate_configs():
     return configs
 
 
-def generate_context_parallel_configs():
-    """Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only"""
+def generate_context_parallel_configs_for_attn():
+    '''Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only'''
     configsL1 = []
     configsL2 = []
     mr = MeshResource(dp_resource="dp", cp_resource="cp", tp_resource="tp")

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -40,7 +40,7 @@ def generate_configs():
 
 
 def generate_context_parallel_configs():
-    '''Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only'''
+    """Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only"""
     configsL1 = []
     configsL2 = []
     mr = MeshResource(dp_resource="dp", cp_resource="cp", tp_resource="tp")

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -60,7 +60,7 @@ def generate_context_parallel_configs():
                 configsL2.append(
                     pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}")
                 )
-    configs = {"L1": configsL1, "L2": configsL2}
+    configs = {"L0": [], "L1": configsL1, "L2": configsL2}
     return configs
 
 

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -40,7 +40,7 @@ def generate_configs():
 
 
 def generate_context_parallel_configs_for_attn():
-    '''Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only'''
+    """Generate CP combinations along with TP+DP for TestDistributedContextParallelSelfAttn only"""
     configsL1 = []
     configsL2 = []
     mr = MeshResource(dp_resource="dp", cp_resource="cp", tp_resource="tp")

--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -40,7 +40,8 @@ def generate_configs():
 
 
 def generate_context_parallel_configs():
-    configs = []
+    configsL1 = []
+    configsL2 = []
     mr = MeshResource(dp_resource="dp", cp_resource="cp", tp_resource="tp")
     axes = ("dp", "cp", "tp")
     DP_sizes = (1, 2)
@@ -49,10 +50,11 @@ def generate_context_parallel_configs():
     for dp, cp, tp in product(DP_sizes, CP_sizes, TP_sizes):
         ndev = cp * tp * dp
         if is_devices_enough(ndev):
-            configs.append(
-                pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}")
-            )
-
+            if cp != 1:
+                configsL1.append(pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}"))
+            else:
+                configsL2.append(pytest.param(ndev, (dp, cp, tp), axes, mr, id=f"n{ndev}_dp{dp}_cp{cp}_tp{tp}"))
+    configs = {"L1": configsL1, "L2": configsL2}
     return configs
 
 

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -29,7 +29,11 @@ from transformer_engine.jax.attention import (
 
 DTYPES = [jnp.bfloat16]
 
-DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {"L0": [()], "L1": [(32, 1024, 16, 128)], "L2": [(32, 512, 12, 64)]}
+DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {
+    "L0": [()],
+    "L1": [(32, 1024, 16, 128)],
+    "L2": [(32, 512, 12, 64)],
+}
 
 
 class TestDistributedSelfAttn:
@@ -189,7 +193,11 @@ class TestDistributedSelfAttn:
         )
 
 
-DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {"L0": [()], "L1": [[32, 512, 16, 64]], "L2": [[32, 128, 12, 64]]}
+DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {
+    "L0": [()],
+    "L1": [[32, 512, 16, 64]],
+    "L2": [[32, 128, 12, 64]],
+}
 
 
 class TestDistributedCrossAttn:

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -29,7 +29,7 @@ from transformer_engine.jax.attention import (
 
 DTYPES = [jnp.bfloat16]
 
-DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {"L1": (32, 1024, 16, 128), "L2": (32, 512, 12, 64)}
+DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {"L1": [(32, 1024, 16, 128)], "L2": [(32, 512, 12, 64)]}
 
 
 class TestDistributedSelfAttn:
@@ -67,7 +67,6 @@ class TestDistributedSelfAttn:
         jax.config.update("jax_use_shardy_partitioner", use_shardy)
         dropout_prob = 0.0
         is_training = True
-
         batch, seqlen, num_head, hidden = data_shape
 
         if not is_fused_attn_kernel_available(
@@ -190,7 +189,7 @@ class TestDistributedSelfAttn:
         )
 
 
-DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {"L1": [32, 512, 16, 64], "L2": [32, 128, 12, 64]}
+DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {"L1": [[32, 512, 16, 64]], "L2": [[32, 128, 12, 64]]}
 
 
 class TestDistributedCrossAttn:
@@ -390,7 +389,7 @@ class TestDistributedContextParallelSelfAttn:
         runner.test_backward()
         del os.environ["NVTE_FUSED_RING_ATTENTION_USE_SCAN"]
 
-    @pytest.mark.parametrize(
+    @pytest_parametrize_wrapper(
         "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES[:1])
@@ -426,7 +425,7 @@ class TestDistributedContextParallelSelfAttn:
             use_shardy=True,
         )
 
-    @pytest.mark.parametrize(
+    @pytest_parametrize_wrapper(
         "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES)
@@ -532,7 +531,7 @@ class TestDistributedContextParallelSelfAttn:
             window_size=window_size,
         )
 
-    @pytest.mark.parametrize(
+    @pytest_parametrize_wrapper(
         "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES[:1])
@@ -571,7 +570,7 @@ class TestDistributedContextParallelSelfAttn:
 
 
 REORDER_CAUSAL_LOAD_BALANCING_DATA_SHAPES = {
-    "L1": [1, 16, 1, 1],
+    "L1": [[1, 16, 1, 1]],
     "L2": [[4, 32, 12, 32], [3, 32, 8, 64]],
 }
 

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 from jax import random
 from distributed_test_base import (
     generate_configs,
-    generate_context_parallel_configs,
+    generate_context_parallel_configs_for_attn,
     generate_collectives_count,
 )
 from test_fused_attn import FusedAttnRunner, BiasShape, SeqDescFormat
@@ -398,7 +398,7 @@ class TestDistributedContextParallelSelfAttn:
         del os.environ["NVTE_FUSED_RING_ATTENTION_USE_SCAN"]
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
+        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES[:1])
     @pytest.mark.parametrize("dtype", [pytest.param(jnp.bfloat16, id="BF16")])
@@ -434,7 +434,7 @@ class TestDistributedContextParallelSelfAttn:
         )
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
+        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES)
     @pytest.mark.parametrize("kv_groups", [1, 8])
@@ -476,7 +476,7 @@ class TestDistributedContextParallelSelfAttn:
         )
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
+        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES)
     @pytest.mark.parametrize("kv_groups", [1, 8])
@@ -540,7 +540,7 @@ class TestDistributedContextParallelSelfAttn:
         )
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
+        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES[:1])
     @pytest.mark.parametrize("dtype", [pytest.param(jnp.bfloat16, id="BF16")])

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -398,7 +398,8 @@ class TestDistributedContextParallelSelfAttn:
         del os.environ["NVTE_FUSED_RING_ATTENTION_USE_SCAN"]
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
+        "device_count,mesh_shape,mesh_axes,mesh_resource",
+        generate_context_parallel_configs_for_attn(),
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES[:1])
     @pytest.mark.parametrize("dtype", [pytest.param(jnp.bfloat16, id="BF16")])
@@ -434,7 +435,8 @@ class TestDistributedContextParallelSelfAttn:
         )
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
+        "device_count,mesh_shape,mesh_axes,mesh_resource",
+        generate_context_parallel_configs_for_attn(),
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES)
     @pytest.mark.parametrize("kv_groups", [1, 8])
@@ -476,7 +478,8 @@ class TestDistributedContextParallelSelfAttn:
         )
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
+        "device_count,mesh_shape,mesh_axes,mesh_resource",
+        generate_context_parallel_configs_for_attn(),
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES)
     @pytest.mark.parametrize("kv_groups", [1, 8])
@@ -540,7 +543,8 @@ class TestDistributedContextParallelSelfAttn:
         )
 
     @pytest_parametrize_wrapper(
-        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs_for_attn()
+        "device_count,mesh_shape,mesh_axes,mesh_resource",
+        generate_context_parallel_configs_for_attn(),
     )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES[:1])
     @pytest.mark.parametrize("dtype", [pytest.param(jnp.bfloat16, id="BF16")])

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -570,8 +570,8 @@ class TestDistributedContextParallelSelfAttn:
 
 
 REORDER_CAUSAL_LOAD_BALANCING_DATA_SHAPES = {
-    "L1": [[1, 16, 1, 1]],
-    "L2": [[4, 32, 12, 32], [3, 32, 8, 64]],
+    "L1": [[3, 32, 8, 64]],
+    "L2": [[4, 32, 12, 32], [1, 16, 1, 1]],
 }
 
 

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -29,7 +29,7 @@ from transformer_engine.jax.attention import (
 
 DTYPES = [jnp.bfloat16]
 
-DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {"L1": [(32, 1024, 16, 128)], "L2": [(32, 512, 12, 64)]}
+DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {"L0": [()], "L1": [(32, 1024, 16, 128)], "L2": [(32, 512, 12, 64)]}
 
 
 class TestDistributedSelfAttn:
@@ -189,7 +189,7 @@ class TestDistributedSelfAttn:
         )
 
 
-DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {"L1": [[32, 512, 16, 64]], "L2": [[32, 128, 12, 64]]}
+DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {"L0": [()], "L1": [[32, 512, 16, 64]], "L2": [[32, 128, 12, 64]]}
 
 
 class TestDistributedCrossAttn:
@@ -570,6 +570,7 @@ class TestDistributedContextParallelSelfAttn:
 
 
 REORDER_CAUSAL_LOAD_BALANCING_DATA_SHAPES = {
+    "L0": [[]],
     "L1": [[3, 32, 8, 64]],
     "L2": [[4, 32, 12, 32], [1, 16, 1, 1]],
 }

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -29,10 +29,9 @@ from transformer_engine.jax.attention import (
 
 DTYPES = [jnp.bfloat16]
 
-DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {
-    "L1": (32, 1024, 16, 128),
-    "L2": (32, 512, 12, 64)
-}
+DISTRIBUTED_SELF_ATTN_DATA_SHAPES = {"L1": (32, 1024, 16, 128), "L2": (32, 512, 12, 64)}
+
+
 class TestDistributedSelfAttn:
 
     def generate_collectives_count_ref(
@@ -123,10 +122,7 @@ class TestDistributedSelfAttn:
         runner.test_backward()
 
     @pytest.mark.parametrize("device_count,mesh_shape,mesh_axes,mesh_resource", generate_configs())
-    @pytest_parametrize_wrapper(
-        "data_shape",
-        DISTRIBUTED_SELF_ATTN_DATA_SHAPES
-    )
+    @pytest_parametrize_wrapper("data_shape", DISTRIBUTED_SELF_ATTN_DATA_SHAPES)
     @pytest.mark.parametrize(
         "attn_bias_type, bias_shape",
         [
@@ -193,10 +189,10 @@ class TestDistributedSelfAttn:
             use_shardy=True,
         )
 
-DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {
-    "L1": [32, 512, 16, 64],
-    "L2": [32, 128, 12, 64]
-}
+
+DISTRIBUTED_CROSS_ATTN_DATA_SHAPES = {"L1": [32, 512, 16, 64], "L2": [32, 128, 12, 64]}
+
+
 class TestDistributedCrossAttn:
 
     def generate_collectives_count_ref(self):
@@ -472,7 +468,9 @@ class TestDistributedContextParallelSelfAttn:
             use_shardy=False,
         )
 
-    @pytest_parametrize_wrapper("device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs())
+    @pytest_parametrize_wrapper(
+        "device_count,mesh_shape,mesh_axes,mesh_resource", generate_context_parallel_configs()
+    )
     @pytest.mark.parametrize("data_shape", DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES)
     @pytest.mark.parametrize("kv_groups", [1, 8])
     @pytest.mark.parametrize("dtype", [pytest.param(jnp.bfloat16, id="BF16")])
@@ -571,16 +569,16 @@ class TestDistributedContextParallelSelfAttn:
             use_scan_ring=True,
         )
 
+
 REORDER_CAUSAL_LOAD_BALANCING_DATA_SHAPES = {
     "L1": [1, 16, 1, 1],
-    "L2": [[4, 32, 12, 32], [3, 32, 8, 64]]
+    "L2": [[4, 32, 12, 32], [3, 32, 8, 64]],
 }
+
+
 class TestReorderCausalLoadBalancing:
     @pytest.mark.parametrize("cp_size", [2, 4, 8])
-    @pytest_parametrize_wrapper(
-        "shape",
-        REORDER_CAUSAL_LOAD_BALANCING_DATA_SHAPES
-    )
+    @pytest_parametrize_wrapper("shape", REORDER_CAUSAL_LOAD_BALANCING_DATA_SHAPES)
     @pytest.mark.parametrize("qkv_format", [QKVFormat.BSHD, QKVFormat.SBHD])
     @pytest.mark.parametrize(
         "reorder_strategy",


### PR DESCRIPTION
# Description

Reduce the number of L1 distributed fused attn tests so as to reduce CI nightly time outs (which runs L0 and L1 tests)
**_Preliminary tests suggest reduction of ~12 mins (720 seconds)_** 


**L1 test timings (before changes in this PR)**:
```
================================================================================
TEST RUNTIME SUMMARY (grouped by function)
================================================================================
test                                                         |  36x |    5.23s | avg:   0.15s
test_context_parallel_allgather_attn                         | 480x | 1446.77s | avg:   3.01s
test_context_parallel_allgather_attn_shardy                  |  60x |  204.83s | avg:   3.41s
test_context_parallel_ring_attn                              | 1920x | 2367.42s | avg:   1.23s
test_context_parallel_ring_attn_shardy                       |  60x |   90.06s | avg:   1.50s
test_cross_attn                                              |  12x |   57.77s | avg:   4.81s
test_layernorm                                               | 144x |   58.24s | avg:   0.40s
test_layernorm_mlp_grad                                      |  96x |  134.95s | avg:   1.41s
test_layernorm_mlp_grad_shardy                               |  96x |  108.47s | avg:   1.13s
test_layernorm_mlp_layer                                     |  32x |   53.94s | avg:   1.69s
test_layernorm_mlp_layer_fp8                                 |  96x |   28.72s | avg:   0.30s
test_layernorm_mlp_layer_fp8_shardy                          |  96x |   29.58s | avg:   0.31s
test_layernorm_mlp_layer_shardy                              |  32x |   14.97s | avg:   0.47s
test_rmsnorm                                                 |  72x |   20.51s | avg:   0.28s
test_self_attn                                               |  36x |  193.28s | avg:   5.37s
test_self_attn_shardy                                        |   6x |   10.54s | avg:   1.76s
test_softmax                                                 | 288x |  218.98s | avg:   0.76s
test_softmax_gspmd                                           |  24x |   10.80s | avg:   0.45s
================================================================================
TOTAL RUNTIME                                                |      | 5055.06s |
================================================================================
```


**L1 test timings (after changes in this PR)**:
```
================================================================================
TEST RUNTIME SUMMARY (grouped by function)
================================================================================
test                                                         |  12x |    1.61s | avg:   0.13s
test_context_parallel_allgather_attn                         | 320x | 1233.43s | avg:   3.85s
test_context_parallel_allgather_attn_shardy                  |  40x |  181.05s | avg:   4.53s
test_context_parallel_ring_attn                              | 1280x | 2007.73s | avg:   1.57s
test_context_parallel_ring_attn_shardy                       |  40x |   83.26s | avg:   2.08s
test_cross_attn                                              |   6x |   36.74s | avg:   6.12s
test_layernorm                                               | 144x |   63.56s | avg:   0.44s
test_layernorm_mlp_grad                                      |  96x |  127.21s | avg:   1.33s
test_layernorm_mlp_grad_shardy                               |  96x |   94.78s | avg:   0.99s
test_layernorm_mlp_layer                                     |  32x |   35.57s | avg:   1.11s
test_layernorm_mlp_layer_fp8                                 |  96x |   25.55s | avg:   0.27s
test_layernorm_mlp_layer_fp8_shardy                          |  96x |   24.30s | avg:   0.25s
test_layernorm_mlp_layer_shardy                              |  32x |   13.19s | avg:   0.41s
test_rmsnorm                                                 |  72x |   19.77s | avg:   0.27s
test_self_attn                                               |  18x |  142.20s | avg:   7.90s
test_self_attn_shardy                                        |   6x |   18.19s | avg:   3.03s
test_softmax                                                 | 288x |  220.14s | avg:   0.76s
test_softmax_gspmd                                           |  24x |   10.72s | avg:   0.45s
================================================================================
TOTAL RUNTIME                                                |      | 4339.02s |
================================================================================
```


**L2 dist test timings (after changes in the PR)**:
```
================================================================================
TEST RUNTIME SUMMARY (grouped by function)
================================================================================
test                                                         |  24x |    3.31s | avg:   0.14s
test_context_parallel_allgather_attn                         | 160x |  208.42s | avg:   1.30s
test_context_parallel_allgather_attn_shardy                  |  20x |   23.12s | avg:   1.16s
test_context_parallel_ring_attn                              | 640x |  433.63s | avg:   0.68s
test_context_parallel_ring_attn_shardy                       |  20x |   14.00s | avg:   0.70s
test_cross_attn                                              |   6x |   19.81s | avg:   3.30s
test_layernorm                                               | 144x |   56.72s | avg:   0.39s
test_layernorm_mlp_grad                                      |  96x |  119.49s | avg:   1.24s
test_layernorm_mlp_grad_shardy                               |  96x |   95.80s | avg:   1.00s
test_layernorm_mlp_layer                                     |  32x |   49.91s | avg:   1.56s
test_layernorm_mlp_layer_fp8                                 |  96x |   26.38s | avg:   0.27s
test_layernorm_mlp_layer_fp8_shardy                          |  96x |   30.88s | avg:   0.32s
test_layernorm_mlp_layer_shardy                              |  32x |   13.60s | avg:   0.43s
test_rmsnorm                                                 |  72x |   18.22s | avg:   0.25s
test_self_attn                                               |  18x |   57.58s | avg:   3.20s
test_self_attn_shardy                                        |   6x |   10.35s | avg:   1.72s
test_softmax                                                 | 288x |  222.98s | avg:   0.77s
test_softmax_gspmd                                           |  24x |   11.92s | avg:   0.50s
================================================================================
TOTAL RUNTIME                                                |      | 1416.12s |
================================================================================
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Infra/Build change
- [ ] Code refactoring

## Changes

888 tests in L1 jax distributed are moved to L2 jax distributed. The split up is outlines below.
Move dist fused attn tests to L2. The following tests are moved from L1 JAX to L2 distributed JAX: 
1. `TestReorderCausalLoadBalancing`: Run two (non symmetric) BSHD/SBHD data shape combination - 24 tests moved
2. `TestDistributedSelfAttn`: Run only one (smaller) BSHD type data shape combination - 18 tests moved
3. `TestDistributedCrossAttn`: Run only one (smaller) BSHD type data shape combination - 6 tests moved
4. `TestDistributedContextParallelSelfAttn`: Run all cp1 combinations - 840 tests moved

Reduce the number of dist fused attn tests in L1 JAX. The following are retained in L1 JAX : 

1. `TestReorderCausalLoadBalancing`: Run only one (non symmetric) BSHD/SBHD data shape combination
2. `TestDistributedSelfAttn`: Run only one (larger) BSHD type data shape combination
3. `TestDistributedCrossAttn`: Run only one (larger) BSHD type data shape combination
4. `TestDistributedContextParallelSelfAttn`: Run only non cp1 combinations

It was confirmed that the original number of tests run in L1 are retained even after splitting : 

1. `Original distribution of tests in L1 JAX (for B200)` : 3586 = (**2610 dist fused attn** + 216 dist layer norm + 448 dist layer norm mlp + 312 dist softmax)
2. `New distributions of tests in L1 JAX (for B200)` : 2698 = (**1722 dist fused attn** + 216 dist layer norm + 448 dist layer norm mlp + 312 dist softmax)
3. `New distribution of tests in L2 JAX dist (for B200)`:  1870 = (**888 dist fused attn** + 216 dist layer norm + 448 dist layer norm mlp + 312 dist softmax + 4) 


# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
