### PR TITLE
fall back after failing ldconfig-based lib loading for cuDNN

### DIFF
--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -252,9 +252,7 @@ def _load_cudnn():
         return handle
 
     # Attempt to locate libcudnn via ldconfig
-    libs = subprocess.check_output(
-        f"ldconfig -p | grep 'libcudnn{_get_sys_extension()}'", shell=True
-    )
+    libs = subprocess.check_output(["ldconfig", "-p"])
     libs = libs.decode("utf-8").split("\n")
     sos = []
     for lib in libs:
@@ -284,9 +282,7 @@ def _load_nvrtc():
         return handle
 
     # Attempt to locate NVRTC via ldconfig
-    libs = subprocess.check_output(
-        f"ldconfig -p | grep 'libnvrtc{_get_sys_extension()}'", shell=True
-    )
+    libs = subprocess.check_output(["ldconfig", "-p"])
     libs = libs.decode("utf-8").split("\n")
     sos = []
     for lib in libs:
@@ -316,9 +312,7 @@ def _load_curand():
         return handle
 
     # Attempt to locate cuRAND via ldconfig
-    libs = subprocess.check_output(
-        f"ldconfig -p | grep 'libcurand{_get_sys_extension()}'", shell=True
-    )
+    libs = subprocess.check_output(["ldconfig", "-p"])
     libs = libs.decode("utf-8").split("\n")
     sos = []
     for lib in libs:


### PR DESCRIPTION
# Description
This PR is a follow-up to #1989 and applies the suggested changes from the comments on that PR.

This change accomplishes two things:
* It avoids the `shell=True` as suggested by the original comment
* The `ldconfig -p | grep <pattern>` fails when the library we're searching for is not found. Since this command is executed with `check_output`, a `CalledProcessError` is raised. That means the final line of the function that uses `LD_LIBRARY_PATH` is effectively unreachable.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
- Remove the early filtering with `grep` to avoid `shell=True` and command failures. 

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
