### PR TITLE
Convert `NVFP4BlockScaling` to dataclass

### DIFF
--- a/transformer_engine/common/recipe/__init__.py
+++ b/transformer_engine/common/recipe/__init__.py
@@ -382,6 +382,7 @@ class Float8BlockScaling(Recipe):
         )
 
 
+@dataclass()
 class NVFP4BlockScaling(Recipe):
     """
     Use the NVFP4 scaling strategy.


### PR DESCRIPTION
# Description

Convert NVFP4 recipe to a data class such that the fields can be passed as arguments during initialization. This is also resulting in the failure of some tests in TE fused ops that rely on the `make_recipe` method in `tests/pytorch/utils.py`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Convert `NVFP4BlockScaling` to a data class.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
