### PR TITLE
[JAX] Add assertion to ffi registration check to ensure JAX FFI extensions were loaded correctly

### DIFF
--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -224,7 +224,9 @@ for _name, _value in transformer_engine_jax.registrations().items():
     ffi.register_ffi_target(_name, _value, platform="CUDA")
     _registered_at_least_one_primitive = True
 
-assert _registered_at_least_one_primitive, "No JAX primitives were registered from the C++ extension! This likely indicates an installation issue with Transformer Engine JAX. Please ensure you are using `--no-build-isolation` when installing TE/JAX. This applies to `pip install --no-build-isolation <TE_DIR_OR_WHEEL>`. However, if you are building TE wheels yourself, for example `uv build --wheel --no-build-isolation -v` and then `uv pip install --no-build-isolation <TE_WHEEL_PATH>`, you must also use `--no-build-isolation` during the wheel build. If you do not use `--no-build-isolation`, the TE JAX C++ extension will not be built into the wheel properly, leading to this error during runtime."  # noqa: E501
+assert (
+    _registered_at_least_one_primitive
+), "No JAX primitives were registered from the C++ extension! This likely indicates an installation issue with Transformer Engine JAX. Please ensure you are using `--no-build-isolation` when installing TE/JAX. This applies to `pip install --no-build-isolation <TE_DIR_OR_WHEEL>`. However, if you are building TE wheels yourself, for example `uv build --wheel --no-build-isolation -v` and then `uv pip install --no-build-isolation <TE_WHEEL_PATH>`, you must also use `--no-build-isolation` during the wheel build. If you do not use `--no-build-isolation`, the TE JAX C++ extension will not be built into the wheel properly, leading to this error during runtime."  # noqa: E501
 
 
 def manage_primitives(enable_names=None, disable_names=None, disable_all_first=False):


### PR DESCRIPTION
# Description

Helps give clarity to some common TE/JAX installation issues such as not using `--no-build-isolation`, which results in TE/JAX being built against the wrong JAX version and failing to load FFI extensions.

For example, the following error can occur and be unclear how to solve to users
```
jaxlib._jax.XlaRuntimeError: UNIMPLEMENTED: No registered implementation for custom call to te_fused_attn_forward_ffi for platform CUDA
```

This change detects this issue pre-emptively and issues a clearer error message with steps on how to properly install TE.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Check if we failed to load any FFI registrations, if so raise an error explaining the problem and steps to install TE with `--no-build-isolation`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
