### PR TITLE
[Pytorch] Enhance bf16 precision optimizer performance with memory buffer

### DIFF
--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from itertools import chain
 from typing import Optional
 import warnings
+import os
 
 import torch
 from torch.distributed._tensor import DTensor


### PR DESCRIPTION
### Problem Description
When using TransformerEngine’s FusedAdam with the low-precision optimizer enabled, there is a per-step performance slowdown of approximately 1–2 seconds.

parameter setings in Megatron:
```shell
--use-precision-aware-optimizer
--exp-avg-dtype bf16
--exp-avg-sq-dtype bf16
```

### Our Solution
We found that when using the BF16 low-precision optimizer, the BF16 states are converted to FP32 during computation.
```python
# Unscaling
unscaled_state = {}
for name in ["exp_avg", "exp_avg_sq", "master_param"]:
    if name in state:
        if name == "master_param" and store_param_remainders:
            unscaled_state[name] = self.state[p][name]
            assert unscaled_state[name].dtype == torch.int16
        else:
            unscaled = self.get_unscaled_state(p, name)
            unscaled_state[name] = unscaled
        if self.name_to_dtype_map[name] != torch.float32:
            unscaled_lists[name].append(unscaled)
            scaled_lists[name].append(state[name])
            state_scales[name].append(self._scales[p][name])
```

This conversion step causes a significant amount of time to be spent on GPU memory allocation by `get_unscaled_state`. This function performs a `.float()` type conversion on each parameter tensor, causing a new GPU memory allocation for every tensor during conversion, which results in significant overhead.

By creating a shared buffer, we reduced the overhead of repeatedly allocating GPU memory during BF16 optimizer computation, thereby improving overall performance. 

```python
def _create_m_v_copy_buffer(self):
    # Get max m, v length to create buffer
    max_m_v_len = 0
    for group in self.param_groups:
        if len(group["params"]) == 0:
            continue

        m_v_len = 0
        for p in group["params"]:
            m_v_len = p.numel()
            if m_v_len > max_m_v_len:
                max_m_v_len = m_v_len

    device = torch.device("cuda")
    m_buffer = torch.zeros(max_m_v_len, dtype=torch.float32, device=device)
    v_buffer = torch.zeros(max_m_v_len, dtype=torch.float32, device=device)
    return m_buffer, v_buffer

def _bf16_to_fp32_with_buffer(self, param, buffer):
    numel = param.numel()
    buf_view = buffer[:numel].view(param.shape)
    buf_view.copy_(param.float())
    return buf_view

def _from_buffer_fp32_to_bf16(self, param, buffer):
    numel = param.numel()
    buf_view = buffer[:numel].view(param.shape)
    param.copy_(buf_view.bfloat16())
```

This buffer is allocated only temporarily during the optimizer `step`. To minimize GPU memory usage, we iterate over all parameters to find the largest parameter tensor and allocate a single GPU buffer based on its size.

On the one hand, we modified the loop logic inside step; on the other hand, to avoid affecting other optimizer functionalities, we introduced a separate `step_with_buffer_for_bf16_m_v` function based on the two considerations.

### Experiment
On H-series GPUs, the total optimizer time was reduced from 1.34s to 358 ms in real dsv3 Scenario.

before change:
<img width="934" height="130" alt="original-bf16-opt" src="https://github.com/user-attachments/assets/ddbad326-d321-4783-ae60-ed58bf5dd18c" />
after change:
<img width="644" height="94" alt="new-bf16-opt" src="https://github.com/user-attachments/assets/db1c4475-065d-4194-bd5f-442593edec1c" />