### PR TITLE
Remove test skip logic for GEMM-AR tests

### DIFF
--- a/tests/cpp_distributed/test_comm_gemm.cu
+++ b/tests/cpp_distributed/test_comm_gemm.cu
@@ -63,12 +63,6 @@ int main(int argc, char* argv[]) {
   return ret;
 }
 
-bool IsMulticastSupported(int device_id) {
-  int supported = 0;
-  CHECK_CU(cuDeviceGetAttribute(&supported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, device_id));
-  return supported;
-}
-
 int GetDeviceComputeCapability(int device_id) {
   int major{};
   int minor{};
@@ -369,13 +363,6 @@ struct GemmAr : public CommGemmFixure {
     nvte_gemm_all_reduce(ctx_, m, n, k, a, b, d, bias, pre_act_out, transa, transb, grad,
                          accumulate, comm_sm_count, stream, kNVTECommGemmAlgoDefault);
   }
-
-#if CUBLASMP_VERSION < 600
-  void SetUp() override {
-    if (!IsMulticastSupported(rank_))
-      GTEST_SKIP() << "Multicast is not supported on device " << rank_;
-  }
-#endif
 };
 
 TEST_P(AgGemm, Gemm) {


### PR DESCRIPTION
# Description

cuBLASMp 0.6 and later uses NCCL fallback for GEMM+AR if NVL / multicast is not available.
This change removes test skip logic.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Don't skip tests, even if multicast is not supported

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
