### PR TITLE
[JAX] Default to fused attention in JAX DPA

### DIFF
--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -406,7 +406,7 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
         Users can select between these two backends via the :attr:`NVTE_FUSED_ATTN` environment
         variable:
 
-        * Set :attr:`NVTE_FUSED_ATTN=0` for unfused attention (default).
+        * Set :attr:`NVTE_FUSED_ATTN=0` for unfused attention.
         * Set :attr:`NVTE_FUSED_ATTN=1` for fused attention (default). If the required cuDNN fused
           attention kernel is not available on the system, a warning will be issued, and the module
           will automatically fall back to the unfused backend.


### PR DESCRIPTION
# Description

In the absence of NVTE_FUSED_ATTN, DPA would default to Unfused attention. This conservative approach was taken when FusedAttn was first introduced earlier last year as it was experimental back then (PR  653). 
Switching to making FusedAttn the default instead


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Fused attention made default in JAX DPA
Documentation updated for the same

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
