### PR TITLE
[Pytorch] change fused cross entropy backward grad to fp32 and reduce one read/…

### DIFF
--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -80,7 +80,14 @@ class CrossEntropyFunction(torch.autograd.Function):
         label_smoothing = ctx.label_smoothing
         reduce_loss = ctx.reduce_loss
         _input = triton_cross_entropy.cross_entropy_backward(
-            _input, target, m_d_X_y, grad_output, label_smoothing, reduce_loss, dist_process_group, ctx.is_cg_capturable
+            _input,
+            target,
+            m_d_X_y,
+            grad_output,
+            label_smoothing,
+            reduce_loss,
+            dist_process_group,
+            ctx.is_cg_capturable,
         )
         return (
             _input,


### PR DESCRIPTION
# Description

The fused cross entropy kernel in Transformer Engine uses 16-bit floating point (BF16) for the backward pass when the input is in BF16, whereas Megatron's VocabParallelCrossEntropy performs its computations in FP32. This discrepancy may lead to divergence in some cases.

This PR also reduces one read of `logits`, which improves the performance by up to 1.25x.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Changed the fused cross entropy backward gradient computation to fp32 for consistency with Megatron's VocabParallelCrossEntropy.
- Optimized the computation logic to reduce one read/write operation of the logits.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
