### PR TITLE
[Common] Fix long compile time in padding.cu on arch 75

### DIFF
--- a/transformer_engine/common/util/padding.cu
+++ b/transformer_engine/common/util/padding.cu
@@ -101,7 +101,7 @@ __global__ void __launch_bounds__(threads_per_block) multi_padding_kernel(MultiP
       if (row < num_rows) {
         for (int j2 = 0; j2 < nvec; ++j2) {
           if (col + j2 < row_length) {
-            local_input.data.elt[j2] = input[static_cast<size_t>(row)*row_length + col + j2];
+            local_input.data.elt[j2] = input[static_cast<size_t>(row) * row_length + col + j2];
           }
         }
       }
@@ -112,14 +112,14 @@ __global__ void __launch_bounds__(threads_per_block) multi_padding_kernel(MultiP
       if (row < num_rows) {
         for (int j2 = 0; j2 < nvec; ++j2) {
           if (col + j2 < row_length) {
-            output[static_cast<size_t>(row)*row_length + col + j2] = local_output.data.elt[j2];
+            output[static_cast<size_t>(row) * row_length + col + j2] = local_output.data.elt[j2];
           }
         }
       } else if (row < padded_num_rows) {
         // padding
         for (int j2 = 0; j2 < nvec; ++j2) {
           if (col + j2 < row_length) {
-            output[static_cast<size_t>(row)*row_length + col + j2] = local_zero;
+            output[static_cast<size_t>(row) * row_length + col + j2] = local_zero;
           }
         }
       }
@@ -185,7 +185,7 @@ __global__ void __launch_bounds__(threads_per_block) multi_unpadding_kernel(Mult
       if (row < num_rows) {
         for (int j2 = 0; j2 < nvec; ++j2) {
           if (col + j2 < row_length) {
-            local_input.data.elt[j2] = input[static_cast<size_t>(row)*row_length + col + j2];
+            local_input.data.elt[j2] = input[static_cast<size_t>(row) * row_length + col + j2];
           }
         }
       }
@@ -196,7 +196,7 @@ __global__ void __launch_bounds__(threads_per_block) multi_unpadding_kernel(Mult
       if (row < num_rows) {
         for (int j2 = 0; j2 < nvec; ++j2) {
           if (col + j2 < row_length) {
-            output[static_cast<size_t>(row)*row_length + col + j2] = local_output.data.elt[j2];
+            output[static_cast<size_t>(row) * row_length + col + j2] = local_output.data.elt[j2];
           }
         }
       }


### PR DESCRIPTION
# Description

After PR #2548 we observe very long compile times in `padding.cu` for arch 75, >20+mins where previously it only took ~30seconds to compile.

To temporarily work around this issue, we are moving the scope of row_offset inward but keeping the cast to `size_t`

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Move scope of static_cast row offset inward to usage to work around long compilation time issue

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
