### PR TITLE
Revert adding pytorch-triton as a build requirement

### DIFF
--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -13,17 +13,7 @@ from typing import List
 
 
 def install_requirements() -> List[str]:
-    """Install dependencies for TE/PyTorch extensions.
-
-    IMPORTANT - PyTorch Index Required for pytorch-triton:
-        These dependencies MUST be installed using PyTorch's package index:
-
-            pip install pytorch-triton --index-url https://download.pytorch.org/whl/<version??>
-
-        - pytorch-triton is only available from PyTorch's index (not PyPI)
-        - The 'pytorch-triton' package on PyPI is a placeholder that will fail
-        - torch.compile() requires pytorch-triton, not OpenAI's 'triton' package
-    """
+    """Install dependencies for TE/PyTorch extensions."""
     return ["torch>=2.1", "einops", "onnxscript", "onnx", "packaging", "pydantic", "nvdlfw-inspect"]
 
 


### PR DESCRIPTION
## Description

Since pytorch-triton is a placeholder in PyPI, it should not be auto fetched and install in TE build. Users that uses torch should already have pytorch-triton installed when they install torch whl.

WE should also not revert this to requires 'triton' either because it is currently not compatible with torch.compile

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

remove pytorch-triton from list of requirements in TE PyTorch build

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
