### PR TITLE
Fix error with triton 3.5

### DIFF
--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -18,9 +18,9 @@ from packaging import version
 # The following three argsort related kernels are adapted from
 # the issue https://github.com/triton-lang/triton/issues/3698
 
-get_int_dtype_wrapped = core.get_int_dtype
+get_int_dtype = core.get_int_dtype
 if version.parse(triton.__version__) >= version.parse("3.5.0"):
-    get_int_dtype_wrapped = triton.constexpr_function(get_int_dtype_wrapped)
+    get_int_dtype = triton.constexpr_function(get_int_dtype)
 
 
 @triton.jit


### PR DESCRIPTION
# Description

btw how shall I trigger CI

w/o fix:

```
  File "/host_home/primary_synced/miles/miles/backends/megatron_utils/actor.py", line 259, in train
    return self.train_actor(rollout_id, rollout_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/primary_synced/miles/miles/backends/megatron_utils/actor.py", line 300, in train_actor
    self.compute_log_prob(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/primary_synced/miles/miles/backends/megatron_utils/actor.py", line 234, in compute_log_prob
    return forward_only(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/primary_synced/miles/miles/backends/megatron_utils/model.py", line 288, in forward_only
    forward_data_store += forward_backward_func(
                          ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 599, in forward_backward_no_pipelining
    output_tensor, num_tokens = forward_step(
                                ^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/pipeline_parallel/schedules.py", line 399, in forward_step
    output_tensor, loss_func = forward_step_func(data_iterator, model)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/primary_synced/miles/miles/backends/megatron_utils/model.py", line 254, in forward_step
    output_tensor = model(
                    ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/distributed/data_parallel_base.py", line 22, in forward
    return self.module(*inputs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/module.py", line 259, in forward
    outputs = self.module(*inputs, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/models/gpt/gpt_model.py", line 383, in forward
    hidden_states = self.decoder(
                    ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/transformer_block.py", line 585, in forward
    hidden_states, context = layer(
                             ^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/transformer_layer.py", line 917, in __call__
    return super(MegatronModule, self).__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/transformer_layer.py", line 471, in forward
    output = self._forward_mlp(hidden_states, kwargs.get("inference_context", None))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/transformer_layer.py", line 653, in _forward_mlp
    mlp_output_with_bias = self.mlp(pre_mlp_layernorm_output)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/moe/moe_layer.py", line 286, in forward
    output, mlp_bias = custom_forward(hidden_states)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/moe/moe_layer.py", line 266, in custom_forward
    hidden_states, probs, residual = self.router_and_preprocess(hidden_states)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/moe/moe_layer.py", line 179, in router_and_preprocess
    hidden_states, probs = self.token_dispatcher.dispatch_preprocess(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/moe/token_dispatcher.py", line 596, in dispatch_preprocess
    ) = permute(
        ^^^^^^^^
  File "/root/Megatron-LM/megatron/core/transformer/moe/moe_utils.py", line 261, in permute
    return fused_permute_with_probs(tokens, probs, routing_map, num_out_tokens=num_out_tokens)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/permutation.py", line 572, in moe_permute_with_probs
    output, row_id_map, permuted_probs = _moe_permute_mask_map.apply(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 581, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/permutation.py", line 212, in forward
    row_id_map = triton_permutation.make_row_id_map(routing_map, num_tokens, num_experts)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/triton/permutation.py", line 280, in make_row_id_map
    _row_id_map_pass_3_kernel[grid](
  File "/tmp/triton/python/triton/runtime/jit.py", line 419, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 733, in run
    kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 861, in _do_compile
    kernel = self.compile(src, target=target, options=options.__dict__)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/compiler/compiler.py", line 242, in compile
    key = get_cache_key(src, backend, options, env_vars=env_vars)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/cache.py", line 308, in get_cache_key
    key = f"{triton_key()}-{src.hash()}-{backend.hash()}-{backend_options.hash()}-{str(sorted(env_vars.items()))}"
                            ^^^^^^^^^^
  File "/tmp/triton/python/triton/compiler/compiler.py", line 75, in hash
    key = f"{self.fn.cache_key}-{str(self.attrs)}-{sorted_sig}-{constants_key}"
             ^^^^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 548, in cache_key
    dependencies_finder.visit(self.parse())
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 194, in visit_FunctionDef
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 248, in visit_Assign
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 172, in visit_Name
    self.record_reference(val, var_dict, node.id)
  File "/tmp/triton/python/triton/runtime/jit.py", line 133, in record_reference
    self._update_hash(val)
  File "/tmp/triton/python/triton/runtime/jit.py", line 113, in _update_hash
    func_key = func.cache_key
               ^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 548, in cache_key
    dependencies_finder.visit(self.parse())
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 194, in visit_FunctionDef
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 260, in visit_For
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 248, in visit_Assign
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 172, in visit_Name
    self.record_reference(val, var_dict, node.id)
  File "/tmp/triton/python/triton/runtime/jit.py", line 133, in record_reference
    self._update_hash(val)
  File "/tmp/triton/python/triton/runtime/jit.py", line 113, in _update_hash
    func_key = func.cache_key
               ^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 548, in cache_key
    dependencies_finder.visit(self.parse())
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 194, in visit_FunctionDef
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 260, in visit_For
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 248, in visit_Assign
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 172, in visit_Name
    self.record_reference(val, var_dict, node.id)
  File "/tmp/triton/python/triton/runtime/jit.py", line 133, in record_reference
    self._update_hash(val)
  File "/tmp/triton/python/triton/runtime/jit.py", line 113, in _update_hash
    func_key = func.cache_key
               ^^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 548, in cache_key
    dependencies_finder.visit(self.parse())
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 194, in visit_FunctionDef
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 415, in generic_visit
    self.visit(item)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 248, in visit_Assign
    self.generic_visit(node)
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 417, in generic_visit
    self.visit(value)
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/tmp/triton/python/triton/runtime/jit.py", line 188, in visit_Attribute
    self.record_reference(ret)
  File "/tmp/triton/python/triton/runtime/jit.py", line 137, in record_reference
    raise RuntimeError(f"Unsupported function referenced: {val}")
RuntimeError: Unsupported function referenced: <function get_int_dtype at 0xfff7805189a0>
wandb:
```

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
