### PR TITLE
[main][feature][under updating]adapt for offload activation

### DIFF
--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -81,7 +81,7 @@ class _GroupedLinear(torch.autograd.Function):
         module,
         skip_fp8_weight_update,
         save_original_input,
-        offload_activation,
+        fine_grained_activation_offloading,
         *weights_and_biases,
     ) -> torch.Tensor:
         # pylint: disable=missing-function-docstring
@@ -215,14 +215,14 @@ class _GroupedLinear(torch.autograd.Function):
                 weights[i].offloading_activation = False
                 weights_fp8[i].offloading_activation = False
                 biases[i].offloading_activation = False
-            ctx.offload_activation = offload_activation
+            ctx.fine_grained_activation_offloading = fine_grained_activation_offloading
 
-            if offload_activation and cpu_offloading:
+            if fine_grained_activation_offloading and cpu_offloading:
                 raise ValueError(
-                    f"Do not use offload_activation and cpu_offloading at the same time."
+                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same time."
                 )
 
-            if offload_activation and weights[0].requires_grad and fuse_wgrad_accumulation:
+            if fine_grained_activation_offloading and weights[0].requires_grad and fuse_wgrad_accumulation:
                 grad_added_to_main_grad_list = []
                 for weight in weights:
                     if weight.requires_grad and hasattr(weight, "grad_added_to_main_grad"):
@@ -292,7 +292,7 @@ class _GroupedLinear(torch.autograd.Function):
             biases = saved_tensors[3 * N : 4 * N]
             main_grads = [main_grad_func() for main_grad_func in ctx.main_grad_funcs]
 
-            if (ctx.cpu_offloading or ctx.offload_activation) and ctx.fuse_wgrad_accumulation:
+            if (ctx.cpu_offloading or ctx.fine_grained_activation_offloading) and ctx.fuse_wgrad_accumulation:
                 for i in range(ctx.num_gemms):
                     if not ctx.cpu_offloading:
                         w = torch.nn.Parameter(weights[i], weights[i].requires_grad)
@@ -586,7 +586,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         ub_overlap_rs: bool = False,
         ub_overlap_ag: bool = False,
         ub_name: Optional[str] = None,
-        offload_activation: bool = False,
+        fine_grained_activation_offloading: bool = False,
         delay_wgrad_compute: bool = False,
         save_original_input: bool = False,
     ) -> None:
@@ -610,7 +610,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         self.get_rng_state_tracker = get_rng_state_tracker
         self.rng_tracker_name = rng_tracker_name
 
-        self.offload_activation = offload_activation
+        self.fine_grained_activation_offloading = fine_grained_activation_offloading
 
         self.wgrad_store = WeightGradStore(delay_wgrad_compute)
 
@@ -827,7 +827,7 @@ class GroupedLinear(TransformerEngineBaseModule):
                 self.sequence_parallel,
                 self.activation_dtype,
                 torch.is_grad_enabled(),
-                self.offload_activation,
+                self.fine_grained_activation_offloading,
                 self,
                 skip_fp8_weight_update,
                 self.save_original_input,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -210,19 +210,21 @@ class _GroupedLinear(torch.autograd.Function):
                         weight.update_usage(columnwise_usage=True)
 
             offload_activation = False
-            if hasattr(inp, 'offloading_activation'):
+            if hasattr(inp, "offloading_activation"):
                 offload_activation = True
                 for i in range(num_gemms):
                     inputmats[i].offloading_activation = inp.offloading_activation
             ctx.offload_activation = offload_activation
 
             if offload_activation and cpu_offloading:
-                raise ValueError(f"Do not use offload_activation and cpu_offloading at the same time.")
+                raise ValueError(
+                    f"Do not use offload_activation and cpu_offloading at the same time."
+                )
 
             if offload_activation and weights[0].requires_grad and fuse_wgrad_accumulation:
                 grad_added_to_main_grad_list = []
                 for weight in weights:
