### PR TITLE
Adds context parallelism utilities: moving cp shards to diff ranks and pad sequence to divisibility factory

### DIFF
--- a/tests/pytorch/distributed/test_cp_utils.py
+++ b/tests/pytorch/distributed/test_cp_utils.py
@@ -544,21 +544,226 @@ class TestSequencePadding(unittest.TestCase):
         self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids))
         self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
 
-# Now let's write a test that utilizes the pad sequence to divisibility function
-# and then shards that on the CP ranks.
-def test_shard_on_cp_ranks():
-    # Make some dummy data.
-    input_ids = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
-    labels = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
-    positional_ids = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
-    cu_seqlens_q = torch.tensor([0, 5])
-    divisibility_factor = 2
-    padding_token_id = 0
-    padding_label_id = -100
-    input_ids_padded, labels_padded, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(input_ids, labels, positional_ids, cu_seqlens_q, divisibility_factor, padding_token_id, padding_label_id)
-    assert input_ids_padded.shape == (2, 10)
+class TestContextParallelUtils(unittest.TestCase):
+    """Test utilities for context parallel functionality."""
     
-    # Ok now we are going to split the data on the CP ranks. I think we can mock the groups?
+    def setUp(self):
+        """Set up mock distributed environment."""
+        # Mock torch.distributed functions
+        self.original_get_world_size = torch.distributed.get_world_size
+        self.original_get_rank = torch.distributed.get_rank
+        
+    def tearDown(self):
+        """Restore original torch.distributed functions."""
+        torch.distributed.get_world_size = self.original_get_world_size
+        torch.distributed.get_rank = self.original_get_rank
+    
+    def _mock_distributed_env(self, cp_size, cp_rank):
+        """Mock the distributed environment for testing."""
+        def mock_get_world_size(group=None):
+            return cp_size
+        def mock_get_rank(group=None):
+            return cp_rank
+            
+        torch.distributed.get_world_size = mock_get_world_size
+        torch.distributed.get_rank = mock_get_rank
+
+    def test_cp_rank_slicing_simple_case(self):
+        """Test CP rank slicing with a simple 2-rank, single sequence case."""
+        # Setup: Single sequence of length 8, CP size = 2
+        # Each sequence gets divided into 2*cp_size = 4 slices of size 2 each
+        # Rank 0 gets slices [0,1] and [6,7] (first and last)
+        # Rank 1 gets slices [2,3] and [4,5] (second and second-to-last)
+        
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])  # Shape: (1, 8) - batch first
+        labels = torch.tensor([[10, 20, 30, 40, 50, 60, 70, 80]])
+        position_ids = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])  # Shape: (8,) - 1D as expected
+        cu_seqlens_q = torch.tensor([0, 8])
+        cu_seqlens_kv = torch.tensor([0, 8])
+        
+        # Test rank 0
+        self._mock_distributed_env(cp_size=2, cp_rank=0)
+        input_ids_r0, labels_r0, pos_ids_r0 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # Rank 0 should get indices [0,1] and [6,7]
+        expected_input_ids_r0 = torch.tensor([[1, 2, 7, 8]])
+        expected_labels_r0 = torch.tensor([[10, 20, 70, 80]])
+        expected_pos_ids_r0 = torch.tensor([0, 1, 6, 7])
+        
+        self.assertTrue(torch.equal(input_ids_r0, expected_input_ids_r0))
+        self.assertTrue(torch.equal(labels_r0, expected_labels_r0))
+        self.assertTrue(torch.equal(pos_ids_r0, expected_pos_ids_r0))
+        
+        # Test rank 1
+        self._mock_distributed_env(cp_size=2, cp_rank=1)
+        input_ids_r1, labels_r1, pos_ids_r1 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # Rank 1 should get indices [2,3] and [4,5]
+        expected_input_ids_r1 = torch.tensor([[3, 4, 5, 6]])
+        expected_labels_r1 = torch.tensor([[30, 40, 50, 60]])
+        expected_pos_ids_r1 = torch.tensor([2, 3, 4, 5])
+        
+        self.assertTrue(torch.equal(input_ids_r1, expected_input_ids_r1))
+        self.assertTrue(torch.equal(labels_r1, expected_labels_r1))
+        self.assertTrue(torch.equal(pos_ids_r1, expected_pos_ids_r1))
+
+    def test_cp_rank_slicing_multiple_sequences(self):
+        """Test CP rank slicing with multiple sequences."""
+        # Setup: Two sequences of length 8 each, CP size = 2
+        # Total sequence length = 16, cu_seqlens = [0, 8, 16]
+        
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16, 17, 18]])
+        labels = torch.tensor([[10, 20, 30, 40, 50, 60, 70, 80, 110, 120, 130, 140, 150, 160, 170, 180]])
+        position_ids = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7])
+        cu_seqlens_q = torch.tensor([0, 8, 16])
+        cu_seqlens_kv = torch.tensor([0, 8, 16])
+        
+        # Test rank 0
+        self._mock_distributed_env(cp_size=2, cp_rank=0)
+        input_ids_r0, labels_r0, pos_ids_r0 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # For each sequence, rank 0 gets first and last slices
+        # Seq 1: indices [0,1] and [6,7] -> values [1,2] and [7,8]
+        # Seq 2: indices [8,9] and [14,15] -> values [11,12] and [17,18]
+        expected_input_ids_r0 = torch.tensor([[1, 2, 7, 8, 11, 12, 17, 18]])
+        expected_labels_r0 = torch.tensor([[10, 20, 70, 80, 110, 120, 170, 180]])
+        expected_pos_ids_r0 = torch.tensor([0, 1, 6, 7, 0, 1, 6, 7])
+        
+        self.assertTrue(torch.equal(input_ids_r0, expected_input_ids_r0))
+        self.assertTrue(torch.equal(labels_r0, expected_labels_r0))
+        self.assertTrue(torch.equal(pos_ids_r0, expected_pos_ids_r0))
+
+    def test_cp_rank_slicing_with_cp_size_1(self):
+        """Test that CP size = 1 returns original tensors unchanged."""
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+        labels = torch.tensor([[10, 20, 30, 40, 50, 60, 70, 80]])
+        position_ids = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        cu_seqlens_q = torch.tensor([0, 8])
+        cu_seqlens_kv = torch.tensor([0, 8])
+        
+        self._mock_distributed_env(cp_size=1, cp_rank=0)
+        input_ids_result, labels_result, pos_ids_result = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # With CP size = 1, should return original tensors
+        self.assertTrue(torch.equal(input_ids_result, input_ids))
+        self.assertTrue(torch.equal(labels_result, labels))
+        self.assertTrue(torch.equal(pos_ids_result, position_ids))
+
+    def test_cp_rank_slicing_sequence_dim_detection(self):
+        """Test that the function correctly detects sequence dimension."""
+        # Test with sequence dimension = 0 (sequence_length, batch_size)
+        input_ids = torch.tensor([[1, 10], [2, 20], [3, 30], [4, 40], [5, 50], [6, 60], [7, 70], [8, 80]])  # (8, 2)
+        labels = torch.tensor([[1, 10], [2, 20], [3, 30], [4, 40], [5, 50], [6, 60], [7, 70], [8, 80]])
+        position_ids = torch.tensor([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6], [7, 7]])
+        cu_seqlens_q = torch.tensor([0, 8])
+        cu_seqlens_kv = torch.tensor([0, 8])
+        
+        self._mock_distributed_env(cp_size=2, cp_rank=0)
+        input_ids_r0, labels_r0, pos_ids_r0 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # Should get indices [0,1] and [6,7] along dimension 0
+        expected_input_ids_r0 = torch.tensor([[1, 10], [2, 20], [7, 70], [8, 80]])
+        expected_labels_r0 = torch.tensor([[1, 10], [2, 20], [7, 70], [8, 80]])
+        expected_pos_ids_r0 = torch.tensor([[0, 0], [1, 1], [6, 6], [7, 7]])
+        
+        self.assertTrue(torch.equal(input_ids_r0, expected_input_ids_r0))
+        self.assertTrue(torch.equal(labels_r0, expected_labels_r0))
+        self.assertTrue(torch.equal(pos_ids_r0, expected_pos_ids_r0))
+
+    def test_cp_rank_slicing_mixed_dimensions(self):
+        """Test CP rank slicing where input_ids/labels are 1D but position_ids has batch dimension."""
+        # Setup: Single sequence of length 8, CP size = 2
+        # This tests the opposite case from the simple test:
+        # - input_ids and labels: 1D (no batch dimension)
+        # - position_ids: 2D (has batch dimension)
+        
+        input_ids = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8])  # Shape: (8,) - 1D
+        labels = torch.tensor([10, 20, 30, 40, 50, 60, 70, 80])  # Shape: (8,) - 1D
+        position_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]])  # Shape: (1, 8) - 2D with batch
+        cu_seqlens_q = torch.tensor([0, 8])
+        cu_seqlens_kv = torch.tensor([0, 8])
+        
+        # Test rank 0
+        self._mock_distributed_env(cp_size=2, cp_rank=0)
+        input_ids_r0, labels_r0, pos_ids_r0 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # Rank 0 should get indices [0,1] and [6,7]
+        expected_input_ids_r0 = torch.tensor([1, 2, 7, 8])  # 1D result
+        expected_labels_r0 = torch.tensor([10, 20, 70, 80])  # 1D result
+        expected_pos_ids_r0 = torch.tensor([[0, 1, 6, 7]])  # 2D result (preserves batch dim)
+        
+        self.assertTrue(torch.equal(input_ids_r0, expected_input_ids_r0))
+        self.assertTrue(torch.equal(labels_r0, expected_labels_r0))
+        self.assertTrue(torch.equal(pos_ids_r0, expected_pos_ids_r0))
+        
+        # Test rank 1
+        self._mock_distributed_env(cp_size=2, cp_rank=1)
+        input_ids_r1, labels_r1, pos_ids_r1 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q, cu_seqlens_kv, input_ids, labels, position_ids
+        )
+        
+        # Rank 1 should get indices [2,3] and [4,5]
+        expected_input_ids_r1 = torch.tensor([3, 4, 5, 6])  # 1D result
+        expected_labels_r1 = torch.tensor([30, 40, 50, 60])  # 1D result
+        expected_pos_ids_r1 = torch.tensor([[2, 3, 4, 5]])  # 2D result (preserves batch dim)
+        
+        self.assertTrue(torch.equal(input_ids_r1, expected_input_ids_r1))
+        self.assertTrue(torch.equal(labels_r1, expected_labels_r1))
+        self.assertTrue(torch.equal(pos_ids_r1, expected_pos_ids_r1))
+
+    def test_integration_with_padding_and_cp_slicing(self):
+        """Integration test: pad sequences then slice for CP ranks."""
+        # Start with unpadded sequences
+        input_ids = torch.tensor([1, 1, 2, 2, 2])  # Two sequences: [1,1] and [2,2,2]
+        labels = torch.tensor([10, 11, 20, 21, 22])
+        positional_ids = torch.tensor([0, 1, 0, 1, 2])
+        cu_seqlens_q = torch.tensor([0, 2, 5])
+        divisibility_factor = 4  # Will pad to lengths 4 and 4
+        
+        # First, pad sequences
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0),
+            labels.unsqueeze(0),
+            positional_ids,
+            cu_seqlens_q,
+            divisibility_factor,
+            padding_token_id=0,
+            padding_label_id=-100,
+        )
+        
+        # Expected after padding: [1,1,0,0,2,2,2,0] with cu_seqlens [0,4,8]
+        expected_padded = torch.tensor([1, 1, 0, 0, 2, 2, 2, 0])
+        self.assertTrue(torch.equal(input_ids_padded, expected_padded))
+        
+        # Now test CP slicing with cp_size=2
+        cu_seqlens_kv_padded = cu_seqlens_q_padded  # Same for self-attention
+        
+        # Test rank 0
+        self._mock_distributed_env(cp_size=2, cp_rank=0)
+        input_ids_r0, labels_r0, pos_ids_r0 = get_thd_batch_on_this_cp_rank(
+            cu_seqlens_q_padded, cu_seqlens_kv_padded, 
+            input_ids_padded.unsqueeze(0), labels_padded.unsqueeze(0), positional_ids_padded
+        )
+        
+        # Each sequence of length 4 gets divided into 4 slices of size 1
+        # Rank 0 gets slices [0] and [3] from each sequence
+        # Seq 1: indices [0] and [3] -> values [1] and [0]
+        # Seq 2: indices [4] and [7] -> values [2] and [0]
+        expected_input_ids_r0 = torch.tensor([[1, 0, 2, 0]])
+        
+        self.assertTrue(torch.equal(input_ids_r0, expected_input_ids_r0))
 
 
 

