### PR TITLE
[JAX] Handle meshs set with jax.set_mesh

### DIFF
--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -36,6 +36,7 @@ W_FSDP_AXES = "nvte_w_fsdp"
 W_TP_AXES = "nvte_w_tp"
 W_JOINED_AXES = "nvte_w_joined"
 
+
 def _get_mesh():
     # Handle Mesh's set via `with mesh:`
     mesh = _PXLA_THREAD_RESOURCES.env.physical_mesh
@@ -43,6 +44,7 @@ def _get_mesh():
         return mesh
     # Handle Mesh's set via `jax.set_mesh(mesh)`
     return jax.sharding.get_abstract_mesh()
+
 
 def _get_mesh_info(resource: str, mesh: jax.sharding.Mesh):
     assert resource in mesh.axis_names, f"{resource} is not in the axis_names of Mesh {mesh}."


### PR DESCRIPTION
# Description

Fixes issue that we cannot query jax Mesh info from Meshs set via `jax.set_mesh`

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Check `get_abstract_mesh()` in addition to pxla thread resources when looking for mesh context

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