-                    if weight.requires_grad and hasattr(weight, 'grad_added_to_main_grad'):
+                    if weight.requires_grad and hasattr(weight, "grad_added_to_main_grad"):
                         grad_added_to_main_grad_list.append(weight.grad_added_to_main_grad)
                         weight.grad_added_to_main_grad = True
                 ctx.grad_added_to_main_grad_list = grad_added_to_main_grad_list

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -827,10 +827,10 @@ class GroupedLinear(TransformerEngineBaseModule):
                 self.sequence_parallel,
                 self.activation_dtype,
                 torch.is_grad_enabled(),
-                self.fine_grained_activation_offloading,
                 self,
                 skip_fp8_weight_update,
                 self.save_original_input,
+                self.fine_grained_activation_offloading,
                 *weight_tensors,
                 *bias_tensors,
             )

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -219,10 +219,15 @@ class _GroupedLinear(torch.autograd.Function):
 
             if fine_grained_activation_offloading and cpu_offloading:
                 raise ValueError(
-                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same time."
+                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same"
+                    f" time."
                 )
 
-            if fine_grained_activation_offloading and weights[0].requires_grad and fuse_wgrad_accumulation:
+            if (
+                fine_grained_activation_offloading
+                and weights[0].requires_grad
+                and fuse_wgrad_accumulation
+            ):
                 grad_added_to_main_grad_list = []
                 for weight in weights:
                     if weight.requires_grad and hasattr(weight, "grad_added_to_main_grad"):
@@ -292,7 +297,9 @@ class _GroupedLinear(torch.autograd.Function):
             biases = saved_tensors[3 * N : 4 * N]
             main_grads = [main_grad_func() for main_grad_func in ctx.main_grad_funcs]
 
-            if (ctx.cpu_offloading or ctx.fine_grained_activation_offloading) and ctx.fuse_wgrad_accumulation:
+            if (
+                ctx.cpu_offloading or ctx.fine_grained_activation_offloading
+            ) and ctx.fuse_wgrad_accumulation:
                 for i in range(ctx.num_gemms):
                     if not ctx.cpu_offloading:
                         w = torch.nn.Parameter(weights[i], weights[i].requires_grad)

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -14,6 +14,7 @@ import transformer_engine_torch as tex
 from transformer_engine.common.recipe import Recipe
 from .base import (
     get_multi_stream_cublas_workspace,
+    get_dummy_wgrad,
     TransformerEngineBaseModule,
     _2X_ACC_FPROP,
     _2X_ACC_DGRAD,
@@ -80,6 +81,7 @@ class _GroupedLinear(torch.autograd.Function):
         module,
         skip_fp8_weight_update,
         save_original_input,
+        offload_activation,
         *weights_and_biases,
     ) -> torch.Tensor:
         # pylint: disable=missing-function-docstring
@@ -209,11 +211,10 @@ class _GroupedLinear(torch.autograd.Function):
                     if isinstance(weight, QuantizedTensorBase):
                         weight.update_usage(columnwise_usage=True)
 
-            offload_activation = False
-            if hasattr(inp, "offloading_activation"):
-                offload_activation = True
-                for i in range(num_gemms):
-                    inputmats[i].offloading_activation = inp.offloading_activation
+            for i in range(num_gemms):
+                weights[i].offloading_activation = False
+                weights_fp8[i].offloading_activation = False
+                biases[i].offloading_activation = False
             ctx.offload_activation = offload_activation
 
             if offload_activation and cpu_offloading:
@@ -448,18 +449,15 @@ class _GroupedLinear(torch.autograd.Function):
                         ):
                             weight.grad_added_to_main_grad = True
                             if getattr(weight, "zero_out_wgrad", False):
