### PR TITLE
Enables specified cp rank slicing

### DIFF
--- a/tests/pytorch/attention/test_cp_utils.py
+++ b/tests/pytorch/attention/test_cp_utils.py
@@ -519,7 +519,7 @@ class TestContextParallelUtils(unittest.TestCase):
         # Test rank 0
         self._mock_distributed_env(cp_size=2, cp_rank=0)
         input_ids_r0, labels_r0, pos_ids_r0 = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=2, cp_rank=0
         )
 
         # Rank 0 should get indices [0,1] and [6,7]
@@ -534,7 +534,7 @@ class TestContextParallelUtils(unittest.TestCase):
         # Test rank 1
         self._mock_distributed_env(cp_size=2, cp_rank=1)
         input_ids_r1, labels_r1, pos_ids_r1 = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=2, cp_rank=1
         )
 
         # Rank 1 should get indices [2,3] and [4,5]
@@ -561,7 +561,7 @@ class TestContextParallelUtils(unittest.TestCase):
         # Test rank 0
         self._mock_distributed_env(cp_size=2, cp_rank=0)
         input_ids_r0, labels_r0, pos_ids_r0 = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=2, cp_rank=0
         )
 
         # For each sequence, rank 0 gets first and last slices
@@ -584,7 +584,7 @@ class TestContextParallelUtils(unittest.TestCase):
 
         self._mock_distributed_env(cp_size=1, cp_rank=0)
         input_ids_result, labels_result, pos_ids_result = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=1, cp_rank=0
         )
 
         # With CP size = 1, should return original tensors
@@ -608,7 +608,7 @@ class TestContextParallelUtils(unittest.TestCase):
 
         self._mock_distributed_env(cp_size=2, cp_rank=0)
         input_ids_r0, labels_r0, pos_ids_r0 = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=2, cp_rank=0
         )
 
         # Should get indices [0,1] and [6,7] along dimension 0
@@ -635,7 +635,7 @@ class TestContextParallelUtils(unittest.TestCase):
         # Test rank 0
         self._mock_distributed_env(cp_size=2, cp_rank=0)
         input_ids_r0, labels_r0, pos_ids_r0 = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=2, cp_rank=0
         )
 
         # Rank 0 should get indices [0,1] and [6,7]
@@ -650,7 +650,7 @@ class TestContextParallelUtils(unittest.TestCase):
         # Test rank 1
         self._mock_distributed_env(cp_size=2, cp_rank=1)
         input_ids_r1, labels_r1, pos_ids_r1 = get_batch_on_this_cp_rank(
-            cu_seqlens, input_ids, labels, position_ids
+            cu_seqlens, input_ids, labels, position_ids, cp_size=2, cp_rank=1
         )
 
         # Rank 1 should get indices [2,3] and [4,5]


### PR DESCRIPTION
# Description

This MR enables one to specify the `cp_rank` to `get_batch_on_this_cp_rank` which lets one grab the specific CP shard from a FULL tensor for the specific CP rank.

For example, let's say that I have the following data
```
data = [1, 2, 3, 4, 5, 6, 7, 8]
```
And if I have `cp_size=2` then I would expect to have two shards
```
shard1 = [1, 2, 7, 8]
shard2 = [3, 4, 5, 6]
```
This function, lets me call `get_batch_on_this_cp_rank` and specifify which shard I want data for by specifying the `cp_rank`.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Adds the `cp_rank` Optional argument to `get_batch_on_this_cp_rank`.
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
