### PR TITLE
Build comm_gemm tests conditionally

### DIFF
--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -34,6 +34,20 @@ endif()
 
 find_library(TE_LIB NAMES transformer_engine PATHS "${TE_LIB_PATH}/.." ${TE_LIB_PATH} ENV TE_LIB_PATH REQUIRED)
 
+execute_process(
+  COMMAND nm -g ${TE_LIB}
+  COMMAND grep -- nvte_comm_gemm_ctx_create
+  RESULT_VARIABLE _rc
+  OUTPUT_QUIET
+)
+if(_rc EQUAL 0)
+  set(HAVE_COMM_GEMM ON)
+  message("Found COMM_GEMM")
+else()
+  set(HAVE_COMM_GEMM OFF)
+  message("Not found COMM_GEMM")
+endif()
+
 message(STATUS "Found transformer_engine library: ${TE_LIB}")
 include_directories(../../transformer_engine/common/include)
 include_directories(../../transformer_engine/common)
@@ -43,6 +57,9 @@ include_directories(${CMAKE_SOURCE_DIR})
 find_package(CUDAToolkit REQUIRED)
 include(${CMAKE_SOURCE_DIR}/../../3rdparty/cudnn-frontend/cmake/cuDNN.cmake)
 
+if(HAVE_COMM_GEMM)
 add_subdirectory(comm_gemm)
+endif()
+
 add_subdirectory(operator)
 add_subdirectory(util)


### PR DESCRIPTION
# Description

Comm-gemm API in TE is currently behind NVTE_WITH_CUBLASMP flag, but cpp tests add the corresponding tests unconditionally, which can lead to build failure if TE was built with the flag off. This change makes test build conditional.

It seems we currently don't have any CMake-level dependencies between cpp tests' build and TE lib build. So this change just inspects the binary. Which's kind of hacky, but should work.

Unless we want to introduce some sort dependencies on the cmake level, which's probably a bigger change.

A question to the reviewers: can I rely on "nm" and "grep" to be always present, or should I make it more platform-independent, somehow?

Or yet another option - just add some explicit build flag to cpp tests, like HAVE_COMM_GEMM?

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Make comm_gemm tests build conditionally

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