-                                wgrad = torch.zeros(
-                                    weight.main_grad.shape,
-                                    dtype=weight.dtype,
-                                    device=torch.cuda.current_device(),
-                                    requires_grad=False,
+                                wgrad = get_dummy_wgrad(
+                                    list(weight.main_grad.shape),
+                                    weight.dtype,
+                                    zero=True,
                                 )
                             else:
-                                wgrad = torch.empty(
-                                    weight.main_grad.shape,
-                                    dtype=weight.dtype,
-                                    device=torch.cuda.current_device(),
-                                    requires_grad=False,
+                                wgrad = get_dummy_wgrad(
+                                    list(weight.main_grad.shape),
+                                    weight.dtype,
                                 )
                         elif ctx.fuse_wgrad_accumulation:
                             wgrad = None
@@ -488,6 +486,7 @@ class _GroupedLinear(torch.autograd.Function):
             FP8GlobalStateManager.reduce_and_update_fp8_tensors(forward=False)
         return (
             dgrad.view(ctx.inp_shape) if ctx.requires_dgrad else None,
+            None,
             None,
             None,
             None,
@@ -587,6 +586,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         ub_overlap_rs: bool = False,
         ub_overlap_ag: bool = False,
         ub_name: Optional[str] = None,
+        offload_activation: bool = False,
         delay_wgrad_compute: bool = False,
         save_original_input: bool = False,
     ) -> None:
@@ -609,6 +609,8 @@ class GroupedLinear(TransformerEngineBaseModule):
         ), "GroupedLinear doesn't support Userbuffer overlap."
         self.get_rng_state_tracker = get_rng_state_tracker
         self.rng_tracker_name = rng_tracker_name
+
+        self.offload_activation = offload_activation
 
         self.wgrad_store = WeightGradStore(delay_wgrad_compute)
 
@@ -825,6 +827,7 @@ class GroupedLinear(TransformerEngineBaseModule):
                 self.sequence_parallel,
                 self.activation_dtype,
                 torch.is_grad_enabled(),
+                self.offload_activation,
                 self,
                 skip_fp8_weight_update,
                 self.save_original_input,

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -435,10 +435,15 @@ class _LayerNormLinear(torch.autograd.Function):
 
             if fine_grained_activation_offloading and cpu_offloading:
                 raise ValueError(
-                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same time."
+                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same"
+                    f" time."
                 )
 
-            if fine_grained_activation_offloading and weight.requires_grad and fuse_wgrad_accumulation:
+            if (
+                fine_grained_activation_offloading
+                and weight.requires_grad
+                and fuse_wgrad_accumulation
+            ):
                 if hasattr(weight, "grad_added_to_main_grad"):
                     ctx.has_grad_added_to_main_grad = True
                     ctx.grad_added_to_main_grad = weight.grad_added_to_main_grad

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -425,17 +425,19 @@ class _LayerNormLinear(torch.autograd.Function):
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
             offload_activation = False
-            if hasattr(inp, 'offloading_activation'):
+            if hasattr(inp, "offloading_activation"):
                 offload_activation = True
                 if inputmat.is_contiguous():
                     inputmat = inputmat.contiguous()
             ctx.offload_activation = offload_activation
 
             if offload_activation and cpu_offloading:
-                raise ValueError(f"Do not use offload_activation and cpu_offloading at the same time.")
+                raise ValueError(
+                    f"Do not use offload_activation and cpu_offloading at the same time."
+                )
 
             if offload_activation and weight.requires_grad and fuse_wgrad_accumulation:
-                if hasattr(weight, 'grad_added_to_main_grad'):
+                if hasattr(weight, "grad_added_to_main_grad"):
                     ctx.has_grad_added_to_main_grad = True
                     ctx.grad_added_to_main_grad = weight.grad_added_to_main_grad
                     weight.grad_added_to_main_grad = True

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -424,10 +424,28 @@ class _LayerNormLinear(torch.autograd.Function):
             )
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
-            if cpu_offloading:
-                ctx.grad_added_to_main_grad = hasattr(weight, "grad_added_to_main_grad")
+            offload_activation = False
+            if hasattr(inp, 'offloading_activation'):
+                offload_activation = True
+                if inputmat.is_contiguous():
+                    inputmat = inputmat.contiguous()
+            ctx.offload_activation = offload_activation
 
