### PR TITLE
[JAX] Remove unnecessary SWA calculation in _segment_ids_pos_to_seqlens_offsets()

### DIFF
--- a/transformer_engine/jax/attention.py
+++ b/transformer_engine/jax/attention.py
@@ -531,7 +531,7 @@ def _segment_ids_pos_to_seqlens_offsets(
     # This fast path avoids expanding the mask to Q * KV matrix and instead allows us to
     # examine only O(Q+KV) elements.
 
-    # For seqlens and seqoffsets calculations, the intermediate(temp) attn_mask creation 
+    # For seqlens and seqoffsets calculations, the intermediate(temp) attn_mask creation
     # using the segment ids and pos along with mask type (causal or brcm) is sufficient.
     # It does not need to involve SW for this mask's creation
 


### PR DESCRIPTION
# Description

I noticed that in `_segment_ids_pos_to_seqlens_offsets()`, a temp / intermediate mask is created, the purpose of which is only to help with the calculation of seqlens and offsets which is then passed onto the cuDNN backend. 
This intermediate attn_mask should only need to use the segment ids and pos to create the attn_mask followed by a layer of masking based on the application of the type of mask (causal or brcm) as that would influence the final seqlens and offsets generated.
However, SW mask calculation and application to attn_mask in no way should affect the final seqlens and offsets generated hence this is an unnecessary operation. I tested this out as well and it seems to check out.

I had put in a TODO for this observation and am addressing the same in this PR

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
