### PR TITLE
Reset cache logic of weight workspace for NVFP4TensorStorage

### DIFF
--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -45,6 +45,7 @@ from ..tensor.mxfp8_tensor import MXFP8Quantizer
 from ..tensor.float8_blockwise_tensor import Float8BlockQuantizer
 from ..tensor.storage.float8_tensor_storage import Float8TensorStorage
 from ..tensor.storage.mxfp8_tensor_storage import MXFP8TensorStorage
+from ..tensor.storage.nvfp4_tensor_storage import NVFP4TensorStorage
 from ..utils import (
     is_non_tn_fp8_gemm_supported,
     torch_get_autocast_gpu_dtype,
@@ -1384,6 +1385,11 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 ):
                     reset_cache = True
             elif isinstance(out, MXFP8TensorStorage):
+                if quantizer.rowwise_usage and out._rowwise_data is None:
+                    reset_cache = True
+                elif quantizer.columnwise_usage and out._columnwise_data is None:
+                    reset_cache = True
+            elif isinstance(out, NVFP4TensorStorage):
                 if quantizer.rowwise_usage and out._rowwise_data is None:
                     reset_cache = True
                 elif quantizer.columnwise_usage and out._columnwise_data is None:


### PR DESCRIPTION
# Description

This PR fixes NVFP4 weight quantizer to check columwise data in recomputation phase.

```console
Traceback (most recent call last):
  File "repos/megatron-lm//pretrain_gpt.py", line 263, in <module>
    pretrain(
  File "repos/megatron-lm/megatron/training/training.py", line 835, in pretrain
    iteration, num_floating_point_operations_so_far = train(
                                                      ^^^^^^
  File "repos/megatron-lm/megatron/training/training.py", line 2442, in train
    ) = train_step(
        ^^^^^^^^^^^
  File "repos/megatron-lm/megatron/training/training.py", line 1382, in train_step
    losses_reduced = forward_backward_func(
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "repos/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 2240, in forward_backward_pipelining_without_interleaving
    input_tensor_grad = backward_step(
                        ^^^^^^^^^^^^^^
  File "repos/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 471, in backward_step
    custom_backward(output_tensor[0], output_tensor_grad[0])
  File "repos/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 173, in custom_backward
    Variable._execution_engine.run_backward(
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 307, in apply
    return user_fn(self, *args)
           ^^^^^^^^^^^^^^^^^^^^
  File "repos/megatron-lm/megatron/core/tensor_parallel/random.py", line 518, in backward
    torch.autograd.backward(outputs, args)
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/__init__.py", line 353, in backward
    _engine_run_backward(
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/graph.py", line 824, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 307, in apply
    return user_fn(self, *args)
           ^^^^^^^^^^^^^^^^^^^^
  File "repos/transformerengine/transformer_engine/pytorch/module/layernorm_linear.py", line 710, in backward
    weight.update_usage(columnwise_usage=True)
  File "repos/transformerengine/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py", line 304, in update_usage
    raise RuntimeError(
RuntimeError: Requested column-wise usage, but NVFP4Tensor is missing column-scaled FP8 data
```


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `base.py`: Add cache reset logic for `NVFP4TensorStorage` 

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