-                if ctx.grad_added_to_main_grad:
+            if offload_activation and cpu_offloading:
+                raise ValueError(f"Do not use offload_activation and cpu_offloading at the same time.")
+
+            if offload_activation and weight.requires_grad and fuse_wgrad_accumulation:
+                if hasattr(weight, 'grad_added_to_main_grad'):
+                    ctx.has_grad_added_to_main_grad = True
+                    ctx.grad_added_to_main_grad = weight.grad_added_to_main_grad
+                    weight.grad_added_to_main_grad = True
+                else:
+                    ctx.has_grad_added_to_main_grad = False
+
+            if cpu_offloading:
+                ctx.has_grad_added_to_main_grad = hasattr(weight, "grad_added_to_main_grad")
+
+                if ctx.has_grad_added_to_main_grad:
                     # If you are passing torch.nn.Parameter through the Torch hooks, you will
                     # get back torch.Tensor. Torch rips off the Parameter wrapper.
                     # You need to preserve the weight object to have all the attributes user
@@ -560,9 +578,11 @@ class _LayerNormLinear(torch.autograd.Function):
 
             # For CPU offloading, we offloaded weight and weight.main_grad to different tensors,
             # we need to connect them into one.
-            if ctx.cpu_offloading:
-                if ctx.grad_added_to_main_grad:
+            if ctx.cpu_offloading or ctx.offload_activation:
+                if ctx.has_grad_added_to_main_grad:
                     origin_weight = ctx.weight_object
+                    if ctx.offload_activation:
+                        origin_weight.grad_added_to_main_grad = ctx.grad_added_to_main_grad
                 if ctx.requires_wgrad and ctx.fuse_wgrad_accumulation:
                     origin_weight.main_grad = main_grad
 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -122,7 +122,7 @@ class _LayerNormLinear(torch.autograd.Function):
         ub_bulk_wgrad: bool,
         ub_bulk_dgrad: bool,
         ub_name: str,
-        offload_activation: bool,
+        fine_grained_activation_offloading: bool,
         fsdp_group: Union[dist_group_type, None],
         module: torch.nn.Module,
         skip_fp8_weight_update: bool,
@@ -431,14 +431,14 @@ class _LayerNormLinear(torch.autograd.Function):
             if bias is not None:
                 bias.offloading_activation = False
             ln_weight.offloading_activation = False
-            ctx.offload_activation = offload_activation
+            ctx.fine_grained_activation_offloading = fine_grained_activation_offloading
 
-            if offload_activation and cpu_offloading:
+            if fine_grained_activation_offloading and cpu_offloading:
                 raise ValueError(
-                    f"Do not use offload_activation and cpu_offloading at the same time."
+                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same time."
                 )
 
-            if offload_activation and weight.requires_grad and fuse_wgrad_accumulation:
+            if fine_grained_activation_offloading and weight.requires_grad and fuse_wgrad_accumulation:
                 if hasattr(weight, "grad_added_to_main_grad"):
                     ctx.has_grad_added_to_main_grad = True
                     ctx.grad_added_to_main_grad = weight.grad_added_to_main_grad
@@ -583,10 +583,10 @@ class _LayerNormLinear(torch.autograd.Function):
 
             # For CPU offloading, we offloaded weight and weight.main_grad to different tensors,
             # we need to connect them into one.
-            if ctx.cpu_offloading or ctx.offload_activation:
+            if ctx.cpu_offloading or ctx.fine_grained_activation_offloading:
                 if ctx.has_grad_added_to_main_grad:
                     origin_weight = ctx.weight_object
-                    if ctx.offload_activation:
+                    if ctx.fine_grained_activation_offloading:
                         origin_weight.grad_added_to_main_grad = ctx.grad_added_to_main_grad
                 if ctx.requires_wgrad and ctx.fuse_wgrad_accumulation:
                     origin_weight.main_grad = main_grad
@@ -1046,7 +1046,7 @@ class _LayerNormLinear(torch.autograd.Function):
             None,  # ub_bulk_dgrad
             None,  # ub_bulk_wgrad
             None,  # ub_name
