### PR TITLE
[JAX] Fix GroupedScaledTensor creation with keyword arg

### DIFF
--- a/transformer_engine/jax/dense.py
+++ b/transformer_engine/jax/dense.py
@@ -442,7 +442,7 @@ def _grouped_dense_fwd_rule(
             ctx_kernel = ScaledTensorFactory.create_1x(
                 global_ctx_kernel_data.reshape(-1),
                 ctx_kernel.scale_inv,
-                ctx_kernel.scaling_mode,
+                scaling_mode=ctx_kernel.scaling_mode,
                 dq_dtype=ctx_kernel.dq_dtype,
                 is_colwise=False,
                 data_layout="N",
@@ -459,7 +459,7 @@ def _grouped_dense_fwd_rule(
                 grouped_gemm_kernel = ScaledTensorFactory.create_1x(
                     grouped_gemm_kernel_data.reshape(-1),
                     ctx_kernel.scale_inv,
-                    ctx_kernel.scaling_mode,
+                    scaling_mode=ctx_kernel.scaling_mode,
                     dq_dtype=ctx_kernel.dq_dtype,
                     is_colwise=True,
                     data_layout="T",


### PR DESCRIPTION
# Description

 Fix GroupedScaledTensor creation with keyword arg

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
