### PR TITLE
Update minimum python version to 3.10 and add checks in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,9 @@ repos:
         entry: clang-format -i
         args: ["-style=file"]
         files: ^transformer_engine.*\.(c|cc|cxx|cpp|cu|cuh|h|hpp)$
+
+  - repo: https://github.com/netromdk/vermin
+    rev: c75aca72f4e85c6e47252139e8695f1c8b5f9ae3
+    hooks:
+      - id: vermin
+        args: ['-t=3.10', '--violations']

--- a/build_tools/utils.py
+++ b/build_tools/utils.py
@@ -12,10 +12,28 @@ import re
 import shutil
 import subprocess
 import sys
+import platform
 from pathlib import Path
 from importlib.metadata import version as get_version
 from subprocess import CalledProcessError
 from typing import List, Optional, Tuple, Union
+
+
+# Needs to stay consistent with .pre-commit-config.yaml
+python_min_version = (3, 10, 0)
+python_min_version_str = ".".join(map(str, python_min_version))
+if sys.version_info < python_min_version:
+    print(
+        f"You are using Python {platform.python_version()}. Python >={python_min_version_str} is"
+        " required."
+    )
+    sys.exit(-1)
+
+
+@functools.lru_cache(maxsize=None)
+def get_min_python_version_str() -> str:
+    """Returns the minimum supported python version"""
+    return python_min_version_str
 
 
 @functools.lru_cache(maxsize=None)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from build_tools.utils import (
     cuda_version,
     get_frameworks,
     remove_dups,
+    get_min_python_version_str,
 )
 
 frameworks = get_frameworks()
@@ -190,7 +191,7 @@ if __name__ == "__main__":
         long_description_content_type="text/x-rst",
         ext_modules=ext_modules,
         cmdclass={"build_ext": CMakeBuildExtension, "bdist_wheel": TimedBdist},
-        python_requires=">=3.8",
+        python_requires=f">={get_min_python_version_str()}",
         classifiers=["Programming Language :: Python :: 3"],
         install_requires=install_requires,
         license_files=("LICENSE",),

--- a/transformer_engine/jax/setup.py
+++ b/transformer_engine/jax/setup.py
@@ -44,7 +44,7 @@ if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or os.path.isdir(build_tools_
 
 
 from build_tools.build_ext import get_build_ext
-from build_tools.utils import copy_common_headers
+from build_tools.utils import copy_common_headers, get_min_python_version_str
 from build_tools.te_version import te_version
 from build_tools.jax import setup_jax_extension, install_requirements, test_requirements
 
@@ -100,6 +100,7 @@ if __name__ == "__main__":
         description="Transformer acceleration library - Jax Lib",
         ext_modules=ext_modules,
         cmdclass={"build_ext": CMakeBuildExtension},
+        python_requires=f">={get_min_python_version_str()}",
         install_requires=install_requirements(),
         tests_require=test_requirements(),
     )

--- a/transformer_engine/pytorch/setup.py
+++ b/transformer_engine/pytorch/setup.py
@@ -45,7 +45,7 @@ if bool(int(os.getenv("NVTE_RELEASE_BUILD", "0"))) or os.path.isdir(build_tools_
 
 
 from build_tools.build_ext import get_build_ext
-from build_tools.utils import copy_common_headers
+from build_tools.utils import copy_common_headers, get_min_python_version_str
 from build_tools.te_version import te_version
 from build_tools.pytorch import (
     setup_pytorch_extension,
@@ -152,6 +152,7 @@ if __name__ == "__main__":
         description="Transformer acceleration library - Torch Lib",
         ext_modules=ext_modules,
         cmdclass={"build_ext": CMakeBuildExtension, "bdist_wheel": CachedWheelsCommand},
+        python_requires=f">={get_min_python_version_str()}",
         install_requires=install_requirements(),
         tests_require=test_requirements(),
     )


### PR DESCRIPTION
# Description

We have a minimum python version requirement for our build (currently v3.8) but no way of checking whether new changes introduced violate this rule, e.g:

- #964 and #2012 used Structural Pattern Matching, support for which is only available from python 3.10 ([pep](https://peps.python.org/pep-0634/)).
- Several PRs also added the use of `functools.cache` as a decorator which is a 3.9+ feature.

Instead of changing the functionality to not use these features, I've taken the opportunity to update the minimum required python version to v3.10 since python v3.8 is at [end of life](https://devguide.python.org/versions/) (and v3.9 will also be by the end of the month) .

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Update minimum python version requirement to 3.10.
- Add python version requirements to the framework's `setup.py`s.
- Use a pre-commit hook to catch changes that violate the minimum version requirement.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
