### PR TITLE
[JAX] Fix code block in fp8_autocast docstring

### DIFF
--- a/transformer_engine/jax/quantize/helper.py
+++ b/transformer_engine/jax/quantize/helper.py
@@ -404,20 +404,20 @@ def fp8_autocast(
     This context manager enables FP8 quantization for the duration of its context.
         .. code-block:: python
 
-        mesh_shape = (4, 2)
-        dp_mesh_axis_name = 'data_parallel'
-        tp_mesh_axis_name = 'tensor_parallel'
-        devices = np.asarray(jax.devices()).reshape(*mesh_shape)
+            mesh_shape = (4, 2)
+            dp_mesh_axis_name = 'data_parallel'
+            tp_mesh_axis_name = 'tensor_parallel'
+            devices = np.asarray(jax.devices()).reshape(*mesh_shape)
 
-        with maps.Mesh(devices, (dp_mesh_axis_name, tp_mesh_axis_name)):
-            mesh_resource=MeshResource(dp_mesh_axis_name, tp_mesh_axis_name)
+            with maps.Mesh(devices, (dp_mesh_axis_name, tp_mesh_axis_name)):
+                mesh_resource=MeshResource(dp_mesh_axis_name, tp_mesh_axis_name)
 
-            with fp8_autocast(enabled=True, mesh_resource=mesh_resource):
-                rules = extend_logical_axis_rules(tuple())
-                transformer = TransformerLayer()
+                with fp8_autocast(enabled=True, mesh_resource=mesh_resource):
+                    rules = extend_logical_axis_rules(tuple())
+                    transformer = TransformerLayer()
 
-                with partitioning.axis_rules(rules):
-                    pjit(transformer.init, ...)(...)
+                    with partitioning.axis_rules(rules):
+                        pjit(transformer.init, ...)(...)
 
     .. note::
         We only support :attr:`margin`, :attr:`fp8_format`, :attr:`amax_history_len`,


### PR DESCRIPTION
# Description

Before
<img width="1000" height="725" alt="image" src="https://github.com/user-attachments/assets/ee9a0373-d018-4766-bb1c-018dd9a839e2" />


After
<img width="944" height="666" alt="image" src="https://github.com/user-attachments/assets/85076d3d-1e62-4047-84d1-a3a3e6a59d58" />


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Indent fp8_autocast docstring so it's detected as a codeblock

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
