### PR TITLE
Do not use normalization forward + amax fusion if cuDNN backend is requested

### DIFF
--- a/transformer_engine/common/normalization/layernorm/ln_api.cpp
+++ b/transformer_engine/common/normalization/layernorm/ln_api.cpp
@@ -66,7 +66,8 @@ void layernorm_fwd(const Tensor& x,      // BxSxhidden_size
   bool cudnn_backend = use_cudnn_norm_fwd() || is_mxfp_scaling(z->scaling_mode);
 
   if (!is_fp8_dtype(z->data.dtype) && z->amax.dptr != nullptr) {
-    NVTE_CHECK(!cudnn_backend, "cuDNN does not currently support amax output for non quantized output");
+    NVTE_CHECK(!cudnn_backend,
+               "cuDNN does not currently support amax output for non quantized output");
   }
 
   bool gamma_in_weight_dtype = false;

--- a/transformer_engine/common/normalization/layernorm/ln_api.cpp
+++ b/transformer_engine/common/normalization/layernorm/ln_api.cpp
@@ -66,7 +66,7 @@ void layernorm_fwd(const Tensor& x,      // BxSxhidden_size
   bool cudnn_backend = use_cudnn_norm_fwd() || is_mxfp_scaling(z->scaling_mode);
 
   if (!is_fp8_dtype(z->data.dtype) && z->amax.dptr != nullptr) {
-    cudnn_backend = false;  // cuDNN does not currently support amax output for non quantized output
+    NVTE_CHECK(!cudnn_backend, "cuDNN does not currently support amax output for non quantized output");
   }
 
   bool gamma_in_weight_dtype = false;

--- a/transformer_engine/common/normalization/rmsnorm/rmsnorm_api.cpp
+++ b/transformer_engine/common/normalization/rmsnorm/rmsnorm_api.cpp
@@ -52,7 +52,7 @@ void rmsnorm_fwd(const Tensor &x, const Tensor &gamma, const float epsilon, Tens
   bool cudnn_backend = use_cudnn_norm_fwd() || is_mxfp_scaling(z->scaling_mode);
 
   if (!is_fp8_dtype(z->data.dtype) && z->amax.dptr != nullptr) {
-    cudnn_backend = false;  // cuDNN does not currently support amax output for non quantized output
+    NVTE_CHECK(!cudnn_backend, "cuDNN does not currently support amax output for non quantized output");
   }
 
   bool training =

--- a/transformer_engine/common/normalization/rmsnorm/rmsnorm_api.cpp
+++ b/transformer_engine/common/normalization/rmsnorm/rmsnorm_api.cpp
@@ -52,7 +52,8 @@ void rmsnorm_fwd(const Tensor &x, const Tensor &gamma, const float epsilon, Tens
   bool cudnn_backend = use_cudnn_norm_fwd() || is_mxfp_scaling(z->scaling_mode);
 
   if (!is_fp8_dtype(z->data.dtype) && z->amax.dptr != nullptr) {
-    NVTE_CHECK(!cudnn_backend, "cuDNN does not currently support amax output for non quantized output");
+    NVTE_CHECK(!cudnn_backend,
+               "cuDNN does not currently support amax output for non quantized output");
   }
 
   bool training =

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -4,6 +4,8 @@
  * See LICENSE for license information.
  ************************************************************************/
 
+#include "common/normalization/common.h"
+
 #include "../extensions.h"
 #include "common/util/system.h"
 #include "pybind.h"
@@ -110,7 +112,7 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
   TensorWrapper unquantized_out_cu;
   py::object unquantized_out;
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       std::tie(unquantized_out_cu, unquantized_out) =
           my_quantizer_cs->create_hp_tensor_with_amax(size, out_dtype);
@@ -145,7 +147,7 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
 
   // Quantize output if using unfused kernel
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       my_quantizer_cs->quantize_with_amax(unquantized_out_cu, out_cu);
     } else {
@@ -290,7 +292,7 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
   TensorWrapper unquantized_out_cu;
   py::object unquantized_out;
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       std::tie(unquantized_out_cu, unquantized_out) =
           my_quantizer_cs->create_hp_tensor_with_amax(size, out_dtype);
@@ -325,7 +327,7 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
 
   // Quantize output if using unfused kernel
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       my_quantizer_cs->quantize_with_amax(unquantized_out_cu, out_cu);
     } else {

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -5,7 +5,6 @@
  ************************************************************************/
 
 #include "../extensions.h"
-#include "common/normalization/common.h"
 #include "common/util/system.h"
 #include "pybind.h"
 
@@ -112,7 +111,7 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
   py::object unquantized_out;
   if (force_unfused_kernel) {
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
-        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+        !transformer_engine::getenv<bool>("NVTE_NORM_FWD_USE_CUDNN")) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       std::tie(unquantized_out_cu, unquantized_out) =
           my_quantizer_cs->create_hp_tensor_with_amax(size, out_dtype);
@@ -148,7 +147,7 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
   // Quantize output if using unfused kernel
   if (force_unfused_kernel) {
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
-        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+        !transformer_engine::getenv<bool>("NVTE_NORM_FWD_USE_CUDNN")) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       my_quantizer_cs->quantize_with_amax(unquantized_out_cu, out_cu);
     } else {
@@ -294,7 +293,7 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
   py::object unquantized_out;
   if (force_unfused_kernel) {
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
-        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+        !transformer_engine::getenv<bool>("NVTE_NORM_FWD_USE_CUDNN")) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       std::tie(unquantized_out_cu, unquantized_out) =
           my_quantizer_cs->create_hp_tensor_with_amax(size, out_dtype);
@@ -330,7 +329,7 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
   // Quantize output if using unfused kernel
   if (force_unfused_kernel) {
     if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
-        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+        !transformer_engine::getenv<bool>("NVTE_NORM_FWD_USE_CUDNN")) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       my_quantizer_cs->quantize_with_amax(unquantized_out_cu, out_cu);
     } else {

--- a/transformer_engine/pytorch/csrc/extensions/normalization.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/normalization.cpp
@@ -4,9 +4,8 @@
  * See LICENSE for license information.
  ************************************************************************/
 
-#include "common/normalization/common.h"
-
 #include "../extensions.h"
+#include "common/normalization/common.h"
 #include "common/util/system.h"
 #include "pybind.h"
 
@@ -112,7 +111,8 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
   TensorWrapper unquantized_out_cu;
   py::object unquantized_out;
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
+        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       std::tie(unquantized_out_cu, unquantized_out) =
           my_quantizer_cs->create_hp_tensor_with_amax(size, out_dtype);
@@ -147,7 +147,8 @@ std::vector<py::object> layernorm_fwd(py::handle input, py::handle weight, Maybe
 
   // Quantize output if using unfused kernel
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
+        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       my_quantizer_cs->quantize_with_amax(unquantized_out_cu, out_cu);
     } else {
@@ -292,7 +293,8 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
   TensorWrapper unquantized_out_cu;
   py::object unquantized_out;
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
+        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       std::tie(unquantized_out_cu, unquantized_out) =
           my_quantizer_cs->create_hp_tensor_with_amax(size, out_dtype);
@@ -327,7 +329,8 @@ std::vector<py::object> rmsnorm_fwd(const py::handle &input, const py::handle &w
 
   // Quantize output if using unfused kernel
   if (force_unfused_kernel) {
-    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) && !transformer_engine::normalization::use_cudnn_norm_fwd()) {
+    if (IsFloat8CurrentScalingQuantizers(quantizer.ptr()) &&
+        !transformer_engine::normalization::use_cudnn_norm_fwd()) {
       auto my_quantizer_cs = dynamic_cast<Float8CurrentScalingQuantizer *>(my_quantizer.get());
       my_quantizer_cs->quantize_with_amax(unquantized_out_cu, out_cu);
     } else {


### PR DESCRIPTION
# Description

This PR changes the behavior of the normalization forward + amax computation fusion introduced in #2013.

Currently, if the cuDNN normalization backend is requested by using the `NVTE_NORM_FWD_USE_CUDNN` flag, this will result in use of the cuDNN backend in most cases. However, if FP8 current scaling is used, [the TE backend will be used instead](https://github.com/NVIDIA/TransformerEngine/blob/59130cc9d0bd7cc66457556373d731ca0744cf9b/transformer_engine/common/normalization/layernorm/ln_api.cpp#L69), as the cuDNN backend does not currently support the amax fusion. This PR changes this behavior.

Now, if the cuDNN backend is requested, the amax fusion will be disabled and the cuDNN backend will be used as requested.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

* In `transformer_engine/pytorch/csrc/extensions/normalization.cpp` check if the cuDNN backend is requested before enabling amax fusion, rather than checking only if FP8 current scaling is used.
* In `transformer_engine/common/normalization/layernorm/ln_api.cpp` and `transformer_engine/common/normalization/rmsnorm/rmsnorm_api.cpp` error out if the cuDNN backend is requested while amax fusion is used. This is a sanity check, as this should not occur because of the check in `normalization.cpp`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
