### PR TITLE
Add device-Initiated Grouped GEMM supporting m_splits on device

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -1758,6 +1758,7 @@ def _test_grouped_linear_accuracy(
     fp8,
     fuse_wgrad_accumulation,
     delay_wgrad_compute=False,
+    m_splits_on_device=False,
 ):
     reset_rng_states()
     if fp8:
@@ -1769,6 +1770,11 @@ def _test_grouped_linear_accuracy(
         device="cuda",
         requires_grad=True,
     )
+    # for i in range(config.max_seqlen_q):
+    #     for j in range(config.hidden_size):
+    #         inp_hidden_states[i, :, j] = 1
+    # print("inp_hidden_states:", inp_hidden_states)
+    # inp_hidden_states.requires_grad_()
     inp_hidden_states.retain_grad()
 
     if num_gemms > 1:
@@ -1776,20 +1782,24 @@ def _test_grouped_linear_accuracy(
         if fp8:
             split_size = 16
             if recipe.mxfp8() or recipe.nvfp4():
-                split_size = 32
+                split_size = 128
         m = config.max_seqlen_q // split_size
         dist = torch.sort(torch.randint(0, m, (num_gemms - 2,))).values.tolist()
         dist.append(dist[-1])  # Manually add a zero
+        # dist = torch.sort(torch.randint(0, m, (num_gemms - 1,))).values.tolist()
         m_splits = torch.tensor(dist + [m]) - torch.tensor([0] + dist)
         m_splits = m_splits * split_size
         assert m_splits.sum() == config.max_seqlen_q and len(m_splits) == num_gemms
     else:
         m_splits = torch.tensor([config.max_seqlen_q])
+    # print("m_splits:", m_splits)
 
     with autocast(enabled=fp8, recipe=recipe):
+        if m_splits_on_device:
+            m_splits = m_splits.to("cuda")
         if isinstance(block, GroupedLinear):
             m_splits = m_splits * bs
-            out = block(inp_hidden_states, m_splits.tolist())
+            out = block(inp_hidden_states, m_splits)
         else:
             out = torch.cat(
                 [
@@ -1797,7 +1807,12 @@ def _test_grouped_linear_accuracy(
                     for i, inp in enumerate(torch.split(inp_hidden_states, m_splits.tolist()))
                 ]
             )
-    loss = out.sum()
+    target = torch.rand_like(out, device=out.device, dtype=out.dtype)
+    # for i in range(out.shape[0]):
+    #     for j in range(out.shape[1]):
+    #         for k in range(out.shape[2]):
+    #             target[i, j, k] = 1
+    loss = (out * target).sum()
     loss.backward()
     if delay_wgrad_compute:
         if isinstance(block, GroupedLinear):
@@ -1815,6 +1830,7 @@ def _test_grouped_linear_accuracy(
                 assert p.grad is None  # grad should be None if fuse_wgrad_accumulation is True
             else:
                 outputs.append(p.grad)
+    # outputs = [out]
     return outputs
 
 
@@ -1839,6 +1855,8 @@ def test_grouped_linear_accuracy(
     delay_wgrad_compute,
     parallel_mode=None,
     use_cutlass=False,
+    m_splits_on_device=False,
+    num_unfuse_wgrad_accumulation=0,
 ):
     fp8 = recipe is not None
     if fp8 and fp8_model_params and NVTE_TEST_NVINSPECT_ENABLED:
@@ -1853,7 +1871,17 @@ def test_grouped_linear_accuracy(
             pytest.skip(
                 f"Input dtype {dtype} not supported for NVFP4 Recipe {recipe.__class__.__name__}"
             )
-
+    if num_unfuse_wgrad_accumulation > 0 and not m_splits_on_device:
+        pytest.skip("Partial accumulate is not supported when m_splits_on_device is False")
+    wgrad_accumulation_mask = None
+    if fuse_wgrad_accumulation and num_unfuse_wgrad_accumulation > 0 and num_unfuse_wgrad_accumulation < num_gemms:
+        wgrad_accumulation_mask = torch.ones(num_gemms, dtype=torch.bool)
+        indices = list(range(num_gemms))
+        random.shuffle(indices)
+        for idx in indices[:num_unfuse_wgrad_accumulation]:
+            wgrad_accumulation_mask[idx] = False
+    # print("fuse_wgrad_accumulation:", fuse_wgrad_accumulation)
+    # print("wgrad_accumulation_mask:", wgrad_accumulation_mask)
     with quantized_model_init(enabled=fp8 and fp8_model_params, recipe=recipe):
         grouped_linear = GroupedLinear(
             num_gemms,
@@ -1864,9 +1892,12 @@ def test_grouped_linear_accuracy(
             parallel_mode=parallel_mode,
             device="cuda",
             fuse_wgrad_accumulation=fuse_wgrad_accumulation,
+            wgrad_accumulation_mask=wgrad_accumulation_mask,
             delay_wgrad_compute=delay_wgrad_compute,
             save_original_input=False,
         ).eval()
+        if wgrad_accumulation_mask is None:
+            wgrad_accumulation_mask = torch.full((num_gemms,), fuse_wgrad_accumulation, dtype=torch.bool)
         sequential_linear = torch.nn.ModuleList(
             [
                 Linear(
@@ -1876,9 +1907,9 @@ def test_grouped_linear_accuracy(
                     params_dtype=dtype,
                     parallel_mode=parallel_mode,
                     device="cuda",
-                    fuse_wgrad_accumulation=fuse_wgrad_accumulation,
+                    fuse_wgrad_accumulation=wgrad_accumulation_mask[i],
                 ).eval()
-                for _ in range(num_gemms)
+                for i in range(num_gemms)
             ]
         )
 
@@ -1888,11 +1919,12 @@ def test_grouped_linear_accuracy(
             sequential_linear[i].weight = Parameter(getattr(grouped_linear, f"weight{i}").clone())
             if bias:
                 sequential_linear[i].bias = Parameter(getattr(grouped_linear, f"bias{i}").clone())
-            if fuse_wgrad_accumulation:
+            if wgrad_accumulation_mask[i]:
                 weight_i = getattr(grouped_linear, f"weight{i}")
                 weight_i.main_grad = torch.rand_like(weight_i, dtype=torch.float32)
                 sequential_linear[i].weight.main_grad = weight_i.main_grad.clone()
-
+    import torch.cuda.nvtx as nvtx
+    nvtx.range_push("sequential_gemm")
     outputs_ref = _test_grouped_linear_accuracy(
         sequential_linear,
         num_gemms,
@@ -1903,7 +1935,11 @@ def test_grouped_linear_accuracy(
         fp8,
         fuse_wgrad_accumulation,
         delay_wgrad_compute,
+        m_splits_on_device
     )
+    nvtx.range_pop()
+    torch.cuda.synchronize()
+    nvtx.range_push("grouped_gemm")
     outputs = _test_grouped_linear_accuracy(
         grouped_linear,
         num_gemms,
@@ -1914,7 +1950,10 @@ def test_grouped_linear_accuracy(
         fp8,
         fuse_wgrad_accumulation,
         delay_wgrad_compute,
+        m_splits_on_device
     )
+    nvtx.range_pop()
+   
 
     for o, o_ref in zip(outputs, outputs_ref):
         if use_cutlass:
@@ -1923,6 +1962,46 @@ def test_grouped_linear_accuracy(
             # cuBLAS implementation should be bit-wise match
             torch.testing.assert_close(o, o_ref, rtol=0, atol=0)
 
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability() != (10, 0),
+    reason="Only enable CUTLASS device grouped gemm on Blackwell",
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=str)
+@pytest.mark.parametrize("num_gemms", [3, 6])
+@pytest.mark.parametrize("bs", batch_sizes)
+@pytest.mark.parametrize("model", ["126m"])
+@pytest.mark.parametrize("recipe", [recipe.MXFP8BlockScaling()])
+@pytest.mark.parametrize("fp8_model_params", all_boolean)
+@pytest.mark.parametrize("fuse_wgrad_accumulation", all_boolean)
+@pytest.mark.parametrize("delay_wgrad_compute", all_boolean)
+@pytest.mark.parametrize("num_unfuse_wgrad_accumulation", [0, 1, 2])
+def test_grouped_linear_accuracy_cutlass_device(
+    dtype,
+    num_gemms,
+    bs,
+    model,
+    recipe,
+    fp8_model_params,
+    fuse_wgrad_accumulation,
+    num_unfuse_wgrad_accumulation,
+    delay_wgrad_compute,
+):
+    test_grouped_linear_accuracy(
+        dtype,
+        num_gemms,
+        bs,
+        model,
+        recipe,
+        fp8_model_params,
+        fuse_wgrad_accumulation,
+        False,
+        delay_wgrad_compute,
+        m_splits_on_device=True,
+        num_unfuse_wgrad_accumulation=num_unfuse_wgrad_accumulation,
+    )
 
 @pytest.mark.skipif(
     torch.cuda.get_device_capability() != (9, 0),
@@ -1968,6 +2047,7 @@ def test_grouped_linear_accuracy_cutlass(
 @pytest.mark.parametrize("fuse_wgrad_accumulation", [True])
 @pytest.mark.parametrize("bias", [False])
 @pytest.mark.parametrize("delay_wgrad_compute", [True])
+@pytest.mark.parametrize("m_splits_on_device", all_boolean)
 def test_grouped_linear_accuracy_save_original_input(
     dtype,
     num_gemms,
@@ -1978,6 +2058,7 @@ def test_grouped_linear_accuracy_save_original_input(
     fuse_wgrad_accumulation,
     bias,
     delay_wgrad_compute,
+    m_splits_on_device,
     parallel_mode=None,
 ):
     fp8 = recipe is not None
@@ -1985,6 +2066,8 @@ def test_grouped_linear_accuracy_save_original_input(
         pytest.skip("FP8 parameters are not supported in debug mode.")
     if fp8 and recipe.delayed():
         pytest.skip("DelayedScaling recipe is not supported with save_original_input")
+    if m_splits_on_device and (not (fp8 and recipe.mxfp8()) or dtype not in [torch.bfloat16]):
+        pytest.skip("m_splits_on_device is only supported with MXFP8 recipe and bfloat16 dtype")
 
     config = model_configs[model]
     if config.max_seqlen_q % 16 != 0 and fp8:
@@ -2045,6 +2128,7 @@ def test_grouped_linear_accuracy_save_original_input(
         fp8,
         fuse_wgrad_accumulation,
         delay_wgrad_compute,
+        m_splits_on_device,
     )
     outputs = _test_grouped_linear_accuracy(
         grouped_linear,
@@ -2056,6 +2140,7 @@ def test_grouped_linear_accuracy_save_original_input(
         fp8,
         fuse_wgrad_accumulation,
         delay_wgrad_compute,
+        m_splits_on_device,
     )
 
     # Shoule be bit-wise match
@@ -2079,12 +2164,12 @@ def test_grouped_linear_accuracy_single_gemm(recipe):
     )
 
 
-def _test_padding_grouped_linear_accuracy(block, num_gemms, bs, dtype, config, recipe, fp8=False):
+def _test_padding_grouped_linear_accuracy(block, num_gemms, bs, dtype, config, recipe, fp8=False, m_splits_on_device=False):
 
     def _pad_tensor_for_fp8(hidden_states, tokens_per_expert):
         align_size = 16
         if recipe.mxfp8() or recipe.nvfp4():
-            align_size = 32
+            align_size = 128
         padded_tokens_per_expert = [
             (num_tokens + align_size - 1) // align_size * align_size
             for num_tokens in tokens_per_expert
@@ -2158,7 +2243,7 @@ def _test_padding_grouped_linear_accuracy(block, num_gemms, bs, dtype, config, r
                 padded_inp_hidden_states, padding_m_splits = _pad_tensor_for_fp8(
                     inp_hidden_states, m_splits
                 )
-                padded_inp_hidden_states = block(padded_inp_hidden_states, padding_m_splits)
+                padded_inp_hidden_states = block(padded_inp_hidden_states, torch.tensor(padding_m_splits, device="cuda" if m_splits_on_device else "cpu"))
                 out = _unpad_tensor_for_fp8(padded_inp_hidden_states, m_splits, padding_m_splits)
             else:
                 out = block(inp_hidden_states, m_splits)
@@ -2181,6 +2266,7 @@ def _test_padding_grouped_linear_accuracy(block, num_gemms, bs, dtype, config, r
 @pytest.mark.parametrize("fp8", [True])
 @pytest.mark.parametrize("recipe", fp8_recipes)
 @pytest.mark.parametrize("fp8_model_params", all_boolean)
+@pytest.mark.parametrize("m_splits_on_device", all_boolean)
 def test_padding_grouped_linear_accuracy(
     dtype,
     num_gemms,
@@ -2189,6 +2275,7 @@ def test_padding_grouped_linear_accuracy(
     fp8,
     recipe,
     fp8_model_params,
+    m_splits_on_device,
     parallel_mode=None,
 ):
     if fp8_model_params and NVTE_TEST_NVINSPECT_ENABLED:
@@ -2203,6 +2290,8 @@ def test_padding_grouped_linear_accuracy(
             pytest.skip(
                 f"Input dtype {dtype} not supported for NVFP4 Recipe {recipe.__class__.__name__}"
             )
+    if m_splits_on_device and (not recipe.mxfp8() or dtype not in [torch.bfloat16]):
+        pytest.skip("m_splits_on_device is only supported with MXFP8 recipe and bfloat16 dtype")
 
     with quantized_model_init(enabled=fp8 and fp8_model_params, recipe=recipe):
         grouped_linear = TorchGroupedLinearWithPadding(
@@ -2238,10 +2327,10 @@ def test_padding_grouped_linear_accuracy(
             )
 
     outputs = _test_padding_grouped_linear_accuracy(
-        grouped_linear, num_gemms, bs, dtype, config, recipe, fp8
+        grouped_linear, num_gemms, bs, dtype, config, recipe, fp8, m_splits_on_device
     )
     outputs_ref = _test_padding_grouped_linear_accuracy(
-        ref_grouped_linear, num_gemms, bs, dtype, config, recipe, fp8
+        ref_grouped_linear, num_gemms, bs, dtype, config, recipe, fp8, m_splits_on_device
     )
 
     # Shoule be bit-wise match
@@ -2256,6 +2345,7 @@ def test_padding_grouped_linear_accuracy(
 @pytest.mark.parametrize("fp8", [True])
 @pytest.mark.parametrize("recipe", fp8_recipes)
 @pytest.mark.parametrize("fp8_model_params", [False])
+@pytest.mark.parametrize("m_splits_on_device", all_boolean)
 def test_padding_grouped_linear_accuracy_save_original_input(
     dtype,
     num_gemms,
@@ -2264,6 +2354,7 @@ def test_padding_grouped_linear_accuracy_save_original_input(
     fp8,
     recipe,
     fp8_model_params,
+    m_splits_on_device,
     parallel_mode=None,
 ):
     if fp8_model_params and NVTE_TEST_NVINSPECT_ENABLED:
@@ -2280,6 +2371,9 @@ def test_padding_grouped_linear_accuracy_save_original_input(
             pytest.skip(
                 f"Input dtype {dtype} not supported for NVFP4 Recipe {recipe.__class__.__name__}"
             )
+
+    if m_splits_on_device and (not recipe.mxfp8() or dtype not in [torch.bfloat16]):
+        pytest.skip("m_splits_on_device is only supported with MXFP8 recipe and bfloat16 dtype")
 
     with quantized_model_init(enabled=fp8 and fp8_model_params, recipe=recipe):
         grouped_linear = TorchGroupedLinearWithPadding(
@@ -2315,10 +2409,10 @@ def test_padding_grouped_linear_accuracy_save_original_input(
             )
 
     outputs = _test_padding_grouped_linear_accuracy(
-        grouped_linear, num_gemms, bs, dtype, config, recipe, fp8
+        grouped_linear, num_gemms, bs, dtype, config, recipe, fp8, m_splits_on_device
     )
     outputs_ref = _test_padding_grouped_linear_accuracy(
-        ref_grouped_linear, num_gemms, bs, dtype, config, recipe, fp8
+        ref_grouped_linear, num_gemms, bs, dtype, config, recipe, fp8, m_splits_on_device
     )
 
     # Shoule be bit-wise match
@@ -2683,6 +2777,7 @@ def test_grouped_gemm(shape, dtype, layout, accumulate, use_cutlass):
         grad = True
         single_output = False
 
+    m_splits = torch.tensor(m_splits)
     if use_cutlass:
         os.environ["NVTE_USE_CUTLASS_GROUPED_GEMM"] = "1"
 
@@ -2857,7 +2952,7 @@ def test_fp8_grouped_gemm(shape, accumulate):
         out,
         dtype,
         get_multi_stream_cublas_workspace(),
-        m_splits=m_splits,
+        m_splits=torch.tensor(m_splits),
         accumulate=accumulate,
     )
 

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -168,6 +168,7 @@ list(APPEND transformer_engine_cuda_sources
 
 list(APPEND transformer_engine_cuda_arch_specific_sources
      gemm/cutlass_grouped_gemm.cu
+     gemm/cutlass_device_grouped_gemm.cu
      util/cast.cu
      activation/gelu.cu
      activation/relu.cu
@@ -232,6 +233,11 @@ set_property(
   APPEND
   PROPERTY
   COMPILE_OPTIONS "--generate-code=arch=compute_90a,code=sm_90a;-g0")
+set_property(
+  SOURCE gemm/cutlass_device_grouped_gemm.cu
+  APPEND
+  PROPERTY
+  COMPILE_OPTIONS "--generate-code=arch=compute_100a,code=sm_100a;-g0")
 
 # Configure dependencies
 target_link_libraries(transformer_engine PUBLIC

--- a/transformer_engine/common/gemm/cutlass_device_grouped_gemm.cu
+++ b/transformer_engine/common/gemm/cutlass_device_grouped_gemm.cu
@@ -166,7 +166,7 @@ void generic_moe_gemm_kernelLauncher(ElementInput *A, ElementSF *SFA, const void
     throw std::runtime_error("TE CUTLASS device grouped gemm workspace is null");
   }
 
-  size_t offset = 0;
+  size_t offset = get_aligned_offset(num_experts * 2 * sizeof(uint64_t), 128); // inputA_and_SF_addrs
   auto ptr_A = reinterpret_cast<typename GemmGrouped::ElementA *>(A);
   auto ptr_A_list = reinterpret_cast<typename GemmGrouped::ElementA **>(
       reinterpret_cast<char *>(workspace) + offset);
@@ -652,7 +652,7 @@ void generic_moe_gemm_wgrad_kernelLauncher(ElementInput *A, ElementSF *SFA, Elem
     throw std::runtime_error("TE CUTLASS device grouped gemm workspace is null");
   }
 
-  size_t offset = 0;
+  size_t offset = get_aligned_offset(num_experts * sizeof(uint64_t), 128); // outputD_addrs
   auto ptr_A = reinterpret_cast<typename GemmGrouped::ElementA *>(A);
   auto ptr_A_list = reinterpret_cast<typename GemmGrouped::ElementA **>(
       reinterpret_cast<char *>(workspace) + offset);

--- a/transformer_engine/common/gemm/cutlass_device_grouped_gemm.cu
+++ b/transformer_engine/common/gemm/cutlass_device_grouped_gemm.cu
@@ -1,0 +1,921 @@
+/*************************************************************************
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <cuda_fp16.h>
+#include <float.h>
+#include <transformer_engine/gemm.h>
+#include <transformer_engine/transformer_engine.h>
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include "../common.h"
+#include "../util/handle_manager.h"
+#include "../util/logging.h"
+#include "common/util/cuda_runtime.h"
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/util/device_memory.h"
+
+using namespace cute;
+
+
+/*****
+ * Fprop and Dgrad
+ ******/
+
+template <typename Sm1xxBlkScaledConfig, typename UnderlyingProblemShape, typename ElementA,
+          typename ElementD, typename ElementSF, typename StrideA, typename StrideB,
+          typename StrideD, typename LayoutSFA, typename LayoutSFB, bool transB>
+__global__ void setGroupedGemmArguments(int num_experts, const int64_t *gemm_m_per_expert,
+                                        int gemm_n, int gemm_k, ElementA *ptr_A, ElementSF *ptr_SFA,
+                                        ElementD *ptr_D, UnderlyingProblemShape *problem_sizes,
+                                        ElementA **ptr_A_list, ElementSF **ptr_SFA_list,
+                                        StrideA *stride_A_list, LayoutSFA *layout_SFA_list,
+                                        StrideB *stride_B_list, LayoutSFB *layout_SFB_list,
+                                        ElementD **ptr_D_list, StrideD *stride_D_list) {
+  int m_offset = 0;
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    for (int expert_id = 0; expert_id < num_experts; expert_id++) {
+      int gemm_m = int(gemm_m_per_expert[expert_id]);
+      problem_sizes[expert_id] = cute::make_shape(gemm_m, gemm_n, gemm_k);
+      // printf("problem_sizes: %d, %d, %d\n", gemm_m, gemm_n, gemm_k);
+
+      ptr_A_list[expert_id] = ptr_A + m_offset * gemm_k;
+      ptr_SFA_list[expert_id] = ptr_SFA + m_offset * ((gemm_k + 127) / 128 * 4);
+      stride_A_list[expert_id] = cute::make_stride(int64_t(gemm_k), _1{}, _0{});
+      layout_SFA_list[expert_id] =
+          Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(cute::make_shape(gemm_m, gemm_n, gemm_k, 1));
+
+      if constexpr (transB) {
+        stride_B_list[expert_id] = cute::make_stride(int64_t(gemm_k), _1{}, _0{});
+      } else {
+        stride_B_list[expert_id] = cute::make_stride(_1{}, int64_t(gemm_n), _0{});
+      }
+      layout_SFB_list[expert_id] =
+          Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(cute::make_shape(gemm_m, gemm_n, gemm_k, 1));
+
+      ptr_D_list[expert_id] = ptr_D + m_offset * gemm_n;
+      stride_D_list[expert_id] = cute::make_stride(int64_t(gemm_n), _1{}, _0{});
+
+      m_offset += gemm_m;
+    }
+  }
+}
+
+template <typename ElementInput, typename ElementSF, typename ElementC, bool DGrad, bool TransB>
+void generic_moe_gemm_kernelLauncher(ElementInput *A, ElementSF *SFA, const void** ptr_B_list, const void** ptr_SFB_list,
+                                     ElementC *D, const int64_t *gemm_m_per_expert, int gemm_n,
+                                     int gemm_k, int num_experts, size_t workspaceSize,
+                                     void *workspace, cudaStream_t stream,
+                                     int *kernel_occupancy = nullptr) {
+  static_assert(cute::is_same_v<ElementInput, cutlass::float_e4m3_t> || cute::is_same_v<ElementInput, cutlass::float_e5m2_t>, "Unsupported input type. Expected e4m3 or e5m2.");
+  static_assert(cute::is_same_v<ElementSF, cutlass::float_ue8m0_t>, "Unsupported SF type. Expected ue8m0.");
+  static_assert(cute::is_same_v<ElementC, cutlass::bfloat16_t> || cute::is_same_v<ElementC, cutlass::half_t> || cute::is_same_v<ElementC, float>, "Unsupported output type. Expected bf16/fp16/fp32.");
+  
+  using ProblemShape = cutlass::gemm::GroupProblemShape<Shape<int, int, int>>;  // <M,N,K> per group
+
+  using ElementA = cutlass::mx_float8_t<ElementInput>;  // Element type for A matrix operand
+  using LayoutA = cutlass::layout::RowMajor;            // Layout type for A matrix operand
+  constexpr int AlignmentA = 32;  // Alignment of A matrix in units of elements (up to 16 bytes)
+
+  // B matrix configuration
+  using ElementB = cutlass::mx_float8_t<ElementInput>;  // Element type for B matrix operand
+  using LayoutB =
+      cute::conditional_t<TransB, cutlass::layout::ColumnMajor,
+                          cutlass::layout::RowMajor>;  // Layout type for B matrix operand
+  constexpr int AlignmentB = 32;  // Alignment of A matrix in units of elements (up to 16 bytes)
+
+  // C/D matrix configuration
+  using ElementD = ElementC;
+  using LayoutC = cutlass::layout::RowMajor;
+  constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  using ElementAccumulator = float;
+
+  // Core kernel configurations
+  using ArchTag = cutlass::arch::Sm100;
+  using EpilogueOperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+  using MainloopOperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+  using StageCountType = cutlass::gemm::collective::StageCountAuto;
+
+  // Runtime Cluster Shape
+  using ClusterShape = Shape<int32_t, int32_t, _1>;
+
+  struct MMA2SMConfig {
+    using MmaTileShape = cute::conditional_t<DGrad, Shape<_256, _256, _128>, Shape<_256, _256, _128>>;
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmMxf8f6f4Sm100;  // Kernel to launch
+    using EpilogueSchedule =
+        cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm;  // Epilogue to launch
+  };
+
+  using CollectiveEpilogue2SM = typename cutlass::epilogue::collective::CollectiveBuilder<
+      ArchTag, EpilogueOperatorClass, typename MMA2SMConfig::MmaTileShape, ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator, ElementAccumulator, void,
+      LayoutC *, AlignmentC, ElementD, LayoutC *, AlignmentD,
+      typename MMA2SMConfig::EpilogueSchedule
+      >::CollectiveOp;
+  using CollectiveMainloop2SM = typename cutlass::gemm::collective::CollectiveBuilder<
+      ArchTag, MainloopOperatorClass, ElementA, LayoutA *, AlignmentA, ElementB, LayoutB *,
+      AlignmentB, ElementAccumulator, typename MMA2SMConfig::MmaTileShape, ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue2SM::SharedStorage))>,
+      typename MMA2SMConfig::KernelSchedule>::CollectiveOp;
+  using GemmKernel2SM = cutlass::gemm::kernel::GemmUniversal<ProblemShape, CollectiveMainloop2SM,
+                                                             CollectiveEpilogue2SM>;
+  using GemmGrouped = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel2SM>;
+
+  using StrideA = typename GemmGrouped::GemmKernel::InternalStrideA;
+  using StrideB = typename GemmGrouped::GemmKernel::InternalStrideB;
+  using StrideC = typename GemmGrouped::GemmKernel::InternalStrideC;
+  using StrideD = typename GemmGrouped::GemmKernel::InternalStrideD;
+
+  using LayoutSFA = typename GemmGrouped::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+  using LayoutSFB = typename GemmGrouped::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+  using Sm1xxBlkScaledConfig =
+      typename GemmGrouped::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  using RasterOrderOptions = cutlass::gemm::kernel::detail::RasterOrderOptions;
+
+  auto get_aligned_offset = [](size_t current_offset, size_t alignment) -> size_t {
+    return (current_offset + alignment - 1) & ~(alignment - 1);
+  };
+
+  if (workspace == nullptr) {
+    throw std::runtime_error("TE CUTLASS device grouped gemm workspace is null");
+  }
+
+  size_t offset = 0;
+  auto ptr_A = reinterpret_cast<typename GemmGrouped::ElementA *>(A);
+  auto ptr_A_list = reinterpret_cast<typename GemmGrouped::ElementA **>(
+      reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(typename GemmGrouped::ElementA *), 128);
+
+  auto ptr_D = reinterpret_cast<typename GemmGrouped::ElementD *>(D);
+  auto ptr_D_list = reinterpret_cast<typename GemmGrouped::ElementD **>(
+      reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(typename GemmGrouped::ElementD *), 128);
+
+  auto ptr_SFA =
+      reinterpret_cast<typename GemmGrouped::GemmKernel::ElementSF *>(SFA);
+  auto ptr_SFA_list =
+      reinterpret_cast<typename GemmGrouped::GemmKernel::ElementSF **>(
+          reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(
+      offset + num_experts * sizeof(typename GemmGrouped::GemmKernel::ElementSF *), 128);
+
+  auto stride_A_list = reinterpret_cast<StrideA *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(StrideA), 128);
+  auto stride_B_list = reinterpret_cast<StrideB *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(StrideB), 128);
+  auto stride_D_list = reinterpret_cast<StrideD *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(StrideD), 128);
+
+  auto layout_SFA_list = reinterpret_cast<LayoutSFA *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(LayoutSFA), 128);
+  auto layout_SFB_list = reinterpret_cast<LayoutSFB *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(LayoutSFB), 128);
+
+  auto problem_sizes = reinterpret_cast<ProblemShape::UnderlyingProblemShape *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(ProblemShape::UnderlyingProblemShape), 128);
+
+  setGroupedGemmArguments<Sm1xxBlkScaledConfig, ProblemShape::UnderlyingProblemShape,
+                          typename GemmGrouped::ElementA, typename GemmGrouped::ElementD,
+                          typename GemmGrouped::GemmKernel::ElementSF, StrideA, StrideB, StrideD,
+                          LayoutSFA, LayoutSFB, TransB><<<1, 32, 0, stream>>>(
+      num_experts, gemm_m_per_expert, gemm_n, gemm_k, ptr_A, ptr_SFA, ptr_D, problem_sizes,
+      ptr_A_list, ptr_SFA_list, stride_A_list, layout_SFA_list, stride_B_list, layout_SFB_list,
+      ptr_D_list, stride_D_list);
+
+  typename GemmGrouped::Arguments args;
+  decltype(args.epilogue.thread) fusion_args;
+  fusion_args.alpha_ptr = nullptr;
+  fusion_args.beta_ptr = nullptr;
+  // Set alpha and beta to 1 and 0 for the fusion operation
+  fusion_args.alpha = 1;
+  fusion_args.alpha_ptr_array = nullptr;
+  fusion_args.dAlpha = {_0{}, _0{}, 0};
+  fusion_args.beta = 0;
+  fusion_args.beta_ptr_array = nullptr;
+  fusion_args.dBeta = {_0{}, _0{}, 0};
+
+  cutlass::KernelHardwareInfo hw_info;
+  // Change device_id to another value if you are running on a machine with multiple GPUs and wish
+  // to use a GPU other than that with device ID 0.
+  hw_info.device_id = 0;
+  hw_info.sm_count =
+      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+  if (!is_static_v<ClusterShape>) {
+    hw_info.cluster_shape = DGrad ? dim3(2, 2, 1) : dim3(4, 4, 1);
+    hw_info.cluster_shape_fallback = dim3(2, 1, 1);
+  }
+
+  typename GemmGrouped::GemmKernel::TileSchedulerArguments scheduler;
+  scheduler.raster_order = RasterOrderOptions::AlongN;
+
+  args = typename GemmGrouped::Arguments{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {num_experts, problem_sizes, nullptr},
+      {const_cast<const typename GemmGrouped::ElementA **>(ptr_A_list), stride_A_list,
+       reinterpret_cast<const typename GemmGrouped::ElementB **>(ptr_B_list), stride_B_list,
+       const_cast<const typename GemmGrouped::GemmKernel::ElementSF **>(ptr_SFA_list),
+       layout_SFA_list,
+       reinterpret_cast<const typename GemmGrouped::GemmKernel::ElementSF **>(ptr_SFB_list),
+       layout_SFB_list},
+      {fusion_args, nullptr, stride_D_list, ptr_D_list, stride_D_list},
+      hw_info,
+      scheduler};
+
+  GemmGrouped gemm;
+
+  // Using the arguments, query for extra workspace required for matrix multiplication computation
+  size_t workspace_size = GemmGrouped::get_workspace_size(args);
+  if (workspaceSize < offset + workspace_size) {  // 16MB limit
+    throw std::runtime_error("TE CUTLASS device grouped gemm calculated workspace size (" +
+                             std::to_string(offset + workspace_size) + ") exceeds buffer size (" +
+                             std::to_string(workspaceSize) + ")\n");
+  }
+
+  auto can_implement = gemm.can_implement(args);
+  if (can_implement != cutlass::Status::kSuccess) {
+    std::string err_msg = "TE CUTLASS device grouped gemm will fail for params. Error: " +
+                          std::string(cutlassGetStatusString(can_implement));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+
+  auto init_status = gemm.initialize(args, reinterpret_cast<char *>(workspace) + offset);
+  if (init_status != cutlass::Status::kSuccess) {
+    std::string err_msg = "Failed to initialize cutlass device grouped gemm. Error: " +
+                          std::string(cutlassGetStatusString(init_status));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+
+  auto run_status = gemm.run(stream);
+  if (run_status != cutlass::Status::kSuccess) {
+    std::string err_msg = "Failed to run cutlass device grouped gemm. Error: " +
+                          std::string(cutlassGetStatusString(run_status));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+}
+
+// Only mxfp8 is supported for now
+// A is single Tensor, B is splited tensor list, D is single Tensor
+void nvte_device_cutlass_grouped_gemm(const NVTETensor *A, const void** B_and_SF_addrs, NVTETensor *D,
+                               const int64_t *m_splits, const int gemm_n, const NVTETensor *bias,
+                               NVTETensor *pre_gelu_out, const int num_gemms, bool transa,
+                               bool transb, bool grad, NVTETensor *workspace, size_t workspaceSize,
+                               bool use_split_accumulator, int math_sm_count,
+                               cudaStream_t stream) {
+  NVTE_API_CALL(nvte_device_cutlass_grouped_gemm);
+  using namespace transformer_engine;
+  // printf("===========nvte_cutlass_grouped_gemm===========\n");
+  // printf("transa: %d, transb: %d\n", transa, transb);
+  // printf("grad: %d\n", grad);
+
+  // Process A
+  const transformer_engine::Tensor *inputA = convertNVTETensor(A[0]);
+  if (transa) {
+    NVTE_CHECK(inputA->has_columnwise_data(), "Input A is missing column-wise usage");
+  } else {
+    NVTE_CHECK(inputA->has_data(), "Input A is missing row-wise usage");
+  }
+  void *raw_inputA_ptr = transa ? inputA->columnwise_data.dptr : inputA->data.dptr;
+  void *raw_inputA_SF_ptr = transa ? inputA->columnwise_scale_inv.dptr : inputA->scale_inv.dptr;
+
+  // Process D
+  const transformer_engine::Tensor *outputD = convertNVTETensor(D[0]);
+  NVTE_CHECK(outputD->has_data(), "Input D is missing row-wise usage");
+  void *raw_outputD_ptr = outputD->data.dptr;
+
+  // Get GEMM shape
+  const int gemm_k = transa ? inputA->flat_first_dim() : inputA->flat_last_dim();
+  // const int gemm_n =
+  //     transb ? convertNVTETensor(B[0])->flat_first_dim() : convertNVTETensor(B[0])->flat_last_dim();
+  //   printf("num_gemms: %d\n", num_gemms);
+  //   printf("gemm_n: %d, gemm_k: %d\n", gemm_n, gemm_k);
+  if ((gemm_k & 0x1F) != 0) {
+    throw std::runtime_error("gemm_k of grouped gemm with variable M must be a multiple of 32.");
+  }
+
+  // Dispatch
+  using transformer_engine::DType;
+  const DType ab_dtype = transa ? inputA->columnwise_data.dtype : inputA->data.dtype;
+  const DType d_dtype = outputD->data.dtype;
+
+  auto workspace_ptr = convertNVTETensor(workspace[0])->data.dptr;
+
+  auto dispatch_layout = [&](auto ab_dtype, auto d_dtype) {
+    // dispatch based on input layout and dgrad flag
+    using ABType = decltype(ab_dtype);
+    using ABSFType = cutlass::float_ue8m0_t;
+    using DType = decltype(d_dtype);
+
+    ABType *inputA_ptr = reinterpret_cast<ABType *>(raw_inputA_ptr);
+    ABSFType *inputA_SF_ptr = reinterpret_cast<ABSFType *>(raw_inputA_SF_ptr);
+    DType *outputD_ptr = reinterpret_cast<DType *>(raw_outputD_ptr);
+
+    if (transb) {
+      if (grad) {
+        generic_moe_gemm_kernelLauncher<ABType, ABSFType, DType, true, true>(
+            inputA_ptr, inputA_SF_ptr, B_and_SF_addrs, B_and_SF_addrs + num_gemms, outputD_ptr,
+            m_splits, gemm_n, gemm_k, num_gemms, workspaceSize, workspace_ptr, stream);
+      } else {
+        generic_moe_gemm_kernelLauncher<ABType, ABSFType, DType, false, true>(
+            inputA_ptr, inputA_SF_ptr, B_and_SF_addrs, B_and_SF_addrs + num_gemms, outputD_ptr,
+            m_splits, gemm_n, gemm_k, num_gemms, workspaceSize, workspace_ptr, stream);
+      }
+    } else {
+      if (grad) {
+        generic_moe_gemm_kernelLauncher<ABType, ABSFType, DType, true, false>(
+            inputA_ptr, inputA_SF_ptr, B_and_SF_addrs, B_and_SF_addrs + num_gemms, outputD_ptr,
+            m_splits, gemm_n, gemm_k, num_gemms, workspaceSize, workspace_ptr, stream);
+      } else {
+        generic_moe_gemm_kernelLauncher<ABType, ABSFType, DType, false, false>(
+            inputA_ptr, inputA_SF_ptr, B_and_SF_addrs, B_and_SF_addrs + num_gemms, outputD_ptr,
+            m_splits, gemm_n, gemm_k, num_gemms, workspaceSize, workspace_ptr, stream);
+      }
+    }
+  };
+
+  auto dispatch_output_dtype = [&](auto ab_dtype) {
+    // dispatch based on D dtype
+    switch (d_dtype) {
+      case DType::kBFloat16:
+        dispatch_layout(ab_dtype, cutlass::bfloat16_t{});
+        break;
+      case DType::kFloat16:
+        dispatch_layout(ab_dtype, cutlass::half_t{});
+        break;
+      case DType::kFloat32:
+        dispatch_layout(ab_dtype, float{});
+        break;
+      default:
+        throw std::runtime_error("Unsupported output dtype. Expected BF16/FP16/FP32.");
+    }
+  };
+
+  auto dispatch = [&]() {
+    // dispatch based on A/B dtype
+    switch (ab_dtype) {
+      case DType::kFloat8E4M3:
+        dispatch_output_dtype(cutlass::float_e4m3_t{});
+        break;
+      case DType::kFloat8E5M2:
+        dispatch_output_dtype(cutlass::float_e5m2_t{});
+        break;
+      default:
+        throw std::runtime_error("Unsupported input dtype. A/B must be FP8 e4m3 or e5m2.");
+    }
+  };
+
+  dispatch();
+}
+
+/*****
+ * Wgrad
+ ******/
+
+namespace {
+static inline const char* dtype_to_cstr(transformer_engine::DType dt) {
+  using transformer_engine::DType;
+  switch (dt) {
+    case DType::kFloat8E4M3: return "Float8E4M3";
+    case DType::kFloat8E5M2: return "Float8E5M2";
+    case DType::kBFloat16:   return "BFloat16";
+    case DType::kFloat16:    return "Float16";
+    case DType::kFloat32:    return "Float32";
+    default:                 return "Unknown";
+  }
+}
+}
+
+// Wgrad accumulate policy: supports optional per-expert bitmap (up to 1024 experts)
+// and global accumulate switch. Passed by value to device kernel to avoid cudaMemcpyAsync.
+struct WgradAccumulatePolicy {
+  unsigned long long words[16];
+  bool partial_wgrad_accumulate; // true only when partial accumulate is enabled and mask provided
+  bool accumulate; // global accumulate switch
+
+  __host__ __device__ inline bool need_accumulate(int expert_id) const {
+    if (!accumulate) return false;
+    if (!partial_wgrad_accumulate) return true;
+    int chunk = (expert_id >> 6);
+    int bit = expert_id & 63;
+    unsigned long long w = words[chunk];
+    return ((w >> bit) & 1ull) != 0ull;
+  }
+
+  __host__ inline void set(bool do_accumulate, const bool* mask, int num_experts) {
+    accumulate = do_accumulate;
+    partial_wgrad_accumulate = (do_accumulate && mask != nullptr);
+
+    // Initialize words only when mask is used; otherwise words are don't-care
+    if (partial_wgrad_accumulate) {
+      for (int k = 0; k < 16; ++k) words[k] = ~0ull;
+      for (int i = 0; i < num_experts; ++i) {
+        if (mask[i]) continue;
+        int chunk = (i >> 6);
+        int bit = i & 63;
+        // Already checked num_experts <= 1024 when initializing GroupedLinear op.
+        // Skip out-of-range check here to avoid redundant computation.
+        words[chunk] &= ~(1ull << bit);
+      }
+    }
+  }
+};
+
+template <typename Sm1xxBlkScaledConfig, typename UnderlyingProblemShape, typename ElementA,
+          typename ElementB, typename ElementC, typename ElementD, typename ElementAccumulator, typename ElementSF, typename StrideA,
+          typename StrideB, typename StrideD, typename LayoutSFA, typename LayoutSFB, bool transD>
+__global__ void setGroupedGemmWgradArguments(
+    int num_experts, int gemm_m, int gemm_n, const int64_t *gemm_k_per_expert, int total_gemm_k,
+    ElementA *ptr_A, ElementSF *ptr_SFA, ElementB *ptr_B, ElementSF *ptr_SFB,
+    UnderlyingProblemShape *problem_sizes, ElementA **ptr_A_list, ElementSF **ptr_SFA_list,
+    StrideA *stride_A_list, LayoutSFA *layout_SFA_list, ElementB **ptr_B_list,
+    ElementSF **ptr_SFB_list, StrideB *stride_B_list, LayoutSFB *layout_SFB_list,
+    ElementD **ptr_D_list, StrideD *stride_D_list, ElementC **ptr_C_list,
+    ElementAccumulator **beta_ptr_list, ElementAccumulator *beta_zero, ElementAccumulator *beta_one,
+    WgradAccumulatePolicy accumulate_policy) {
+  // printf("===========wgrad setGroupedGemmWgradArguments===========\n");
+  // printf("transD: %d\n", transD);
+  int k_offset = 0;
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *beta_zero = 0;
+    *beta_one = 1;
+#pragma unroll
+    for (int expert_id = 0; expert_id < num_experts; ++expert_id) {
+      int gemm_k = int(gemm_k_per_expert[expert_id]);
+      if (!accumulate_policy.need_accumulate(expert_id)) {
+        ptr_C_list[expert_id] = nullptr;
+        beta_ptr_list[expert_id] = beta_zero;
+      } else {
+        ptr_C_list[expert_id] = ptr_D_list[expert_id];
+        beta_ptr_list[expert_id] = beta_one;
+      }
+
+      problem_sizes[expert_id] = cute::make_shape(gemm_m, gemm_n, gemm_k);
+      if (gemm_k == 0) {
+        // If gemm_k is 0, we need to set the problem_sizes to 0, 0, 0 to skip the gemm
+        problem_sizes[expert_id] = cute::make_shape(0, 0, 0);
+        continue;
+      }
+      // printf("wgrad problem_sizes: %d, %d, %d\n", gemm_m, gemm_n, gemm_k);
+
+      ptr_A_list[expert_id] = ptr_A + gemm_m * k_offset;
+      ptr_SFA_list[expert_id] = ptr_SFA + 128 * ((k_offset + 127) / 128 * 4);
+      stride_A_list[expert_id] = cute::make_stride(_1{}, int64_t(gemm_m), _0{});
+      auto temp_sfa_layout = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+          cute::make_shape(gemm_m, gemm_n, total_gemm_k, 1));
+      layout_SFA_list[expert_id] = cute::make_layout(
+          get<0>(temp_sfa_layout),
+          make_layout(get<0>(get<1>(temp_sfa_layout)),
+                      make_layout(gemm_k / 128, get<1>(get<1>(temp_sfa_layout.stride())))),
+
+          get<2>(temp_sfa_layout));
+
+      ptr_B_list[expert_id] = ptr_B + gemm_n * k_offset;
+      ptr_SFB_list[expert_id] = ptr_SFB + 128 * ((k_offset + 127) / 128 * 4);
+      stride_B_list[expert_id] = cute::make_stride(_1{}, int64_t(gemm_n), _0{});
+      auto temp_sfb_layout = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+          cute::make_shape(gemm_m, gemm_n, total_gemm_k, 1));
+      layout_SFB_list[expert_id] = cute::make_layout(
+          get<0>(temp_sfb_layout),
+          make_layout(get<0>(get<1>(temp_sfb_layout)),
+                      make_layout(gemm_k / 128, get<1>(get<1>(temp_sfb_layout.stride())))),
+          get<2>(temp_sfb_layout));
+
+      if constexpr (transD) {
+        stride_D_list[expert_id] = cute::make_stride(_1{}, int64_t(gemm_m), _0{});
+      } else {
+        stride_D_list[expert_id] = cute::make_stride(int64_t(gemm_n), _1{}, _0{});
+      }
+
+      // printf("expert_id: %d, accumulate_D: %d, beta_ptr_list: %d, ptr_C_list: %s(%p)\n", expert_id, int(accumulate_D[expert_id]), int(*beta_ptr_list[expert_id]), ptr_C_list[expert_id] == nullptr ? "nullptr" : "valid", ptr_C_list[expert_id]);
+
+      k_offset += gemm_k;
+    }
+  }
+
+  // Parallel zero-fill for experts with gemm_k == 0 when not accumulating into D
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int stride = blockDim.x * gridDim.x;
+  int total_elems = gemm_m * gemm_n;
+
+  // Try 16-byte vectorized stores when alignment permits, fallback to scalar otherwise
+  constexpr int bytes_per_vec = 16;
+  constexpr int elem_size = int(sizeof(ElementD));
+  constexpr int elems_per_vec = bytes_per_vec / elem_size;  // 8 for bf16
+  int total_vec = total_elems / elems_per_vec;
+
+#pragma unroll
+  for (int expert_id = 0; expert_id < num_experts; ++expert_id) {
+    if (int(gemm_k_per_expert[expert_id]) != 0 || accumulate_policy.need_accumulate(expert_id)) {
+      continue; // Skip zero-fill if gemm_k is not 0 or current expert need accumulate
+    }
+
+    ElementD *d_ptr = ptr_D_list[expert_id];
+    bool aligned16 = ((reinterpret_cast<size_t>(d_ptr) & (bytes_per_vec - 1)) == 0);
+
+    if (aligned16 && elems_per_vec > 0) {
+      int4 zero4; zero4.x = 0; zero4.y = 0; zero4.z = 0; zero4.w = 0;
+      int4 *vec_ptr = reinterpret_cast<int4 *>(d_ptr);
+
+#pragma unroll
+      for (int j = tid; j < total_vec; j += stride) {
+        vec_ptr[j] = zero4;
+      }
+#pragma unroll
+      for (int k = total_vec * elems_per_vec + tid; k < total_elems; k += stride) {
+        d_ptr[k] = ElementD(0);
+      }
+    } else {
+#pragma unroll
+      for (int i = tid; i < total_elems; i += stride) {
+        d_ptr[i] = ElementD(0);
+      }
+    }
+  }
+}
+
+template <typename ElementInput, typename ElementSF, typename ElementC, bool TransD>
+void generic_moe_gemm_wgrad_kernelLauncher(ElementInput *A, ElementSF *SFA, ElementInput *B, ElementSF *SFB,
+                                           void **ptr_D_list, int gemm_m, int gemm_n,
+                                           const int64_t *gemm_k_per_expert, int total_gemm_k,
+                                           int num_experts, bool accumulate, bool* accumulate_mask, size_t workspaceSize,
+                                           void *workspace, cudaStream_t stream,
+                                           int *kernel_occupancy = nullptr) {
+  static_assert(cute::is_same_v<ElementInput, cutlass::float_e4m3_t> || cute::is_same_v<ElementInput, cutlass::float_e5m2_t>, "Unsupported input type. Expected e4m3 or e5m2.");
+  static_assert(cute::is_same_v<ElementSF, cutlass::float_ue8m0_t>, "Unsupported SF type. Expected ue8m0.");
+  static_assert(cute::is_same_v<ElementC, cutlass::bfloat16_t> || cute::is_same_v<ElementC, cutlass::half_t> || cute::is_same_v<ElementC, float>, "Unsupported output type. Expected bf16/fp16/fp32.");
+                                            
+  using ProblemShape = cutlass::gemm::GroupProblemShape<Shape<int, int, int>>;  // <M,N,K> per group
+
+  using ElementA = cutlass::mx_float8_t<ElementInput>;  // Element type for A matrix operand
+  using LayoutA = cutlass::layout::ColumnMajor;         // Layout type for A matrix operand
+  constexpr int AlignmentA = 32;  // Alignment of A matrix in units of elements (up to 16 bytes)
+
+  // B matrix configuration
+  using ElementB = cutlass::mx_float8_t<ElementInput>;  // Element type for B matrix operand
+  using LayoutB = cutlass::layout::RowMajor;            // Layout type for B matrix operand
+  constexpr int AlignmentB = 32;  // Alignment of A matrix in units of elements (up to 16 bytes)
+
+  // C/D matrix configuration
+  using ElementD = ElementC;
+  using LayoutC = typename cutlass::platform::conditional<
+      TransD, cutlass::layout::ColumnMajor,cutlass::layout::RowMajor>::type;
+  constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  using ElementAccumulator = float;
+
+  // Core kernel configurations
+  using ArchTag = cutlass::arch::Sm100;
+  using EpilogueOperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+  using MainloopOperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+  using StageCountType = cutlass::gemm::collective::StageCountAuto;
+
+  // Runtime Cluster Shape
+  using ClusterShape = Shape<int32_t, int32_t, _1>;
+
+  struct MMA2SMConfig {
+    using MmaTileShape = Shape<_256, _128, _128>;
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecialized2SmMxf8f6f4Sm100;  // Kernel to launch
+    using EpilogueSchedule =
+        cutlass::epilogue::PtrArrayTmaWarpSpecialized2Sm;  // Epilogue to launch
+  };
+
+  using CollectiveEpilogue2SM = typename cutlass::epilogue::collective::CollectiveBuilder<
+      ArchTag, EpilogueOperatorClass, typename MMA2SMConfig::MmaTileShape, ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator, ElementAccumulator,
+      ElementC, LayoutC *, AlignmentC, ElementD, LayoutC *, AlignmentD,
+      typename MMA2SMConfig::EpilogueSchedule
+      >::CollectiveOp;
+  using CollectiveMainloop2SM = typename cutlass::gemm::collective::CollectiveBuilder<
+      ArchTag, MainloopOperatorClass, ElementA, LayoutA *, AlignmentA, ElementB, LayoutB *,
+      AlignmentB, ElementAccumulator, typename MMA2SMConfig::MmaTileShape, ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue2SM::SharedStorage))>,
+      typename MMA2SMConfig::KernelSchedule>::CollectiveOp;
+  using GemmKernel2SM = cutlass::gemm::kernel::GemmUniversal<ProblemShape, CollectiveMainloop2SM,
+                                                             CollectiveEpilogue2SM>;
+  using GemmGrouped = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel2SM>;
+
+  using StrideA = typename GemmGrouped::GemmKernel::InternalStrideA;
+  using StrideB = typename GemmGrouped::GemmKernel::InternalStrideB;
+  using StrideC = typename GemmGrouped::GemmKernel::InternalStrideC;
+  using StrideD = typename GemmGrouped::GemmKernel::InternalStrideD;
+
+  using LayoutSFA = typename GemmGrouped::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+  using LayoutSFB = typename GemmGrouped::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+  using Sm1xxBlkScaledConfig =
+      typename GemmGrouped::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  using RasterOrderOptions = cutlass::gemm::kernel::detail::RasterOrderOptions;
+
+  // Helper function to calculate aligned offset
+  auto get_aligned_offset = [](size_t current_offset, size_t alignment) -> size_t {
+    return (current_offset + alignment - 1) & ~(alignment - 1);
+  };
+
+  if (workspace == nullptr) {
+    throw std::runtime_error("TE CUTLASS device grouped gemm workspace is null");
+  }
+
+  size_t offset = 0;
+  auto ptr_A = reinterpret_cast<typename GemmGrouped::ElementA *>(A);
+  auto ptr_A_list = reinterpret_cast<typename GemmGrouped::ElementA **>(
+      reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(typename GemmGrouped::ElementA *), size_t(128));
+
+  auto ptr_B = reinterpret_cast<typename GemmGrouped::ElementB *>(B);
+  auto ptr_B_list = reinterpret_cast<typename GemmGrouped::ElementB **>(
+      reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(typename GemmGrouped::ElementB *), size_t(128));
+
+  auto ptr_C_list = reinterpret_cast<typename GemmGrouped::ElementC **>(
+  reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(typename GemmGrouped::ElementC *), size_t(128));
+
+  auto ptr_SFA = reinterpret_cast<typename GemmGrouped::GemmKernel::ElementSF *>(SFA);
+  auto ptr_SFA_list = reinterpret_cast<typename GemmGrouped::GemmKernel::ElementSF **>(
+          reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(
+      offset + num_experts * sizeof(typename GemmGrouped::GemmKernel::ElementSF *), size_t(128));
+
+  auto ptr_SFB = reinterpret_cast<typename GemmGrouped::GemmKernel::ElementSF *>(SFB);
+  auto ptr_SFB_list = reinterpret_cast<typename GemmGrouped::GemmKernel::ElementSF **>(
+          reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(
+      offset + num_experts * sizeof(typename GemmGrouped::GemmKernel::ElementSF *), size_t(128));
+
+  auto stride_A_list = reinterpret_cast<StrideA *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(StrideA), size_t(128));
+  auto stride_B_list = reinterpret_cast<StrideB *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(StrideB), size_t(128));
+  auto stride_D_list = reinterpret_cast<StrideD *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(StrideD), size_t(128));
+
+  auto layout_SFA_list = reinterpret_cast<LayoutSFA *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(LayoutSFA), size_t(128));
+  auto layout_SFB_list = reinterpret_cast<LayoutSFB *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(LayoutSFB), size_t(128));
+
+  auto problem_sizes = reinterpret_cast<ProblemShape::UnderlyingProblemShape *>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(ProblemShape::UnderlyingProblemShape), size_t(128));
+
+  auto beta_ptr_list = reinterpret_cast<ElementAccumulator **>(reinterpret_cast<char *>(workspace) + offset);
+  offset = get_aligned_offset(offset + num_experts * sizeof(ElementAccumulator *), size_t(128));
+  auto beta_zero = reinterpret_cast<ElementAccumulator *>(reinterpret_cast<char *>(workspace) + offset);
+  auto beta_one = reinterpret_cast<ElementAccumulator *>(reinterpret_cast<char *>(workspace) + offset + sizeof(ElementAccumulator));
+  offset = get_aligned_offset(offset + 2 * sizeof(ElementAccumulator), size_t(128));
+
+  // Build accumulate decision:
+  // - accumulate == false      -> no expert accumulates
+  // - accumulate == true
+  //     - accumulate_mask == nullptr -> all experts accumulate (supports any num_experts)
+  //     - accumulate_mask != nullptr -> partial accumulate; supports up to 1024 experts
+  WgradAccumulatePolicy accumulate_policy{};
+  accumulate_policy.set(accumulate, accumulate_mask, num_experts);
+  
+  // Launch setGroupedGemmWgradArguments
+  constexpr int kVecBytes = 16;
+  constexpr int kElemSize = int(sizeof(typename GemmGrouped::ElementD));
+  const int elems_per_vec = kVecBytes > kElemSize ? kVecBytes / kElemSize : 1;
+  const int total_elems = gemm_m * gemm_n;
+  const int work_units = (total_elems + elems_per_vec - 1) / elems_per_vec;
+  const int threads_per_block = 256;
+  const int blocks = (work_units + threads_per_block - 1) / threads_per_block;
+  setGroupedGemmWgradArguments<Sm1xxBlkScaledConfig, ProblemShape::UnderlyingProblemShape,
+                               typename GemmGrouped::ElementA, typename GemmGrouped::ElementB,
+                               typename GemmGrouped::ElementC, typename GemmGrouped::ElementD,
+                               ElementAccumulator, typename GemmGrouped::GemmKernel::ElementSF, StrideA, StrideB,
+                               StrideD, LayoutSFA, LayoutSFB, TransD><<<blocks, threads_per_block, 0, stream>>>(
+      num_experts, gemm_m, gemm_n, gemm_k_per_expert, total_gemm_k, ptr_A, ptr_SFA, ptr_B, ptr_SFB,
+      problem_sizes, ptr_A_list, ptr_SFA_list, stride_A_list, layout_SFA_list, ptr_B_list,
+      ptr_SFB_list, stride_B_list, layout_SFB_list, reinterpret_cast<typename GemmGrouped::ElementD **>(ptr_D_list),
+      stride_D_list, ptr_C_list, beta_ptr_list, beta_zero, beta_one, accumulate_policy);
+
+  // Check for CUDA errors after kernel launch
+  cudaError_t cuda_error = cudaGetLastError();
+  if (cuda_error != cudaSuccess) {
+    std::string err_msg = "Failed to run setGroupedGemmWgradArguments. CUDA Error: " +
+                          std::string(cudaGetErrorString(cuda_error));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+
+  typename GemmGrouped::Arguments args;
+  decltype(args.epilogue.thread) fusion_args;
+  fusion_args.alpha_ptr = nullptr;
+  fusion_args.beta_ptr = nullptr;
+  // Set alpha and beta
+  fusion_args.alpha = 1;
+  fusion_args.alpha_ptr_array = nullptr;
+  fusion_args.dAlpha = {_0{}, _0{}, 0};
+  fusion_args.beta = 0;
+  fusion_args.beta_ptr_array = beta_ptr_list;
+  fusion_args.dBeta = {_0{}, _0{}, 1};
+
+  cutlass::KernelHardwareInfo hw_info;
+  // Change device_id to another value if you are running on a machine with multiple GPUs and wish
+  // to use a GPU other than that with device ID 0.
+  hw_info.device_id = 0;
+  hw_info.sm_count =
+      cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+  if (!is_static_v<ClusterShape>) {
+    hw_info.cluster_shape = dim3(2, 2, 1);
+    hw_info.cluster_shape_fallback = dim3(2, 1, 1);
+  }
+
+  typename GemmGrouped::GemmKernel::TileSchedulerArguments scheduler;
+  scheduler.raster_order = RasterOrderOptions::AlongM;
+
+  args = typename GemmGrouped::Arguments{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {num_experts, problem_sizes, nullptr},
+      {const_cast<const typename GemmGrouped::ElementA **>(ptr_A_list), stride_A_list,
+       const_cast<const typename GemmGrouped::ElementB **>(ptr_B_list), stride_B_list,
+       const_cast<const typename GemmGrouped::GemmKernel::ElementSF **>(ptr_SFA_list),
+       layout_SFA_list,
+       const_cast<const typename GemmGrouped::GemmKernel::ElementSF **>(ptr_SFB_list),
+       layout_SFB_list},
+      {fusion_args,
+       const_cast<const typename GemmGrouped::ElementC **>(ptr_C_list),
+       stride_D_list, reinterpret_cast<typename GemmGrouped::ElementD **>(ptr_D_list), stride_D_list},
+      hw_info,
+      scheduler};
+
+  GemmGrouped gemm;
+
+  // Using the arguments, query for extra workspace required for matrix multiplication computation
+  size_t workspace_size = GemmGrouped::get_workspace_size(args);
+  if (workspaceSize < offset + workspace_size) {  // 16MB limit
+    throw std::runtime_error("TE CUTLASS device grouped gemm calculated workspace size (" +
+                             std::to_string(offset + workspace_size) + ") exceeds buffer size (" +
+                             std::to_string(workspaceSize) + ")\n");
+  }
+
+  auto can_implement = gemm.can_implement(args);
+  if (can_implement != cutlass::Status::kSuccess) {
+    std::string err_msg = "TE CUTLASS device grouped gemm will fail for params. Error: " +
+                          std::string(cutlassGetStatusString(can_implement));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+
+  auto init_status = gemm.initialize(args, reinterpret_cast<char *>(workspace) + offset);
+  if (init_status != cutlass::Status::kSuccess) {
+    std::string err_msg = "Failed to initialize cutlass grouped gemm. Error: " +
+                          std::string(cutlassGetStatusString(init_status));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+
+  auto run_status = gemm.run(stream);
+  if (run_status != cutlass::Status::kSuccess) {
+    std::string err_msg = "Failed to run cutlass grouped gemm. Error: " +
+                          std::string(cutlassGetStatusString(run_status));
+    throw std::runtime_error("TE CUTLASS device grouped gemm error: " + err_msg);
+  }
+}
+
+// Only mxfp8 is supported for now
+// A and B is single Tensor, D is splited tensor list
+void nvte_device_cutlass_grouped_gemm_wgrad(const NVTETensor *A, const NVTETensor *B, void **outputD_ptr_list,
+                                     transformer_engine::DType D_type, const int64_t *m_splits, const NVTETensor *bias,
+                                     NVTETensor *pre_gelu_out, const int num_gemms, bool transa,
+                                     bool transb, NVTETensor *workspace, size_t workspaceSize, bool accumulate,
+                                     bool* accumulate_mask, bool use_split_accumulator, int math_sm_count,
+                                     cudaStream_t stream) {
+  NVTE_API_CALL(nvte_device_cutlass_grouped_gemm_wgrad);
+  using namespace transformer_engine;
+  //   printf("===========nvte_cutlass_grouped_gemm===========\n");
+  //   printf("transa: %d, transb: %d\n", transa, transb);
+  //   printf("accumulate: %d\n", accumulate);
+  NVTE_CHECK(transa && !transb, "wgrad grouped gemm currently only support TN layout.");
+
+  // Process A
+  const transformer_engine::Tensor *inputA = convertNVTETensor(A[0]);
+  if (transa) {
+    NVTE_CHECK(inputA->has_columnwise_data(), "Input A is missing column-wise usage");
+  } else {
+    NVTE_CHECK(inputA->has_data(), "Input A is missing row-wise usage");
+  }
+  void *raw_inputA_ptr = transa ? inputA->columnwise_data.dptr : inputA->data.dptr;
+  void *raw_inputA_SF_ptr = transa ? inputA->columnwise_scale_inv.dptr : inputA->scale_inv.dptr;
+
+  // Process B
+  const transformer_engine::Tensor *inputB = convertNVTETensor(B[0]);
+  if (transb) {
+    NVTE_CHECK(inputB->has_data(), "Input B is missing row-wise usage");
+  } else {
+    NVTE_CHECK(inputB->has_columnwise_data(), "Input B is missing column-wise usage");
+  }
+  void *raw_inputB_ptr = transb ? inputB->data.dptr : inputB->columnwise_data.dptr;
+  void *raw_inputB_SF_ptr = transb ? inputB->scale_inv.dptr : inputB->columnwise_scale_inv.dptr;
+
+  // Get GEMM shape
+  const int gemm_m = transa ? inputA->flat_last_dim() : inputA->flat_first_dim();
+  const int gemm_n = transb ? inputB->flat_first_dim() : inputB->flat_last_dim();
+  const int total_gemm_k = transa ? inputA->flat_first_dim() : inputA->flat_last_dim();
+  //   printf("num_gemms: %d\n", num_gemms);
+  //   printf("gemm_m: %d, gemm_n: %d\n", gemm_m, gemm_n);
+  //   printf("total_gemm_k: %d\n", total_gemm_k);
+  if ((gemm_m & 0x1F) != 0 || (gemm_n & 0xF) != 0) {
+    throw std::runtime_error(
+        "gemm_m and gemm_n of grouped gemm with variable K must be multiples of 32.");
+  }
+
+  // printf("inputA_SF_ptr: \n");
+  // Print_tensor<<<1, 1>>>(inputA_SF_ptr, 128, gemm_k/32);
+  // cudaDeviceSynchronize();
+
+  //   printf("B_SF_ptr: \n");
+  //   Print_tensor<<<1, 1>>>(B_SF_ptr, gemm_n, 256/32);
+  //   cudaDeviceSynchronize();
+
+  // Dispatch
+  using transformer_engine::DType;
+  const DType a_dtype = transa ? inputA->columnwise_data.dtype : inputA->data.dtype;
+  const DType b_dtype = transb ? inputB->data.dtype : inputB->columnwise_data.dtype;
+  NVTE_CHECK(a_dtype == b_dtype,
+             transformer_engine::concat_strings(
+                 "Input A/B dtypes mismatch for wgrad. A=",
+                 dtype_to_cstr(b_dtype), ", B=", dtype_to_cstr(b_dtype)));
+
+  auto workspace_ptr = convertNVTETensor(workspace[0])->data.dptr;
+
+  bool transD = true;  // transD should mirror fprop's transB; currently always true
+
+  auto dispatch_layout = [&](auto ab_dtype, auto out_dtype) {
+    // dispatch based on output layout
+    using ABType = decltype(ab_dtype);
+    using ABSFType = cutlass::float_ue8m0_t;
+    using OutType = decltype(out_dtype);
+
+    ABType *inputA_ptr = reinterpret_cast<ABType *>(raw_inputA_ptr);
+    ABSFType *inputA_SF_ptr = reinterpret_cast<ABSFType *>(raw_inputA_SF_ptr);
+    ABType *inputB_ptr = reinterpret_cast<ABType *>(raw_inputB_ptr);
+    ABSFType *inputB_SF_ptr = reinterpret_cast<ABSFType *>(raw_inputB_SF_ptr);
+
+    if (transD) {
+      generic_moe_gemm_wgrad_kernelLauncher<ABType, ABSFType, OutType, true>(
+          inputA_ptr, inputA_SF_ptr, inputB_ptr, inputB_SF_ptr, outputD_ptr_list, gemm_m, gemm_n,
+          m_splits, total_gemm_k, num_gemms, accumulate, accumulate_mask, workspaceSize,
+          workspace_ptr, stream);
+    } else {
+      generic_moe_gemm_wgrad_kernelLauncher<ABType, ABSFType, OutType, false>(
+          inputA_ptr, inputA_SF_ptr, inputB_ptr, inputB_SF_ptr, outputD_ptr_list, gemm_m, gemm_n,
+          m_splits, total_gemm_k, num_gemms, accumulate, accumulate_mask, workspaceSize,
+          workspace_ptr, stream);
+    }
+  };
+  auto dispatch_output_dtype = [&](auto ab_dtype) {
+    switch (D_type) {
+      case DType::kFloat32:
+        dispatch_layout(ab_dtype, float{});
+        break;
+      case DType::kBFloat16:
+        dispatch_layout(ab_dtype, cutlass::bfloat16_t{});
+        break;
+      case DType::kFloat16:
+        dispatch_layout(ab_dtype, cutlass::half_t{});
+        break;
+      default:
+        throw std::runtime_error("Unsupported output dtype. Expected Float32/BFloat16/Float16");
+    }
+  };
+
+  auto dispatch = [&]() {
+    // dispatch based on A/B dtype and D type
+    switch (a_dtype) {
+      case DType::kFloat8E4M3:
+        dispatch_output_dtype(cutlass::float_e4m3_t{});
+        break;
+      case DType::kFloat8E5M2:
+        dispatch_output_dtype(cutlass::float_e5m2_t{});
+        break;
+      default:
+        throw std::runtime_error("Unsupported input dtype. A/B must be FP8 e4m3 or e5m2.");
+    }
+  };
+
+  dispatch();
+}

--- a/transformer_engine/common/include/transformer_engine/gemm.h
+++ b/transformer_engine/common/include/transformer_engine/gemm.h
@@ -12,6 +12,7 @@
 #define TRANSFORMER_ENGINE_GEMM_H_
 
 #include "transformer_engine.h"
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {
@@ -228,6 +229,20 @@ void nvte_multi_tensor_gemm(const NVTETensor *A, const NVTETensor *B, NVTETensor
                             bool transa, bool transb, bool grad, NVTETensor *workspace,
                             bool accumulate, bool use_split_accumulator, int math_sm_count,
                             cudaStream_t stream);
+
+void nvte_device_cutlass_grouped_gemm(const NVTETensor* A, const void** B_and_SF_addrs, NVTETensor* D,
+                               const int64_t* m_splits, const int gemm_n, const NVTETensor* bias,
+                               NVTETensor* pre_gelu_out, const int num_gemms, bool transa,
+                               bool transb, bool grad, NVTETensor* workspace, size_t workspaceSize,
+                               bool use_split_accumulator, int math_sm_count,
+                               cudaStream_t stream);
+
+void nvte_device_cutlass_grouped_gemm_wgrad(const NVTETensor* A, const NVTETensor* B, void** D,
+                                     transformer_engine::DType D_type, const int64_t* m_splits, const NVTETensor* bias,
+                                     NVTETensor* pre_gelu_out, const int num_gemms, bool transa,
+                                     bool transb, NVTETensor* workspace, size_t workspaceSize,
+                                     bool accumulate, bool* accumulate_mask, bool use_split_accumulator,
+                                     int math_sm_count, cudaStream_t stream);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/transformer_engine/common/include/transformer_engine/gemm.h
+++ b/transformer_engine/common/include/transformer_engine/gemm.h
@@ -239,8 +239,8 @@ void nvte_multi_tensor_gemm(const NVTETensor *A, const NVTETensor *B, NVTETensor
  *  - `D = GELU(AB + bias)` if both `bias` and `pre_gelu_out` are not empty tensors
  *  Note: bias and GELU are not supported yet.
  *
- *  \param[in]     A                     The list of A matrices.
- *  \param[in]     B_and_SF_addrs        The list of B and SF matrices addresses.
+ *  \param[in]     A_and_SF_addrs        The list of A and SF matrices addresses.
+ *  \param[in]     B                     The list of B matrices.
  *  \param[in,out] D                     List of output matrices.
  *  \param[in]     m_splits              List of m-dimension splits.
  *  \param[in]     gemm_n                GEMM n dimension.

--- a/transformer_engine/common/include/transformer_engine/gemm.h
+++ b/transformer_engine/common/include/transformer_engine/gemm.h
@@ -257,8 +257,8 @@ void nvte_multi_tensor_gemm(const NVTETensor *A, const NVTETensor *B, NVTETensor
  *  \param[in]     math_sm_count         Number of GPU SMs to use (default=0: use cuBLAS heuristics)
  *  \param[in]     stream                CUDA stream to wait on.
  */
-void nvte_device_cutlass_grouped_gemm(const NVTETensor* A, const void** B_and_SF_addrs, NVTETensor* D,
-                               const int64_t* m_splits, const int gemm_n, const NVTETensor* bias,
+void nvte_device_cutlass_grouped_gemm(const void** A_and_SF_addrs, const NVTETensor* B, NVTETensor* D,
+                               const int64_t* m_splits, const int gemm_k, const NVTETensor* bias,
                                NVTETensor* pre_gelu_out, const int num_gemms, bool transa,
                                bool transb, bool grad, NVTETensor* workspace, size_t workspaceSize,
                                bool use_split_accumulator, int math_sm_count,

--- a/transformer_engine/common/libtransformer_engine.version
+++ b/transformer_engine/common/libtransformer_engine.version
@@ -15,6 +15,8 @@
 			transformer_engine::nvte_cublas_handle_init*;
 			transformer_engine::typeToSize*;
 			transformer_engine::is_fp8_dtype*;
+			transformer_engine::to_string*;
+			transformer_engine::convertNVTETensor*;
 			*transformer_engine::CommOverlapBase*;
 			*transformer_engine::CommOverlapP2PBase*;
 			*transformer_engine::CommOverlapCore*;

--- a/transformer_engine/pytorch/cpp_extensions/gemm.py
+++ b/transformer_engine/pytorch/cpp_extensions/gemm.py
@@ -178,9 +178,6 @@ def general_grouped_gemm(
     """
     TN layout Grouped GEMM with fp8 inputs.
     """
-    # print("===========general_grouped_gemm===========")
-    # print("accumulate:", accumulate)
-    # print(f"layout: {layout}")
     if isinstance(m_splits, list):
         m_splits = torch.tensor(m_splits)
     num_gemms = m_splits.size(0)
@@ -213,9 +210,6 @@ def general_grouped_gemm(
             for o in out
         ]  # this should differ with respect to single output
 
-    # print("===========call tex.te_general_grouped_gemm===========")
-    # print("A[0]:",  A[0].get_metadata_debug())
-    # print("B[0]:",  B[0].get_metadata_debug())
     if not m_splits_on_devie:
         bias = tex.te_general_grouped_gemm(
             A,
@@ -237,11 +231,14 @@ def general_grouped_gemm(
             sm_count - int(os.getenv("NVTE_EXT_MARGIN_SM", str(sm_count))),
         )
     else:
-        assert isinstance(A[0], MXFP8TensorStorage) and isinstance(B[0], MXFP8TensorStorage), "Only MXFP8 A and B are supported when m_splits is on device"
-        assert out[0].dtype == torch.bfloat16 or out[0].dtype == torch.float16 or (wgrad and out[0].dtype == torch.float32), "Only BF16, FP16 or FP32(only for wgrad accumulation) output is supported when m_splits is on device"
+        assert isinstance(A[0], MXFP8TensorStorage) and isinstance(
+            B[0], MXFP8TensorStorage), "Only MXFP8 A and B are supported when m_splits is on device"
+        assert out[0].dtype == torch.bfloat16 or out[0].dtype == torch.float16 or (
+            wgrad and out[0].dtype == torch.float32), "Only BF16, FP16 or FP32(only for wgrad accumulation) output is supported when m_splits is on device"
         assert not use_bias, "Bias is not supported when m_splits is on device"
         assert not gelu, "GELU is not supported when m_splits is on device"
-        assert TE_DType[out[0].dtype] == out_dtype, "Output dtype mismatch: out[0].dtype=" + str(out[0].dtype) + ", out_dtype=" + str(out_dtype)
+        assert TE_DType[out[0].dtype] == out_dtype, "Output dtype mismatch: out[0].dtype=" + \
+            str(out[0].dtype) + ", out_dtype=" + str(out_dtype)
         bias = tex.te_general_device_initiated_grouped_gemm(
             A,
             transa,
@@ -255,7 +252,7 @@ def general_grouped_gemm(
             single_output,
             gelu_input,  # this is pre_gelu_out
             grad,  # grad
-            wgrad, # wgrad
+            wgrad,  # wgrad
             workspaces,
             workspaces[0].shape[0],
             accumulate,

--- a/transformer_engine/pytorch/cpp_extensions/gemm.py
+++ b/transformer_engine/pytorch/cpp_extensions/gemm.py
@@ -163,7 +163,7 @@ def general_grouped_gemm(
     workspaces: List[torch.Tensor],
     layout: str = "TN",
     m_splits: Optional[torch.Tensor] = None,
-    m_splits_on_devie: bool = False,
+    m_splits_on_device: bool = False,
     gelu: bool = False,
     grad=False,
     wgrad=False,
@@ -210,7 +210,7 @@ def general_grouped_gemm(
             for o in out
         ]  # this should differ with respect to single output
 
-    if not m_splits_on_devie:
+    if not m_splits_on_device:
         bias = tex.te_general_grouped_gemm(
             A,
             transa,

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -144,10 +144,18 @@ void te_atomic_gemm(at::Tensor A, at::Tensor A_scale_inverse, DType A_type,
 
 std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
     std::vector<py::handle> A, bool transa, std::vector<py::handle> B, bool transb,
-    std::optional<std::vector<at::Tensor>> D, DType D_type, std::vector<int64_t> m_splits,
+    std::optional<std::vector<at::Tensor>> D, DType D_type, at::Tensor m_splits,
     std::vector<at::Tensor> bias, DType bias_type, bool single_output,
     std::vector<at::Tensor> pre_gelu_out, bool grad, std::vector<at::Tensor> workspace,
     size_t workspaceSize, bool accumulate, bool use_split_accumulator, int math_sm_count);
+
+                        
+std::optional<std::vector<at::Tensor>> te_general_device_initiated_grouped_gemm(
+    std::vector<py::handle> A, bool transa, std::vector<py::handle> B, bool transb,
+    std::optional<std::vector<at::Tensor>> D, DType D_type, at::Tensor m_splits,
+    std::vector<at::Tensor> bias, DType bias_type, bool single_output,
+    std::vector<at::Tensor> pre_gelu_out, bool grad, bool wgrad, std::vector<at::Tensor> workspace,
+    size_t workspaceSize, bool accumulate, std::optional<at::Tensor> accumulate_mask, bool use_split_accumulator, int math_sm_count);
 
 /***************************************************************************************************
  * Transpose

--- a/transformer_engine/pytorch/csrc/extensions/gemm.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/gemm.cpp
@@ -392,7 +392,7 @@ void te_atomic_gemm(at::Tensor A, at::Tensor A_scale_inverse, DType A_type,
 
 std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
     std::vector<py::handle> A, bool transa, std::vector<py::handle> B, bool transb,
-    std::optional<std::vector<at::Tensor>> D, DType D_type, std::vector<int64_t> m_splits,
+    std::optional<std::vector<at::Tensor>> D, DType D_type, at::Tensor m_splits,
     std::vector<at::Tensor> bias, DType bias_type, bool single_output,
     std::vector<at::Tensor> pre_gelu_out, bool grad, std::vector<at::Tensor> workspace,
     size_t workspaceSize, bool accumulate, bool use_split_accumulator, int math_sm_count) {
@@ -549,6 +549,209 @@ std::optional<std::vector<at::Tensor>> te_general_grouped_gemm(
                            transa, transb, grad, te_workspace_vector.data(), accumulate,
                            use_split_accumulator, math_sm_count, at::cuda::getCurrentCUDAStream());
   });
+  return bias;
+}
+
+// Index of the next available slot in the pinned host buffer. Concurrency control is not implemented
+// here, as the current execution model is strictly single-threaded. For CUDA Graph, we need to use a
+// pinned host buffer to avoid illegal memory access during H2D copy.
+// To avoid synchronization after H2D copy, each operator instance must use its own host buffer to
+// prevent data races — e.g., one H2D copy may still be running while another operator attempts to
+// reuse and overwrite the same buffer.
+// A global variable is used because the function doesn't know how many instances there are and which
+// instance is calling.
+int pinned_host_buffer_index = 0;
+
+std::optional<std::vector<at::Tensor>> te_general_device_initiated_grouped_gemm(
+    std::vector<py::handle> A, bool transa, std::vector<py::handle> B, bool transb,
+    std::optional<std::vector<at::Tensor>> D, DType D_type, at::Tensor m_splits,
+    std::vector<at::Tensor> bias, DType bias_type, bool single_output,
+    std::vector<at::Tensor> pre_gelu_out, bool grad, bool wgrad, std::vector<at::Tensor> workspace,
+    size_t workspaceSize, bool accumulate, std::optional<at::Tensor> accumulate_mask, bool use_split_accumulator, int math_sm_count) {
+  // printf("===========call te_general_device_initiated_grouped_gemm===========\n");
+  // printf("single_output: %d\n", single_output);
+  // printf("grad: %d, wgrad: %d\n", grad, wgrad);
+  if (D == std::nullopt) {
+    NVTE_ERROR("not implemented, D should be allocated.");
+  }
+
+  const auto none = py::none();
+  // Keep tensors alive during the GEMM.
+  std::vector<TensorWrapper> te_A_wrappers, te_B_wrappers, te_D_wrappers, te_bias_wrappers,
+      te_pre_gelu_out_wrappers, te_workspace_wrappers;
+  std::vector<at::Tensor> D_vectors;
+  std::vector<std::optional<at::Tensor>> swizzled_scale_inverses_list;
+  std::vector<NVTETensor> te_A_vector, te_B_vector, te_D_vector, te_bias_vector, 
+      te_pre_gelu_out_vector, te_workspace_vector;
+
+  bool* accumulate_mask_ptr = accumulate_mask != std::nullopt ? (*accumulate_mask).data_ptr<bool>() : nullptr;
+
+  NVTE_CHECK(m_splits.dtype() == torch::kInt64, "Data type of m_splits should be int64.");
+  NVTE_CHECK(A.size() == 1,
+              "Grouped GEMM input A should not be splited when m_splits is on device.");
+
+  auto te_A = makeTransformerEngineTensor(A[0], none);
+
+  if (!wgrad) {  // fprop or dgrad
+    NVTE_CHECK(!transa,
+                "Not implemented, Grouped GEMM input A should not be transposed for fprop and "
+                "dgrad when when m_splits is on device.");
+    NVTE_CHECK(single_output,
+                "single_output=False is not supported for fprop and dgrad when when m_splits is "
+                "on device.");
+    if (te_A.numel() == 0) {  // skip the GEMM
+      auto te_D = makeTransformerEngineTensor((*D)[0]);
+      if (te_D.numel() != 0) {
+        (*D)[0].zero_();
+      }
+      return bias;
+    }
+
+    te_A_vector.emplace_back(te_A.data());
+    te_A_wrappers.emplace_back(std::move(te_A));
+    const int num_gemms = B.size();
+    for (size_t i = 0; i < num_gemms; i++) {
+      auto te_B = makeTransformerEngineTensor(B[i], none);
+      te_B_vector.emplace_back(te_B.data());
+      te_B_wrappers.emplace_back(std::move(te_B));
+    }
+
+    // Optionally swizzle the scaling factors
+    swizzled_scale_inverses_list.emplace_back(multi_tensor_swizzle_scaling_factors(te_A_wrappers, !transa));
+    swizzled_scale_inverses_list.emplace_back(multi_tensor_swizzle_scaling_factors(te_B_wrappers, transb));
+
+    // Prepare addresses array of input B and scaling factors.
+    // To enable CUDA Graph, we need to use a pinned host buffer to avoid illegal memory access during H2D copy.
+    at::Tensor inputB_and_SF_addrs;
+    if (at::cuda::currentStreamCaptureStatusMayInitCtx() != at::cuda::CaptureStatus::None) {
+      NVTE_CHECK(pinned_host_buffer_index + num_gemms * 2 <= workspace[1].size(0), 
+            "Pinned host buffer out of bounds, please increase the capacity by setting NVTE_CUTLASS_HOST_PINNED_U64_CAPACITY. "
+            "Current buffer size: ", workspace[1].size(0));
+      inputB_and_SF_addrs = workspace[1].narrow(0, pinned_host_buffer_index, num_gemms * 2);
+      pinned_host_buffer_index += num_gemms * 2;
+    } else {
+      // For eager mode, use a temporary tensor to prevent exhausting the global workspace.
+      auto options = at::TensorOptions().dtype(torch::kUInt64).pinned_memory(true);
+      // Utilise torch tensor management to ensure memory is retained until the H2D copy is complete.
+      inputB_and_SF_addrs = at::empty(num_gemms * 2, options); 
+    }
+    int gemm_n;
+    for (size_t i = 0; i < num_gemms; i++) {
+      transformer_engine::Tensor *inputB = convertNVTETensor(te_B_vector[i]);
+      gemm_n = transb ? inputB->flat_first_dim() : inputB->flat_last_dim();
+      if (transb) {
+        NVTE_CHECK(inputB->has_data(), "Input B is missing row-wise usage");
+      } else {
+        NVTE_CHECK(inputB->has_columnwise_data(), "Input B is missing column-wise usage");
+      }
+      inputB_and_SF_addrs[i] = transb ? static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(inputB->data.dptr)) : static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(inputB->columnwise_data.dptr));
+      inputB_and_SF_addrs[num_gemms+i] = transb ? static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(inputB->scale_inv.dptr)) : static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(inputB->columnwise_scale_inv.dptr));
+    }
+    // H2D copy
+    at::Tensor inputB_and_SF_addrs_cuda = inputB_and_SF_addrs.to("cuda", /*non_blocking=*/true);
+
+    auto te_D = makeTransformerEngineTensor((*D)[0]);
+    te_D_vector.emplace_back(te_D.data());
+    te_D_wrappers.emplace_back(std::move(te_D));
+
+    auto wsp = makeTransformerEngineTensor(workspace[0].data_ptr(),
+                                            std::vector<size_t>{workspaceSize}, DType::kByte);
+    te_workspace_vector.emplace_back(wsp.data());
+    te_workspace_wrappers.emplace_back(std::move(wsp));
+
+    NVTE_SCOPED_GIL_RELEASE({
+      nvte_device_cutlass_grouped_gemm(
+          te_A_vector.data(), reinterpret_cast<const void**>(inputB_and_SF_addrs_cuda.data_ptr()), te_D_vector.data(),
+          reinterpret_cast<int64_t*>(m_splits.data_ptr()), gemm_n, te_bias_vector.data(),
+          te_pre_gelu_out_vector.data(), te_B_vector.size(), transa, transb, grad,
+          te_workspace_vector.data(), workspaceSize, use_split_accumulator,
+          math_sm_count, at::cuda::getCurrentCUDAStream());
+    });
+  } else {  // wgrad
+    NVTE_CHECK(transa,
+                "Not implemented, Grouped GEMM input A should be transposed for wgrad when "
+                "m_splits is on device.");
+    NVTE_CHECK(!transb,
+                "Not implemented, Grouped GEMM input B should not be transposed for wgrad when "
+                "m_splits is on device.");
+    NVTE_CHECK(
+        B.size() == 1,
+        "Grouped GEMM input B should not be splited for wgrad when m_splits is on device.");
+    NVTE_CHECK(D != std::nullopt,
+                "Grouped GEMM output D should be allocated for wgrad when m_splits is on device.");
+    // TODO: handle single_output case
+    NVTE_CHECK(
+        !single_output,
+        "Not implemented, single output is not supported for wgrad when m_splits is on device.");
+
+    auto te_B = makeTransformerEngineTensor(B[0], none);
+
+    if (te_A.numel() == 0 || te_B.numel() == 0) {  // skip the GEMM
+      for (size_t i = 0; i < (*D).size(); i++) {
+        if (!accumulate || (accumulate_mask_ptr && !accumulate_mask_ptr[i])) {
+          auto te_D = makeTransformerEngineTensor((*D)[i]);
+          if (te_D.numel() != 0) {
+            (*D)[i].zero_();
+          }
+        }
+      }
+      return bias;
+    }
+
+    te_A_vector.emplace_back(te_A.data());
+    te_A_wrappers.emplace_back(std::move(te_A));
+    te_B_vector.emplace_back(te_B.data());
+    te_B_wrappers.emplace_back(std::move(te_B));
+    // Optionally swizzle the scaling factors
+    swizzled_scale_inverses_list.emplace_back(multi_tensor_swizzle_scaling_factors(te_B_wrappers, transb));
+    swizzled_scale_inverses_list.emplace_back(multi_tensor_swizzle_scaling_factors(te_A_wrappers, !transa));
+
+    const int num_gemms = (*D).size();
+    for (size_t i = 0; i < num_gemms; i++) {
+      auto te_D = makeTransformerEngineTensor((*D)[i]);
+      te_D_vector.emplace_back(te_D.data());
+      te_D_wrappers.emplace_back(std::move(te_D));
+    }
+
+    // Prepare addresses array of output D.
+    // To enable CUDA Graph, we need to use a pinned host buffer to avoid illegal memory access during H2D copy.
+    at::Tensor outputD_addrs;
+    if (at::cuda::currentStreamCaptureStatusMayInitCtx() != at::cuda::CaptureStatus::None) {
+      NVTE_CHECK(pinned_host_buffer_index + num_gemms <= workspace[1].size(0), 
+            "Pinned host buffer out of bounds, please increase the capacity by setting NVTE_CUTLASS_HOST_PINNED_U64_CAPACITY. "
+            "Current buffer size: ", workspace[1].size(0));
+      outputD_addrs = workspace[1].narrow(0, pinned_host_buffer_index, num_gemms);
+      pinned_host_buffer_index += num_gemms;
+    } else {
+      // For eager mode, use a temporary tensor to prevent exhausting the global workspace.
+      auto options = at::TensorOptions().dtype(torch::kUInt64).pinned_memory(true);
+      // Utilise torch tensor management to ensure memory is retained until the H2D copy is complete.
+      outputD_addrs = at::empty(num_gemms, options);
+    }
+
+    for (size_t i = 0; i < num_gemms; i++) {
+      transformer_engine::Tensor *outputD = convertNVTETensor(te_D_vector[i]);
+      NVTE_CHECK(outputD->has_data(), "Input D is missing row-wise usage");
+      outputD_addrs[i] = static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(outputD->data.dptr));
+    }
+    // H2D copy
+    at::Tensor outputD_addrs_cuda = outputD_addrs.to("cuda", /*non_blocking=*/true);
+
+    auto wsp = makeTransformerEngineTensor(workspace[0].data_ptr(),
+                                            std::vector<size_t>{workspaceSize}, DType::kByte);
+    te_workspace_vector.emplace_back(wsp.data());
+    te_workspace_wrappers.emplace_back(std::move(wsp));
+
+    NVTE_SCOPED_GIL_RELEASE({
+      nvte_device_cutlass_grouped_gemm_wgrad(
+          te_A_vector.data(), te_B_vector.data(), reinterpret_cast<void**>(outputD_addrs_cuda.data_ptr()), D_type,
+          reinterpret_cast<int64_t*>(m_splits.data_ptr()), te_bias_vector.data(),
+          te_pre_gelu_out_vector.data(), te_D_vector.size(), transa, transb,
+          te_workspace_vector.data(), workspaceSize, accumulate, accumulate_mask_ptr, use_split_accumulator,
+          math_sm_count, at::cuda::getCurrentCUDAStream());
+    });
+  }
+  
   return bias;
 }
 

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -251,6 +251,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("quantizer_list"));
   m.def("te_general_grouped_gemm", &transformer_engine::pytorch::te_general_grouped_gemm,
         "Grouped GEMM");
+  m.def("te_general_device_initiated_grouped_gemm", &transformer_engine::pytorch::te_general_device_initiated_grouped_gemm,
+        "Device-initiated Grouped GEMM");
   m.def("fp8_transpose", &transformer_engine::pytorch::fp8_transpose, "Transpose with FP8 I/O",
         py::arg("input"), py::arg("dtype"), py::kw_only(), py::arg("out"),
         py::call_guard<py::gil_scoped_release>());

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -185,13 +185,13 @@ class _GroupedLinear(torch.autograd.Function):
 
         # Perform GEMM
         _ = general_grouped_gemm(
-            weights_fp8 if not m_splits_on_device else inputmats,
-            inputmats if not m_splits_on_device else weights_fp8,
+            weights_fp8,
+            inputmats,
             [out],
             activation_dtype,
             get_general_grouped_gemm_workspace(m_splits_on_device),
             single_output=True,
-            layout="TN" if not m_splits_on_device else "NT",
+            layout="TN",
             m_splits=m_splits,
             m_splits_on_device=m_splits_on_device,
             bias=biases,
@@ -402,8 +402,8 @@ class _GroupedLinear(torch.autograd.Function):
                             columnwise_usage=quantizer.columnwise_usage,
                         )
                 general_grouped_gemm(
-                    weights if not ctx.m_splits_on_device else grad_output,
-                    grad_output if not ctx.m_splits_on_device else weights,
+                    weights,
+                    grad_output,
                     [dgrad],
                     ctx.activation_dtype,
                     get_general_grouped_gemm_workspace(ctx.m_splits_on_device),
@@ -466,7 +466,7 @@ class _GroupedLinear(torch.autograd.Function):
                     general_grouped_gemm,
                     out_dtype=ctx.activation_dtype,
                     workspaces=get_general_grouped_gemm_workspace(ctx.m_splits_on_device),
-                    layout="NT" if not ctx.m_splits_on_device else "TN",
+                    layout="NT",
                     grad=True,
                     wgrad=True, # For cutlass backend
                     m_splits=ctx.m_splits,


### PR DESCRIPTION
# Description

Introduces a CUTLASS-based grouped GEMM implementation that reads m_splits directly on the device. 

This optimization removes the need for device-to-host data transfers and synchronization in MCore, while allowing the number of quantization kernels to be reduced to one. 

The kernel is fully compatible with CUDA Graphs.

Key points:
•	Does not break the existing API. The operator now accepts m_splits as either a torch.Tensor (on CPU or GPU) or a Python list.
•	Reduces CPU overhead, especially for large expert counts, by using a single quantization kernel instead of one per GEMM.
•	Currently supports only MXFP8.


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change `m_splits` from `List[int]` to `torch.Tensor`, but can still run correctly with `List[int]` (will be internally converted to a tensor)
- Add `te_general_device_initiated_grouped_gemm`

## Unit Test
`pytest -v -s tests/pytorch/test_numerics.py::test_grouped_linear_accuracy_cutlass_device`

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
