### PR TITLE
Fix bug where CUTLASS kernel was not being compiled for SM90a

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -155,18 +155,12 @@ add_library(transformer_engine SHARED ${transformer_engine_SOURCES})
 target_include_directories(transformer_engine PUBLIC
                            "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.0)
-  set_source_files_properties(
-    "gemm/cutlass_grouped_gemm.cu"
-    PROPERTIES
-    COMPILE_FLAGS
-    "-gencode arch=compute_90a,code=sm_90a")
-else()
-  message(FATAL_ERROR "cutlass gemm/cutlass_grouped_gemm.cu kernel required sm 90a")
-endif()
-
-# Disable debug build for cutlass due to hang.
-set_source_files_properties("gemm/cutlass_grouped_gemm.cu" PROPERTIES COMPILE_FLAGS "-g0")
+# CUTLASS kernels require SM90a and cause hang in debug build
+set_property(
+  SOURCE gemm/cutlass_grouped_gemm.cu
+  APPEND
+  PROPERTY
+  COMPILE_OPTIONS "--generate-code=arch=compute_90a,code=sm_90a;-g0")
 
 # Configure dependencies
 target_link_libraries(transformer_engine PUBLIC


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/2045 added support for a group GEMM kernel using CUTLASS, which requires compilation for SM90a (see [kernel impl](https://github.com/NVIDIA/cutlass/blob/c6aeb9179c5f74a0fcdbd28527bf4b6ba8c60752/include/cutlass/gemm/kernel/sm90_gemm_tma_warpspecialized_pingpong.hpp#L357-L365)). https://github.com/NVIDIA/TransformerEngine/pull/2221 fixed a hang when compiling the CUTLASS kernels with debug flags, but also accidentally overwrote the logic enabling SM90a compilation. This has resulted in test failures and warnings like:
```
ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Fix bug where CUTLASS kernel was not being compiled for SM90a

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
