### PR TITLE
(Bug fix) Fix accuracy issue for blockwise scaling+E8 scale on Blackwell

### DIFF
--- a/transformer_engine/common/swizzle/swizzle_block_scaling.cu
+++ b/transformer_engine/common/swizzle/swizzle_block_scaling.cu
@@ -199,8 +199,9 @@ void __global__ __launch_bounds__(WARPS_X_PER_TB* WARPS_Y_PER_TB* WARP_SIZE)
   uint32_t sf = *reinterpret_cast<const uint32_t*>(warp_src);
 
   // broadcast it to four scaling factors for 1x32 tiles
-  sf = (sf << 1) | (sf >> 7);
-  sf = sf | (sf >> 16);
+  // extract and broadcast the exponent byte to four bytes for E8M0 format
+  uint32_t exp_byte = (sf >> 23) & 0xFF;
+  sf = exp_byte | (exp_byte << 8) | (exp_byte << 16) | (exp_byte << 24);
 
   // broadcast it to sixteen scaling factors for 1x32 tiles
   const uint4 sf4{sf, sf, sf, sf};


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.
nvbug: https://nvbugspro.nvidia.com/bug/5754531

1. When computing scaling, a very small amax will return a scale of FP32 maximum representable value: https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/common/recipe/recipe_common.cuh#L37
2. Then the generated pow-2-scale will be 0x7F000000, where the mantissa bits are masked: https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/common/recipe/recipe_common.cuh#L41
3. The scale_inv is computed by 1 / scale so that it will be 0x400000, whose exp bits are 0, but its mantissa bits are not full zeros (100 0000 0000 0000 0000 0000): https://github.com/NVIDIA/TransformerEngine/blob/main/transformer_engine/common/transpose/quantize_transpose_vector_blockwise.cu#L302
4. When converting the blockwise-scale_inv to mxfp8-scale_inv, we extract the exponent bits of four scale_invs and pack them together for further broadcast by following the code line:
uint32_t packed_exponents = (sf.x >> 23) | (sf.y >> 15) | (sf.z >> 7) | (sf.w << 1);
This assumes the mantissa bits of scale_invs are full zeros, which works in most cases because we mask out the mantissa bits in step 2. However, in this corner case, the scale_inv of 0x400000 has non-zero mantissa bits, which will modify the bits of other scale_invs. That's an unexpected behaviour.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
