### PR TITLE
Set RPATH for cuda libraries from python package

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -79,6 +79,9 @@ if(NOT arch_120_index EQUAL -1)
   endif()
 endif()
 
+# Python
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
 # cuDNN frontend API
 set(CUDNN_FRONTEND_INCLUDE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/cudnn-frontend/include")
@@ -90,13 +93,14 @@ if(NOT EXISTS "${CUDNN_FRONTEND_INCLUDE_DIR}")
 endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/cudnn-frontend/cmake/cuDNN.cmake)
 
+if(cudnn_LIBRARY MATCHES "nvidia/cudnn")
+  set(CMAKE_INSTALL_RPATH "\${ORIGIN}/../nvidia/cudnn/lib:\${ORIGIN}/../nvidia/cublas/lib:\${ORIGIN}/../nvidia/cuda_runtime/lib")
+endif()
+
 set(CUTLASS_INCLUDE_DIR
   "${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/cutlass/include")
 set(CUTLASS_TOOLS_INCLUDE_DIR
   "${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/cutlass/tools/util/include")
-
-# Python
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 
 # Configure Transformer Engine library
 include_directories(${PROJECT_SOURCE_DIR}/..)


### PR DESCRIPTION
# Description

Fixes crashs for binary linked with both libtorch and libtransformer_engine running with `nsys profile` .
It was caused by wrong libcudnn.so loaded when system package like `libcudnn9-cuda-12` is installed current Transfomer Engine use it instead of `nvidia-cudnn-cu12` pypi package.
Though by setting `export LD_LIBRARY_PATH=$(pip show nvidia-cudnn-cu12 | awk '/Location:/ { print $2 }')/nvidia/cudnn/lib` maybe a workaround.

May also need https://github.com/NVIDIA/cudnn-frontend/pull/180

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Finds Python before including cuDNN.cmake from cudnn-frontend
- Sets `CMAKE_INSTALL_RPATH` like pytorch does: https://github.com/pytorch/pytorch/blob/e2c683458476be48569098d74cb9fd41315376e9/.ci/manywheel/build_cuda.sh#L248-L260

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