-            None,  # offload_activation
+            None,  # fine_grained_activation_offloading
             None,  # fsdp_group
             None,  # debug
             None,  # module
@@ -1182,7 +1182,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         name: str = None,
-        offload_activation: bool = False,
+        fine_grained_activation_offloading: bool = False,
     ) -> None:
         super().__init__()
 
@@ -1199,7 +1199,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
         self.return_layernorm_output_gathered = return_layernorm_output_gathered
         self.zero_centered_gamma = zero_centered_gamma
         self.symmetric_ar_type = symmetric_ar_type
-        self.offload_activation = offload_activation
+        self.fine_grained_activation_offloading = fine_grained_activation_offloading
         self.wgrad_store = WeightGradStore(delay_wgrad_compute, ub_bulk_wgrad)
         self.name = name
 
@@ -1602,7 +1602,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.ub_bulk_wgrad,
                 self.ub_bulk_dgrad,
                 self.ub_name,
-                self.offload_activation,
+                self.fine_grained_activation_offloading,
                 self.fsdp_group,
                 self,
                 skip_fp8_weight_update,

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -396,17 +396,19 @@ class _Linear(torch.autograd.Function):
             nvtx_range_pop(f"{nvtx_label}.fsdp_scatter")
 
             offload_activation = False
-            if hasattr(inp, 'offload_activation'):
+            if hasattr(inp, "offload_activation"):
                 offload_activation = True
                 if saved_inputmat.is_contiguous():
                     saved_inputmat = saved_inputmat.contiguous()
             ctx.offload_activation = offload_activation
 
             if offload_activation and cpu_offloading:
-                raise ValueError(f"Do not use offload_activation and cpu_offloading at the same time.")
-            
+                raise ValueError(
+                    f"Do not use offload_activation and cpu_offloading at the same time."
+                )
+
             if offload_activation and weight.requires_grad and fuse_wgrad_accumulation:
-                if hasattr(weight, 'grad_added_to_main_grad'):
+                if hasattr(weight, "grad_added_to_main_grad"):
                     ctx.has_grad_added_to_main_grad = True
                     ctx.grad_added_to_main_grad = weight.grad_added_to_main_grad
                     weight.grad_added_to_main_grad = True

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -400,10 +400,15 @@ class _Linear(torch.autograd.Function):
 
             if fine_grained_activation_offloading and cpu_offloading:
                 raise ValueError(
-                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same time."
+                    f"Do not use fine_grained_activation_offloading and cpu_offloading at the same"
+                    f" time."
                 )
 
-            if fine_grained_activation_offloading and weight.requires_grad and fuse_wgrad_accumulation:
+            if (
+                fine_grained_activation_offloading
+                and weight.requires_grad
+                and fuse_wgrad_accumulation
+            ):
                 if hasattr(weight, "grad_added_to_main_grad"):
                     ctx.has_grad_added_to_main_grad = True
                     ctx.grad_added_to_main_grad = weight.grad_added_to_main_grad


### PR DESCRIPTION
# Description

This pr is used to adapt for offload activation (a new feature in Megatron-LM, https://github.com/NVIDIA/Megatron-LM/pull/1752).

Offload activation select inputs of specific modules (such as `core_attn`,  `qkv_linear`, `router_fc1`), offloading them to CPU in forward pass and reloading them to GPU in backward pass.

When offloading the modules that include weights (`nn.Parameter`), attributes of these weights (such as `main_grad`, `grad_added_to_main_grad`)  are ripped off by torch. Therefore, this feature needs to modify the basic modules in TE (such as `grouped_linear.py`, 'layernorm_linear.py') to preserve these necessary attributes.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Based on whether the input tensor contains the `offloading_activation` attribute, add support for retrieving the `offload_activation` flag in `grouped_linear.py`, `linear.py`, and `layernorm_linear.py`.
- Save the `grad_added_to_main_grad ` attribute in forward pass and get it in backward pass in `grouped_linear.py`, `linear.py`, and `layernorm_linear.py`.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
