### PR TITLE
[JAX] Unset NVTE_FUSED_RING_ATTENTION_USE_SCAN by default

### DIFF
--- a/transformer_engine/jax/cpp_extensions/attention.py
+++ b/transformer_engine/jax/cpp_extensions/attention.py
@@ -2396,7 +2396,7 @@ class _FusedAttnCPWithP2PHelper:
                 f"{header} only supports VANILLA_SOFTMAX, got: {self.config.softmax_type}"
             )
 
-        #TODO(KshitijLakhani): Flip the condition to check for disabled scan loop and warn
+        # TODO(KshitijLakhani): Flip the condition to check for disabled scan loop and warn
         # against using unrolled loops once the scan issue is resolved.
         # We want to discourage the use of scan loop as additional kv permute op observed.
         # The scan loop flavor will be supported but not the prefered implementation until


### PR DESCRIPTION
# Description
Unset NVTE_FUSED_RING_ATTENTION_USE_SCAN by default to not use scan loop when using CP P2P attn primitives

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

An extra permute op was observed when using CP Ring attn primitives with env var `NVTE_FUSED_RING_ATTENTION_USE_SCAN=1` (default) - this is counter-intuitive to what is expected when using fori_loop/scan under the hood, however, until a long term solution is found for scan perf, unsetting this env var ensures that the scan loop is not used (which does not really seem to affect compile time substantially and hence safe to go ahead with)

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
