### PR TITLE
[JAX] `dot_1_output` sharding constraint + use AXIS_IS_UNSHARDED

### DIFF
--- a/transformer_engine/jax/layernorm_mlp.py
+++ b/transformer_engine/jax/layernorm_mlp.py
@@ -289,6 +289,11 @@ def _layernorm_mlp_fwd_rule(
         bias_1_new_shape = (1,) * (dot_1_output.ndim - bias_1.ndim) + bias_1_shape
         dot_1_output += jnp.reshape(bias_1, bias_1_new_shape)
 
+    # This sharding constraint is needed to correct the Shardy sharding propagation
+    if dot_2_input_axes is not None:
+        dot_1_output_axes = dot_2_input_axes[:-1] + (None,) + dot_2_input_axes[-1:] # add the act_num axis
+        dot_1_output = with_sharding_constraint_by_logical_axes(dot_1_output, dot_1_output_axes)
+
     dot_1_output = checkpoint_name(dot_1_output, ffn1_ckpt_name)
 
     # (batch..., hidden_in) -> (batch..., hidden)

--- a/transformer_engine/jax/layernorm_mlp.py
+++ b/transformer_engine/jax/layernorm_mlp.py
@@ -291,7 +291,9 @@ def _layernorm_mlp_fwd_rule(
 
     # This sharding constraint is needed to correct the Shardy sharding propagation
     if dot_2_input_axes is not None:
-        dot_1_output_axes = dot_2_input_axes[:-1] + (None,) + dot_2_input_axes[-1:] # add the act_num axis
+        dot_1_output_axes = (
+            dot_2_input_axes[:-1] + (None,) + dot_2_input_axes[-1:]
+        )  # add the act_num axis
         dot_1_output = with_sharding_constraint_by_logical_axes(dot_1_output, dot_1_output_axes)
 
     dot_1_output = checkpoint_name(dot_1_output, ffn1_ckpt_name)

--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -155,7 +155,7 @@ def with_sharding_constraint_by_logical_axes(
         flax_rules = flax.linen.get_logical_axis_rules()
         if len(flax_rules) > 0:
             return flax.linen.with_logical_constraint(
-                x, logical_axis_names, fallback=flax.linen.spmd.RulesFallback.NO_CONSTRAINT
+                x, logical_axis_names, fallback=flax.linen.spmd.RulesFallback.AXIS_IS_UNSHARDED
             )
     except ImportError:
         pass


### PR DESCRIPTION
# Description

1. Using `RulesFallback.AXIS_IS_UNSHARDED` instead of the `RulesFallback.NO_CONSTRAINT` in the `flax.linen.with_logical_constraint` so that if an axis is undefined in the mesh, it will still apply the sharding constraint for the given tensor in other axes instead of skipping ([More info](https://github.com/google/flax/blob/485e101df79376851e2da407f36d266ebebc6574/flax/linen/spmd.py#L216-L223)).

2. Add a `dot_1_output` sharding constraint if `dot_2_input_axes` is provided. This is a WAR for the known Shardy shading propagation issue.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
