### PR TITLE
Lower precision gated-act to accelerate FP8 current-scaling.

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -464,14 +464,25 @@ class TestNorm:
                 x, gamma, beta, zero_centered_gamma, epsilon, quantizer=quantizer
             )
             ref_out, ref_mu, ref_rsigma = _jax_layernorm(
-                x, gamma, beta, zero_centered_gamma, epsilon, quantizer=ref_quantizer
+                x,
+                gamma,
+                beta,
+                zero_centered_gamma,
+                epsilon,
+                quantizer=ref_quantizer,
+                high_precision_norm_out=True,
             )
         else:
             output, rsigma = tex.rmsnorm_fwd(
                 x, gamma, zero_centered_gamma, epsilon, quantizer=quantizer
             )
             ref_out, ref_rsigma = _jax_rmsnorm(
-                x, gamma, zero_centered_gamma, epsilon, quantizer=ref_quantizer
+                x,
+                gamma,
+                zero_centered_gamma,
+                epsilon,
+                quantizer=ref_quantizer,
+                high_precision_norm_out=True,
             )
             ref_mu = None
 

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -470,7 +470,6 @@ class TestNorm:
                 zero_centered_gamma,
                 epsilon,
                 quantizer=ref_quantizer,
-                high_precision_norm_out=True,
             )
         else:
             output, rsigma = tex.rmsnorm_fwd(
@@ -482,7 +481,6 @@ class TestNorm:
                 zero_centered_gamma,
                 epsilon,
                 quantizer=ref_quantizer,
-                high_precision_norm_out=True,
             )
             ref_mu = None
 

--- a/transformer_engine/jax/cpp_extensions/activation.py
+++ b/transformer_engine/jax/cpp_extensions/activation.py
@@ -1044,7 +1044,7 @@ def act_lu(
     if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
         # Current scaling does not support fused operations. Perform dact in higher precision then quantize after.
         out = act_lu(
-            x=x.astype(jnp.float32),
+            x=x,
             activation_type=activation_type,
             quantizer=None,
         )
@@ -1188,8 +1188,8 @@ def quantize_dact_dbias(
     if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
         # Current scaling does not support fused operations. Perform dact in higher precision then quantize after.
         out = dact_lu(
-            dz=dz.astype(jnp.float32),
-            x=x.astype(jnp.float32),
+            dz=dz,
+            x=x,
             activation_type=activation_type,
             quantizer=None,
         )

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -824,9 +824,7 @@ class NormBwdPrimitive(BasePrimitive):
 register_primitive(NormBwdPrimitive)
 
 
-def _jax_layernorm(
-    x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None, high_precision_norm_out=False
-):
+def _jax_layernorm(x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None):
     """
     JAX native layernorm implementation
     """
@@ -842,7 +840,7 @@ def _jax_layernorm(
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma + beta
-    if not high_precision_norm_out:
+    if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
         output = output.astype(x.dtype)
 
     if quantizer:
@@ -853,9 +851,7 @@ def _jax_layernorm(
     return ln_out, jnp.squeeze(mean, axis=-1), jnp.squeeze(rsigma, axis=-1)
 
 
-def _jax_rmsnorm(
-    x, gamma, zero_centered_gamma, epsilon, quantizer=None, high_precision_norm_out=False
-):
+def _jax_rmsnorm(x, gamma, zero_centered_gamma, epsilon, quantizer=None):
     """
     JAX native rmsnorm implementation
     """
@@ -870,7 +866,7 @@ def _jax_rmsnorm(
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma
-    if not high_precision_norm_out:
+    if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
         output = output.astype(x.dtype)
 
     if quantizer:

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -824,7 +824,9 @@ class NormBwdPrimitive(BasePrimitive):
 register_primitive(NormBwdPrimitive)
 
 
-def _jax_layernorm(x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None):
+def _jax_layernorm(
+    x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None, high_precision_norm_out=False
+):
     """
     JAX native layernorm implementation
     """
@@ -840,7 +842,8 @@ def _jax_layernorm(x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None)
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma + beta
-    output = output.astype(x.dtype)
+    if not high_precision_norm_out:
+        output = output.astype(x.dtype)
 
     if quantizer:
         ln_out = quantizer.quantize(output, dq_dtype=x.dtype)
@@ -850,7 +853,9 @@ def _jax_layernorm(x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None)
     return ln_out, jnp.squeeze(mean, axis=-1), jnp.squeeze(rsigma, axis=-1)
 
 
-def _jax_rmsnorm(x, gamma, zero_centered_gamma, epsilon, quantizer=None):
+def _jax_rmsnorm(
+    x, gamma, zero_centered_gamma, epsilon, quantizer=None, high_precision_norm_out=False
+):
     """
     JAX native rmsnorm implementation
     """
@@ -865,7 +870,8 @@ def _jax_rmsnorm(x, gamma, zero_centered_gamma, epsilon, quantizer=None):
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma
-    output = output.astype(x.dtype)
+    if not high_precision_norm_out:
+        output = output.astype(x.dtype)
 
     if quantizer:
         ln_out = quantizer.quantize(output, dq_dtype=x.dtype)

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -840,10 +840,10 @@ def _jax_layernorm(x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None)
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma + beta
-    if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
-        output = output.astype(x.dtype)
 
     if quantizer:
+        if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
+            output = output.astype(x.dtype)
         ln_out = quantizer.quantize(output, dq_dtype=x.dtype)
     else:
         ln_out = jnp.asarray(output).astype(x.dtype)
@@ -866,10 +866,10 @@ def _jax_rmsnorm(x, gamma, zero_centered_gamma, epsilon, quantizer=None):
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma
-    if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
-        output = output.astype(x.dtype)
 
     if quantizer:
+        if quantizer.scaling_mode == ScalingMode.CURRENT_TENSOR_SCALING:
+            output = output.astype(x.dtype)
         ln_out = quantizer.quantize(output, dq_dtype=x.dtype)
     else:
         ln_out = jnp.asarray(output).astype(x.dtype)

--- a/transformer_engine/jax/cpp_extensions/normalization.py
+++ b/transformer_engine/jax/cpp_extensions/normalization.py
@@ -840,6 +840,7 @@ def _jax_layernorm(x, gamma, beta, zero_centered_gamma, epsilon, quantizer=None)
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma + beta
+    output = output.astype(x.dtype)
 
     if quantizer:
         ln_out = quantizer.quantize(output, dq_dtype=x.dtype)
@@ -864,6 +865,7 @@ def _jax_rmsnorm(x, gamma, zero_centered_gamma, epsilon, quantizer=None):
     if zero_centered_gamma:
         gamma += 1.0
     output = normed_input * gamma
+    output = output.astype(x.dtype)
 
     if quantizer:
         ln_out = quantizer.quantize(output, dq_dtype=x.dtype)


### PR DESCRIPTION
# Description

Applying lower precision as the original inputs to accelerate FP8 current-scaling. In our reduced-layer llama-3.1-8b experiments, this change could bring ~3% performance and ~5% with PGLE, which narrow the performance gap to ~3% compared to delayed-scaling.

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Reset the Norm outputs' precision as the input to trigger lower-precision ARs for amax compuation.
- Remove FP32 up-casting for gated activation.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
