### PR TITLE
[PyTorch] Change arguments order in triton kernels to make jax-triton work

### DIFF
--- a/transformer_engine/common/triton/permutation.py
+++ b/transformer_engine/common/triton/permutation.py
@@ -156,12 +156,11 @@ def _row_id_map_pass_2_kernel(
 def _row_id_map_pass_3_kernel(
     # pointers
     row_id_map_ptr,
-    # sizes
-    num_experts,
     # strides
     stride_row_id_map_token,
     stride_row_id_map_expert,
     # metas
+    num_experts: tl.constexpr,
     LOAD_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)

--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -110,9 +110,9 @@ def make_row_id_map(
     grid = (num_tokens,)
     _row_id_map_pass_3_kernel[grid](
         row_id_map,
-        num_experts,
         row_id_map.stride(0),
         row_id_map.stride(1),
+        num_experts,
         triton.next_power_of_2(num_experts),
     )
     return row_id_map


### PR DESCRIPTION
# Description

Jax-triton needs to have a specific order of arguments for it to work. Specifically, output pointers need to be at the end of the list of arguments, but before all tl.constexpr. This PR changes this order in the common triton kernels and make sure the Pytorch wrappers still work. A different PR will be send out for the Jax side implementation

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Change order of arguments in common triton kernels
- Change order of input passed into pytorch wrappers to match the triton kernels

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes