### PR TITLE
[PyTorch] Propagate `requires_grad` for dequantize and torch dispatch

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -79,6 +79,7 @@ py::object dequantize(const py::handle &input, transformer_engine::DType otype) 
     nvte_dequantize(input_tensor.data(), out_tensor.data(), at::cuda::getCurrentCUDAStream());
   });
 
+  out.attr("requires_grad_")(input.attr("requires_grad"));
   return out;
 }
 

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -549,7 +549,7 @@ class Float8Tensor(Float8TensorBase, QuantizedTensor):
             return Float8Tensor(
                 shape=out_shape,
                 dtype=tensor.dtype,
-                requires_grad=False,
+                requires_grad=tensor.requires_grad,
                 data=out_data,
                 fp8_scale_inv=tensor._scale_inv,
                 fp8_dtype=tensor._fp8_dtype,

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -339,7 +339,7 @@ class MXFP8Tensor(MXFP8TensorBase, QuantizedTensor):
                 columnwise_data=tensor._columnwise_data,
                 columnwise_scale_inv=tensor._columnwise_scale_inv,
                 quantizer=tensor._quantizer,
-                requires_grad=False,
+                requires_grad=tensor.requires_grad,
                 fp8_dtype=tensor._fp8_dtype,
             )
 

--- a/transformer_engine/pytorch/tensor/quantized_tensor.py
+++ b/transformer_engine/pytorch/tensor/quantized_tensor.py
@@ -469,6 +469,9 @@ class QuantizedTensor(torch.Tensor):
         if kwargs is not None:
             kwargs = tree_map(maybe_unwrap, kwargs)
         out = super().__torch_dispatch__(func, types, args, kwargs)
+
+        # Retain requires_grad, which __torch_dispatch__ always seems to set to False.
+        out.requires_grad = args[0].requires_grad
         return out
 
     @classmethod


### PR DESCRIPTION
# Description

Converting a TE model using `.to` currently does not retain the `requires_grad` field for parameters, more details in [this comment](https://github.com/NVIDIA/TransformerEngine/issues/1687#issuecomment-3199308629).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Set `requires_grad` in dequantize extension.
- Set `requires_grad` in `__torch_dispatch__`

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
