### PR TITLE
[JAX] Better error message when Q, K, V are sharded differently

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -708,13 +708,13 @@ class TestMismatchingQKVSharding:
         kv_segment_ids_spec,
     ):
         query = jax.random.uniform(
-            jax.random.PRNGKey(0), (batch_size, num_heads, seq_len, head_dim), dtype=jnp.bfloat16
+            jax.random.PRNGKey(0), (batch_size, seq_len, num_heads, head_dim), dtype=jnp.bfloat16
         )
         key = jax.random.uniform(
-            jax.random.PRNGKey(1), (batch_size, num_heads, seq_len, head_dim), dtype=jnp.bfloat16
+            jax.random.PRNGKey(1), (batch_size, seq_len, num_heads, head_dim), dtype=jnp.bfloat16
         )
         value = jax.random.uniform(
-            jax.random.PRNGKey(2), (batch_size, num_heads, seq_len, head_dim), dtype=jnp.bfloat16
+            jax.random.PRNGKey(2), (batch_size, seq_len, num_heads, head_dim), dtype=jnp.bfloat16
         )
         q_segment_ids = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
         kv_segment_ids = jnp.ones((batch_size, seq_len), dtype=jnp.int32)
@@ -760,11 +760,11 @@ class TestMismatchingQKVSharding:
 
         return dpa_layer.apply(
             {},
-            query.swapaxes(1, 2).astype(jax.numpy.bfloat16),
-            key.swapaxes(1, 2).astype(jax.numpy.bfloat16),
-            value.swapaxes(1, 2).astype(jax.numpy.bfloat16),
+            query.astype(jax.numpy.bfloat16),
+            key.astype(jax.numpy.bfloat16),
+            value.astype(jax.numpy.bfloat16),
             segment_ids,
-        ).swapaxes(1, 2)
+        )
 
     def _impl(
         self,

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -690,6 +690,10 @@ class TestMismatchingQKVSharding:
                 "fsdp",
                 "context",
             ),
+            axis_types=(
+                jax.sharding.AxisType.Auto,
+                jax.sharding.AxisType.Auto,
+            ),
         )
         with global_shard_guard(mesh_resource), mesh:
             yield mesh, mesh_resource

--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -687,6 +687,16 @@ class FusedAttnFwdPrimitive(BasePrimitive):
         arg_shardings[-2] = arg_shardings[-4]
         arg_shardings = tuple(arg_shardings)
         out_shardings = (out_sharding, softmax_aux_sharding, rng_state_sharding)
+
+        if config.qkv_layout.is_separate():
+            q_spec = get_padded_spec(arg_infos[0])
+            k_spec = get_padded_spec(arg_infos[1])
+            v_spec = get_padded_spec(arg_infos[2])
+            assert q_spec == k_spec == v_spec, (
+                f"Q, K, and V sharding specs must be identical but received {q_spec=}, {k_spec=},"
+                f" {v_spec=}"
+            )
+
         impl = partial(FusedAttnFwdPrimitive.impl, config=config)
         return mesh, impl, out_shardings, arg_shardings
 


### PR DESCRIPTION
# Description

When using TE/JAX's DPA and Q, K, or V are sharded differently, the downstream error message only occurs in the inner abstract and reports a shape issue.

For example, when sharded along the batch dim, the previous error message was:
```
AssertionError: Mismatched qkv batch size for q_batch_shape: [1], k_batch_shape: [1] and v_batch_shape: [4]
```
The new error message is:
```
AssertionError: Q, K, and V sharding specs must be identical but received q_spec=PartitionSpec('fsdp', None, None, None), k_spec=PartitionSpec('fsdp', None, None, None), v_spec=PartitionSpec(None, None, None, None)
```


The newly added test `test_mismatching_qkv_sharding_separate_qkv` only takes ~1 second.
```
================================================================================
TEST RUNTIME SUMMARY (grouped by function)
================================================================================
test                                                         |  12x |    2.14s | avg:   0.18s
test_context_parallel_allgather_attn                         | 320x | 1134.35s | avg:   3.54s
test_context_parallel_allgather_attn_shardy                  |  40x |  155.82s | avg:   3.90s
test_context_parallel_ring_attn                              | 1280x | 1753.03s | avg:   1.37s
test_context_parallel_ring_attn_shardy                       |  40x |   50.99s | avg:   1.27s
test_cross_attn                                              |  18x |   30.76s | avg:   1.71s
test_mismatching_qkv_sharding_separate_qkv                   |   1x |    1.16s | avg:   1.16s
test_self_attn                                               |  54x |  123.97s | avg:   2.30s
test_self_attn_shardy                                        |  18x |   16.04s | avg:   0.89s
================================================================================
TOTAL RUNTIME                                                |      | 3268.24s |
================================================================================
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add assertion that Q, K, and V shardings match when `qkv_layout.is_separate()`
- Add test to run with mismatched sharding (Q and K are sharded fsdp in batch dim, V is replicated in batch dim) and check that the new error message is reported as expected

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
