### PR TITLE
[JAX] Scale swizzling via JAX transpose op

### DIFF
--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -134,6 +134,13 @@ class BasePrimitive(metaclass=ABCMeta):
         """
         return NotImplemented
 
+    @classmethod
+    def outer_impl(cls, *args, **kwargs):
+        """
+        to describe implementation for outer primitive
+        """
+        return cls.impl(*args, **kwargs)
+
     @staticmethod
     @abstractmethod
     def batcher():
@@ -196,10 +203,10 @@ def register_primitive(cls):
     outer_p = core.Primitive(name_of_wrapper_p())
     dispatch.prim_requires_devices_during_lowering.add(outer_p)
     outer_p.multiple_results = cls.multiple_results
-    outer_p.def_impl(cls.impl)
+    outer_p.def_impl(cls.outer_impl)
     outer_p.def_abstract_eval(cls.outer_abstract)
     batching.primitive_batchers[outer_p] = cls.batcher
-    outer_p_lower = custom_partitioning(cls.impl, static_argnums=cls.impl_static_args)
+    outer_p_lower = custom_partitioning(cls.outer_impl, static_argnums=cls.impl_static_args)
     outer_p_lower.def_partition(
         infer_sharding_from_operands=cls.infer_sharding_from_operands,
         partition=cls.partition,

--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -206,7 +206,7 @@ def register_primitive(cls):
     outer_p.def_impl(cls.outer_impl)
     outer_p.def_abstract_eval(cls.outer_abstract)
     batching.primitive_batchers[outer_p] = cls.batcher
-    outer_p_lower = custom_partitioning(cls.outer_impl, static_argnums=cls.impl_static_args)
+    outer_p_lower = custom_partitioning(cls.impl, static_argnums=cls.impl_static_args)
     outer_p_lower.def_partition(
         infer_sharding_from_operands=cls.infer_sharding_from_operands,
         partition=cls.partition,

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -394,7 +394,7 @@ class GemmPrimitive(BasePrimitive):
                 rhs_scale_inv, scaling_mode, rhs.shape, not rhs_transposed, rhs_flatten_axis
             )
             lhs_scale_inv = swizzled_scale(lhs_scale_inv, lhs_flatten_axis, lhs_transposed)
-            rhs_scale_inv = swizzled_scale(rhs_scale_inv, not rhs_transposed, rhs_transposed)
+            rhs_scale_inv = swizzled_scale(rhs_scale_inv, rhs_flatten_axis, not rhs_transposed)
 
         outputs = GemmPrimitive.inner_primitive.bind(
             lhs,

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -152,7 +152,7 @@ def _quantize_gemm_operands(lhs, rhs, lhs_quantizer, rhs_quantizer, contracting_
     return lhs_q, rhs_q
 
 
-@partial(jax.jit, static_argnums=(1,2))
+@partial(jax.jit, static_argnums=(1, 2))
 def swizzled_scale(scale_inv, flatten_axis, is_colwise):
     original_shape = scale_inv.shape
     shape_2d = (math.prod(original_shape[:flatten_axis]), math.prod(original_shape[flatten_axis:]))
@@ -379,8 +379,9 @@ class GemmPrimitive(BasePrimitive):
         use_split_accumulator,
     ):
         lhs_cdims, rhs_cdims = map(sanitize_dims, (lhs.ndim, rhs.ndim), contracting_dims)
-        lhs_transposed, rhs_transposed = _get_gemm_layout((lhs.ndim, rhs.ndim),
-                                                          (lhs_cdims, rhs_cdims))
+        lhs_transposed, rhs_transposed = _get_gemm_layout(
+            (lhs.ndim, rhs.ndim), (lhs_cdims, rhs_cdims)
+        )
 
         lhs_scale_inv = apply_padding_to_scale_inv(
             lhs_scale_inv,

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -154,6 +154,7 @@ def _quantize_gemm_operands(lhs, rhs, lhs_quantizer, rhs_quantizer, contracting_
 
 @partial(jax.jit, static_argnums=(1, 2))
 def swizzled_scale(scale_inv, flatten_axis, is_colwise):
+    "Swizzle scale_inv via JAX transpose ops"
     original_shape = scale_inv.shape
     shape_2d = (math.prod(original_shape[:flatten_axis]), math.prod(original_shape[flatten_axis:]))
     if is_colwise:

--- a/transformer_engine/jax/csrc/extensions/gemm.cpp
+++ b/transformer_engine/jax/csrc/extensions/gemm.cpp
@@ -85,14 +85,16 @@ std::tuple<TensorWrapper, std::vector<size_t>> xla_buffer_to_nvte_gemm_operand(
       }
 
       // Launch swizzle kernel
-      nvte_swizzle_scaling_factors(input.data(), output.data(), stream);
+      // nvte_swizzle_scaling_factors(input.data(), output.data(), stream);
 
       // Set swizzled scales into the input tensor
       if (rowwise) {
-        input.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
+        // input.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
+        input.set_rowwise_scale_inv(scale_inv->untyped_data(), scale_dtype, scale_shape);
       } else {
-        input.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
-                                       scale_shape);
+        // input.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
+        //                                scale_shape);
+        input.set_columnwise_scale_inv(scale_inv->untyped_data(), scale_dtype, scale_shape);
       }
     }
   }

--- a/transformer_engine/jax/csrc/extensions/gemm.cpp
+++ b/transformer_engine/jax/csrc/extensions/gemm.cpp
@@ -28,8 +28,8 @@ static uint8_t *move_ptr_to_next_256B_aligned(uint8_t *ptr) {
 }
 
 std::tuple<TensorWrapper, std::vector<size_t>> xla_buffer_to_nvte_gemm_operand(
-    cudaStream_t stream, Buffer_Type buffer, Buffer_Type scale_inv,
-    JAXX_Scaling_Mode scaling_mode, size_t axis_boundary, bool rowwise) {
+    cudaStream_t stream, Buffer_Type buffer, Buffer_Type scale_inv, JAXX_Scaling_Mode scaling_mode,
+    size_t axis_boundary, bool rowwise) {
   // Set tensor data with collapsed 2D shape
   auto buffer_dims = buffer.dimensions();
   std::vector<size_t> input_shape = {product(buffer_dims, 0, axis_boundary),
@@ -69,8 +69,7 @@ std::tuple<TensorWrapper, std::vector<size_t>> xla_buffer_to_nvte_gemm_operand(
 Error_Type GemmFFI(cudaStream_t stream, Buffer_Type lhs, Buffer_Type lhs_scale_inv, Buffer_Type rhs,
                    Buffer_Type rhs_scale_inv, Buffer_Type bias, Buffer_Type gelu_input,
                    Result_Type output, Result_Type bias_grad, Result_Type pre_gelu_out,
-                   Result_Type workspace,
-                   JAXX_Scaling_Mode scaling_mode, int64_t lhs_axis_boundary,
+                   Result_Type workspace, JAXX_Scaling_Mode scaling_mode, int64_t lhs_axis_boundary,
                    int64_t rhs_axis_boundary, bool lhs_transposed, bool rhs_transposed,
                    bool fuse_bias, bool fuse_gelu, bool grad, bool use_split_accumulator) {
   // NOTE: TensorWrapper operands are always rowwise for full-precision GEMM, or FP8 GEMM when
@@ -79,10 +78,10 @@ Error_Type GemmFFI(cudaStream_t stream, Buffer_Type lhs, Buffer_Type lhs_scale_i
                          (is_tensor_scaling(scaling_mode) && nvte_is_non_tn_fp8_gemm_supported()));
   bool make_lhs_rowwise = (always_rowwise) ? true : !lhs_transposed;
   bool make_rhs_rowwise = (always_rowwise) ? true : rhs_transposed;
-  auto [lhs_, lhs_shape] = xla_buffer_to_nvte_gemm_operand(
-      stream, lhs, lhs_scale_inv, scaling_mode, lhs_axis_boundary, make_lhs_rowwise);
-  auto [rhs_, rhs_shape] = xla_buffer_to_nvte_gemm_operand(
-      stream, rhs, rhs_scale_inv, scaling_mode, rhs_axis_boundary, make_rhs_rowwise);
+  auto [lhs_, lhs_shape] = xla_buffer_to_nvte_gemm_operand(stream, lhs, lhs_scale_inv, scaling_mode,
+                                                           lhs_axis_boundary, make_lhs_rowwise);
+  auto [rhs_, rhs_shape] = xla_buffer_to_nvte_gemm_operand(stream, rhs, rhs_scale_inv, scaling_mode,
+                                                           rhs_axis_boundary, make_rhs_rowwise);
 
   // Output tensor
   std::vector<size_t> out_shape = {(lhs_transposed) ? lhs_shape[1] : lhs_shape[0],

--- a/transformer_engine/jax/csrc/extensions/gemm.cpp
+++ b/transformer_engine/jax/csrc/extensions/gemm.cpp
@@ -61,42 +61,6 @@ std::tuple<TensorWrapper, std::vector<size_t>> xla_buffer_to_nvte_gemm_operand(
     } else {
       input.set_columnwise_scale_inv(scale_inv.untyped_data(), scale_dtype, scale_shape);
     }
-
-    // // Swizzle scaling factors for MXFP8
-    // if (scaling_mode == JAXX_Scaling_Mode::MXFP8_1D_SCALING) {
-    //   // Get the swizzle buffer
-    //   NVTE_CHECK(swizzled_scale_inv->element_count() > 0,
-    //              "Missing swizzled inverse scale buffer in the JAX primitive.");
-    //   auto scale_inv_dtype = convert_ffi_datatype_to_te_dtype(scale_inv.element_type());
-    //   auto swizzled_scale_inv_dtype =
-    //       convert_ffi_datatype_to_te_dtype(swizzled_scale_inv->element_type());
-    //   NVTE_CHECK(typeToSize(scale_inv_dtype) == 1 && typeToSize(swizzled_scale_inv_dtype) == 1,
-    //              "Inverse scale factors need to have an 8-bit data type.");
-    //
-    //   // Create tensor to hold swizzled scale factor
-    //   TensorWrapper output(get_nvte_scaling_mode(scaling_mode));
-    //   if (rowwise) {
-    //     output.set_rowwise_data(buffer.untyped_data(), input_dtype, input_shape);
-    //     output.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
-    //   } else {
-    //     output.set_columnwise_data(buffer.untyped_data(), input_dtype, input_shape);
-    //     output.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
-    //                                     scale_shape);
-    //   }
-    //
-    //   // Launch swizzle kernel
-    //   // nvte_swizzle_scaling_factors(input.data(), output.data(), stream);
-    //
-    //   // Set swizzled scales into the input tensor
-    //   if (rowwise) {
-    //     // input.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
-    //     input.set_rowwise_scale_inv(scale_inv.untyped_data(), scale_dtype, scale_shape);
-    //   } else {
-    //     // input.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
-    //     //                                scale_shape);
-    //     input.set_columnwise_scale_inv(scale_inv.untyped_data(), scale_dtype, scale_shape);
-    //   }
-    // }
   }
 
   return std::make_tuple(std::move(input), input_shape);

--- a/transformer_engine/jax/csrc/extensions/gemm.cpp
+++ b/transformer_engine/jax/csrc/extensions/gemm.cpp
@@ -62,41 +62,41 @@ std::tuple<TensorWrapper, std::vector<size_t>> xla_buffer_to_nvte_gemm_operand(
       input.set_columnwise_scale_inv(scale_inv.untyped_data(), scale_dtype, scale_shape);
     }
 
-    // Swizzle scaling factors for MXFP8
-    if (scaling_mode == JAXX_Scaling_Mode::MXFP8_1D_SCALING) {
-      // Get the swizzle buffer
-      NVTE_CHECK(swizzled_scale_inv->element_count() > 0,
-                 "Missing swizzled inverse scale buffer in the JAX primitive.");
-      auto scale_inv_dtype = convert_ffi_datatype_to_te_dtype(scale_inv.element_type());
-      auto swizzled_scale_inv_dtype =
-          convert_ffi_datatype_to_te_dtype(swizzled_scale_inv->element_type());
-      NVTE_CHECK(typeToSize(scale_inv_dtype) == 1 && typeToSize(swizzled_scale_inv_dtype) == 1,
-                 "Inverse scale factors need to have an 8-bit data type.");
-
-      // Create tensor to hold swizzled scale factor
-      TensorWrapper output(get_nvte_scaling_mode(scaling_mode));
-      if (rowwise) {
-        output.set_rowwise_data(buffer.untyped_data(), input_dtype, input_shape);
-        output.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
-      } else {
-        output.set_columnwise_data(buffer.untyped_data(), input_dtype, input_shape);
-        output.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
-                                        scale_shape);
-      }
-
-      // Launch swizzle kernel
-      // nvte_swizzle_scaling_factors(input.data(), output.data(), stream);
-
-      // Set swizzled scales into the input tensor
-      if (rowwise) {
-        // input.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
-        input.set_rowwise_scale_inv(scale_inv->untyped_data(), scale_dtype, scale_shape);
-      } else {
-        // input.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
-        //                                scale_shape);
-        input.set_columnwise_scale_inv(scale_inv->untyped_data(), scale_dtype, scale_shape);
-      }
-    }
+    // // Swizzle scaling factors for MXFP8
+    // if (scaling_mode == JAXX_Scaling_Mode::MXFP8_1D_SCALING) {
+    //   // Get the swizzle buffer
+    //   NVTE_CHECK(swizzled_scale_inv->element_count() > 0,
+    //              "Missing swizzled inverse scale buffer in the JAX primitive.");
+    //   auto scale_inv_dtype = convert_ffi_datatype_to_te_dtype(scale_inv.element_type());
+    //   auto swizzled_scale_inv_dtype =
+    //       convert_ffi_datatype_to_te_dtype(swizzled_scale_inv->element_type());
+    //   NVTE_CHECK(typeToSize(scale_inv_dtype) == 1 && typeToSize(swizzled_scale_inv_dtype) == 1,
+    //              "Inverse scale factors need to have an 8-bit data type.");
+    //
+    //   // Create tensor to hold swizzled scale factor
+    //   TensorWrapper output(get_nvte_scaling_mode(scaling_mode));
+    //   if (rowwise) {
+    //     output.set_rowwise_data(buffer.untyped_data(), input_dtype, input_shape);
+    //     output.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
+    //   } else {
+    //     output.set_columnwise_data(buffer.untyped_data(), input_dtype, input_shape);
+    //     output.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
+    //                                     scale_shape);
+    //   }
+    //
+    //   // Launch swizzle kernel
+    //   // nvte_swizzle_scaling_factors(input.data(), output.data(), stream);
+    //
+    //   // Set swizzled scales into the input tensor
+    //   if (rowwise) {
+    //     // input.set_rowwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype, scale_shape);
+    //     input.set_rowwise_scale_inv(scale_inv.untyped_data(), scale_dtype, scale_shape);
+    //   } else {
+    //     // input.set_columnwise_scale_inv(swizzled_scale_inv->untyped_data(), scale_dtype,
+    //     //                                scale_shape);
+    //     input.set_columnwise_scale_inv(scale_inv.untyped_data(), scale_dtype, scale_shape);
+    //   }
+    // }
   }
 
   return std::make_tuple(std::move(input), input_shape);


### PR DESCRIPTION
# Description

XLA often inserts transpose ops before and after the `custom_partitioning` in the custom call to transform and partition the data and scale_inv.
This PR fuses the swizzle with the transpose after the `custom_partitioning`, resulting in up to 1.4% speedup in the E2E training of LLama3.1 8B on GB200x4.  

Profiling with TPSP2 + FSDP2, focusing on the First GEMM in the MLP.
 - Before fusing swizzling:
<img width="1254" height="616" alt="Screenshot 2025-09-08 at 12 29 27" src="https://github.com/user-attachments/assets/bb18e02d-f287-426a-9ef8-e388cc54417a" />
- After fusing swizzling:
<img width="1254" height="616" alt="Screenshot 2025-09-08 at 12 29 45" src="https://github.com/user-attachments/assets/3e7e9d72-439c-4bf6-8e88-1d0985f54b99" />

The time between AG and launching the GEMM kernel reduces from 70us to 53us.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
