### PR TITLE
[PyTorch]Add Casting-Free FP8-Flow-MoE Blockwise Optimizations

### DIFF
--- a/transformer_engine/pytorch/triton/blockwise_scaling_aware_fp8_transpose.py
+++ b/transformer_engine/pytorch/triton/blockwise_scaling_aware_fp8_transpose.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""PyTorch wrapper functions and scaling_aware_fp8_transpose Triton kernels."""
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scaling_aware_fp8_transpose_kernel(
+    # input pointers
+    rowwise_data_ptrs,
+    rowwise_scale_inv_ptrs,
+    columnwise_data_ptrs,
+    columnwise_scale_inv_ptrs,
+    rowwise_scale_inv_t_ptrs,
+    rows_ptr,
+    # sizes
+    cols,
+    rsi_cols,
+    # strides
+    stride_rowwise_data_r,
+    stride_rsi_r,
+    # metas
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_group_index = tl.program_id(0)
+    pid_row = tl.program_id(1)
+    pid_col = tl.program_id(2)
+
+    rows = tl.load(rows_ptr + pid_group_index)
+    nbrows = (rows + BLOCK_SIZE - 1) // BLOCK_SIZE
+    if pid_row >= nbrows:
+        return
+
+    row_base = tl.load(rowwise_data_ptrs + pid_group_index).to(
+        tl.pointer_type(tl.uint8)
+    )
+    rsi_base = tl.load(rowwise_scale_inv_ptrs + pid_group_index).to(
+        tl.pointer_type(tl.float32)
+    )
+    col_base = tl.load(columnwise_data_ptrs + pid_group_index).to(
+        tl.pointer_type(tl.uint8)
+    )
+    csi_base = tl.load(columnwise_scale_inv_ptrs + pid_group_index).to(
+        tl.pointer_type(tl.float32)
+    )
+
+    r_start = pid_row * BLOCK_SIZE
+    c_start = pid_col * BLOCK_SIZE
+    r_offsets = r_start + tl.arange(0, BLOCK_SIZE)
+    c_offsets = c_start + tl.arange(0, BLOCK_SIZE)
+    valid_r = r_offsets < rows
+    valid_c = c_offsets < cols
+    data = tl.load(
+        row_base + (r_offsets[:, None] * stride_rowwise_data_r + c_offsets[None, :]),
+        mask=valid_r[:, None] & valid_c[None, :],
+        other=0,
+    )
+
+    rsi_c_offsets = pid_col + tl.arange(0, 1)
+    valid_rsi_c = rsi_c_offsets < rsi_cols
+    si = tl.load(
+        rsi_base + r_offsets[:, None] * stride_rsi_r + rsi_c_offsets[None, :],
+        mask=valid_r[:, None] & valid_rsi_c[None, :],
+        other=0.0,
+    )
+
+    # Write rowwise_scale_inv.T
+    rst_base = tl.load(rowwise_scale_inv_t_ptrs + pid_group_index).to(
+        tl.pointer_type(tl.float32)
+    )
+    tl.store(
+        rst_base + (rsi_c_offsets[:, None] * rows + r_offsets[None, :]),
+        si.T,
+        mask=valid_rsi_c[:, None] & valid_r[None, :],
+    )
+
+    # For the current block-row (128 rows), take the per-channel max of rowwise_scale_inv
+    # This max value becomes the columnwise scaling factor for this block
+    target_si = tl.max(si, axis=0)
+    tl.store(csi_base + (pid_row * cols + c_offsets), target_si, mask=valid_c)
+
+    # FP8 decode/encode
+    sign = (data >> 7) & 1
+    exp = (data >> 3) & 0xF
+    mant = data & 0x7
+    # log2_t = tl.log2(target_si)
+    # log2_si = tl.log2(si + 1e-30)
+    # kf = log2_t - log2_si
+    # k = tl.cast(tl.floor(kf + 0.5), tl.int32)
+    bits_target = tl.cast(target_si, tl.uint32, bitcast=True)
+    bits_si = tl.cast(si, tl.uint32, bitcast=True)
+    exp_t = ((bits_target & 0x7F800000) >> 23) - 127
+    exp_s = ((bits_si & 0x7F800000) >> 23) - 127
+    k_approx = exp_t[None, :] - exp_s
+    k = tl.cast(k_approx, tl.int32)
+    exp_new = exp - k
+    exp_new = tl.where(exp_new < 1, 0, exp_new)
+    new_data = (sign << 7) | (exp_new << 3) | mant
+    new_data = tl.where(exp == 0, 0, new_data)
+
+    # write columnwise_data (uint8) to [K,M] (c, r)
+    tl.store(
+        col_base + (c_offsets[:, None] * rows + r_offsets[None, :]),
+        new_data.T,
+        mask=valid_c[:, None] & valid_r[None, :],
+    )
+
+
+def blockwise_scaling_aware_fp8_transpose(
+    rowwise_data: torch.Tensor,
+    rowwise_scale_inv: torch.Tensor,
+    m_splits: list[int],
+    block_size: int = 128,
+):
+    """
+    Scaling-aware FP8 transpose that converts row-wise quantized FP8 tensors to a
+    column-wise layout in the FP8 domain.
+
+    The input is split along the M dimension according to ``m_splits``. For each split,
+    the kernel transposes FP8 data from shape ``[m_i, cols]`` to ``[cols, m_i]`` while
+    producing column-wise scaling factors at block-row granularity. The operation is
+    performed without dequantizing to higher precision types.
+
+    Parameters
+    ----------
+    rowwise_data : torch.Tensor
+        Row-wise FP8-encoded data stored as ``uint8`` with shape
+        ``[sum(m_splits), cols]``.
+
+    rowwise_scale_inv : torch.Tensor
+        Row-wise scaling factors associated with ``rowwise_data`` with shape
+        ``[sum(m_splits), rsi_cols]``.
+
+    m_splits : list[int]
+        Sizes of splits along the M dimension. Each entry ``m_i`` defines the number of
+        rows in one group.
+
+    block_size : int, optional
+        Tile size for the blockwise transpose and scaling-aware conversion.
+
+    Returns
+    -------
+    rowwise_data_list : list[torch.Tensor]
+        List of input views split by ``m_splits``, each with shape ``[m_i, cols]`` and
+        dtype matching ``rowwise_data``.
+
+    rowwise_scale_inv_t_list : list[torch.Tensor]
+        List of transposed row-wise inverse scaling tensors, each with shape
+        ``[nbcols, m_i]``, where ``nbcols = ceil(cols / block_size)`` and dtype matching
+        ``rowwise_scale_inv``.
+
+    columnwise_data_list : list[torch.Tensor]
+        List of column-wise FP8-encoded output tensors, each with shape ``[cols, m_i]``
+        and dtype matching ``rowwise_data`` (raw FP8 bits in ``uint8``).
+
+    columnwise_scale_inv_list : list[torch.Tensor]
+        List of column-wise inverse scaling tensors at block-row granularity, each with
+        shape ``[nbrows_i, cols]``, where ``nbrows_i = ceil(m_i / block_size)`` and dtype
+        matching ``rowwise_scale_inv``.
+
+    """
+    assert len(m_splits) > 0, "m_splits can not be zero"
+    device = rowwise_data.device
+    data_dtype = rowwise_data.dtype
+    scale_dtype = rowwise_scale_inv.dtype
+
+    cols = rowwise_data.shape[1]
+    rsi_cols = rowwise_scale_inv.shape[1]
+    # Number of block-rows (along the M dimension) for each tensor,
+    # since each Mi differs, we must take the maximum among them
+    nbrows_list = [(m + block_size - 1) // block_size for m in m_splits]
+    nbcols = (cols + block_size - 1) // block_size
+
+    rowwise_data_list = list(torch.split(rowwise_data, m_splits, dim=0))
+    rowwise_scale_inv_list = list(torch.split(rowwise_scale_inv, m_splits, dim=0))
+    rowwise_scale_inv_t_list = [
+        torch.empty((nbcols, m), dtype=scale_dtype, device=device) for m in m_splits
+    ]
+    columnwise_data_list = [
+        torch.empty((cols, m), dtype=data_dtype, device=device) for m in m_splits
+    ]
+    columnwise_scale_inv_list = [
+        torch.empty((nb, cols), dtype=scale_dtype, device=device) for nb in nbrows_list
+    ]
+
+    rowwise_data_ptrs = torch.as_tensor([t.data_ptr() for t in rowwise_data_list]).to(
+        device=device, non_blocking=True
+    )
+    rowwise_scale_inv_ptrs = torch.as_tensor(
+        [t.data_ptr() for t in rowwise_scale_inv_list]
+    ).to(device=device, non_blocking=True)
+    rowwise_scale_inv_t_ptrs = torch.as_tensor(
+        [t.data_ptr() for t in rowwise_scale_inv_t_list]
+    ).to(device=device, non_blocking=True)
+    columnwise_data_ptrs = torch.as_tensor(
+        [t.data_ptr() for t in columnwise_data_list]
+    ).to(device=device, non_blocking=True)
+    columnwise_scale_inv_ptrs = torch.as_tensor(
+        [t.data_ptr() for t in columnwise_scale_inv_list]
+    ).to(device=device, non_blocking=True)
+
+    rows_t = torch.as_tensor(m_splits, dtype=torch.int32).to(
+        device=device, non_blocking=True
+    )
+
+    grid = (len(m_splits), max(nbrows_list), nbcols)
+    _scaling_aware_fp8_transpose_kernel[grid](
+        rowwise_data_ptrs,
+        rowwise_scale_inv_ptrs,
+        columnwise_data_ptrs,
+        columnwise_scale_inv_ptrs,
+        rowwise_scale_inv_t_ptrs,
+        rows_t,
+        cols,
+        rsi_cols,
+        rowwise_data.stride(0),
+        rowwise_scale_inv.stride(0),
+        BLOCK_SIZE=block_size,
+    )
+
+    return (
+        rowwise_data_list,
+        rowwise_scale_inv_t_list,
+        columnwise_data_list,
+        columnwise_scale_inv_list,
+    )

--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -165,7 +165,7 @@ def permute_with_mask_map(
         alloc((num_out_tokens,), dtype=probs.dtype, device="cuda") if probs is not None else None
     )
     permuted_scale = (
-        torch.empty((num_out_tokens, scale_hidden_dim), dtype=scale.dtype, device="cuda")
+        alloc((num_out_tokens, scale_hidden_dim), dtype=scale.dtype, device="cuda")
         if scale is not None
         else None
     )


### PR DESCRIPTION
# Description

This PR introduces **blockwise, scaling-aware FP8 transpose optimizations** for FP8 MoE that enable a **casting-free, FP8-centric MoE dataflow** in TransformerEngine by eliminating unnecessary cast and re-quantization steps, while maintaining numerical stability in existing FP8 training workflows.

This PR is designed to be used in conjunction with PR https://github.com/NVIDIA/Megatron-LM/pull/2764

Further optimizations are introduced via two additional PRs:
- https://github.com/NVIDIA/Megatron-LM/pull/2763
- https://github.com/NVIDIA/TransformerEngine/pull/1921

### Background / Motivation

The design and theoretical background of this PR are described in the paper:  
[**FP8-Flow-MoE: A Casting-Free FP8 Recipe without Double Quantization Error**](https://arxiv.org/abs/2511.02302)

The follow figure illustrates the optimized MoE dataflow and highlights the key optimization points (marked as ①–⑤).

<img width="5651" height="1574" alt="FP8FLOW-MoE" src="https://github.com/user-attachments/assets/f7dd72e0-a690-48a5-b451-214c3e8234f8" />

#### 1. FP8 Quantization Before Dispatch (DeepEP → GroupedLinear)

Quantization is performed **before DeepEP dispatch**, and **row-wise FP8 tensors are directly fed into GroupedLinear**.

- Keeps `dispatch → permute → expert computation` entirely in FP8
- `Float8BlockwiseQTensor` is propagated with a COMPACT layout (for `_rowwise_scale_inv`) along the `dispatch → permute → GroupedLinear` path, avoiding layout-induced `.T.contiguous()` calls and reducing unnecessary memory copies.

(Shown as **marker ①** in the figure)

#### 2. Scaling-Aware FP8 Transpose for Wgrad

GroupedLinear requires:
- **row-wise FP8** for Fprop/Dgrad
- **column-wise FP8** for Wgrad

To avoid `dequantize → transpose → requantize` , this PR introduces **`scaling_aware_fp8_transpose`**, which:

- Converts row-wise FP8 to column-wise FP8 via exponent manipulation only
- Preserves scale consistency across layouts
- reduce cpu overhead

(Shown as **marker ④** in the figure)

#### 3. Fused Permute + Padding / Unpermute + Unpadding

We fuse two memory movement operators along the MoE path：

- `permute + pad` in the forward pass  
- `unpermute + unpad` in the backward pass  

For details of this optimization, please refer to PR https://github.com/NVIDIA/TransformerEngine/pull/1921

(Shown as **marker ②** in the figure)

#### 4. Fused Activation + Quantization

Activation and FP8 quantization are fused into a single kernel, Produces FP8 outputs directly, while enabling FP8 persistence 

(Shown as **marker ③** in the figure)

#### 5. Add fine-grained recompute `moe_expert`

Because the entire `dispatch → permute → GroupedLinear` path stays in FP8, we enable **fine-grained recomputation at the `moe_expert` level**:

- Saves ~50% peak activation memory and avoids recomputation of the router compared to recomputing the full module `moe` level

(Shown as **marker ⑤** in the figure)

### Performance Results

We evaluate FP8-Flow-MoE on **DeepSeek-V3 (671B)** to validate scalability and robustness under realistic large-scale training conditions.

#### Throughput

Measured throughput (TGS, tokens/GPU/s) under different expert parallelism (EP) on **DeepSeek-V3 (671B)** :

- **vs. BF16**  
  +6% (EP8), +8% (EP16), +16% (EP32)

- **vs. TransformerEngine blockwise FP8 recipe**  
  +3% (EP8), +8% (EP16), up to **+21% (EP32)**

#### Memory Efficiency

With **AC = selective checkpointing** and **recompute-modules = moe_expert**:

- At EP8:
  - ~8 GB lower peak memory vs. BF16
  - ~16.5 GB lower peak memory vs. blockwise FP8

#### Numerical Accuracy

We trained for **>200B tokens**. The loss deviation of FP8-Flow-MoE stays within **0.19%** compared to both BF16 baselines and TransformerEngine blockwise FP8 recipe, with no observed instability or divergence.

### Limitations

- Currently validated on **NVIDIA Hopper architecture** with **blockwise FP8 recipe**

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- **Megatron-LM**: Added fused FP8 kernels for activation + quantization in `fused_bias_swiglu.py` and `fused_weighted_swiglu_quant.py`
- **Megatron-LM**: Integrated FP8 dispatch and expert recomputation support in Megatron-LM `fused_a2a.py`
- **TransformerEngine**: Added support for `Float8BlockwiseQTensor` inputs in `grouped_linear.py`
- **TransformerEngine**: Added `scaling_aware_fp8_transpose` operator in `triton/blockwise_scaling_aware_fp8_transpose.py` 

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