--- a/tests/pytorch/distributed/test_cp_utils.py
+++ b/tests/pytorch/distributed/test_cp_utils.py
@@ -1,0 +1,566 @@
+import torch
+import unittest
+from typing import Tuple
+from transformer_engine.pytorch.attention.dot_product_attention.context_parallel import get_thd_batch_on_this_cp_rank, pad_sequences_to_divisibility
+
+
+class TestSequencePadding(unittest.TestCase):
+    def test_basic_padding_with_labels(self):
+        """Test basic padding functionality including labels."""
+        # Setup
+        input_ids = torch.tensor([1, 1, 2, 2, 2])  # Two sequences: [1,1] and [2,2,2]
+        labels = torch.tensor([10, 11, 20, 21, 22])  # Labels for each token
+        positional_ids = torch.tensor([0, 1, 0, 1, 2])
+        cu_seqlens_q = torch.tensor([0, 2, 5])
+        divisibility_factor = 4
+
+        # Execute
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0),  # Add batch dimension
+            labels.unsqueeze(0),  # Add batch dimension
+            positional_ids,
+            cu_seqlens_q,
+            divisibility_factor,
+            padding_token_id=0,
+            padding_label_id=-100,
+        )
+
+        # Assert
+        # First sequence [1,1] needs 2 padding tokens to be divisible by 4
+        # Second sequence [2,2,2] needs 1 padding token to be divisible by 4
+        expected_input_ids = torch.tensor([1, 1, 0, 0, 2, 2, 2, 0])
+        expected_labels = torch.tensor([10, 11, -100, -100, 20, 21, 22, -100])
+        # Position IDs continue counting: [0,1] -> [0,1,2,3], [0,1,2] -> [0,1,2,3]
+        expected_positional_ids_padded = torch.tensor([0, 1, 2, 3, 0, 1, 2, 3])
+        expected_cu_seqlens_padded = torch.tensor([0, 4, 8])
+
+        self.assertTrue(torch.equal(input_ids_padded, expected_input_ids))
+        self.assertTrue(torch.equal(labels_padded, expected_labels))
+        self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids_padded))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
+
+    def test_no_padding_needed_with_labels(self):
+        """Test when sequences are already divisible (with labels)."""
+        # Setup - sequences of length 4 and 8, divisibility factor 4
+        input_ids = torch.tensor([1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2])
+        labels = torch.tensor([10, 11, 12, 13, 20, 21, 22, 23, 24, 25, 26, 27])
+        positional_ids = torch.tensor([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7])
+        cu_seqlens_q = torch.tensor([0, 4, 12])
+        divisibility_factor = 4
+
+        # Execute
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0), labels.unsqueeze(0), positional_ids, cu_seqlens_q, divisibility_factor
+        )
+
+        # Assert - no padding should be added
+        self.assertTrue(torch.equal(input_ids_padded, input_ids))
+        self.assertTrue(torch.equal(labels_padded, labels))
+        self.assertTrue(torch.equal(positional_ids_padded, positional_ids))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, cu_seqlens_q))
+
+    def test_single_sequence_with_labels(self):
+        """Test with a single sequence including labels."""
+        # Setup
+        input_ids = torch.tensor([3, 3, 3])
+        labels = torch.tensor([30, 31, 32])
+        positional_ids = torch.tensor([0, 1, 2])
+        cu_seqlens_q = torch.tensor([0, 3])
+        divisibility_factor = 5
+
+        # Execute
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0),
+            labels.unsqueeze(0),
+            positional_ids,
+            cu_seqlens_q,
+            divisibility_factor,
+            padding_token_id=99,
+            padding_label_id=-100,
+        )
+
+        # Assert - need 2 padding tokens to make length 5
+        expected_input_ids = torch.tensor([3, 3, 3, 99, 99])
+        expected_labels = torch.tensor([30, 31, 32, -100, -100])
+        # Position IDs continue: [0,1,2] -> [0,1,2,3,4]
+        expected_positional_ids_padded = torch.tensor([0, 1, 2, 3, 4])
+        expected_cu_seqlens_padded = torch.tensor([0, 5])
+
+        self.assertTrue(torch.equal(input_ids_padded, expected_input_ids))
+        self.assertTrue(torch.equal(labels_padded, expected_labels))
+        self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids_padded))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
+
+    def test_multiple_sequences_varied_padding_with_labels(self):
+        """Test with multiple sequences requiring different padding amounts (with labels)."""
+        # Setup - 3 sequences: lengths 1, 3, 5
+        input_ids = torch.tensor([1, 2, 2, 2, 3, 3, 3, 3, 3])
+        labels = torch.tensor([100, 200, 201, 202, 300, 301, 302, 303, 304])
+        positional_ids = torch.tensor([0, 0, 1, 2, 0, 1, 2, 3, 4])
+        cu_seqlens_q = torch.tensor([0, 1, 4, 9])
+        divisibility_factor = 3
+
+        # Execute
+        input_ids_padded, labels_padded, original_pos_ids, positional_ids_padded, cu_seqlens_q_padded = (
+            pad_sequences_to_divisibility(
+                input_ids.unsqueeze(0), labels.unsqueeze(0), positional_ids, cu_seqlens_q, divisibility_factor
+            )
+        )
+
+        # Assert
+        # Seq 1: length 1 -> needs 2 padding tokens, positions continue [0] -> [0,1,2]
+        # Seq 2: length 3 -> needs 0 padding tokens, stays [0,1,2]
+        # Seq 3: length 5 -> needs 1 padding token, positions continue [0,1,2,3,4] -> [0,1,2,3,4,5]
+        expected_input_ids = torch.tensor([1, 0, 0, 2, 2, 2, 3, 3, 3, 3, 3, 0])
+        expected_labels = torch.tensor([100, -100, -100, 200, 201, 202, 300, 301, 302, 303, 304, -100])
+        expected_positional_ids_padded = torch.tensor([0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 4, 5])
+        expected_cu_seqlens_padded = torch.tensor([0, 3, 6, 12])
+
+        self.assertTrue(torch.equal(input_ids_padded, expected_input_ids))
+        self.assertTrue(torch.equal(labels_padded, expected_labels))
+        self.assertTrue(torch.equal(original_pos_ids, positional_ids))  # Original unchanged
+        self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids_padded))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
+
+    def test_divisibility_factor_one_with_labels(self):
+        """Test with divisibility factor of 1 (no padding needed) with labels."""
+        # Setup
+        input_ids = torch.tensor([1, 2, 3, 4, 5])
+        labels = torch.tensor([10, 20, 30, 40, 50])
+        positional_ids = torch.tensor([0, 1, 2, 3, 4])
+        cu_seqlens_q = torch.tensor([0, 2, 5])
+        divisibility_factor = 1
+
+        # Execute
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0), labels.unsqueeze(0), positional_ids, cu_seqlens_q, divisibility_factor
+        )
+
+        # Assert - everything divisible by 1, no padding
+        self.assertTrue(torch.equal(input_ids_padded, input_ids))
+        self.assertTrue(torch.equal(labels_padded, labels))
+        self.assertTrue(torch.equal(positional_ids_padded, positional_ids))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, cu_seqlens_q))
+
+    def test_custom_padding_values(self):
+        """Test with custom padding values for input_ids and labels."""
+        # Setup
+        input_ids = torch.tensor([1, 1])
+        labels = torch.tensor([10, 11])
+        positional_ids = torch.tensor([0, 1])
+        cu_seqlens_q = torch.tensor([0, 2])
+        divisibility_factor = 3
+
+        # Execute with custom padding values
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0),
+            labels.unsqueeze(0),
+            positional_ids,
+            cu_seqlens_q,
+            divisibility_factor,
+            padding_token_id=777,
+            padding_label_id=-999,
+        )
+
+        # Assert - need 1 padding token to make length 3
+        expected_input_ids = torch.tensor([1, 1, 777])
+        expected_labels = torch.tensor([10, 11, -999])
+        # Position IDs continue: [0,1] -> [0,1,2]
+        expected_positional_ids_padded = torch.tensor([0, 1, 2])
+        expected_cu_seqlens_padded = torch.tensor([0, 3])
+
+        self.assertTrue(torch.equal(input_ids_padded, expected_input_ids))
+        self.assertTrue(torch.equal(labels_padded, expected_labels))
+        self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids_padded))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
+
+    def test_padding_with_custom_padding_values_sequences_shorter_than_divisibility_factor(self):
+        """Test with custom padding values for all tensors."""
+        # Setup
+
+        input_ids = torch.tensor([1, 1, 1, 2, 2, 3, 3, 3, 3])
+        cu_seqlens_q = torch.tensor([0, 3, 5, 9])
+        labels = torch.tensor([-100, -100, -100, -100, -100, -100, -100, 13, -100])
+        positional_ids = torch.tensor([0, 1, 2, 0, 1, 0, 1, 2, 3])
+        divisibility_factor = 8
+
+        pid = 777
+        label_pad = -200
+
+        input_ids_padded, labels_padded, positional_ids, positional_ids_padded, cu_seqlens_q_padded = (
+            pad_sequences_to_divisibility(
+                input_ids.unsqueeze(0),
+                labels.unsqueeze(0),
+                positional_ids,
+                cu_seqlens_q,
+                divisibility_factor,
+                padding_token_id=pid,
+                padding_label_id=label_pad,
+            )
+        )
+
+        # Sequence: [ a a a p p p p p b b pppppp ccccpppp]
+        print("input_ids_padded: ", input_ids_padded)
+        print("labels_padded: ", labels_padded)
+        print("positional_ids_padded: ", positional_ids_padded)
+        print("cu_seqlens_q_padded: ", cu_seqlens_q_padded)
+
+        expected_input_ids = torch.tensor(
+            [1, 1, 1, pid, pid, pid, pid, pid, 2, 2, pid, pid, pid, pid, pid, pid, 3, 3, 3, 3, pid, pid, pid, pid]
+        )
+        expected_cu_seqlens_q_padded = torch.tensor([0, 8, 16, 24])
+        expected_labels_padded = torch.tensor(
+            [
+                -100,
+                -100,
+                -100,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                -100,
+                -100,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                -100,
+                -100,
+                13,
+                -100,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+            ]
+        )
+        expected_positional_ids = torch.tensor(
+            [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]
+        )
+
+        assert torch.equal(input_ids_padded, expected_input_ids)
+        assert torch.equal(labels_padded, expected_labels_padded)
+        assert torch.equal(positional_ids_padded, expected_positional_ids)
+        assert torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_q_padded)
+
+    def test_mixed_sequence_lengths_with_divisibility_factor(self):
+        """Test with sequences both shorter and longer than divisibility factor."""
+        # Setup - divisibility factor 6
+        # Seq 1: length 2 (shorter than 6, needs 4 padding)
+        # Seq 2: length 7 (longer than 6, needs 5 padding to reach 12)
+        # Seq 3: length 4 (shorter than 6, needs 2 padding)
+        # Seq 4: length 10 (longer than 6, needs 2 padding to reach 12)
+
+        input_ids = torch.tensor([1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4])
+        labels = torch.tensor(
+            [10, 11, 20, 21, 22, 23, 24, 25, 26, 30, 31, 32, 33, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+        )
+        positional_ids = torch.tensor([0, 1, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        cu_seqlens_q = torch.tensor([0, 2, 9, 13, 23])
+        divisibility_factor = 6
+
+        pid = 999
+        label_pad = -300
+
+        # Execute
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0),
+            labels.unsqueeze(0),
+            positional_ids,
+            cu_seqlens_q,
+            divisibility_factor,
+            padding_token_id=pid,
+            padding_label_id=label_pad,
+        )
+
+        # Assert
+        # Seq 1: [1,1] + 4 pads = 6 total
+        # Seq 2: [2,2,2,2,2,2,2] + 5 pads = 12 total
+        # Seq 3: [3,3,3,3] + 2 pads = 6 total
+        # Seq 4: [4,4,4,4,4,4,4,4,4,4] + 2 pads = 12 total
+
+        expected_input_ids = torch.tensor(
+            [
+                1,
+                1,
+                pid,
+                pid,
+                pid,
+                pid,  # Seq 1: 2 + 4 padding
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                pid,
+                pid,
+                pid,
+                pid,
+                pid,  # Seq 2: 7 + 5 padding
+                3,
+                3,
+                3,
+                3,
+                pid,
+                pid,  # Seq 3: 4 + 2 padding
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                4,
+                pid,
+                pid,  # Seq 4: 10 + 2 padding
+            ]
+        )
+
+        expected_labels = torch.tensor(
+            [
+                10,
+                11,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                label_pad,
+                30,
+                31,
+                32,
+                33,
+                label_pad,
+                label_pad,
+                40,
+                41,
+                42,
+                43,
+                44,
+                45,
+                46,
+                47,
+                48,
+                49,
+                label_pad,
+                label_pad,
+            ]
+        )
+
+        expected_positional_ids = torch.tensor(
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,  # Seq 1 positions continue through padding
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,  # Seq 2 positions continue
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,  # Seq 3 positions continue
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,  # Seq 4 positions continue
+            ]
+        )
+
+        expected_cu_seqlens_padded = torch.tensor([0, 6, 18, 24, 36])
+
+        self.assertTrue(torch.equal(input_ids_padded, expected_input_ids))
+        self.assertTrue(torch.equal(labels_padded, expected_labels))
+        self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
+
+    def test_sequences_longer_than_divisibility_factor(self):
+        """Test with all sequences longer than the divisibility factor."""
+        # Setup - divisibility factor 4, all sequences longer than 4
+        # Seq 1: length 7 (needs 1 padding to reach 8)
+        # Seq 2: length 11 (needs 1 padding to reach 12)
+        # Seq 3: length 5 (needs 3 padding to reach 8)
+
+        input_ids = torch.tensor(
+            [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,  # 7 tokens
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,
+                2,  # 11 tokens
+                3,
+                3,
+                3,
+                3,
+                3,  # 5 tokens
+            ]
+        )
+        labels = torch.tensor(
+            [
+                100,
+                101,
+                102,
+                103,
+                104,
+                105,
+                106,
+                200,
+                201,
+                202,
+                203,
+                204,
+                205,
+                206,
+                207,
+                208,
+                209,
+                210,
+                300,
+                301,
+                302,
+                303,
+                304,
+            ]
+        )
+        positional_ids = torch.tensor([0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4])
+        cu_seqlens_q = torch.tensor([0, 7, 18, 23])
+        divisibility_factor = 4
+
+        pid = 888
+        label_pad = -400
+
+        # Execute
+        input_ids_padded, labels_padded, _, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(
+            input_ids.unsqueeze(0),
+            labels.unsqueeze(0),
+            positional_ids,
+            cu_seqlens_q,
+            divisibility_factor,
+            padding_token_id=pid,
+            padding_label_id=label_pad,
+        )
+
+        # Assert
+        # Seq 1: 7 + 1 pad = 8 (divisible by 4)
+        # Seq 2: 11 + 1 pad = 12 (divisible by 4)
+        # Seq 3: 5 + 3 pads = 8 (divisible by 4)
+
+        expected_input_ids = torch.tensor(
+            [1, 1, 1, 1, 1, 1, 1, pid, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, pid, 3, 3, 3, 3, 3, pid, pid, pid]
+        )
+
+        expected_labels = torch.tensor(
+            [
+                100,
+                101,
+                102,
+                103,
+                104,
+                105,
+                106,
+                label_pad,
+                200,
+                201,
+                202,
+                203,
+                204,
+                205,
+                206,
+                207,
+                208,
+                209,
+                210,
+                label_pad,
+                300,
+                301,
+                302,
+                303,
+                304,
+                label_pad,
+                label_pad,
+                label_pad,
+            ]
+        )
+
+        expected_positional_ids = torch.tensor(
+            [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 6, 7]
+        )
+
+        expected_cu_seqlens_padded = torch.tensor([0, 8, 20, 28])
+
+        self.assertTrue(torch.equal(input_ids_padded, expected_input_ids))
+        self.assertTrue(torch.equal(labels_padded, expected_labels))
+        self.assertTrue(torch.equal(positional_ids_padded, expected_positional_ids))
+        self.assertTrue(torch.equal(cu_seqlens_q_padded, expected_cu_seqlens_padded))
+
+# Now let's write a test that utilizes the pad sequence to divisibility function
+# and then shards that on the CP ranks.
+def test_shard_on_cp_ranks():
+    # Make some dummy data.
+    input_ids = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
+    labels = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
+    positional_ids = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
+    cu_seqlens_q = torch.tensor([0, 5])
+    divisibility_factor = 2
+    padding_token_id = 0
+    padding_label_id = -100
+    input_ids_padded, labels_padded, positional_ids_padded, cu_seqlens_q_padded = pad_sequences_to_divisibility(input_ids, labels, positional_ids, cu_seqlens_q, divisibility_factor, padding_token_id, padding_label_id)
+    assert input_ids_padded.shape == (2, 10)
+    
+    # Ok now we are going to split the data on the CP ranks. I think we can mock the groups?
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -234,12 +234,28 @@ def get_thd_batch_on_this_cp_rank(
         def process_tensor(val):
             if val is not None:
                 # Determine which dimension is the sequence dimension
-                if val.shape[1] == cu_seqlens_padded[-1]:
-                    current_seq_dim = 1
-                elif val.shape[0] == cu_seqlens_padded[-1]:
-                    current_seq_dim = 0
+                # TODO: Add support for if the cu_seqlens_padded gives you a tensor of shape (1,)
+                # Ensure cu_seqlens_padded[-1] is a Python int, not a 0-dim tensor
+                if isinstance(cu_seqlens_padded[-1], torch.Tensor):
+                    seq_len_val = cu_seqlens_padded[-1].item()
                 else:
-                    raise ValueError("Make sure the inputs are in THD format and padded correctly.")
+                    seq_len_val = cu_seqlens_padded[-1]
+                
+                # Handle 1D tensors (like position_ids that don't have batch dimension)
+                if val.ndim == 1:
+                    if val.shape[0] == seq_len_val:
+                        current_seq_dim = 0
+                    else:
+                        raise ValueError("1D tensor shape doesn't match expected sequence length. Make sure the inputs are in THD format and padded correctly.")
+                elif val.ndim >= 2:
+                    if val.shape[1] == seq_len_val:
+                        current_seq_dim = 1
+                    elif val.shape[0] == seq_len_val:
+                        current_seq_dim = 0
+                    else:
+                        raise ValueError("Make sure the inputs are in THD format and padded correctly.")
+                else:
+                    raise ValueError("Tensor must be at least 1D")
 
                 # On this particular rank, for each sequence, get two slices, one from the beginning
                 # and one from the end.

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -4,7 +4,7 @@
 
 """Context Parallelism."""
 import os
-from typing import List, Union
+from typing import List, Union, Tuple
 import torch
 import transformer_engine_torch as tex
 
@@ -47,6 +47,231 @@ _cu_seqlens_info_with_cp_cache = {}
 _seq_chunk_ids_cache_for_reordering_before_attn = {}
 _seq_chunk_ids_cache_for_reordering_after_attn = {}
 
+
+def pad_sequences_to_divisibility(
+    input_ids: torch.Tensor,
+    labels: torch.Tensor,
+    positional_ids: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    divisibility_factor: int,
+    padding_token_id: int = 0,
+    padding_label_id: int = -100,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pads sequences to be divisible by the divisibility factor.
+
+    Args:
+        input_ids: Tensor of shape (1, N) containing concatenated sequences
+        labels: Tensor of shape (1, N) containing labels for each token
+        positional_ids: Tensor of shape (N,) containing position IDs for each token
+        cu_seqlens_q: Tensor of shape (M,) containing cumulative sequence lengths
+        divisibility_factor: Each sequence length must be divisible by this factor
+        padding_token_id: Token ID to use for padding (default: 0)
+        padding_label_id: Label ID to use for padding (default: -100)
+
+    Returns:
+        Tuple of:
+        - input_ids_padded: Padded input_ids tensor
+        - labels_padded: Padded labels tensor
+        - positional_ids: Original positional_ids (unchanged)
+        - positional_ids_padded: Padded positional_ids tensor with continued positions
+        - cu_seqlens_q_padded: Cumulative sequence lengths accounting for padding
+    """
+    # Flatten input_ids and labels if needed
+    if input_ids.dim() == 2:
+        input_ids = input_ids.squeeze(0)
+    if labels.dim() == 2:
+        labels = labels.squeeze(0)
+
+    # Extract individual sequences
+    batch_sequences = extract_sequences(input_ids, cu_seqlens_q)
+    batch_labels = extract_sequences(labels, cu_seqlens_q)
+
+    # Calculate padding needed for each sequence
+    padding_amounts = calculate_padding_amounts(batch_sequences, divisibility_factor)
+
+    # Pad the sequences
+    padded_sequences = pad_batch_sequences(batch_sequences, padding_amounts, padding_token_id)
+
+    # Pad the labels
+    padded_labels = pad_batch_sequences(batch_labels, padding_amounts, padding_label_id)
+
+    # Create padded input_ids tensor
+    input_ids_padded = torch.cat(padded_sequences)
+
+    # Create padded labels tensor
+    labels_padded = torch.cat(padded_labels)
+
+    # Create padded positional_ids (positions continue incrementing through padding)
+    positional_ids_padded = create_padded_positional_ids(positional_ids, cu_seqlens_q, padding_amounts)
+
+    # Create padded cumulative sequence lengths
+    cu_seqlens_q_padded = create_padded_cu_seqlens(cu_seqlens_q, padding_amounts)
+
+    return input_ids_padded, labels_padded, positional_ids, positional_ids_padded, cu_seqlens_q_padded
+
+
+def extract_sequences(input_ids: torch.Tensor, cu_seqlens_q: torch.Tensor) -> List[torch.Tensor]:
+    """Extract individual sequences from concatenated input_ids."""
+    sequences = []
+    for i in range(len(cu_seqlens_q) - 1):
+        start_idx = cu_seqlens_q[i].item()
+        end_idx = cu_seqlens_q[i + 1].item()
+        sequences.append(input_ids[start_idx:end_idx])
+    return sequences
+
+
+def calculate_padding_amounts(sequences: List[torch.Tensor], divisibility_factor: int) -> List[int]:
+    """Calculate padding needed for each sequence to be divisible by factor."""
+    padding_amounts = []
+    for seq in sequences:
+        seq_len = len(seq)
+        remainder = seq_len % divisibility_factor
+        padding_needed = (divisibility_factor - remainder) % divisibility_factor
+        padding_amounts.append(padding_needed)
+    return padding_amounts
+
+
+def pad_batch_sequences(
+    sequences: List[torch.Tensor], padding_amounts: List[int], padding_value: int
+) -> List[torch.Tensor]:
+    """Pad each sequence with the specified amount of padding tokens."""
+    padded_sequences = []
+    for seq, pad_amount in zip(sequences, padding_amounts):
+        if pad_amount > 0:
+            padding = torch.full((pad_amount,), padding_value, dtype=seq.dtype)
+            padded_seq = torch.cat([seq, padding])
+        else:
+            padded_seq = seq
+        padded_sequences.append(padded_seq)
+    return padded_sequences
+
+
+def create_padded_positional_ids(
+    positional_ids: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    padding_amounts: List[int],
+) -> torch.Tensor:
+    """Create padded version of positional_ids tensor.
+
+    Position IDs continue incrementing through the padding tokens.
+    """
+    padded_pos_ids = []
+
+    for i in range(len(cu_seqlens_q) - 1):
+        start_idx = cu_seqlens_q[i].item()
+        end_idx = cu_seqlens_q[i + 1].item()
+
+        # Get original position IDs for this sequence
+        seq_pos_ids = positional_ids[start_idx:end_idx]
+        padded_pos_ids.append(seq_pos_ids)
+
+        # Add padding position IDs if needed - continue counting from last position
+        pad_amount = padding_amounts[i]
+        if pad_amount > 0:
+            last_position = seq_pos_ids[-1].item()
+            # Continue position IDs through the padding
+            padding_positions = torch.arange(
+                last_position + 1, last_position + 1 + pad_amount, dtype=positional_ids.dtype
+            )
+            padded_pos_ids.append(padding_positions)
+
+    return torch.cat(padded_pos_ids)
+
+
+def create_padded_cu_seqlens(cu_seqlens_q: torch.Tensor, padding_amounts: List[int]) -> torch.Tensor:
+    """Create cumulative sequence lengths accounting for padding."""
+    cu_seqlens_padded = [cu_seqlens_q[0].item()]
+
+    for i in range(len(cu_seqlens_q) - 1):
+        prev_cu_len = cu_seqlens_padded[-1]
+        orig_seq_len = cu_seqlens_q[i + 1].item() - cu_seqlens_q[i].item()
+        padded_seq_len = orig_seq_len + padding_amounts[i]
+        cu_seqlens_padded.append(prev_cu_len + padded_seq_len)
+
+    return torch.tensor(cu_seqlens_padded, dtype=cu_seqlens_q.dtype)
+
+
+def get_thd_batch_on_this_cp_rank(
+    cu_seqlens_q_padded: torch.Tensor,
+    cu_seqlens_kv_padded: torch.Tensor,
+    input_ids_padded: torch.Tensor,
+    labels_padded: torch.Tensor,
+    position_ids_padded: torch.Tensor,
+    cp_group: torch.distributed.ProcessGroup = None,
+):
+    """Slice batch input along sequence dimension into multiple chunks for THD format.
+
+    This function is inteded for use in self attention. It will not work for cross attention because 
+    it does not handle the case where the sequence length of the query and key are different.
+
+    Which are parallelized across GPUs in a context parallel group.
+    This version works with variable-length sequences using cumulative sequence lengths.
+    """
+    # Get context parallel size and rank
+    cp_size = torch.distributed.get_world_size(group=cp_group)
+    if cp_size > 1:
+        cp_rank = torch.distributed.get_rank(group=cp_group)
+
+        # Get cumulative sequence lengths from batch
+        cu_seqlens_padded = cu_seqlens_q_padded
+        assert cu_seqlens_padded is not None, (
+            "cu_seqlens_padded is required for THD format to calculate "
+            "the right chunk sizes for each sequence. cu_seqlens_q_padded is required for THD format to calculate "
+            "the right chunk sizes for each sequence."
+        )
+
+        # Get the cu_seqlens_kv_padded
+        cu_seqlens_kv_padded = cu_seqlens_kv_padded
+        assert cu_seqlens_kv_padded is not None, (
+            "cu_seqlens_kv_padded is required for THD format to calculate the right chunk sizes for each sequence."
+        )
+
+        # Calculate the chunk sizes for each sequence
+        total_slices_of_any_sequence = 2 * cp_size
+        slice_sizes = (cu_seqlens_padded[1:] - cu_seqlens_padded[:-1]) // total_slices_of_any_sequence
+
+        # Process each tensor directly instead of using keys_to_change loop
+        def process_tensor(val):
+            if val is not None:
+                # Determine which dimension is the sequence dimension
+                if val.shape[1] == cu_seqlens_padded[-1]:
+                    current_seq_dim = 1
+                elif val.shape[0] == cu_seqlens_padded[-1]:
+                    current_seq_dim = 0
+                else:
+                    raise ValueError("Make sure the inputs are in THD format and padded correctly.")
+
+                # On this particular rank, for each sequence, get two slices, one from the beginning
+                # and one from the end.
+                cp_rank_slices = []
+                for slice_size, seq_start in zip(slice_sizes, cu_seqlens_padded[:-1]):
+                    # 1st segment
+                    cp_rank_slices.append(
+                        torch.arange(
+                            seq_start + (cp_rank * slice_size),
+                            seq_start + ((cp_rank + 1) * slice_size),
+                            device=val.device,
+                        )
+                    )
+
+                    # 2nd segment
+                    cp_rank_slices.append(
+                        torch.arange(
+                            seq_start + ((total_slices_of_any_sequence - cp_rank - 1) * slice_size),
+                            seq_start + ((total_slices_of_any_sequence - cp_rank) * slice_size),
+                            device=val.device,
+                        )
+                    )
+
+                return val.index_select(current_seq_dim, torch.cat(cp_rank_slices))
+            return val
+
+        # Process each tensor directly
+        input_ids_padded = process_tensor(input_ids_padded)
+        labels_padded = process_tensor(labels_padded)
+        position_ids_padded = process_tensor(position_ids_padded)
+
+    return input_ids_padded, labels_padded, position_ids_padded
 
 def flash_attn_p2p_communicate(
     rank, send_tensor, send_dst, recv_tensor, recv_src, cp_group, batch_p2p_comm


### PR DESCRIPTION
# Description

In order to utilize the context parallelism functionality as part of TransformerEngine we must perform some manipulation on the training data and its metadata to make it ammendable towards context parallelism.

In doing so, we must pad our sequences to be divisible by `cp_size*2` so that we are able to perform the dual chunking method. This utility function is now added in this MR, such that it will pad each sequence to make it divisible.

Moreover, we also add the functionality to move data to each CP rank. For example if you have a sequence
```
Sequence=[1, 2, 3, 4, 5, 6, 7, 8]
```
The function `get_thd_batch_on_this_cp_rank` will move data to each shard
```
cp0: [1, 2, 7, 8]
cp1: [3, 4, 5, 6]
```
So that its easy to use ring attention on it. 

Here I've added both utility functions as well as rigorous unit testing to ensure these functions are durable.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Adds the function get_thd_batch_on_this_cp_rank for CP sharding
- Adds the function pad_sequences_to_divisibility to augment training data to make it amenable toward context parallelism.

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [no] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
