### PR TITLE
[Build] fix: TE installation failed to find uv-installed cuDNN libraries

### DIFF
--- a/build_tools/build_ext.py
+++ b/build_tools/build_ext.py
@@ -57,6 +57,7 @@ class CMakeExtension(setuptools.Extension):
             build_dir,
             f"-DPython_EXECUTABLE={sys.executable}",
             f"-DPython_INCLUDE_DIR={sysconfig.get_path('include')}",
+            f"-DPython_SITEARCH={sysconfig.get_path('platlib')}",
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
         ]


### PR DESCRIPTION
# Description

Fixes #2206 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

Add `-DPython_SITEARCH` to TE's CMake build args, as a supplement to existing "-DPython_INCLUDE_DIR", "-DPython_EXECUTABLE" etc.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
