### PR TITLE
[JAX] Pass mesh_resource context through VJP and into primitives

### DIFF
--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -34,6 +34,7 @@ from ..quantize import (
     is_fp8_gemm_with_all_layouts_supported,
     apply_padding_to_scale_inv,
 )
+from ..sharding import global_mesh_resource
 from .misc import get_padded_spec
 
 
@@ -490,7 +491,8 @@ class GemmPrimitive(BasePrimitive):
 
             # Non-contracting dims of RHS always needs to be gathered along the FSDP axis
             rhs_non_cspecs = tuple(
-                None if spec is not None and "fsdp" in spec else spec for spec in rhs_non_cspecs
+                None if spec is not None and global_mesh_resource().fsdp_resource in spec else spec
+                for spec in rhs_non_cspecs
             )
 
         # Non-contracting dims of LHS to be gathered along the SP axis.

--- a/transformer_engine/jax/dense.py
+++ b/transformer_engine/jax/dense.py
@@ -21,6 +21,7 @@ from .quantize import (
     with_sharding_constraint_by_logical_axes,
     TensorUsage,
 )
+from .sharding import global_mesh_resource, global_shard_guard
 
 
 def dense(
@@ -56,6 +57,7 @@ def dense(
             bias_new_shape = (1,) * (output.ndim - bias.ndim) + bias.shape
             output += jnp.reshape(bias, bias_new_shape)
     else:
+        mesh_resource = global_mesh_resource()
         output = _dense(
             x,
             kernel,
@@ -64,6 +66,7 @@ def dense(
             input_axes,
             kernel_axes,
             quantizer_set,
+            mesh_resource,
         )
     return output
 
@@ -74,6 +77,7 @@ def dense(
         3,
         4,
         5,
+        7,
     ),
 )
 def _dense(
@@ -84,6 +88,7 @@ def _dense(
     input_axes,
     kernel_axes,
     quantizer_set,
+    mesh_resource,
 ):
     """Internal implementation of dense layer transformation with custom VJP.
 
@@ -98,6 +103,7 @@ def _dense(
         input_axes: Logical axes for sharding the activation input
         kernel_axes: Logical axes for sharding the weight matrix
         quantizer_set: QuantizerSet which contains quantizers for different tensor types
+        mesh_resource: Mesh resource for sharding
 
     Returns:
         Transformed output tensor
@@ -110,6 +116,7 @@ def _dense(
         input_axes,
         kernel_axes,
         quantizer_set,
+        mesh_resource,
     )
     return output
 
@@ -122,126 +129,129 @@ def _dense_fwd_rule(
     input_axes,
     kernel_axes,
     quantizer_set,
+    mesh_resource,
 ):
     """Forward pass rule for dense layer transformation.
 
     Returns:
         Tuple of (output, context) for backward pass
     """
-    x_contracting_dims, k_contracting_dims = map(
-        tex.sanitize_dims, (x.ndim, kernel.ndim), contracting_dims
-    )
+    with global_shard_guard(mesh_resource):
+        x_contracting_dims, k_contracting_dims = map(
+            tex.sanitize_dims, (x.ndim, kernel.ndim), contracting_dims
+        )
 
-    # Check supported input layout
-    x_is_transposed = x.ndim - 1 not in x_contracting_dims
-    k_is_transposed = kernel.ndim - 1 in k_contracting_dims
-    assert (
-        not x_is_transposed and not k_is_transposed
-    ), "Dense layer only supports `NN` layout inputs, i.e. non-transposed X and Kernel."
+        # Check supported input layout
+        x_is_transposed = x.ndim - 1 not in x_contracting_dims
+        k_is_transposed = kernel.ndim - 1 in k_contracting_dims
+        assert (
+            not x_is_transposed and not k_is_transposed
+        ), "Dense layer only supports `NN` layout inputs, i.e. non-transposed X and Kernel."
 
-    flatten_axis_x = -len(x_contracting_dims)
-    flatten_axis_k = len(k_contracting_dims) - len(kernel.shape)
+        flatten_axis_x = -len(x_contracting_dims)
+        flatten_axis_k = len(k_contracting_dims) - len(kernel.shape)
 
-    casted_x = tex.quantize(
-        x, flatten_axis=flatten_axis_x, quantizer=quantizer_set.x, noop_scaled_tensor=True
-    )
-    casted_x = with_sharding_constraint_by_logical_axes(casted_x, input_axes)
+        casted_x = tex.quantize(
+            x, flatten_axis=flatten_axis_x, quantizer=quantizer_set.x, noop_scaled_tensor=True
+        )
+        casted_x = with_sharding_constraint_by_logical_axes(casted_x, input_axes)
 
-    casted_kernel = tex.quantize(
-        kernel,
-        flatten_axis=flatten_axis_k,
-        quantizer=quantizer_set.kernel,
-        noop_scaled_tensor=True,
-    )
-    casted_kernel = with_sharding_constraint_by_logical_axes(casted_kernel, kernel_axes)
+        casted_kernel = tex.quantize(
+            kernel,
+            flatten_axis=flatten_axis_k,
+            quantizer=quantizer_set.kernel,
+            noop_scaled_tensor=True,
+        )
+        casted_kernel = with_sharding_constraint_by_logical_axes(casted_kernel, kernel_axes)
 
-    # GEMM NN
-    use_bias = bias is not None
-    output = tex.gemm(
-        casted_x.get_tensor(usage=TensorUsage.LHS),
-        casted_kernel.get_tensor(usage=TensorUsage.RHS),
-        contracting_dims=(x_contracting_dims, k_contracting_dims),
-        bias=bias if not tex.gemm_uses_jax_dot() else None,
-        fuse_bias=use_bias if not tex.gemm_uses_jax_dot() else False,
-    )
+        # GEMM NN
+        use_bias = bias is not None
+        output = tex.gemm(
+            casted_x.get_tensor(usage=TensorUsage.LHS),
+            casted_kernel.get_tensor(usage=TensorUsage.RHS),
+            contracting_dims=(x_contracting_dims, k_contracting_dims),
+            bias=bias if not tex.gemm_uses_jax_dot() else None,
+            fuse_bias=use_bias if not tex.gemm_uses_jax_dot() else False,
+        )
 
-    if use_bias and tex.gemm_uses_jax_dot():
-        bias_new_shape = (1,) * (output.ndim - bias.ndim) + bias.shape
-        output += jnp.reshape(bias, bias_new_shape)
+        if use_bias and tex.gemm_uses_jax_dot():
+            bias_new_shape = (1,) * (output.ndim - bias.ndim) + bias.shape
+            output += jnp.reshape(bias, bias_new_shape)
 
-    ctx = (
-        casted_x.get_tensor(usage=TensorUsage.LHS_TRANS),
-        casted_kernel.get_tensor(usage=TensorUsage.RHS_TRANS),
-        x.shape,
-        kernel.shape,
-        use_bias,
-        quantizer_set,
-        flatten_axis_k,
-    )
-    return output, ctx
+        ctx = (
+            casted_x.get_tensor(usage=TensorUsage.LHS_TRANS),
+            casted_kernel.get_tensor(usage=TensorUsage.RHS_TRANS),
+            x.shape,
+            kernel.shape,
+            use_bias,
+            quantizer_set,
+            flatten_axis_k,
+        )
+        return output, ctx
 
 
 def _dense_bwd_rule(
-    contracting_dims, input_axes, kernel_axes, ctx, grad
+    contracting_dims, input_axes, kernel_axes, mesh_resource, ctx, grad
 ):  # pylint: disable=unused-argument
     """Backward pass rule for dense layer transformation.
 
     Returns:
         Tuple of gradients with respect to inputs
     """
-    (
-        casted_x_lhs,
-        casted_kernel_rhs,
-        x_shape,
-        kernel_shape,
-        use_bias,
-        quantizer_set,
-        flatten_axis_k,
-    ) = ctx
+    with global_shard_guard(mesh_resource):
+        (
+            casted_x_lhs,
+            casted_kernel_rhs,
+            x_shape,
+            kernel_shape,
+            use_bias,
+            quantizer_set,
+            flatten_axis_k,
+        ) = ctx
 
-    fwd_x_contracting_dims, fwd_k_contracting_dims = map(
-        tex.sanitize_dims, (casted_x_lhs.ndim, casted_kernel_rhs.ndim), contracting_dims
-    )
+        fwd_x_contracting_dims, fwd_k_contracting_dims = map(
+            tex.sanitize_dims, (casted_x_lhs.ndim, casted_kernel_rhs.ndim), contracting_dims
+        )
 
-    casted_grad, dbias = tex.quantize_dbias(
-        grad,
-        is_dbias=use_bias,
-        flatten_axis=flatten_axis_k,
-        quantizer=quantizer_set.dgrad,
-        noop_scaled_tensor=True,
-    )
+        casted_grad, dbias = tex.quantize_dbias(
+            grad,
+            is_dbias=use_bias,
+            flatten_axis=flatten_axis_k,
+            quantizer=quantizer_set.dgrad,
+            noop_scaled_tensor=True,
+        )
 
-    # GEMM NT
-    # k_non_contracting_dims calibrated with the shape difference of grad.ndim vs kernel.ndim
-    g_contracting_dim = tuple(
-        range(grad.ndim - len(kernel_shape) + len(fwd_k_contracting_dims), grad.ndim)
-    )
-    # k_non_contracting_dims
-    k_contracting_dim = tuple(
-        dim for dim in range(len(kernel_shape)) if dim not in fwd_k_contracting_dims
-    )
+        # GEMM NT
+        # k_non_contracting_dims calibrated with the shape difference of grad.ndim vs kernel.ndim
+        g_contracting_dim = tuple(
+            range(grad.ndim - len(kernel_shape) + len(fwd_k_contracting_dims), grad.ndim)
+        )
+        # k_non_contracting_dims
+        k_contracting_dim = tuple(
+            dim for dim in range(len(kernel_shape)) if dim not in fwd_k_contracting_dims
+        )
 
-    dgrad = tex.gemm(
-        casted_grad.get_tensor(usage=TensorUsage.LHS),
-        casted_kernel_rhs,
-        contracting_dims=(g_contracting_dim, k_contracting_dim),
-    )
-    dgrad = with_sharding_constraint_by_logical_axes(dgrad, input_axes)
+        dgrad = tex.gemm(
+            casted_grad.get_tensor(usage=TensorUsage.LHS),
+            casted_kernel_rhs,
+            contracting_dims=(g_contracting_dim, k_contracting_dim),
+        )
+        dgrad = with_sharding_constraint_by_logical_axes(dgrad, input_axes)
 
-    # GEMM TN
-    # x_non_contracting_dims
-    g_contracting_dim = x_contracting_dim = tuple(
-        range(0, len(x_shape) - len(fwd_x_contracting_dims))
-    )
+        # GEMM TN
+        # x_non_contracting_dims
+        g_contracting_dim = x_contracting_dim = tuple(
+            range(0, len(x_shape) - len(fwd_x_contracting_dims))
+        )
 
-    wgrad = tex.gemm(
-        casted_x_lhs,
-        casted_grad.get_tensor(usage=TensorUsage.RHS),
-        contracting_dims=(x_contracting_dim, g_contracting_dim),
-    )
-    wgrad = with_sharding_constraint_by_logical_axes(wgrad, kernel_axes)
+        wgrad = tex.gemm(
+            casted_x_lhs,
+            casted_grad.get_tensor(usage=TensorUsage.RHS),
+            contracting_dims=(x_contracting_dim, g_contracting_dim),
+        )
+        wgrad = with_sharding_constraint_by_logical_axes(wgrad, kernel_axes)
 
-    return dgrad, wgrad, dbias, quantizer_set
+        return dgrad, wgrad, dbias, quantizer_set
 
 
 _dense.defvjp(_dense_fwd_rule, _dense_bwd_rule)
@@ -276,6 +286,7 @@ def grouped_dense(
     Returns:
         A jnp.ndarray containing the result of the grouped linear operation
     """
+    mesh_resource = global_mesh_resource()
     output = _grouped_dense(
         x,
         kernel,
@@ -290,7 +301,7 @@ def grouped_dense(
     return output
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(3, 5, 6, 7))
+@partial(jax.custom_vjp, nondiff_argnums=(3, 5, 6, 7, 9))
 def _grouped_dense(
     x,
     kernel,
@@ -301,6 +312,7 @@ def _grouped_dense(
     preferred_element_type,
     group_offset,
     quantizer_set,
+    mesh_resource,
 ):
     output, _ = _grouped_dense_fwd_rule(
         x,
@@ -312,6 +324,7 @@ def _grouped_dense(
         preferred_element_type,
         group_offset,
         quantizer_set,
+        mesh_resource,
     )
     return output
 
@@ -326,159 +339,162 @@ def _grouped_dense_fwd_rule(
     preferred_element_type,
     group_offset,
     quantizer_set,
+    mesh_resource,
 ):
-    use_bias = bias is not None
-    is_noop_quantizer_set = quantizer_set == noop_quantizer_set
+    with global_shard_guard(mesh_resource):
+        use_bias = bias is not None
+        is_noop_quantizer_set = quantizer_set == noop_quantizer_set
 
-    if is_noop_quantizer_set:
-        grouped_gemm_x = x
-        grouped_gemm_kernel = kernel
-        ctx_x = x
-        ctx_kernel = kernel
-        flatten_axis_k = None
-    else:
-        x_contracting_dims, k_contracting_dims = contracting_dims
-        flatten_axis_x = -len(x_contracting_dims)
-        flatten_axis_k = len(k_contracting_dims) - len(kernel.shape) + 1  # +1 for G axis
+        if is_noop_quantizer_set:
+            grouped_gemm_x = x
+            grouped_gemm_kernel = kernel
+            ctx_x = x
+            ctx_kernel = kernel
+            flatten_axis_k = None
+        else:
+            x_contracting_dims, k_contracting_dims = contracting_dims
+            flatten_axis_x = -len(x_contracting_dims)
+            flatten_axis_k = len(k_contracting_dims) - len(kernel.shape) + 1  # +1 for G axis
 
-        assert x.ndim == 2, "Grouped dense expects a 2D input tensor of shape (M, K)"
-        assert kernel.ndim == 3, "Grouped dense expects a 3D kernel tensor of shape (G, K, N)"
-        # Expected k_contracting_dims == (1,), need to tweak it for grouped_gemm FP8 extra transpose
-        # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
-        assert x_contracting_dims == (1,) and k_contracting_dims == (1,), (
-            "grouped_dense for FP8 can only handle x_contracting_dims=(1,) "
-            "and k_contracting_dims=(1,) for now, "
-            f"got {x_contracting_dims=} and {k_contracting_dims=}"
+            assert x.ndim == 2, "Grouped dense expects a 2D input tensor of shape (M, K)"
+            assert kernel.ndim == 3, "Grouped dense expects a 3D kernel tensor of shape (G, K, N)"
+            # Expected k_contracting_dims == (1,), need to tweak it for grouped_gemm FP8 extra transpose
+            # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
+            assert x_contracting_dims == (1,) and k_contracting_dims == (1,), (
+                "grouped_dense for FP8 can only handle x_contracting_dims=(1,) "
+                "and k_contracting_dims=(1,) for now, "
+                f"got {x_contracting_dims=} and {k_contracting_dims=}"
+            )
+
+            casted_x = tex.grouped_quantize(
+                x, quantizer_set.x, group_sizes, flatten_axis=flatten_axis_x
+            )
+            casted_kernel = tex.grouped_quantize(
+                kernel, quantizer_set.kernel, flatten_axis=flatten_axis_k
+            )
+            contracting_dims = (x_contracting_dims, k_contracting_dims)
+
+            # For x_contracting_dims == (1,) and k_contracting_dims == (1,), we should have
+            # rowwise_casted_x.original_shape == (M, K)
+            # colwise_casted_kernel.original_shape == (G, N, K)
+            grouped_gemm_x = casted_x.get_tensor(usage=TensorUsage.LHS)
+            grouped_gemm_kernel = casted_kernel.get_tensor(usage=TensorUsage.RHS)
+            ctx_x = casted_x.get_tensor(usage=TensorUsage.LHS_TRANS)
+            ctx_kernel = casted_kernel.get_tensor(usage=TensorUsage.RHS_TRANS)
+
+        output = tex.grouped_gemm(
+            grouped_gemm_x,
+            grouped_gemm_kernel,
+            group_sizes,
+            contracting_dims,
+            bias,
+            precision,
+            preferred_element_type,
+            group_offset,
         )
 
-        casted_x = tex.grouped_quantize(
-            x, quantizer_set.x, group_sizes, flatten_axis=flatten_axis_x
+        ctx = (
+            group_sizes,
+            ctx_x,
+            ctx_kernel,
+            x.shape,
+            kernel.shape,
+            use_bias,
+            is_noop_quantizer_set,
+            quantizer_set,
+            flatten_axis_k,
         )
-        casted_kernel = tex.grouped_quantize(
-            kernel, quantizer_set.kernel, flatten_axis=flatten_axis_k
-        )
-        contracting_dims = (x_contracting_dims, k_contracting_dims)
-
-        # For x_contracting_dims == (1,) and k_contracting_dims == (1,), we should have
-        # rowwise_casted_x.original_shape == (M, K)
-        # colwise_casted_kernel.original_shape == (G, N, K)
-        grouped_gemm_x = casted_x.get_tensor(usage=TensorUsage.LHS)
-        grouped_gemm_kernel = casted_kernel.get_tensor(usage=TensorUsage.RHS)
-        ctx_x = casted_x.get_tensor(usage=TensorUsage.LHS_TRANS)
-        ctx_kernel = casted_kernel.get_tensor(usage=TensorUsage.RHS_TRANS)
-
-    output = tex.grouped_gemm(
-        grouped_gemm_x,
-        grouped_gemm_kernel,
-        group_sizes,
-        contracting_dims,
-        bias,
-        precision,
-        preferred_element_type,
-        group_offset,
-    )
-
-    ctx = (
-        group_sizes,
-        ctx_x,
-        ctx_kernel,
-        x.shape,
-        kernel.shape,
-        use_bias,
-        is_noop_quantizer_set,
-        quantizer_set,
-        flatten_axis_k,
-    )
-    return output, ctx
+        return output, ctx
 
 
 def _grouped_dense_bwd_rule(
-    contracting_dims, precision, preferred_element_type, group_offset, ctx, grad
+    contracting_dims, precision, preferred_element_type, group_offset, mesh_resource, ctx, grad
 ):
-    fwd_x_contracting_dims, fwd_k_contracting_dims = contracting_dims
+    with global_shard_guard(mesh_resource):
+        fwd_x_contracting_dims, fwd_k_contracting_dims = contracting_dims
 
-    (
-        group_sizes,
-        ctx_x,
-        ctx_kernel,
-        x_shape,
-        kernel_shape,
-        use_bias,
-        is_noop_quantizer_set,
-        quantizer_set,
-        flatten_axis_k,
-    ) = ctx
+        (
+            group_sizes,
+            ctx_x,
+            ctx_kernel,
+            x_shape,
+            kernel_shape,
+            use_bias,
+            is_noop_quantizer_set,
+            quantizer_set,
+            flatten_axis_k,
+        ) = ctx
 
-    if is_noop_quantizer_set:
-        # The 1 in range is for excluding the group dimension (shall we use the hardcoded results below?)
-        # g_contracting_dim = (1, )
-        # k_contracting_dim = (2, )
-        g_contracting_dim = tuple(
-            range(1 + grad.ndim - len(kernel_shape) + len(fwd_k_contracting_dims), grad.ndim)
+        if is_noop_quantizer_set:
+            # The 1 in range is for excluding the group dimension (shall we use the hardcoded results below?)
+            # g_contracting_dim = (1, )
+            # k_contracting_dim = (2, )
+            g_contracting_dim = tuple(
+                range(1 + grad.ndim - len(kernel_shape) + len(fwd_k_contracting_dims), grad.ndim)
+            )
+            k_contracting_dim = tuple(
+                dim for dim in range(1, len(kernel_shape)) if dim not in fwd_k_contracting_dims
+            )
+            dgrad_contracting_dims = (g_contracting_dim, k_contracting_dim)
+            dgrad_grad = grad
+            dgrad_kernel_T = ctx_kernel
+
+            # g_contracting_dim = (0, )
+            # x_contracting_dim = (0, )
+            g_contracting_dim = x_contracting_dim = tuple(
+                range(0, len(x_shape) - len(fwd_x_contracting_dims))
+            )
+            wgrad_contracting_dims = (x_contracting_dim, g_contracting_dim)
+            wgrad_x_T = ctx_x
+            wgrad_grad = grad
+        else:
+            casted_grad = tex.grouped_quantize(
+                grad, quantizer_set.dgrad, group_sizes, flatten_axis=flatten_axis_k
+            )
+
+            # For x_contracting_dims == (1,) and k_contracting_dims == (1,), we need to use
+            # g_contracting_dim = (1,) and k_contracting_dim = (2,) to make it work after the
+            # extra transpose for FP8 in grouped_gemm
+            # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
+            g_contracting_dim = (1,)
+            k_contracting_dim = (2,)
+            dgrad_contracting_dims = (g_contracting_dim, k_contracting_dim)
+            dgrad_grad = casted_grad.get_tensor(usage=TensorUsage.LHS)
+            dgrad_kernel_T = ctx_kernel
+
+            # We need to use g_contracting_dim = (0,) and x_contracting_dim = (0,) to make it work
+            # after the extra transpose for FP8 in grouped_gemm
+            # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
+            g_contracting_dim = (0,)
+            x_contracting_dim = (0,)
+            wgrad_contracting_dims = (x_contracting_dim, g_contracting_dim)
+            wgrad_x_T = ctx_x
+            wgrad_grad = casted_grad.get_tensor(usage=TensorUsage.RHS)
+
+        dgrad = tex.grouped_gemm(
+            dgrad_grad,
+            dgrad_kernel_T,
+            group_sizes,
+            dgrad_contracting_dims,
+            precision=precision,
+            preferred_element_type=preferred_element_type,
+            group_offset=group_offset,
         )
-        k_contracting_dim = tuple(
-            dim for dim in range(1, len(kernel_shape)) if dim not in fwd_k_contracting_dims
-        )
-        dgrad_contracting_dims = (g_contracting_dim, k_contracting_dim)
-        dgrad_grad = grad
-        dgrad_kernel_T = ctx_kernel
 
-        # g_contracting_dim = (0, )
-        # x_contracting_dim = (0, )
-        g_contracting_dim = x_contracting_dim = tuple(
-            range(0, len(x_shape) - len(fwd_x_contracting_dims))
-        )
-        wgrad_contracting_dims = (x_contracting_dim, g_contracting_dim)
-        wgrad_x_T = ctx_x
-        wgrad_grad = grad
-    else:
-        casted_grad = tex.grouped_quantize(
-            grad, quantizer_set.dgrad, group_sizes, flatten_axis=flatten_axis_k
+        wgrad = tex.grouped_gemm(
+            wgrad_x_T,
+            wgrad_grad,
+            group_sizes,
+            wgrad_contracting_dims,
+            precision=precision,
+            preferred_element_type=preferred_element_type,
+            group_offset=group_offset,
         )
 
-        # For x_contracting_dims == (1,) and k_contracting_dims == (1,), we need to use
-        # g_contracting_dim = (1,) and k_contracting_dim = (2,) to make it work after the
-        # extra transpose for FP8 in grouped_gemm
-        # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
-        g_contracting_dim = (1,)
-        k_contracting_dim = (2,)
-        dgrad_contracting_dims = (g_contracting_dim, k_contracting_dim)
-        dgrad_grad = casted_grad.get_tensor(usage=TensorUsage.LHS)
-        dgrad_kernel_T = ctx_kernel
+        group_sizes_grad = None
+        dbias = tex.grouped_dbias(grad, group_sizes) if use_bias else None
 
-        # We need to use g_contracting_dim = (0,) and x_contracting_dim = (0,) to make it work
-        # after the extra transpose for FP8 in grouped_gemm
-        # TODO(Hua): Do we have a better way for this? What if is_gemm_with_all_layouts_supported()?
-        g_contracting_dim = (0,)
-        x_contracting_dim = (0,)
-        wgrad_contracting_dims = (x_contracting_dim, g_contracting_dim)
-        wgrad_x_T = ctx_x
-        wgrad_grad = casted_grad.get_tensor(usage=TensorUsage.RHS)
-
-    dgrad = tex.grouped_gemm(
-        dgrad_grad,
-        dgrad_kernel_T,
-        group_sizes,
-        dgrad_contracting_dims,
-        precision=precision,
-        preferred_element_type=preferred_element_type,
-        group_offset=group_offset,
-    )
-
-    wgrad = tex.grouped_gemm(
-        wgrad_x_T,
-        wgrad_grad,
-        group_sizes,
-        wgrad_contracting_dims,
-        precision=precision,
-        preferred_element_type=preferred_element_type,
-        group_offset=group_offset,
-    )
-
-    group_sizes_grad = None
-    dbias = tex.grouped_dbias(grad, group_sizes) if use_bias else None
-
-    return dgrad, wgrad, group_sizes_grad, dbias, quantizer_set
+        return dgrad, wgrad, group_sizes_grad, dbias, quantizer_set
 
 
 _grouped_dense.defvjp(_grouped_dense_fwd_rule, _grouped_dense_bwd_rule)

--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -404,9 +404,6 @@ def fp8_autocast(
     if fp8_recipe is None:
         fp8_recipe = recipe.DelayedScaling()
 
-    if mesh_resource is None:
-        mesh_resource = MeshResource()
-
     Config = DelayedScalingQuantizeConfig
     if isinstance(fp8_recipe, recipe.MXFP8BlockScaling):
         Config = BlockScalingQuantizeConfig


### PR DESCRIPTION
# Description

Passes `MeshResource` set by `global_shard_guard` through VJP and into TE primitives.

VJP rules are run in a separate pass for the autograd transformation, so any narrowly-scoped `global_shard_guard` contexts will cause `global_mesh_resource()` to be unavailable instead both the forward and backward VJP definitions. This PR updates our VJPs to explicitly pass the mesh resource through and wrap the body in a new `global_shard_guard` context.

Primitive partitioning (`Primitive.partition`) is run in a later pass where narrowly-scoped `global_shard_guard` contexts will also no longer be active. This PR updates each primitive that relies on the `MeshResource` either directly like GemmPrimitive or indirectly via `all_reduce_...` helper functions in `sharding.py`. The PR updates the primitives to take an explicit `MeshResource` as a static argument which will be captured and available in the `partition` function.

This PR allows `global_shard_guard` to be used at any level, including inside JIT, instead of requiring a single `global_shard_guard` at the top-level of the entire program. This can make TE integrations into larger systems easier to isolate to a few minimal files.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Updates VJPs in `transformer_engine/jax/*.py` to explicitly pass through the mesh resource and re-create the context inside
- Updates primitives in `transformer_engine/jax/cpp_extensions/*.py` to take the mesh resource as a static argument
- Updates `sharding.py` to default the global mesh resource to `None` instead of `MeshResource()` with all fields set to `None`. This allows us to differentiate between an incorrectly missing mesh resource context and a user intentionally setting certain `MeshResource` axes to `None` when they are not supported on their physical mesh.
- Error checking in `sharding.py` for whenever the `global_mesh_resource()` is queried it must be set in a context. Unfortunately, we cannot definitively tell at trace-time that we are intending to run replicated or on a single device, so this is slightly overbearing in that it requires an MeshResource context (all axes can be `None`) even when running single-GPU. The error message instructs the user how to fix this issue, but it's not ideal.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
