### PR TITLE
[PyTorch] Prototype of torch.compile support for TE Sequential

### DIFF
--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -1,0 +1,441 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Test torch.compile(fullgraph=True) with Transformer Engine operations."""
+
+import pytest
+import torch
+import transformer_engine.pytorch as te
+from transformer_engine.pytorch.quantization import FP8GlobalStateManager
+from transformer_engine.pytorch.ops.compile_compat import TorchCompileCompatibleFuser
+from utils import reset_rng_states
+
+
+@pytest.fixture(autouse=True)
+def reset_global_fp8_state():
+    yield
+    FP8GlobalStateManager.reset()
+
+
+class TestBasicLinear:
+    """Tests for BasicLinear operation."""
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_forward_backward(self, dtype):
+        """Test BasicLinear forward+backward with torch.compile(fullgraph=True)."""
+        reset_rng_states()
+
+        # Create operation
+        linear = te.ops.BasicLinear(256, 512, device="cuda", dtype=dtype)
+        
+        # Create TorchCompileCompatibleFuser OUTSIDE compiled region
+        fuser = TorchCompileCompatibleFuser([linear])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+
+        # Eager reference
+        y_eager = fuser(x)
+        loss = y_eager.sum()
+        loss.backward()
+        grad_x_eager = x.grad.clone()
+        grad_w_eager = linear.weight.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear.weight.grad = None
+
+        # Compiled with fullgraph=True
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w_eager, linear.weight.grad, **tols)
+
+
+class TestBias:
+    """Tests for Bias operation."""
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_forward_backward(self, dtype):
+        """Test Bias forward+backward with torch.compile(fullgraph=True)."""
+        reset_rng_states()
+
+        # Create operation
+        bias = te.ops.Bias(512, device="cuda", dtype=dtype)
+        
+        # Create TorchCompileCompatibleFuser
+        fuser = TorchCompileCompatibleFuser([bias])
+        
+        x = torch.randn(32, 64, 512, device="cuda", dtype=dtype, requires_grad=True)
+
+        # Eager reference
+        y_eager = fuser(x)
+        loss = y_eager.sum()
+        loss.backward()
+        grad_x_eager = x.grad.clone()
+        grad_b_eager = bias.bias.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        bias.bias.grad = None
+
+        # Compiled with fullgraph=True
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_b_eager, bias.bias.grad, **tols)
+
+
+class TestLinearWithBias:
+    """Tests for Linear (BasicLinear + Bias) operation."""
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_forward_backward(self, dtype):
+        """Test Linear with bias forward+backward with torch.compile(fullgraph=True)."""
+        reset_rng_states()
+
+        # Create fused Linear operation (contains BasicLinear + Bias)
+        linear = te.ops.Linear(256, 512, bias=True, device="cuda", dtype=dtype)
+        
+        # Create TorchCompileCompatibleFuser
+        fuser = TorchCompileCompatibleFuser([linear])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+
+        # Eager reference
+        y_eager = fuser(x)
+        loss = y_eager.sum()
+        loss.backward()
+        grad_x_eager = x.grad.clone()
+        grad_w_eager = linear.weight.grad.clone()
+        grad_b_eager = linear.bias.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear.weight.grad = None
+        linear.bias.grad = None
+
+        # Compiled with fullgraph=True
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w_eager, linear.weight.grad, **tols)
+        torch.testing.assert_close(grad_b_eager, linear.bias.grad, **tols)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_without_bias(self, dtype):
+        """Test Linear without bias with torch.compile(fullgraph=True)."""
+        reset_rng_states()
+
+        # Create Linear without bias
+        linear = te.ops.Linear(256, 512, bias=False, device="cuda", dtype=dtype)
+        
+        fuser = TorchCompileCompatibleFuser([linear])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+
+        # Eager reference
+        y_eager = fuser(x)
+        y_eager.sum().backward()
+        grad_x_eager = x.grad.clone()
+        grad_w_eager = linear.weight.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear.weight.grad = None
+
+        # Compiled
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w_eager, linear.weight.grad, **tols)
+
+
+class TestFP8:
+    """Tests for FP8 quantization support."""
+
+    @pytest.mark.parametrize("linear_cls", ["BasicLinear", "Linear"])
+    def test_fp8_forward_backward(self, linear_cls):
+        """Test FP8 forward+backward with torch.compile(fullgraph=True)."""
+        reset_rng_states()
+
+        # Create operation
+        if linear_cls == "BasicLinear":
+            linear = te.ops.BasicLinear(256, 512, device="cuda", dtype=torch.bfloat16)
+        else:
+            linear = te.ops.Linear(256, 512, bias=True, device="cuda", dtype=torch.bfloat16)
+        
+        fuser = TorchCompileCompatibleFuser([linear])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+
+        # Enable FP8
+        from transformer_engine.common.recipe import DelayedScaling, Format
+        fp8_recipe = DelayedScaling(fp8_format=Format.HYBRID)
+        
+        # Warmup: run several iterations to stabilize DelayedScaling amax history
+        # This ensures eager and compiled use the same scaling factors
+        for _ in range(5):
+            x.grad = None
+            linear.weight.grad = None
+            with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+                y_warmup = fuser(x)
+            y_warmup.sum().backward()
+        
+        # Reset grads after warmup
+        x.grad = None
+        linear.weight.grad = None
+        
+        # Eager reference with FP8 (amax history is now stable)
+        with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+            y_eager = fuser(x)
+        y_eager.sum().backward()
+        grad_x_eager = x.grad.clone()
+        grad_w_eager = linear.weight.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear.weight.grad = None
+
+        # Compiled with fullgraph=True and FP8
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+            y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics (FP8 has lower precision, but with stable scaling should match closely)
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w_eager, linear.weight.grad, **tols)
+
+
+class TestFusion:
+    """Tests for fused operations (LinearBiasActivation fusion)."""
+
+    def test_linear_bias_fusion_bf16(self):
+        """Test BasicLinear + Bias fusion with torch.compile(fullgraph=True).
+        
+        This pattern should trigger ForwardLinearBiasActivation fusion when using bf16.
+        """
+        reset_rng_states()
+        dtype = torch.bfloat16
+
+        # Create operations - this pattern triggers fusion in bf16
+        linear = te.ops.BasicLinear(256, 512, device="cuda", dtype=dtype)
+        bias = te.ops.Bias(512, device="cuda", dtype=dtype)
+        
+        fuser = TorchCompileCompatibleFuser([linear, bias])
+        
+        # Check that fusion happened
+        # After _maybe_fuse_ops, forward_ops should have fewer entries than basic_ops
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+        
+        # Trigger fusion by running forward
+        _ = fuser(x)
+        
+        # Verify fusion: 2 basic ops should become 1 fused forward op
+        assert len(fuser.ops_container._forward_ops) == 1, (
+            f"Expected 1 fused forward op, got {len(fuser.ops_container._forward_ops)}"
+        )
+        
+        # Eager reference
+        y_eager = fuser(x)
+        y_eager.sum().backward()
+        grad_x_eager = x.grad.clone()
+        grad_w_eager = linear.weight.grad.clone()
+        grad_b_eager = bias.bias.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear.weight.grad = None
+        bias.bias.grad = None
+
+        # Compiled with fullgraph=True
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w_eager, linear.weight.grad, **tols)
+        torch.testing.assert_close(grad_b_eager, bias.bias.grad, **tols)
+
+    def test_no_fusion_fp32(self):
+        """Test that fusion doesn't happen with fp32 (cuBLAS limitation)."""
+        reset_rng_states()
+        dtype = torch.float32
+
+        # Create operations - fp32 should NOT trigger fusion
+        linear = te.ops.BasicLinear(256, 512, device="cuda", dtype=dtype)
+        bias = te.ops.Bias(512, device="cuda", dtype=dtype)
+        
+        fuser = TorchCompileCompatibleFuser([linear, bias])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+        
+        # Trigger fusion attempt by running forward
+        _ = fuser(x)
+        
+        # Verify no fusion: 2 basic ops should remain as 2 forward ops
+        assert len(fuser.ops_container._forward_ops) == 2, (
+            f"Expected 2 forward ops (no fusion for fp32), got {len(fuser.ops_container._forward_ops)}"
+        )
+        
+        # Still test that it works correctly
+        y_eager = fuser(x)
+        y_eager.sum().backward()
+        grad_x_eager = x.grad.clone()
+
+        x.grad = None
+
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+
+
+class TestMultipleOps:
+    """Tests for multiple operations."""
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_two_linears(self, dtype):
+        """Test two BasicLinear ops with torch.compile(fullgraph=True)."""
+        reset_rng_states()
+
+        # Create operations
+        linear1 = te.ops.BasicLinear(256, 512, device="cuda", dtype=dtype)
+        linear2 = te.ops.BasicLinear(512, 128, device="cuda", dtype=dtype)
+        
+        fuser = TorchCompileCompatibleFuser([linear1, linear2])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+
+        # Eager reference
+        y_eager = fuser(x)
+        y_eager.sum().backward()
+        grad_x_eager = x.grad.clone()
+        grad_w1_eager = linear1.weight.grad.clone()
+        grad_w2_eager = linear2.weight.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear1.weight.grad = None
+        linear2.weight.grad = None
+
+        # Compiled
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w1_eager, linear1.weight.grad, **tols)
+        torch.testing.assert_close(grad_w2_eager, linear2.weight.grad, **tols)
+
+    def test_linear_bias_linear_with_fusion(self):
+        """Test BasicLinear + Bias + BasicLinear with fusion (bf16).
+        
+        The first Linear+Bias should fuse into ForwardLinearBiasActivation.
+        """
+        reset_rng_states()
+        dtype = torch.bfloat16
+
+        # Create operations
+        linear1 = te.ops.BasicLinear(256, 512, device="cuda", dtype=dtype)
+        bias = te.ops.Bias(512, device="cuda", dtype=dtype)
+        linear2 = te.ops.BasicLinear(512, 128, device="cuda", dtype=dtype)
+        
+        fuser = TorchCompileCompatibleFuser([linear1, bias, linear2])
+        
+        x = torch.randn(32, 64, 256, device="cuda", dtype=dtype, requires_grad=True)
+
+        # Trigger fusion
+        _ = fuser(x)
+        
+        # Verify fusion: 3 basic ops should become 2 forward ops 
+        # (linear1+bias fused, linear2 separate)
+        assert len(fuser.ops_container._forward_ops) == 2, (
+            f"Expected 2 forward ops after fusion, got {len(fuser.ops_container._forward_ops)}"
+        )
+
+        # Eager reference
+        y_eager = fuser(x)
+        y_eager.sum().backward()
+        grad_x_eager = x.grad.clone()
+        grad_w1_eager = linear1.weight.grad.clone()
+        grad_b_eager = bias.bias.grad.clone()
+        grad_w2_eager = linear2.weight.grad.clone()
+
+        # Reset grads
+        x.grad = None
+        linear1.weight.grad = None
+        bias.bias.grad = None
+        linear2.weight.grad = None
+
+        # Compiled
+        @torch.compile(fullgraph=True)
+        def compiled_forward(fuser, x):
+            return fuser(x)
+
+        y_compiled = compiled_forward(fuser, x)
+        y_compiled.sum().backward()
+
+        # Check numerics
+        tols = dict(rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y_eager, y_compiled, **tols)
+        torch.testing.assert_close(grad_x_eager, x.grad, **tols)
+        torch.testing.assert_close(grad_w1_eager, linear1.weight.grad, **tols)
+        torch.testing.assert_close(grad_b_eager, bias.bias.grad, **tols)
+        torch.testing.assert_close(grad_w2_eager, linear2.weight.grad, **tols)

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 import contextlib
 import math
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from ..compile_compat.tensor_info import TensorInfo, PseudoForwardResult
 
 from ...cpp_extensions import general_gemm
 from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
@@ -1036,6 +1039,7 @@ class BasicLinear(BasicOperation):
         else:
             accumulate_into_main_grad = False
 
+
         # Linear backward pass
         grad_input, grad_weight = BasicLinear._functional_backward(
             grad_output=grad_output,
@@ -1055,9 +1059,9 @@ class BasicLinear(BasicOperation):
             grad_output_quantizer=ctx.grad_output_quantizer,
             grad_input_quantizer=ctx.grad_input_quantizer,
         )
-
+        
         # Clear input tensor if possible
-        clear_tensor_data(x_local)
+        #clear_tensor_data(x_local)
 
         # Megatron-LM wgrad fusion
         # Note: Return dummy tensor for grad weight if needed.
@@ -1073,3 +1077,103 @@ class BasicLinear(BasicOperation):
                 )
 
         return grad_input, [grad_weight]
+
+    def pseudo_forward(
+        self,
+        input_info: "TensorInfo",
+        extra_inputs_info: tuple["TensorInfo", ...],
+        **kwargs,
+    ) -> "PseudoForwardResult":
+        """Compute forward metadata for BasicLinear.
+        
+        Output shape: input shape with last dim changed from in_features to out_features.
+        Saves: x_local (input), w (weight) for backward.
+        """
+        from ..compile_compat.tensor_info import TensorInfo, PseudoForwardResult
+        
+        # Output shape: replace last dim with out_features
+        output_shape = input_info.shape[:-1] + (self.local_out_features,)
+        output_info = TensorInfo(
+            shape=output_shape,
+            dtype=input_info.dtype,
+            requires_grad=input_info.requires_grad,
+        )
+        
+        # Tensors to save for backward: x_local and w
+        # x_local has same shape as input (possibly after sequence parallel gather)
+        # w has shape (out_features, in_features)
+        # NOTE: We always return the same structure regardless of requires_grad
+        # because torch.compile requires consistent output shapes from custom ops.
+        # At runtime, if requires_grad=False, we may save empty/dummy tensors.
+        tensors_to_save_info = []
+        tensor_sources = []  # -1 = new tensor, 0 = x, 1+ = params/extra_inputs
+        
+        # Always add tensors to save (structure must be consistent for torch.compile)
+        if True:  # was: if input_info.requires_grad:
+            # x_local shape depends on tensor parallel mode
+            if self.tensor_parallel_mode == "column" and self.sequence_parallel:
+                # After all-gather, first dim is multiplied by TP size
+                x_local_shape = (
+                    input_info.shape[0] * self.tensor_parallel_size,
+                ) + input_info.shape[1:]
+            else:
+                x_local_shape = input_info.shape
+            
+            tensors_to_save_info.append(TensorInfo(
+                shape=x_local_shape,
+                dtype=input_info.dtype,
+                requires_grad=False,  # Saved tensors don't track grad
+            ))
+            # x_local aliases the input only for the FIRST op in the pipeline.
+            # For subsequent ops, x_local is an intermediate output (new tensor).
+            # The fuser passes _is_first_op in kwargs to indicate this.
+            is_first_op = kwargs.get("_is_first_op", True)
+            if is_first_op:
+                # x_local may or may not alias input depending on quantization.
+                # In non-FP8 mode, x_local = input (alias). In FP8 mode, x_local is quantized (new).
+                # Conservatively mark as aliasing input (source=0) to avoid saving twice.
+                tensor_sources.append(0)
+            else:
+                # Intermediate op - x_local is previous op's output (new tensor, not alias)
+                tensor_sources.append(-1)
+            
+            # Weight shape - this IS the weight parameter (params[0] for this op)
+            tensors_to_save_info.append(TensorInfo(
+                shape=(self.local_out_features, self.local_in_features),
+                dtype=self.weight.dtype,
+                requires_grad=False,
+            ))
+            # w is params[0], so source = 1 (offset by 1 because 0 = input x)
+            tensor_sources.append(1)
+        
+        # Context data for backward reconstruction
+        # Note: dtype and quantizers are determined at backward time from op state
+        from ...quantization import FP8GlobalStateManager
+        
+        # Get dtype (same logic as op_forward)
+        if torch.is_autocast_enabled():
+            dtype = torch.get_autocast_dtype("cuda")
+        else:
+            dtype = self.weight.dtype
+        
+        ctx_data = {
+            "input_requires_grad": input_info.requires_grad,
+            "weight_requires_grad": self.weight.requires_grad if input_info.requires_grad else False,
+            "num_saved_tensors": len(tensors_to_save_info),
+            "dtype": dtype,
+            "with_quantized_compute": FP8GlobalStateManager.is_fp8_enabled(),
+            # Note: Quantizers are NOT stored here (they're not picklable for torch.compile).
+            # They will be set in run_backward from the operation directly.
+            "input_quantizer": None,
+            "weight_quantizer": None,
+            "grad_output_quantizer": None,
+            "grad_input_quantizer": None,
+        }
+        
+        return PseudoForwardResult(
+            output_info=output_info,
+            tensors_to_save_info=tensors_to_save_info,
+            extra_outputs_info=[],
+            ctx_data=ctx_data,
+            tensor_sources=tensor_sources,
+        )

--- a/transformer_engine/pytorch/ops/basic/bias.py
+++ b/transformer_engine/pytorch/ops/basic/bias.py
@@ -5,9 +5,12 @@
 """Fusible operation for bias."""
 
 from __future__ import annotations
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from ..compile_compat.tensor_info import TensorInfo, PseudoForwardResult
 
 import transformer_engine_torch as tex
 from ..op import BasicOperation, OperationContext
@@ -142,3 +145,36 @@ class Bias(BasicOperation):
         else:
             db = dy
         return dy, (db,)
+
+    def pseudo_forward(
+        self,
+        input_info: "TensorInfo",
+        extra_inputs_info: tuple["TensorInfo", ...],
+        **kwargs,
+    ) -> "PseudoForwardResult":
+        """Compute forward metadata for Bias.
+        
+        Bias is element-wise addition - output shape equals input shape.
+        No tensors saved for backward.
+        """
+        from ..compile_compat.tensor_info import TensorInfo, PseudoForwardResult
+        
+        # Output has same shape as input
+        output_info = TensorInfo(
+            shape=input_info.shape,
+            dtype=input_info.dtype,
+            requires_grad=input_info.requires_grad,
+        )
+        
+        # Note: grad_input_quantizer is set by the fuser based on prev_op
+        # For now, set to None (will be overwritten by run_backward if needed)
+        return PseudoForwardResult(
+            output_info=output_info,
+            tensors_to_save_info=[],
+            extra_outputs_info=[],
+            ctx_data={
+                "num_saved_tensors": 0,
+                "grad_input_quantizer": None,
+            },
+            tensor_sources=[],
+        )

--- a/transformer_engine/pytorch/ops/basic/bias.py
+++ b/transformer_engine/pytorch/ops/basic/bias.py
@@ -153,19 +153,19 @@ class Bias(BasicOperation):
         **kwargs,
     ) -> "PseudoForwardResult":
         """Compute forward metadata for Bias.
-        
+
         Bias is element-wise addition - output shape equals input shape.
         No tensors saved for backward.
         """
         from ..compile_compat.tensor_info import TensorInfo, PseudoForwardResult
-        
+
         # Output has same shape as input
         output_info = TensorInfo(
             shape=input_info.shape,
             dtype=input_info.dtype,
             requires_grad=input_info.requires_grad,
         )
-        
+
         # Note: grad_input_quantizer is set by the fuser based on prev_op
         # For now, set to None (will be overwritten by run_backward if needed)
         return PseudoForwardResult(

--- a/transformer_engine/pytorch/ops/basic/identity.py
+++ b/transformer_engine/pytorch/ops/basic/identity.py
@@ -5,9 +5,12 @@
 """Fusible operation for identity."""
 
 from __future__ import annotations
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from ..compile_compat.tensor_info import TensorInfo, PseudoForwardResult
 
 from transformer_engine.pytorch.ops.op import (
     BasicOperation,

--- a/transformer_engine/pytorch/ops/compile_compat/__init__.py
+++ b/transformer_engine/pytorch/ops/compile_compat/__init__.py
@@ -4,15 +4,15 @@
 
 """torch.compile compatibility module for Transformer Engine operations.
 
-This module provides components to make te.ops work with 
+This module provides components to make te.ops work with
 torch.compile(fullgraph=True) by using custom operators that wrap fusion logic.
 
 Usage:
     from transformer_engine.pytorch.ops.compile_compat import TorchCompileCompatibleFuser
-    
+
     # Create fuser OUTSIDE compiled region
     fuser = TorchCompileCompatibleFuser([op1, op2, op3])
-    
+
     @torch.compile(fullgraph=True)
     def forward(x):
         return fuser(x)
@@ -29,16 +29,14 @@ from .fuser import TorchCompileCompatibleFuser
 __all__ = [
     # Main API
     "TorchCompileCompatibleFuser",
-    
     # Supporting classes
     "TensorInfo",
     "TensorInfoList",
-    "PseudoForwardResult", 
+    "PseudoForwardResult",
     "OpaqueKwargs",
     "OpsContainer",
     "NoneRecipe",
     "NONE_RECIPE",
-    
     # Custom operators (for advanced usage)
     "fused_forward_impl",
     "fused_backward_impl",

--- a/transformer_engine/pytorch/ops/compile_compat/__init__.py
+++ b/transformer_engine/pytorch/ops/compile_compat/__init__.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""torch.compile compatibility module for Transformer Engine operations.
+
+This module provides components to make te.ops work with 
+torch.compile(fullgraph=True) by using custom operators that wrap fusion logic.
+
+Usage:
+    from transformer_engine.pytorch.ops.compile_compat import TorchCompileCompatibleFuser
+    
+    # Create fuser OUTSIDE compiled region
+    fuser = TorchCompileCompatibleFuser([op1, op2, op3])
+    
+    @torch.compile(fullgraph=True)
+    def forward(x):
+        return fuser(x)
+"""
+
+# Import and re-export public API
+# Note: NoneRecipe is used as sentinel when recipe is None (FP8 disabled)
+from .tensor_info import TensorInfo, TensorInfoList, PseudoForwardResult
+from .opaque_kwargs import OpaqueKwargs
+from .ops_container import OpsContainer
+from .operators import fused_forward_impl, fused_backward_impl, NoneRecipe, NONE_RECIPE
+from .fuser import TorchCompileCompatibleFuser
+
+__all__ = [
+    # Main API
+    "TorchCompileCompatibleFuser",
+    
+    # Supporting classes
+    "TensorInfo",
+    "TensorInfoList",
+    "PseudoForwardResult", 
+    "OpaqueKwargs",
+    "OpsContainer",
+    "NoneRecipe",
+    "NONE_RECIPE",
+    
+    # Custom operators (for advanced usage)
+    "fused_forward_impl",
+    "fused_backward_impl",
+]

--- a/transformer_engine/pytorch/ops/compile_compat/fuser.py
+++ b/transformer_engine/pytorch/ops/compile_compat/fuser.py
@@ -19,26 +19,26 @@ from .operators import fused_forward_impl, NONE_RECIPE
 
 class TorchCompileCompatibleFuser:
     """Fuser for torch.compile(fullgraph=True) compatibility.
-    
+
     This class wraps a sequence of FusibleOperations and provides a callable
     that works with torch.compile without graph breaks. The fusion logic
     is hidden inside custom operators.
-    
+
     Usage:
         ops = [LinearOp(...), BiasOp(...), ActivationOp(...)]
         fuser = TorchCompileCompatibleFuser(ops)
-        
+
         @torch.compile(fullgraph=True)
         def forward(x):
             return fuser(x)
-    
+
     Note: The fuser must be created OUTSIDE the compiled region, as OpsContainer
     is a reference-type opaque object.
     """
-    
+
     def __init__(self, ops: list[FusibleOperation]) -> None:
         """Initialize the fuser with a list of operations.
-        
+
         Args:
             ops: List of FusibleOperation instances (can include FusedOperations)
         """
@@ -49,24 +49,24 @@ class TorchCompileCompatibleFuser:
                 basic_ops.extend(op.basic_ops)
             else:
                 basic_ops.append(op)
-        
+
         # Create OpsContainer (outside compiled region)
         self.ops_container = OpsContainer(basic_ops)
-        
+
         # Cache num_ops and default kwargs (avoid accessing these in compiled region)
         self._num_ops = len(basic_ops)
         self._default_kwargs_opaque = opaque_kwargs_from_dicts([{}] * len(basic_ops))
-        
+
         # Flatten parameters for autograd tracking
         self._flat_params = [p for op in basic_ops for p in op.parameters()]
-        
+
         # Track extra inputs/outputs
         self.num_extra_inputs = sum(op.num_extra_inputs for op in basic_ops)
         self.num_extra_outputs = sum(op.num_extra_outputs for op in basic_ops)
-        
+
         # Keep reference to basic ops for module compatibility
         self._basic_ops = basic_ops
-    
+
     def __call__(
         self,
         input: torch.Tensor,
@@ -74,12 +74,12 @@ class TorchCompileCompatibleFuser:
         basic_op_kwargs: Optional[list[dict[str, Any]]] = None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
         """Apply the fused operations to input.
-        
+
         Args:
             input: Input tensor
             *extra_inputs: Extra tensor inputs for operations that need them
             basic_op_kwargs: Optional list of kwargs dicts, one per basic operation
-            
+
         Returns:
             Output tensor, or tuple of (output, *extra_outputs) if any operation
             produces extra outputs.
@@ -90,21 +90,20 @@ class TorchCompileCompatibleFuser:
             recipe = FP8GlobalStateManager.get_fp8_recipe()
         else:
             recipe = NONE_RECIPE
-        
+
         # Create OpaqueKwargs
         # Use cached default kwargs to avoid accessing self._num_ops in compiled region
         if basic_op_kwargs is None:
             kwargs_opaque = self._default_kwargs_opaque
         else:
             kwargs_opaque = opaque_kwargs_from_dicts(basic_op_kwargs)
-        
+
         # Verify extra inputs count
         if len(extra_inputs) != self.num_extra_inputs:
             raise ValueError(
-                f"Expected {self.num_extra_inputs} extra inputs, "
-                f"got {len(extra_inputs)}"
+                f"Expected {self.num_extra_inputs} extra inputs, got {len(extra_inputs)}"
             )
-        
+
         # Call the custom op - returns [output, *non_aliased_tensors_to_save, *extra_outputs]
         # Aliased tensors are NOT included (reconstructed in backward)
         flat_result = fused_forward_impl(
@@ -115,7 +114,7 @@ class TorchCompileCompatibleFuser:
             self._flat_params,
             list(extra_inputs),
         )
-        
+
         # Parse flat result
         output = flat_result[0]
         # non_aliased_tensors_to_save are in the middle (handled by autograd), we skip them
@@ -125,11 +124,11 @@ class TorchCompileCompatibleFuser:
             extra_outputs = flat_result[-num_extra_outputs:]
             return (output, *extra_outputs)
         return output
-    
+
     def parameters(self):
         """Iterate over all parameters in the fused operations."""
         return iter(self._flat_params)
-    
+
     def named_parameters(self, prefix: str = "", recurse: bool = True):
         """Iterate over named parameters."""
         for idx, op in enumerate(self._basic_ops):

--- a/transformer_engine/pytorch/ops/compile_compat/fuser.py
+++ b/transformer_engine/pytorch/ops/compile_compat/fuser.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""torch.compile compatible fuser for Transformer Engine operations."""
+
+from __future__ import annotations
+from typing import Any, Optional
+
+import torch
+
+from ...quantization import FP8GlobalStateManager
+from ..op import BasicOperation, FusibleOperation
+
+from .opaque_kwargs import opaque_kwargs_from_dicts
+from .ops_container import OpsContainer
+from .operators import fused_forward_impl, NONE_RECIPE
+
+
+class TorchCompileCompatibleFuser:
+    """Fuser for torch.compile(fullgraph=True) compatibility.
+    
+    This class wraps a sequence of FusibleOperations and provides a callable
+    that works with torch.compile without graph breaks. The fusion logic
+    is hidden inside custom operators.
+    
+    Usage:
+        ops = [LinearOp(...), BiasOp(...), ActivationOp(...)]
+        fuser = TorchCompileCompatibleFuser(ops)
+        
+        @torch.compile(fullgraph=True)
+        def forward(x):
+            return fuser(x)
+    
+    Note: The fuser must be created OUTSIDE the compiled region, as OpsContainer
+    is a reference-type opaque object.
+    """
+    
+    def __init__(self, ops: list[FusibleOperation]) -> None:
+        """Initialize the fuser with a list of operations.
+        
+        Args:
+            ops: List of FusibleOperation instances (can include FusedOperations)
+        """
+        # Flatten to basic operations
+        basic_ops: list[BasicOperation] = []
+        for op in ops:
+            if op.is_fused_op:
+                basic_ops.extend(op.basic_ops)
+            else:
+                basic_ops.append(op)
+        
+        # Create OpsContainer (outside compiled region)
+        self.ops_container = OpsContainer(basic_ops)
+        
+        # Cache num_ops and default kwargs (avoid accessing these in compiled region)
+        self._num_ops = len(basic_ops)
+        self._default_kwargs_opaque = opaque_kwargs_from_dicts([{}] * len(basic_ops))
+        
+        # Flatten parameters for autograd tracking
+        self._flat_params = [p for op in basic_ops for p in op.parameters()]
+        
+        # Track extra inputs/outputs
+        self.num_extra_inputs = sum(op.num_extra_inputs for op in basic_ops)
+        self.num_extra_outputs = sum(op.num_extra_outputs for op in basic_ops)
+        
+        # Keep reference to basic ops for module compatibility
+        self._basic_ops = basic_ops
+    
+    def __call__(
+        self,
+        input: torch.Tensor,
+        *extra_inputs: torch.Tensor,
+        basic_op_kwargs: Optional[list[dict[str, Any]]] = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        """Apply the fused operations to input.
+        
+        Args:
+            input: Input tensor
+            *extra_inputs: Extra tensor inputs for operations that need them
+            basic_op_kwargs: Optional list of kwargs dicts, one per basic operation
+            
+        Returns:
+            Output tensor, or tuple of (output, *extra_outputs) if any operation
+            produces extra outputs.
+        """
+        # Get recipe from global state
+        # Use NONE_RECIPE singleton when FP8 is disabled (cannot pass None to custom_op)
+        if FP8GlobalStateManager.is_fp8_enabled():
+            recipe = FP8GlobalStateManager.get_fp8_recipe()
+        else:
+            recipe = NONE_RECIPE
+        
+        # Create OpaqueKwargs
+        # Use cached default kwargs to avoid accessing self._num_ops in compiled region
+        if basic_op_kwargs is None:
+            kwargs_opaque = self._default_kwargs_opaque
+        else:
+            kwargs_opaque = opaque_kwargs_from_dicts(basic_op_kwargs)
+        
+        # Verify extra inputs count
+        if len(extra_inputs) != self.num_extra_inputs:
+            raise ValueError(
+                f"Expected {self.num_extra_inputs} extra inputs, "
+                f"got {len(extra_inputs)}"
+            )
+        
+        # Call the custom op - returns [output, *non_aliased_tensors_to_save, *extra_outputs]
+        # Aliased tensors are NOT included (reconstructed in backward)
+        flat_result = fused_forward_impl(
+            input,
+            self.ops_container,
+            recipe,
+            kwargs_opaque,
+            self._flat_params,
+            list(extra_inputs),
+        )
+        
+        # Parse flat result
+        output = flat_result[0]
+        # non_aliased_tensors_to_save are in the middle (handled by autograd), we skip them
+        # extra_outputs are at the end
+        num_extra_outputs = self.num_extra_outputs
+        if num_extra_outputs > 0:
+            extra_outputs = flat_result[-num_extra_outputs:]
+            return (output, *extra_outputs)
+        return output
+    
+    def parameters(self):
+        """Iterate over all parameters in the fused operations."""
+        return iter(self._flat_params)
+    
+    def named_parameters(self, prefix: str = "", recurse: bool = True):
+        """Iterate over named parameters."""
+        for idx, op in enumerate(self._basic_ops):
+            op_prefix = f"{prefix}op_{idx}." if prefix else f"op_{idx}."
+            for name, param in op.named_parameters(prefix="", recurse=recurse):
+                yield op_prefix + name, param

--- a/transformer_engine/pytorch/ops/compile_compat/opaque_kwargs.py
+++ b/transformer_engine/pytorch/ops/compile_compat/opaque_kwargs.py
@@ -12,13 +12,13 @@ from torch._library.opaque_object import register_opaque_type
 
 def opaque_kwargs_from_dicts(kwargs_list: list[dict[str, Any]]) -> "OpaqueKwargs":
     """Create OpaqueKwargs from a list of dictionaries.
-    
+
     This is a module-level function instead of classmethod to be compatible
     with torch.compile (classmethods are not supported on opaque types).
-    
+
     Args:
         kwargs_list: List of kwargs dicts, one per operation
-        
+
     Returns:
         OpaqueKwargs instance
     """
@@ -27,48 +27,48 @@ def opaque_kwargs_from_dicts(kwargs_list: list[dict[str, Any]]) -> "OpaqueKwargs
 
 class OpaqueKwargs:
     """Immutable container for per-op keyword arguments.
-    
+
     Value type because kwargs are constant within a compiled graph -
     changes trigger recompilation via __eq__ guard.
-    
+
     The internal representation uses nested tuples for hashability:
     - Outer tuple: one element per operation
     - Inner tuple: sorted (key, value) pairs for that operation's kwargs
     """
-    
+
     __slots__ = ("_data", "__weakref__")
-    
+
     def __init__(self, data: tuple[tuple[tuple[str, Any], ...], ...]) -> None:
         self._data = data
-    
+
     def to_dicts(self) -> list[dict[str, Any]]:
         """Convert back to list of dictionaries.
-        
+
         Returns:
             List of kwargs dicts, one per operation
         """
         return [dict(items) for items in self._data]
-    
+
     def __len__(self) -> int:
         """Return number of operations."""
         return len(self._data)
-    
+
     def __getitem__(self, idx: int) -> dict[str, Any]:
         """Get kwargs dict for operation at index."""
         return dict(self._data[idx])
-    
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, OpaqueKwargs):
             return NotImplemented
         return self._data == other._data
-    
+
     def __hash__(self) -> int:
         return hash(self._data)
-    
+
     def __fx_repr__(self) -> tuple[str, dict[str, type]]:
         """FX-evaluable representation for graph codegen."""
         return f"OpaqueKwargs({self._data!r})", {"OpaqueKwargs": OpaqueKwargs}
-    
+
     def __repr__(self) -> str:
         return f"OpaqueKwargs({self._data!r})"
 

--- a/transformer_engine/pytorch/ops/compile_compat/opaque_kwargs.py
+++ b/transformer_engine/pytorch/ops/compile_compat/opaque_kwargs.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Opaque kwargs container for torch.compile compatibility."""
+
+from __future__ import annotations
+from typing import Any
+
+from torch._library.opaque_object import register_opaque_type
+
+
+def opaque_kwargs_from_dicts(kwargs_list: list[dict[str, Any]]) -> "OpaqueKwargs":
+    """Create OpaqueKwargs from a list of dictionaries.
+    
+    This is a module-level function instead of classmethod to be compatible
+    with torch.compile (classmethods are not supported on opaque types).
+    
+    Args:
+        kwargs_list: List of kwargs dicts, one per operation
+        
+    Returns:
+        OpaqueKwargs instance
+    """
+    return OpaqueKwargs(tuple(tuple(sorted(d.items())) for d in kwargs_list))
+
+
+class OpaqueKwargs:
+    """Immutable container for per-op keyword arguments.
+    
+    Value type because kwargs are constant within a compiled graph -
+    changes trigger recompilation via __eq__ guard.
+    
+    The internal representation uses nested tuples for hashability:
+    - Outer tuple: one element per operation
+    - Inner tuple: sorted (key, value) pairs for that operation's kwargs
+    """
+    
+    __slots__ = ("_data", "__weakref__")
+    
+    def __init__(self, data: tuple[tuple[tuple[str, Any], ...], ...]) -> None:
+        self._data = data
+    
+    def to_dicts(self) -> list[dict[str, Any]]:
+        """Convert back to list of dictionaries.
+        
+        Returns:
+            List of kwargs dicts, one per operation
+        """
+        return [dict(items) for items in self._data]
+    
+    def __len__(self) -> int:
+        """Return number of operations."""
+        return len(self._data)
+    
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get kwargs dict for operation at index."""
+        return dict(self._data[idx])
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OpaqueKwargs):
+            return NotImplemented
+        return self._data == other._data
+    
+    def __hash__(self) -> int:
+        return hash(self._data)
+    
+    def __fx_repr__(self) -> tuple[str, dict[str, type]]:
+        """FX-evaluable representation for graph codegen."""
+        return f"OpaqueKwargs({self._data!r})", {"OpaqueKwargs": OpaqueKwargs}
+    
+    def __repr__(self) -> str:
+        return f"OpaqueKwargs({self._data!r})"
+
+
+# Register as value type (immutable, can be baked into graph)
+register_opaque_type(OpaqueKwargs, typ="value")

--- a/transformer_engine/pytorch/ops/compile_compat/operators.py
+++ b/transformer_engine/pytorch/ops/compile_compat/operators.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Custom operators for torch.compile compatibility."""
+
+from __future__ import annotations
+from typing import Any, Optional
+
+import torch
+from torch._library.opaque_object import register_opaque_type
+
+from transformer_engine.common.recipe import (
+    Recipe,
+    DelayedScaling,
+    Float8CurrentScaling,
+    MXFP8BlockScaling,
+    Float8BlockScaling,
+    NVFP4BlockScaling,
+    CustomRecipe,
+)
+
+from .tensor_info import TensorInfo, TensorInfoList, PseudoForwardResult
+from .opaque_kwargs import OpaqueKwargs
+from .ops_container import OpsContainer
+
+
+# -----------------------------------------------------------------------------
+# Recipe opaque type registration
+# -----------------------------------------------------------------------------
+
+# Register Recipe and all subclasses as reference types 
+# (delayed scaling and other recipes may mutate internal state)
+# Guard on recipe identity - recompile if recipe instance changes
+_recipe_classes = [
+    Recipe,
+    DelayedScaling,
+    Float8CurrentScaling,
+    MXFP8BlockScaling,
+    Float8BlockScaling,
+    NVFP4BlockScaling,
+    CustomRecipe,
+]
+
+for _recipe_cls in _recipe_classes:
+    register_opaque_type(
+        _recipe_cls,
+        typ="reference",
+        guard_fn=lambda r: (id(r),),
+    )
+
+
+class NoneRecipe(Recipe):
+    """Singleton recipe representing None (FP8 disabled).
+    
+    This class is used to pass through torch.compile custom ops when recipe is None.
+    Inside the operator implementation, NoneRecipe is immediately converted to None.
+    
+    PyTorch's @torch.library.custom_op does not support Optional[OpaqueType]
+    in function signatures, so we use this sentinel class instead.
+    """
+    
+    _instance: Optional["NoneRecipe"] = None
+    
+    def __new__(cls) -> "NoneRecipe":
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+        return cls._instance
+    
+    def __repr__(self) -> str:
+        return "NoneRecipe()"
+
+
+# Register NoneRecipe - use fixed guard (singleton always same)
+register_opaque_type(
+    NoneRecipe,
+    typ="reference",
+    guard_fn=lambda r: (),  # No values to guard on - always same instance
+)
+
+
+# Singleton instance - created at module import time (outside torch.compile regions)
+NONE_RECIPE = NoneRecipe()
+
+
+def get_recipe_or_none(recipe: Recipe) -> Optional[Recipe]:
+    """Convert recipe to Optional[Recipe], handling NoneRecipe sentinel.
+    
+    Args:
+        recipe: Recipe instance (may be NoneRecipe singleton)
+        
+    Returns:
+        None if recipe is NoneRecipe, otherwise the recipe itself.
+    """
+    if isinstance(recipe, NoneRecipe):
+        return None
+    return recipe
+
+
+# -----------------------------------------------------------------------------
+# te_ops::fused_forward
+# -----------------------------------------------------------------------------
+
+def _filter_non_aliased_tensors(
+    tensors_to_save: list[torch.Tensor],
+    tensor_sources: list[int],
+) -> list[torch.Tensor]:
+    """Filter tensors_to_save to only include non-aliased tensors (source == -1)."""
+    return [t for t, src in zip(tensors_to_save, tensor_sources) if src == -1]
+
+
+@torch.library.custom_op("te_ops::fused_forward", mutates_args=())
+def fused_forward_impl(
+    x: torch.Tensor,
+    ops_container: OpsContainer,
+    recipe: Recipe,
+    kwargs_opaque: OpaqueKwargs,
+    params: list[torch.Tensor],
+    extra_inputs: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Perform fused forward pass.
+    
+    Fusion logic happens inside run_forward (invisible to torch.compile).
+    
+    Args:
+        x: Input tensor
+        ops_container: Container with operations
+        recipe: FP8 recipe (NoneRecipe if FP8 is disabled)
+        kwargs_opaque: Per-op keyword arguments
+        params: Flattened list of parameters
+        extra_inputs: Flattened list of extra inputs
+        
+    Returns:
+        [output, *non_aliased_tensors_to_save, *extra_outputs] as flat list
+        Tensors that alias inputs (x, params, extra_inputs) are NOT included in 
+        tensors_to_save - they will be reconstructed in backward using tensor_sources.
+    """
+    # Convert NoneRecipe to None
+    actual_recipe = get_recipe_or_none(recipe)
+    
+    output, tensors_to_save, extra_outputs = ops_container.run_forward(
+        x, actual_recipe, kwargs_opaque, params, extra_inputs
+    )
+    
+    # Get tensor_sources from pseudo_forward to know which tensors are input aliases
+    input_info = TensorInfo(tuple(x.shape), x.dtype, x.requires_grad)
+    extra_inputs_info = TensorInfoList([TensorInfo.from_tensor(t) for t in extra_inputs])
+    pseudo_result = ops_container.run_pseudo_forward(input_info, extra_inputs_info, kwargs_opaque)
+    tensor_sources = pseudo_result.tensor_sources
+    
+    # Filter out tensors that alias inputs
+    non_aliased_tensors = _filter_non_aliased_tensors(tensors_to_save, tensor_sources)
+
+    return [output] + non_aliased_tensors + extra_outputs
+
+
+@fused_forward_impl.register_fake
+def fused_forward_fake(
+    x: torch.Tensor,
+    ops_container: OpsContainer,
+    recipe: Recipe,
+    kwargs_opaque: OpaqueKwargs,
+    params: list[torch.Tensor],
+    extra_inputs: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Fake kernel - uses pseudo_forward for shape inference."""
+    input_info = TensorInfo(tuple(x.shape), x.dtype, x.requires_grad)
+    extra_inputs_info = TensorInfoList([TensorInfo.from_tensor(t) for t in extra_inputs])
+    result = ops_container.run_pseudo_forward(input_info, extra_inputs_info, kwargs_opaque)
+    
+    output = torch.empty(
+        result.output_info.shape, 
+        device=x.device, 
+        dtype=result.output_info.dtype
+    )
+    
+    # Only create tensors for non-aliased sources
+    tensor_sources = result.tensor_sources
+    non_aliased_tensors = [
+        torch.empty(info.shape, device=x.device, dtype=info.dtype)
+        for info, src in zip(result.tensors_to_save_info, tensor_sources)
+        if src == -1
+    ]
+    
+    extra_outputs = [
+        torch.empty(info.shape, device=x.device, dtype=info.dtype)
+        for info in result.extra_outputs_info
+    ]
+    
+    return [output] + non_aliased_tensors + extra_outputs
+
+
+# -----------------------------------------------------------------------------
+# te_ops::fused_backward
+# -----------------------------------------------------------------------------
+
+@torch.library.custom_op("te_ops::fused_backward", mutates_args=())
+def fused_backward_impl(
+    grad_output: torch.Tensor,
+    grad_extra_outputs: list[torch.Tensor],
+    ops_container: OpsContainer,
+    recipe: Recipe,
+    kwargs_opaque: OpaqueKwargs,
+    input_info: TensorInfo,
+    extra_inputs_info: TensorInfoList,
+    tensors_saved: list[torch.Tensor],
+    params: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Perform fused backward pass.
+    
+    Fusion logic happens inside run_backward (invisible to torch.compile).
+    
+    Args:
+        grad_output: Gradient w.r.t. output
+        grad_extra_outputs: Gradients w.r.t. extra outputs
+        ops_container: Container with operations
+        recipe: FP8 recipe (NoneRecipe if FP8 is disabled)
+        kwargs_opaque: Per-op keyword arguments
+        input_info: TensorInfo of original input (for ctx reconstruction)
+        extra_inputs_info: TensorInfo of extra inputs (for ctx reconstruction)
+        tensors_saved: Saved tensors from forward
+        params: Flattened list of parameters
+        
+    Returns:
+        [grad_input, *grad_params, *grad_extra_inputs] as flat list
+    """
+    # Convert NoneRecipe to None
+    actual_recipe = get_recipe_or_none(recipe)
+    
+    # Reconstruct ctx by running pseudo_forward with saved info
+    pseudo_result = ops_container.run_pseudo_forward(
+        input_info, extra_inputs_info, kwargs_opaque
+    )
+    ctx_data = pseudo_result.ctx_data
+    
+    # Run actual backward with ctx_data + tensors_saved
+    grad_input, grad_params, grad_extra_inputs = ops_container.run_backward(
+        grad_output, 
+        grad_extra_outputs, 
+        ctx_data, 
+        tensors_saved, 
+        params, 
+        actual_recipe
+    )
+    
+    # Ensure grad_input doesn't alias grad_output (custom ops don't allow output-input aliasing)
+    # This can happen with ops like Bias where grad_input = grad_output directly
+    if grad_input is not None and grad_input.data_ptr() == grad_output.data_ptr():
+        grad_input = grad_input.clone()
+    
+    # Return as flat list
+    result = [grad_input] if grad_input is not None else [torch.zeros_like(grad_output)]
+    result.extend(grad_params)
+    result.extend(grad_extra_inputs)
+    return result
+
+
+@fused_backward_impl.register_fake
+def fused_backward_fake(
+    grad_output: torch.Tensor,
+    grad_extra_outputs: list[torch.Tensor],
+    ops_container: OpsContainer,
+    recipe: Recipe,
+    kwargs_opaque: OpaqueKwargs,
+    input_info: TensorInfo,
+    extra_inputs_info: TensorInfoList,
+    tensors_saved: list[torch.Tensor],
+    params: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Fake kernel for backward - compute output shapes."""
+    # grad_input has same shape as original input
+    grad_input = torch.empty(
+        input_info.shape,
+        device=grad_output.device,
+        dtype=input_info.dtype,
+    )
+    
+    # grad_params have same shapes as params
+    grad_params = [
+        torch.empty_like(p) for p in params
+    ]
+    
+    # grad_extra_inputs have same shapes as extra_inputs
+    grad_extra_inputs = [
+        torch.empty(info.shape, device=grad_output.device, dtype=info.dtype)
+        for info in extra_inputs_info.items
+    ]
+
+
+    return [grad_input] + grad_params + grad_extra_inputs
+
+
+# -----------------------------------------------------------------------------
+# Autograd registration
+# -----------------------------------------------------------------------------
+
+def _setup_context(ctx, inputs, output):
+    """Save context for backward pass."""
+    x, ops_container, recipe, kwargs_opaque, params, extra_inputs = inputs
+    
+    # output is [output_tensor, *non_aliased_tensors_to_save, *extra_outputs]
+    flat_output = output
+    
+    # Get tensor_sources from pseudo_forward
+    input_info = TensorInfo(tuple(x.shape), x.dtype, x.requires_grad)
+    extra_inputs_info = TensorInfoList([TensorInfo.from_tensor(t) for t in extra_inputs])
+    pseudo_result = ops_container.run_pseudo_forward(input_info, extra_inputs_info, kwargs_opaque)
+    tensor_sources = pseudo_result.tensor_sources
+    
+    # Count non-aliased tensors
+    num_non_aliased = sum(1 for src in tensor_sources if src == -1)
+    num_extra_outputs = ops_container.num_extra_outputs
+    
+    output_tensor = flat_output[0]
+    non_aliased_tensors = flat_output[1:1+num_non_aliased]
+    extra_outputs = flat_output[1+num_non_aliased:]
+    
+    # Save tensors for backward: x, params, extra_inputs, and non-aliased tensors
+    ctx.save_for_backward(x, *params, *extra_inputs, *non_aliased_tensors)
+    
+    # Save non-tensor state
+    ctx.ops_container = ops_container
+    ctx.recipe = recipe
+    ctx.kwargs_opaque = kwargs_opaque
+    ctx.num_params = len(params)
+    ctx.num_extra_inputs = len(extra_inputs)
+    ctx.num_non_aliased = num_non_aliased
+    ctx.num_extra_outputs = num_extra_outputs
+    
+    # Save TensorInfo for pseudo_forward reconstruction in backward
+    ctx.input_info = input_info
+    ctx.extra_inputs_info = extra_inputs_info
+
+
+def _backward(ctx, grads_list):
+    """Backward pass."""
+    # grads_list: [grad_output, *grad_non_aliased_tensors, *grad_extra_outputs]
+
+    grad_output = grads_list[0]
+    num_non_aliased = ctx.num_non_aliased
+    num_extra_outputs = ctx.num_extra_outputs
+    
+    grad_non_aliased = grads_list[1:1+num_non_aliased]  # Usually None
+    grad_extra_outputs = list(grads_list[1+num_non_aliased:])
+    
+    # Retrieve saved tensors: (x, *params, *extra_inputs, *non_aliased_tensors)
+    saved = ctx.saved_tensors
+    x = saved[0]
+    params = list(saved[1:1+ctx.num_params])
+    extra_inputs = list(saved[1+ctx.num_params:1+ctx.num_params+ctx.num_extra_inputs])
+    non_aliased_tensors = list(saved[1+ctx.num_params+ctx.num_extra_inputs:])
+    
+    # Run pseudo_forward to get tensor_sources
+    pseudo_result = ctx.ops_container.run_pseudo_forward(
+        ctx.input_info, ctx.extra_inputs_info, ctx.kwargs_opaque
+    )
+    tensor_sources = pseudo_result.tensor_sources
+    
+    # Build list of all inputs for lookup
+    # source encoding: 0=x, 1..num_params=params, num_params+1..=extra_inputs
+    all_inputs = [x] + params + extra_inputs
+    
+    # Reconstruct full tensors_saved using tensor_sources
+    tensors_saved = []
+    non_aliased_idx = 0
+    for src in tensor_sources:
+        if src == -1:
+            # Non-aliased tensor - take from saved non_aliased_tensors
+            tensors_saved.append(non_aliased_tensors[non_aliased_idx])
+            non_aliased_idx += 1
+        else:
+            # Aliased tensor - reconstruct from inputs
+            tensors_saved.append(all_inputs[src])
+    
+    backward_result = fused_backward_impl(
+        grad_output,
+        grad_extra_outputs,
+        ctx.ops_container,
+        ctx.recipe,
+        ctx.kwargs_opaque,
+        ctx.input_info,
+        ctx.extra_inputs_info,
+        tensors_saved,
+        params,
+    )
+    
+    # backward_result is [grad_input, *grad_params, *grad_extra_inputs]
+    grad_input = backward_result[0]
+    grad_params = backward_result[1:1+ctx.num_params]
+    grad_extra_inputs = backward_result[1+ctx.num_params:]
+
+    # Return grads for: x, ops_container, recipe, kwargs_opaque, params, extra_inputs
+    # ops_container, recipe, kwargs_opaque are non-differentiable
+    return (grad_input, None, None, None, grad_params, grad_extra_inputs)
+
+
+# Register autograd
+fused_forward_impl.register_autograd(_backward, setup_context=_setup_context)

--- a/transformer_engine/pytorch/ops/compile_compat/ops_container.py
+++ b/transformer_engine/pytorch/ops/compile_compat/ops_container.py
@@ -1,0 +1,512 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""OpsContainer class for torch.compile compatibility."""
+
+from __future__ import annotations
+from typing import Any, Optional, TYPE_CHECKING
+
+import torch
+from torch._library.opaque_object import register_opaque_type, MemberType
+
+from transformer_engine.common.recipe import Recipe
+from ...quantization import FP8GlobalStateManager
+from ..op import BasicOperation, OperationContext
+from ..fused import (
+    fuse_backward_activation_bias,
+    fuse_backward_add_rmsnorm,
+    fuse_backward_linear_add,
+    fuse_backward_linear_scale,
+    fuse_forward_linear_bias_activation,
+    fuse_forward_linear_bias_add,
+    fuse_forward_linear_scale_add,
+    fuse_userbuffers_backward_linear,
+    fuse_userbuffers_forward_linear,
+)
+from ...quantized_tensor import prepare_for_saving, restore_from_saved
+
+from .tensor_info import TensorInfo, TensorInfoList, PseudoForwardResult
+from .opaque_kwargs import OpaqueKwargs
+
+if TYPE_CHECKING:
+    from ..op import FusibleOperation
+
+
+def _split_tuple(t: tuple, idx: int) -> tuple[tuple, tuple]:
+    """Split tuple at index."""
+    return t[:idx], t[idx:]
+
+
+class OpsContainer:
+    """Container holding the list of BasicOperations for torch.compile compatibility.
+    
+    This class encapsulates the operation pipeline and provides methods that
+    are invisible to torch.compile (fusion happens inside custom ops).
+    
+    Key methods:
+    - run_pseudo_forward: Shape inference (compile time) and ctx reconstruction (backward time)
+    - run_forward: Actual forward pass with fusion (analogous to OperationFuser.forward)
+    - run_backward: Actual backward pass with fusion (analogous to OperationFuser.backward)
+    """
+    
+    def __init__(self, basic_ops: list[BasicOperation]) -> None:
+        self.basic_ops = basic_ops
+        self._num_ops = len(basic_ops)
+        
+        # Flatten list of parameters
+        self._basic_op_params = [list(op.parameters()) for op in basic_ops]
+        self._basic_op_num_params = list(map(len, self._basic_op_params))
+        
+        # Number of extra inputs/outputs per op
+        self._basic_op_num_extra_inputs = [op.num_extra_inputs for op in basic_ops]
+        self._basic_op_num_extra_outputs = [op.num_extra_outputs for op in basic_ops]
+        self.num_extra_inputs = sum(self._basic_op_num_extra_inputs)
+        self.num_extra_outputs = sum(self._basic_op_num_extra_outputs)
+        
+        # Cached fusion state
+        self._forward_ops: Optional[list[tuple[Any, list[int]]]] = None
+        self._backward_ops: Optional[list[tuple[Any, list[int]]]] = None
+        self._cached_recipe_type: Optional[type] = None
+        self._cached_first_op_requiring_backward: int = 0
+        self._last_amax_history_len: int = 0
+    
+    def _fuse_forward_ops(
+        self,
+        ops: list[tuple[Any, list[int]]],
+        recipe: Optional[Recipe],
+    ) -> list[tuple[Any, list[int]]]:
+        """Attempt to fuse operations in forward pass."""
+        ops = fuse_userbuffers_forward_linear(ops)
+        ops = fuse_forward_linear_bias_add(ops)
+        ops = fuse_forward_linear_bias_activation(ops)
+        ops = fuse_forward_linear_scale_add(ops)
+        return ops
+    
+    def _fuse_backward_ops(
+        self,
+        ops: list[tuple[Any, list[int]]],
+        recipe: Optional[Recipe],
+    ) -> list[tuple[Any, list[int]]]:
+        """Attempt to fuse operations in backward pass."""
+        ops = fuse_userbuffers_backward_linear(ops)
+        ops = fuse_backward_linear_add(ops)
+        ops = fuse_backward_linear_scale(ops)
+        ops = fuse_backward_activation_bias(ops, recipe)
+        ops = fuse_backward_add_rmsnorm(ops)
+        return ops
+    
+    def _maybe_fuse_ops(
+        self,
+        recipe: Optional[Recipe],
+        first_op_requiring_backward: int,
+    ) -> None:
+        """Attempt to fuse operations if necessary."""
+        from transformer_engine.common.recipe import DelayedScaling
+        
+        # Check if fusion parameters changed
+        need_reset = False
+        recipe_type = type(recipe) if recipe is not None else None
+        
+        # Always need reset if not yet initialized
+        if self._forward_ops is None:
+            need_reset = True
+        elif (recipe_type, first_op_requiring_backward) != (
+            self._cached_recipe_type,
+            self._cached_first_op_requiring_backward,
+        ):
+            need_reset = True
+        elif (
+            recipe is not None
+            and recipe.delayed()
+            and self._last_amax_history_len != recipe.amax_history_len
+        ):
+            need_reset = True
+        
+        if not need_reset:
+            return
+        
+        # Reset recipe state on all ops
+        for op in self.basic_ops:
+            op.reset_recipe_state(recipe=recipe)
+        
+        # Check if first iteration
+        if self._cached_recipe_type is None:
+            for op in self.basic_ops:
+                op.pre_first_fuser_forward()
+        
+        # Prepare op lists for fusion
+        forward_ops = [(op, [idx]) for idx, op in enumerate(self.basic_ops)]
+        backward_ops = list(reversed(forward_ops[first_op_requiring_backward:]))
+        
+        # Fuse ops
+        self._forward_ops = self._fuse_forward_ops(forward_ops, recipe)
+        self._backward_ops = self._fuse_backward_ops(backward_ops, recipe)
+        
+        # Cache fusion params
+        self._cached_recipe_type = recipe_type
+        self._cached_first_op_requiring_backward = first_op_requiring_backward
+        
+        # Save amax history length for delayed scaling
+        if isinstance(recipe, DelayedScaling):
+            self._last_amax_history_len = recipe.amax_history_len
+        else:
+            self._last_amax_history_len = 0
+    
+    def run_pseudo_forward(
+        self,
+        input_info: TensorInfo,
+        extra_inputs_info: TensorInfoList,
+        kwargs_opaque: OpaqueKwargs,
+    ) -> PseudoForwardResult:
+        """Shape inference and ctx reconstruction - no actual computation.
+        
+        Used for:
+        1. Compile-time shape inference (register_fake)
+        2. Backward ctx reconstruction (avoids storing ctx in opaque container)
+        
+        Args:
+            input_info: TensorInfo describing input tensor
+            extra_inputs_info: TensorInfo for extra inputs
+            kwargs_opaque: Per-op keyword arguments
+            
+        Returns:
+            PseudoForwardResult with output shape, tensors_to_save shapes, and ctx data
+        """
+        kwargs_list = kwargs_opaque.to_dicts()
+        
+        current_info = input_info
+        all_tensors_to_save_info: list[TensorInfo] = []
+        all_extra_outputs_info: list[TensorInfo] = []
+        all_tensor_sources: list[int] = []
+        all_ctx_data: dict[str, Any] = {}
+        
+        # Get items from TensorInfoList for slicing
+        extra_inputs_info_list = extra_inputs_info.items
+        
+        # Track cumulative offsets for params and extra_inputs
+        # Source encoding: 0 = x, 1..num_total_params = params, num_total_params+1.. = extra_inputs
+        num_total_params = sum(len(list(op.parameters())) for op in self.basic_ops)
+        param_offset = 0  # Cumulative param count before current op
+        extra_inputs_offset = 0  # Cumulative extra inputs count before current op
+        
+        for op_idx, op in enumerate(self.basic_ops):
+            # Get extra inputs for this op
+            num_extra = op.num_extra_inputs
+            op_extra_inputs_info = tuple(extra_inputs_info_list[extra_inputs_offset:extra_inputs_offset + num_extra])
+            
+            # Get kwargs for this op
+            op_kwargs = kwargs_list[op_idx] if op_idx < len(kwargs_list) else {}
+            
+            # Add internal flag to indicate if this is the first op
+            # (affects tensor_sources for input - first op's input aliases original x)
+            op_kwargs = dict(op_kwargs)  # Copy to avoid modifying original
+            op_kwargs["_is_first_op"] = (op_idx == 0)
+            
+            # Call pseudo_forward on the operation
+            op_result = op.pseudo_forward(
+                current_info,
+                op_extra_inputs_info,
+                **op_kwargs,
+            )
+            
+            # Accumulate results
+            current_info = op_result.output_info
+            all_tensors_to_save_info.extend(op_result.tensors_to_save_info)
+            all_extra_outputs_info.extend(op_result.extra_outputs_info)
+            
+            # Adjust tensor_sources for global offsets
+            # Op-local sources: 0=x, 1..num_op_params=params, num_op_params+1..=extra_inputs
+            # Global sources: 0=x, 1..num_total_params=params, num_total_params+1..=extra_inputs
+            num_op_params = len(list(op.parameters()))
+            for src in op_result.tensor_sources:
+                if src == -1:
+                    # New tensor, no adjustment
+                    all_tensor_sources.append(-1)
+                elif src == 0:
+                    # Input x, no adjustment
+                    all_tensor_sources.append(0)
+                elif src <= num_op_params:
+                    # Op-local param index -> global param index
+                    # src=1 means op's params[0], global is params[param_offset + 0]
+                    global_param_idx = param_offset + (src - 1)
+                    all_tensor_sources.append(1 + global_param_idx)
+                else:
+                    # Op-local extra_input index -> global extra_input index
+                    # src=num_op_params+1 means op's extra_inputs[0]
+                    local_extra_idx = src - num_op_params - 1
+                    global_extra_idx = extra_inputs_offset + local_extra_idx
+                    all_tensor_sources.append(1 + num_total_params + global_extra_idx)
+            
+            # Store ctx_data with op index prefix
+            for key, value in op_result.ctx_data.items():
+                all_ctx_data[f"op_{op_idx}_{key}"] = value
+            
+            # Update offsets
+            param_offset += num_op_params
+            extra_inputs_offset += num_extra
+        
+        return PseudoForwardResult(
+            output_info=current_info,
+            tensors_to_save_info=all_tensors_to_save_info,
+            extra_outputs_info=all_extra_outputs_info,
+            ctx_data=all_ctx_data,
+            tensor_sources=all_tensor_sources,
+        )
+    
+    def run_forward(
+        self,
+        x: torch.Tensor,
+        recipe: Optional[Recipe],
+        kwargs_opaque: OpaqueKwargs,
+        params: list[torch.Tensor],
+        extra_inputs: list[torch.Tensor],
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
+        """Actual forward pass - analogous to OperationFuser forward.
+        
+        Fusion happens HERE (inside custom op, invisible to torch.compile):
+        - Fuses operations based on recipe
+        - Handles quantizers (prev_op_grad_output_quantizer, next_op_input_quantizer)
+        - Calls pre_fuser_forward on each op
+        
+        Args:
+            x: Input tensor
+            recipe: FP8 recipe (or None)
+            kwargs_opaque: Per-op keyword arguments
+            params: Flattened list of all parameters
+            extra_inputs: Flattened list of extra inputs
+            
+        Returns:
+            (output, tensors_to_save, extra_outputs)
+        """
+        kwargs_list = kwargs_opaque.to_dicts()
+        
+        # Determine which ops require backward
+        # NOTE: Custom ops run in no_grad context, so we check x.requires_grad instead of is_grad_enabled()
+        if x.requires_grad:
+            first_op_requiring_backward = 0
+        else:
+            first_op_requiring_backward = self._num_ops
+            param_idx = 0
+            extra_idx = 0
+            for op_idx, op in enumerate(self.basic_ops):
+                num_params = self._basic_op_num_params[op_idx]
+                num_extra = op.num_extra_inputs
+                op_params = params[param_idx:param_idx + num_params]
+                op_extra = extra_inputs[extra_idx:extra_idx + num_extra]
+                param_idx += num_params
+                extra_idx += num_extra
+                
+                if any(t.requires_grad for t in op_params) or any(t.requires_grad for t in op_extra):
+                    first_op_requiring_backward = op_idx
+                    break
+        
+        # Fuse operations if needed
+        self._maybe_fuse_ops(recipe, first_op_requiring_backward)
+        
+        # Unflatten extra inputs
+        extra_inputs_copy = list(extra_inputs)
+        basic_op_extra_inputs = []
+        for op in self.basic_ops:
+            xs, extra_inputs_copy = _split_tuple(tuple(extra_inputs_copy), op.num_extra_inputs)
+            basic_op_extra_inputs.append(xs)
+        
+        # Create operation contexts
+        basic_op_ctxs = [OperationContext() for _ in range(self._num_ops)]
+        
+        # Pre-forward initialization
+        for idx, op in enumerate(self.basic_ops):
+            op.pre_fuser_forward(requires_grad=idx >= first_op_requiring_backward)
+        
+        # Run forward ops
+        extra_outputs = [None] * self._num_ops
+        for op, basic_op_idxs in self._forward_ops:
+            # Set requires_grad on contexts
+            for idx in basic_op_idxs:
+                basic_op_ctxs[idx].requires_grad = idx >= first_op_requiring_backward
+            
+            # Get quantizers
+            prev_op_idx = basic_op_idxs[0] - 1
+            prev_op = self.basic_ops[prev_op_idx] if prev_op_idx >= 0 else None
+            prev_op_grad_output_quantizer = None
+            if prev_op is not None:
+                prev_op_grad_output_quantizer = prev_op.get_grad_output_quantizer()
+            
+            next_op_idx = basic_op_idxs[-1] + 1
+            next_op = self.basic_ops[next_op_idx] if next_op_idx < self._num_ops else None
+            next_op_input_quantizer = None
+            if next_op is not None:
+                next_op_input_quantizer = next_op.get_input_quantizer()
+            
+            # Forward op
+            x, fused_op_extra_outputs = op.fuser_forward(
+                [basic_op_ctxs[idx] for idx in basic_op_idxs],
+                x,
+                basic_op_extra_inputs=[basic_op_extra_inputs[idx] for idx in basic_op_idxs],
+                prev_op_grad_output_quantizer=prev_op_grad_output_quantizer,
+                next_op_input_quantizer=next_op_input_quantizer,
+                basic_op_kwargs=[kwargs_list[idx] if idx < len(kwargs_list) else {} for idx in basic_op_idxs],
+            )
+            
+            for idx, ys in zip(basic_op_idxs, fused_op_extra_outputs):
+                for y in ys:
+                    y.requires_grad_(idx >= first_op_requiring_backward)
+                extra_outputs[idx] = ys
+        
+        # Flatten saved tensors
+        tensors_to_save = []
+        for ctx in basic_op_ctxs:
+            if ctx.to_save is not None:
+                tensors_to_save.extend(ctx.to_save)
+                ctx.to_save = None
+        
+        # Flatten extra outputs
+        extra_outputs_flat = []
+        for idx, ys in enumerate(extra_outputs):
+            if ys is not None:
+                extra_outputs_flat.extend(ys)
+        
+        return x, tensors_to_save, extra_outputs_flat
+    
+    def run_backward(
+        self,
+        grad_output: torch.Tensor,
+        grad_extra_outputs: list[torch.Tensor],
+        ctx_data: dict[str, Any],
+        tensors_saved: list[torch.Tensor],
+        params: list[torch.Tensor],
+        recipe: Optional[Recipe],
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
+        """Actual backward pass - analogous to OperationFuser backward.
+        
+        Fusion happens HERE (inside custom op, invisible to torch.compile):
+        - Uses fused backward ops
+        - Handles quantizers
+        
+        Args:
+            grad_output: Gradient w.r.t. output
+            grad_extra_outputs: Gradients w.r.t. extra outputs
+            ctx_data: Non-tensor context data from pseudo_forward
+            tensors_saved: Saved tensors from forward
+            params: Flattened list of all parameters
+            recipe: FP8 recipe (or None)
+            
+        Returns:
+            (grad_input, grad_params, grad_extra_inputs)
+        """
+
+        
+        # Restore saved tensors to contexts
+        basic_op_ctxs = [OperationContext() for _ in range(self._num_ops)]
+        
+        # Distribute ctx_data back to individual contexts
+        for key, value in ctx_data.items():
+            # Parse "op_{idx}_{attr}" format
+            parts = key.split("_", 2)
+            if len(parts) >= 3 and parts[0] == "op":
+                op_idx = int(parts[1])
+                attr_name = parts[2]
+                setattr(basic_op_ctxs[op_idx], attr_name, value)
+        
+        # Distribute saved tensors (need to track ranges per op)
+        # This is a simplified version - in practice we'd need to track ranges
+        tensor_idx = 0
+        for op_idx, ctx in enumerate(basic_op_ctxs):
+            # Get number of saved tensors for this op from ctx_data
+            num_saved_key = f"op_{op_idx}_num_saved_tensors"
+            num_saved = ctx_data.get(num_saved_key, 0)
+            if num_saved > 0:
+                ctx.saved_tensors = tuple(tensors_saved[tensor_idx:tensor_idx + num_saved])
+                tensor_idx += num_saved
+            else:
+                ctx.saved_tensors = ()
+            ctx.requires_grad = True
+        
+        # Set quantizers from operations (they weren't stored in ctx_data for picklability)
+        for op_idx, (op, ctx) in enumerate(zip(self.basic_ops, basic_op_ctxs)):
+            # Check if this op has quantizers (e.g., BasicLinear has them, Bias doesn't)
+            quantizers = getattr(op, '_quantizers', None)
+            if quantizers is not None and len(quantizers.get("forward", [])) > 0:
+                ctx.input_quantizer = op.get_quantizer("forward", 0)
+                if len(quantizers.get("forward", [])) > 1:
+                    ctx.weight_quantizer = op.get_quantizer("forward", 1)
+                if len(quantizers.get("backward", [])) > 0:
+                    ctx.grad_output_quantizer = op.get_quantizer("backward", 0)
+            # grad_input_quantizer comes from prev op
+            if op_idx > 0:
+                prev_op = self.basic_ops[op_idx - 1]
+                if hasattr(prev_op, 'get_grad_output_quantizer'):
+                    ctx.grad_input_quantizer = prev_op.get_grad_output_quantizer()
+        
+        # Unflatten grad_extra_outputs
+        grad_extra_outputs_copy = list(grad_extra_outputs)
+        basic_op_grad_extra_outputs = []
+        for op in self.basic_ops:
+            dys, grad_extra_outputs_copy = _split_tuple(
+                tuple(grad_extra_outputs_copy), 
+                op.num_extra_outputs
+            )
+            basic_op_grad_extra_outputs.append(dys)
+        
+        # Run backward ops
+        dx = grad_output
+        grad_params = [None] * self._num_ops
+        grad_extra_inputs = [None] * self._num_ops
+        
+        # DEBUG: Return fixed shapes
+        for op, basic_op_idxs in self._backward_ops:
+            # Check if gradients required
+            if all(not basic_op_ctxs[idx].requires_grad for idx in basic_op_idxs):
+                dx = None
+                break
+            
+            # Backward op
+            dx, fused_op_grad_params, fused_op_grad_extra_inputs = op.fuser_backward(
+                [basic_op_ctxs[idx] for idx in basic_op_idxs],
+                dx,
+                basic_op_grad_extra_outputs=[basic_op_grad_extra_outputs[idx] for idx in basic_op_idxs],
+            )
+
+            
+            for idx, dparams in zip(basic_op_idxs, fused_op_grad_params):
+                grad_params[idx] = dparams
+                basic_op_ctxs[idx].saved_tensors = None
+            
+            for idx, dxs in zip(basic_op_idxs, fused_op_grad_extra_inputs):
+                grad_extra_inputs[idx] = dxs
+        
+        # Flatten grad_params
+        grad_params_flat = []
+        for idx, dparams in enumerate(grad_params):
+            num_params = self._basic_op_num_params[idx]
+            if dparams is None:
+                dparams = [None] * num_params
+            else:
+                dparams = list(dparams)
+            grad_params_flat.extend(dparams)
+        
+        # Flatten grad_extra_inputs
+        grad_extra_inputs_flat = []
+        for idx, dxs in enumerate(grad_extra_inputs):
+            num_extra = self.basic_ops[idx].num_extra_inputs
+            if dxs is None:
+                dxs = [None] * num_extra
+            else:
+                dxs = list(dxs)
+            grad_extra_inputs_flat.extend(dxs)
+
+        
+        return dx, grad_params_flat, grad_extra_inputs_flat
+
+
+# Register as reference type (mutable, stateful)
+register_opaque_type(
+    OpsContainer,
+    typ="reference",
+    guard_fn=lambda c: (c._num_ops,),
+    members={
+        "run_pseudo_forward": MemberType.USE_REAL,
+        "num_extra_outputs": MemberType.USE_REAL,
+        "num_extra_inputs": MemberType.USE_REAL,
+    },
+)

--- a/transformer_engine/pytorch/ops/compile_compat/ops_container.py
+++ b/transformer_engine/pytorch/ops/compile_compat/ops_container.py
@@ -40,37 +40,37 @@ def _split_tuple(t: tuple, idx: int) -> tuple[tuple, tuple]:
 
 class OpsContainer:
     """Container holding the list of BasicOperations for torch.compile compatibility.
-    
+
     This class encapsulates the operation pipeline and provides methods that
     are invisible to torch.compile (fusion happens inside custom ops).
-    
+
     Key methods:
     - run_pseudo_forward: Shape inference (compile time) and ctx reconstruction (backward time)
     - run_forward: Actual forward pass with fusion (analogous to OperationFuser.forward)
     - run_backward: Actual backward pass with fusion (analogous to OperationFuser.backward)
     """
-    
+
     def __init__(self, basic_ops: list[BasicOperation]) -> None:
         self.basic_ops = basic_ops
         self._num_ops = len(basic_ops)
-        
+
         # Flatten list of parameters
         self._basic_op_params = [list(op.parameters()) for op in basic_ops]
         self._basic_op_num_params = list(map(len, self._basic_op_params))
-        
+
         # Number of extra inputs/outputs per op
         self._basic_op_num_extra_inputs = [op.num_extra_inputs for op in basic_ops]
         self._basic_op_num_extra_outputs = [op.num_extra_outputs for op in basic_ops]
         self.num_extra_inputs = sum(self._basic_op_num_extra_inputs)
         self.num_extra_outputs = sum(self._basic_op_num_extra_outputs)
-        
+
         # Cached fusion state
         self._forward_ops: Optional[list[tuple[Any, list[int]]]] = None
         self._backward_ops: Optional[list[tuple[Any, list[int]]]] = None
         self._cached_recipe_type: Optional[type] = None
         self._cached_first_op_requiring_backward: int = 0
         self._last_amax_history_len: int = 0
-    
+
     def _fuse_forward_ops(
         self,
         ops: list[tuple[Any, list[int]]],
@@ -82,7 +82,7 @@ class OpsContainer:
         ops = fuse_forward_linear_bias_activation(ops)
         ops = fuse_forward_linear_scale_add(ops)
         return ops
-    
+
     def _fuse_backward_ops(
         self,
         ops: list[tuple[Any, list[int]]],
@@ -95,7 +95,7 @@ class OpsContainer:
         ops = fuse_backward_activation_bias(ops, recipe)
         ops = fuse_backward_add_rmsnorm(ops)
         return ops
-    
+
     def _maybe_fuse_ops(
         self,
         recipe: Optional[Recipe],
@@ -103,11 +103,11 @@ class OpsContainer:
     ) -> None:
         """Attempt to fuse operations if necessary."""
         from transformer_engine.common.recipe import DelayedScaling
-        
+
         # Check if fusion parameters changed
         need_reset = False
         recipe_type = type(recipe) if recipe is not None else None
-        
+
         # Always need reset if not yet initialized
         if self._forward_ops is None:
             need_reset = True
@@ -122,37 +122,37 @@ class OpsContainer:
             and self._last_amax_history_len != recipe.amax_history_len
         ):
             need_reset = True
-        
+
         if not need_reset:
             return
-        
+
         # Reset recipe state on all ops
         for op in self.basic_ops:
             op.reset_recipe_state(recipe=recipe)
-        
+
         # Check if first iteration
         if self._cached_recipe_type is None:
             for op in self.basic_ops:
                 op.pre_first_fuser_forward()
-        
+
         # Prepare op lists for fusion
         forward_ops = [(op, [idx]) for idx, op in enumerate(self.basic_ops)]
         backward_ops = list(reversed(forward_ops[first_op_requiring_backward:]))
-        
+
         # Fuse ops
         self._forward_ops = self._fuse_forward_ops(forward_ops, recipe)
         self._backward_ops = self._fuse_backward_ops(backward_ops, recipe)
-        
+
         # Cache fusion params
         self._cached_recipe_type = recipe_type
         self._cached_first_op_requiring_backward = first_op_requiring_backward
-        
+
         # Save amax history length for delayed scaling
         if isinstance(recipe, DelayedScaling):
             self._last_amax_history_len = recipe.amax_history_len
         else:
             self._last_amax_history_len = 0
-    
+
     def run_pseudo_forward(
         self,
         input_info: TensorInfo,
@@ -160,61 +160,63 @@ class OpsContainer:
         kwargs_opaque: OpaqueKwargs,
     ) -> PseudoForwardResult:
         """Shape inference and ctx reconstruction - no actual computation.
-        
+
         Used for:
         1. Compile-time shape inference (register_fake)
         2. Backward ctx reconstruction (avoids storing ctx in opaque container)
-        
+
         Args:
             input_info: TensorInfo describing input tensor
             extra_inputs_info: TensorInfo for extra inputs
             kwargs_opaque: Per-op keyword arguments
-            
+
         Returns:
             PseudoForwardResult with output shape, tensors_to_save shapes, and ctx data
         """
         kwargs_list = kwargs_opaque.to_dicts()
-        
+
         current_info = input_info
         all_tensors_to_save_info: list[TensorInfo] = []
         all_extra_outputs_info: list[TensorInfo] = []
         all_tensor_sources: list[int] = []
         all_ctx_data: dict[str, Any] = {}
-        
+
         # Get items from TensorInfoList for slicing
         extra_inputs_info_list = extra_inputs_info.items
-        
+
         # Track cumulative offsets for params and extra_inputs
         # Source encoding: 0 = x, 1..num_total_params = params, num_total_params+1.. = extra_inputs
         num_total_params = sum(len(list(op.parameters())) for op in self.basic_ops)
         param_offset = 0  # Cumulative param count before current op
         extra_inputs_offset = 0  # Cumulative extra inputs count before current op
-        
+
         for op_idx, op in enumerate(self.basic_ops):
             # Get extra inputs for this op
             num_extra = op.num_extra_inputs
-            op_extra_inputs_info = tuple(extra_inputs_info_list[extra_inputs_offset:extra_inputs_offset + num_extra])
-            
+            op_extra_inputs_info = tuple(
+                extra_inputs_info_list[extra_inputs_offset : extra_inputs_offset + num_extra]
+            )
+
             # Get kwargs for this op
             op_kwargs = kwargs_list[op_idx] if op_idx < len(kwargs_list) else {}
-            
+
             # Add internal flag to indicate if this is the first op
             # (affects tensor_sources for input - first op's input aliases original x)
             op_kwargs = dict(op_kwargs)  # Copy to avoid modifying original
-            op_kwargs["_is_first_op"] = (op_idx == 0)
-            
+            op_kwargs["_is_first_op"] = op_idx == 0
+
             # Call pseudo_forward on the operation
             op_result = op.pseudo_forward(
                 current_info,
                 op_extra_inputs_info,
                 **op_kwargs,
             )
-            
+
             # Accumulate results
             current_info = op_result.output_info
             all_tensors_to_save_info.extend(op_result.tensors_to_save_info)
             all_extra_outputs_info.extend(op_result.extra_outputs_info)
-            
+
             # Adjust tensor_sources for global offsets
             # Op-local sources: 0=x, 1..num_op_params=params, num_op_params+1..=extra_inputs
             # Global sources: 0=x, 1..num_total_params=params, num_total_params+1..=extra_inputs
@@ -237,15 +239,15 @@ class OpsContainer:
                     local_extra_idx = src - num_op_params - 1
                     global_extra_idx = extra_inputs_offset + local_extra_idx
                     all_tensor_sources.append(1 + num_total_params + global_extra_idx)
-            
+
             # Store ctx_data with op index prefix
             for key, value in op_result.ctx_data.items():
                 all_ctx_data[f"op_{op_idx}_{key}"] = value
-            
+
             # Update offsets
             param_offset += num_op_params
             extra_inputs_offset += num_extra
-        
+
         return PseudoForwardResult(
             output_info=current_info,
             tensors_to_save_info=all_tensors_to_save_info,
@@ -253,7 +255,7 @@ class OpsContainer:
             ctx_data=all_ctx_data,
             tensor_sources=all_tensor_sources,
         )
-    
+
     def run_forward(
         self,
         x: torch.Tensor,
@@ -263,24 +265,24 @@ class OpsContainer:
         extra_inputs: list[torch.Tensor],
     ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
         """Actual forward pass - analogous to OperationFuser forward.
-        
+
         Fusion happens HERE (inside custom op, invisible to torch.compile):
         - Fuses operations based on recipe
         - Handles quantizers (prev_op_grad_output_quantizer, next_op_input_quantizer)
         - Calls pre_fuser_forward on each op
-        
+
         Args:
             x: Input tensor
             recipe: FP8 recipe (or None)
             kwargs_opaque: Per-op keyword arguments
             params: Flattened list of all parameters
             extra_inputs: Flattened list of extra inputs
-            
+
         Returns:
             (output, tensors_to_save, extra_outputs)
         """
         kwargs_list = kwargs_opaque.to_dicts()
-        
+
         # Determine which ops require backward
         # NOTE: Custom ops run in no_grad context, so we check x.requires_grad instead of is_grad_enabled()
         if x.requires_grad:
@@ -292,52 +294,54 @@ class OpsContainer:
             for op_idx, op in enumerate(self.basic_ops):
                 num_params = self._basic_op_num_params[op_idx]
                 num_extra = op.num_extra_inputs
-                op_params = params[param_idx:param_idx + num_params]
-                op_extra = extra_inputs[extra_idx:extra_idx + num_extra]
+                op_params = params[param_idx : param_idx + num_params]
+                op_extra = extra_inputs[extra_idx : extra_idx + num_extra]
                 param_idx += num_params
                 extra_idx += num_extra
-                
-                if any(t.requires_grad for t in op_params) or any(t.requires_grad for t in op_extra):
+
+                if any(t.requires_grad for t in op_params) or any(
+                    t.requires_grad for t in op_extra
+                ):
                     first_op_requiring_backward = op_idx
                     break
-        
+
         # Fuse operations if needed
         self._maybe_fuse_ops(recipe, first_op_requiring_backward)
-        
+
         # Unflatten extra inputs
         extra_inputs_copy = list(extra_inputs)
         basic_op_extra_inputs = []
         for op in self.basic_ops:
             xs, extra_inputs_copy = _split_tuple(tuple(extra_inputs_copy), op.num_extra_inputs)
             basic_op_extra_inputs.append(xs)
-        
+
         # Create operation contexts
         basic_op_ctxs = [OperationContext() for _ in range(self._num_ops)]
-        
+
         # Pre-forward initialization
         for idx, op in enumerate(self.basic_ops):
             op.pre_fuser_forward(requires_grad=idx >= first_op_requiring_backward)
-        
+
         # Run forward ops
         extra_outputs = [None] * self._num_ops
         for op, basic_op_idxs in self._forward_ops:
             # Set requires_grad on contexts
             for idx in basic_op_idxs:
                 basic_op_ctxs[idx].requires_grad = idx >= first_op_requiring_backward
-            
+
             # Get quantizers
             prev_op_idx = basic_op_idxs[0] - 1
             prev_op = self.basic_ops[prev_op_idx] if prev_op_idx >= 0 else None
             prev_op_grad_output_quantizer = None
             if prev_op is not None:
                 prev_op_grad_output_quantizer = prev_op.get_grad_output_quantizer()
-            
+
             next_op_idx = basic_op_idxs[-1] + 1
             next_op = self.basic_ops[next_op_idx] if next_op_idx < self._num_ops else None
             next_op_input_quantizer = None
             if next_op is not None:
                 next_op_input_quantizer = next_op.get_input_quantizer()
-            
+
             # Forward op
             x, fused_op_extra_outputs = op.fuser_forward(
                 [basic_op_ctxs[idx] for idx in basic_op_idxs],
@@ -345,29 +349,31 @@ class OpsContainer:
                 basic_op_extra_inputs=[basic_op_extra_inputs[idx] for idx in basic_op_idxs],
                 prev_op_grad_output_quantizer=prev_op_grad_output_quantizer,
                 next_op_input_quantizer=next_op_input_quantizer,
-                basic_op_kwargs=[kwargs_list[idx] if idx < len(kwargs_list) else {} for idx in basic_op_idxs],
+                basic_op_kwargs=[
+                    kwargs_list[idx] if idx < len(kwargs_list) else {} for idx in basic_op_idxs
+                ],
             )
-            
+
             for idx, ys in zip(basic_op_idxs, fused_op_extra_outputs):
                 for y in ys:
                     y.requires_grad_(idx >= first_op_requiring_backward)
                 extra_outputs[idx] = ys
-        
+
         # Flatten saved tensors
         tensors_to_save = []
         for ctx in basic_op_ctxs:
             if ctx.to_save is not None:
                 tensors_to_save.extend(ctx.to_save)
                 ctx.to_save = None
-        
+
         # Flatten extra outputs
         extra_outputs_flat = []
         for idx, ys in enumerate(extra_outputs):
             if ys is not None:
                 extra_outputs_flat.extend(ys)
-        
+
         return x, tensors_to_save, extra_outputs_flat
-    
+
     def run_backward(
         self,
         grad_output: torch.Tensor,
@@ -378,11 +384,11 @@ class OpsContainer:
         recipe: Optional[Recipe],
     ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
         """Actual backward pass - analogous to OperationFuser backward.
-        
+
         Fusion happens HERE (inside custom op, invisible to torch.compile):
         - Uses fused backward ops
         - Handles quantizers
-        
+
         Args:
             grad_output: Gradient w.r.t. output
             grad_extra_outputs: Gradients w.r.t. extra outputs
@@ -390,15 +396,14 @@ class OpsContainer:
             tensors_saved: Saved tensors from forward
             params: Flattened list of all parameters
             recipe: FP8 recipe (or None)
-            
+
         Returns:
             (grad_input, grad_params, grad_extra_inputs)
         """
 
-        
         # Restore saved tensors to contexts
         basic_op_ctxs = [OperationContext() for _ in range(self._num_ops)]
-        
+
         # Distribute ctx_data back to individual contexts
         for key, value in ctx_data.items():
             # Parse "op_{idx}_{attr}" format
@@ -407,7 +412,7 @@ class OpsContainer:
                 op_idx = int(parts[1])
                 attr_name = parts[2]
                 setattr(basic_op_ctxs[op_idx], attr_name, value)
-        
+
         # Distribute saved tensors (need to track ranges per op)
         # This is a simplified version - in practice we'd need to track ranges
         tensor_idx = 0
@@ -416,16 +421,16 @@ class OpsContainer:
             num_saved_key = f"op_{op_idx}_num_saved_tensors"
             num_saved = ctx_data.get(num_saved_key, 0)
             if num_saved > 0:
-                ctx.saved_tensors = tuple(tensors_saved[tensor_idx:tensor_idx + num_saved])
+                ctx.saved_tensors = tuple(tensors_saved[tensor_idx : tensor_idx + num_saved])
                 tensor_idx += num_saved
             else:
                 ctx.saved_tensors = ()
             ctx.requires_grad = True
-        
+
         # Set quantizers from operations (they weren't stored in ctx_data for picklability)
         for op_idx, (op, ctx) in enumerate(zip(self.basic_ops, basic_op_ctxs)):
             # Check if this op has quantizers (e.g., BasicLinear has them, Bias doesn't)
-            quantizers = getattr(op, '_quantizers', None)
+            quantizers = getattr(op, "_quantizers", None)
             if quantizers is not None and len(quantizers.get("forward", [])) > 0:
                 ctx.input_quantizer = op.get_quantizer("forward", 0)
                 if len(quantizers.get("forward", [])) > 1:
@@ -435,46 +440,46 @@ class OpsContainer:
             # grad_input_quantizer comes from prev op
             if op_idx > 0:
                 prev_op = self.basic_ops[op_idx - 1]
-                if hasattr(prev_op, 'get_grad_output_quantizer'):
+                if hasattr(prev_op, "get_grad_output_quantizer"):
                     ctx.grad_input_quantizer = prev_op.get_grad_output_quantizer()
-        
+
         # Unflatten grad_extra_outputs
         grad_extra_outputs_copy = list(grad_extra_outputs)
         basic_op_grad_extra_outputs = []
         for op in self.basic_ops:
             dys, grad_extra_outputs_copy = _split_tuple(
-                tuple(grad_extra_outputs_copy), 
-                op.num_extra_outputs
+                tuple(grad_extra_outputs_copy), op.num_extra_outputs
             )
             basic_op_grad_extra_outputs.append(dys)
-        
+
         # Run backward ops
         dx = grad_output
         grad_params = [None] * self._num_ops
         grad_extra_inputs = [None] * self._num_ops
-        
+
         # DEBUG: Return fixed shapes
         for op, basic_op_idxs in self._backward_ops:
             # Check if gradients required
             if all(not basic_op_ctxs[idx].requires_grad for idx in basic_op_idxs):
                 dx = None
                 break
-            
+
             # Backward op
             dx, fused_op_grad_params, fused_op_grad_extra_inputs = op.fuser_backward(
                 [basic_op_ctxs[idx] for idx in basic_op_idxs],
                 dx,
-                basic_op_grad_extra_outputs=[basic_op_grad_extra_outputs[idx] for idx in basic_op_idxs],
+                basic_op_grad_extra_outputs=[
+                    basic_op_grad_extra_outputs[idx] for idx in basic_op_idxs
+                ],
             )
 
-            
             for idx, dparams in zip(basic_op_idxs, fused_op_grad_params):
                 grad_params[idx] = dparams
                 basic_op_ctxs[idx].saved_tensors = None
-            
+
             for idx, dxs in zip(basic_op_idxs, fused_op_grad_extra_inputs):
                 grad_extra_inputs[idx] = dxs
-        
+
         # Flatten grad_params
         grad_params_flat = []
         for idx, dparams in enumerate(grad_params):
@@ -484,7 +489,7 @@ class OpsContainer:
             else:
                 dparams = list(dparams)
             grad_params_flat.extend(dparams)
-        
+
         # Flatten grad_extra_inputs
         grad_extra_inputs_flat = []
         for idx, dxs in enumerate(grad_extra_inputs):
@@ -495,7 +500,6 @@ class OpsContainer:
                 dxs = list(dxs)
             grad_extra_inputs_flat.extend(dxs)
 
-        
         return dx, grad_params_flat, grad_extra_inputs_flat
 
 

--- a/transformer_engine/pytorch/ops/compile_compat/tensor_info.py
+++ b/transformer_engine/pytorch/ops/compile_compat/tensor_info.py
@@ -15,63 +15,65 @@ from torch._library.opaque_object import register_opaque_type
 @dataclass(frozen=True)
 class TensorInfo:
     """Lightweight tensor descriptor for pseudo_forward - no actual tensor data.
-    
+
     This class carries tensor metadata (shape, dtype, requires_grad) without
     storing actual tensor data. Used for:
     1. Compile-time shape inference (register_fake)
     2. Backward ctx reconstruction (avoids storing ctx in opaque container)
     """
-    
+
     shape: tuple[int, ...]
     dtype: torch.dtype
     requires_grad: bool = False
     extra: tuple[tuple[str, Any], ...] = ()  # Hashable op-specific metadata
-    
+
     @classmethod
     def from_tensor(cls, t: torch.Tensor, **extra) -> "TensorInfo":
         """Create TensorInfo from a tensor with optional extra metadata."""
-        return cls(
-            tuple(t.shape), 
-            t.dtype, 
-            t.requires_grad, 
-            tuple(sorted(extra.items()))
-        )
-    
+        return cls(tuple(t.shape), t.dtype, t.requires_grad, tuple(sorted(extra.items())))
+
     def __hash__(self) -> int:
         return hash((self.shape, self.dtype, self.requires_grad, self.extra))
-    
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TensorInfo):
             return NotImplemented
         return (
-            self.shape == other.shape 
-            and self.dtype == other.dtype 
+            self.shape == other.shape
+            and self.dtype == other.dtype
             and self.requires_grad == other.requires_grad
             and self.extra == other.extra
         )
-    
+
     def __fx_repr__(self) -> tuple[str, dict[str, type]]:
         """FX-evaluable representation for graph codegen."""
         return (
-            f"TensorInfo({self.shape!r}, torch.{self.dtype}, {self.requires_grad!r}, {self.extra!r})",
-            {"TensorInfo": TensorInfo, "torch": torch}
+            (
+                f"TensorInfo({self.shape!r}, torch.{self.dtype}, {self.requires_grad!r},"
+                f" {self.extra!r})"
+            ),
+            {"TensorInfo": TensorInfo, "torch": torch},
         )
 
 
 @dataclass
 class PseudoForwardResult:
     """Result of pseudo_forward - contains ctx info and output shapes.
-    
+
     This is NOT registered as an opaque type because it's only used
     internally during compile-time shape inference (via USE_REAL member)
     and backward ctx reconstruction.
     """
-    
+
     output_info: TensorInfo  # shape/dtype of forward output
-    tensors_to_save_info: list[TensorInfo] = field(default_factory=list)  # shapes of tensors saved for backward
-    extra_outputs_info: list[TensorInfo] = field(default_factory=list)  # shapes of extra outputs (e.g., MakeExtraOutput)
+    tensors_to_save_info: list[TensorInfo] = field(
+        default_factory=list
+    )  # shapes of tensors saved for backward
+    extra_outputs_info: list[TensorInfo] = field(
+        default_factory=list
+    )  # shapes of extra outputs (e.g., MakeExtraOutput)
     ctx_data: dict[str, Any] = field(default_factory=dict)  # non-tensor ctx attributes for backward
-    
+
     # Source of each tensor in tensors_to_save:
     # -1 = new tensor (returned from forward, not an input alias)
     #  0 = input x
@@ -86,53 +88,54 @@ register_opaque_type(TensorInfo, typ="value")
 
 class TensorInfoList:
     """Container for list of TensorInfo to work with torch.compile custom ops.
-    
+
     PyTorch's @torch.library.custom_op does not support list[OpaqueType]
     in function signatures. This container wraps the list so we can pass
     it through custom ops.
-    
+
     Value type because TensorInfo is immutable and the list contents are constant.
     """
-    
+
     __slots__ = ("_items", "__weakref__")
-    
+
     def __init__(self, items: list[TensorInfo]) -> None:
         # Store as tuple for immutability and hashability
         self._items = tuple(items)
-    
+
     @property
     def items(self) -> list[TensorInfo]:
         """Get the contained list of TensorInfo."""
         return list(self._items)
-    
+
     def __len__(self) -> int:
         return len(self._items)
-    
+
     def __getitem__(self, idx: int) -> TensorInfo:
         return self._items[idx]
-    
+
     def __iter__(self):
         return iter(self._items)
-    
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TensorInfoList):
             return NotImplemented
         return self._items == other._items
-    
+
     def __hash__(self) -> int:
         return hash(self._items)
-    
+
     def __fx_repr__(self) -> tuple[str, dict[str, type]]:
         """FX-evaluable representation for graph codegen."""
         items_repr = ", ".join(
-            f"TensorInfo({info.shape!r}, torch.{info.dtype}, {info.requires_grad!r}, {info.extra!r})"
+            f"TensorInfo({info.shape!r}, torch.{info.dtype}, {info.requires_grad!r},"
+            f" {info.extra!r})"
             for info in self._items
         )
         return (
             f"TensorInfoList([{items_repr}])",
-            {"TensorInfoList": TensorInfoList, "TensorInfo": TensorInfo, "torch": torch}
+            {"TensorInfoList": TensorInfoList, "TensorInfo": TensorInfo, "torch": torch},
         )
-    
+
     def __repr__(self) -> str:
         return f"TensorInfoList({list(self._items)!r})"
 

--- a/transformer_engine/pytorch/ops/compile_compat/tensor_info.py
+++ b/transformer_engine/pytorch/ops/compile_compat/tensor_info.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Tensor metadata classes for torch.compile compatibility."""
+
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch._library.opaque_object import register_opaque_type
+
+
+@dataclass(frozen=True)
+class TensorInfo:
+    """Lightweight tensor descriptor for pseudo_forward - no actual tensor data.
+    
+    This class carries tensor metadata (shape, dtype, requires_grad) without
+    storing actual tensor data. Used for:
+    1. Compile-time shape inference (register_fake)
+    2. Backward ctx reconstruction (avoids storing ctx in opaque container)
+    """
+    
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    requires_grad: bool = False
+    extra: tuple[tuple[str, Any], ...] = ()  # Hashable op-specific metadata
+    
+    @classmethod
+    def from_tensor(cls, t: torch.Tensor, **extra) -> "TensorInfo":
+        """Create TensorInfo from a tensor with optional extra metadata."""
+        return cls(
+            tuple(t.shape), 
+            t.dtype, 
+            t.requires_grad, 
+            tuple(sorted(extra.items()))
+        )
+    
+    def __hash__(self) -> int:
+        return hash((self.shape, self.dtype, self.requires_grad, self.extra))
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TensorInfo):
+            return NotImplemented
+        return (
+            self.shape == other.shape 
+            and self.dtype == other.dtype 
+            and self.requires_grad == other.requires_grad
+            and self.extra == other.extra
+        )
+    
+    def __fx_repr__(self) -> tuple[str, dict[str, type]]:
+        """FX-evaluable representation for graph codegen."""
+        return (
+            f"TensorInfo({self.shape!r}, torch.{self.dtype}, {self.requires_grad!r}, {self.extra!r})",
+            {"TensorInfo": TensorInfo, "torch": torch}
+        )
+
+
+@dataclass
+class PseudoForwardResult:
+    """Result of pseudo_forward - contains ctx info and output shapes.
+    
+    This is NOT registered as an opaque type because it's only used
+    internally during compile-time shape inference (via USE_REAL member)
+    and backward ctx reconstruction.
+    """
+    
+    output_info: TensorInfo  # shape/dtype of forward output
+    tensors_to_save_info: list[TensorInfo] = field(default_factory=list)  # shapes of tensors saved for backward
+    extra_outputs_info: list[TensorInfo] = field(default_factory=list)  # shapes of extra outputs (e.g., MakeExtraOutput)
+    ctx_data: dict[str, Any] = field(default_factory=dict)  # non-tensor ctx attributes for backward
+    
+    # Source of each tensor in tensors_to_save:
+    # -1 = new tensor (returned from forward, not an input alias)
+    #  0 = input x
+    #  1..num_params = params[i-1]
+    #  num_params+1..num_params+num_extra_inputs = extra_inputs[i-num_params-1]
+    tensor_sources: list[int] = field(default_factory=list)
+
+
+# Register TensorInfo as value type (immutable, can be baked into graph)
+register_opaque_type(TensorInfo, typ="value")
+
+
+class TensorInfoList:
+    """Container for list of TensorInfo to work with torch.compile custom ops.
+    
+    PyTorch's @torch.library.custom_op does not support list[OpaqueType]
+    in function signatures. This container wraps the list so we can pass
+    it through custom ops.
+    
+    Value type because TensorInfo is immutable and the list contents are constant.
+    """
+    
+    __slots__ = ("_items", "__weakref__")
+    
+    def __init__(self, items: list[TensorInfo]) -> None:
+        # Store as tuple for immutability and hashability
+        self._items = tuple(items)
+    
+    @property
+    def items(self) -> list[TensorInfo]:
+        """Get the contained list of TensorInfo."""
+        return list(self._items)
+    
+    def __len__(self) -> int:
+        return len(self._items)
+    
+    def __getitem__(self, idx: int) -> TensorInfo:
+        return self._items[idx]
+    
+    def __iter__(self):
+        return iter(self._items)
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TensorInfoList):
+            return NotImplemented
+        return self._items == other._items
+    
+    def __hash__(self) -> int:
+        return hash(self._items)
+    
+    def __fx_repr__(self) -> tuple[str, dict[str, type]]:
+        """FX-evaluable representation for graph codegen."""
+        items_repr = ", ".join(
+            f"TensorInfo({info.shape!r}, torch.{info.dtype}, {info.requires_grad!r}, {info.extra!r})"
+            for info in self._items
+        )
+        return (
+            f"TensorInfoList([{items_repr}])",
+            {"TensorInfoList": TensorInfoList, "TensorInfo": TensorInfo, "torch": torch}
+        )
+    
+    def __repr__(self) -> str:
+        return f"TensorInfoList({list(self._items)!r})"
+
+
+# Register TensorInfoList as value type (immutable)
+register_opaque_type(TensorInfoList, typ="value")

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -23,6 +23,7 @@ from ..tensor import Quantizer
 
 # Import for type hints only (avoid circular import)
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from .compile_compat.tensor_info import TensorInfo, PseudoForwardResult
 
@@ -475,33 +476,33 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         **kwargs,
     ) -> "PseudoForwardResult":
         """Compute forward metadata WITHOUT actual tensor computation.
-        
+
         Used for:
         1. Compile-time shape inference (register_fake)
         2. Backward ctx reconstruction (avoids storing ctx in opaque container)
-        
+
         This default implementation provides basic shape propagation.
         Subclasses should override if they have different output shapes
         or need to save tensors for backward.
-        
+
         Args:
             input_info: TensorInfo describing input tensor
             extra_inputs_info: TensorInfo for extra inputs (uses num_extra_inputs attr)
             **kwargs: op-specific arguments
-            
+
         Returns:
             PseudoForwardResult with output shape, tensors_to_save shapes, and ctx data
         """
         # Lazy import to avoid circular dependency
         from .compile_compat.tensor_info import TensorInfo, PseudoForwardResult
-        
+
         # Default: output has same shape/dtype as input
         output_info = TensorInfo(
             shape=input_info.shape,
             dtype=input_info.dtype,
             requires_grad=input_info.requires_grad,
         )
-        
+
         return PseudoForwardResult(
             output_info=output_info,
             tensors_to_save_info=[],
@@ -553,7 +554,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 f"and {self.num_extra_outputs} extra tensor outputs. "
                 "It should override `fuser_backward` instead of `op_backward`."
             )
-        
+
         grad_input, grad_params = self.op_backward(basic_op_ctxs[0], grad_output)
 
         return grad_input, [grad_params], [()]

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -21,6 +21,11 @@ from ..quantization import (
 )
 from ..tensor import Quantizer
 
+# Import for type hints only (avoid circular import)
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .compile_compat.tensor_info import TensorInfo, PseudoForwardResult
+
 
 @dataclasses.dataclass
 class OperationContext:
@@ -463,6 +468,47 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
 
         """
 
+    def pseudo_forward(
+        self,
+        input_info: "TensorInfo",
+        extra_inputs_info: tuple["TensorInfo", ...],
+        **kwargs,
+    ) -> "PseudoForwardResult":
+        """Compute forward metadata WITHOUT actual tensor computation.
+        
+        Used for:
+        1. Compile-time shape inference (register_fake)
+        2. Backward ctx reconstruction (avoids storing ctx in opaque container)
+        
+        This default implementation provides basic shape propagation.
+        Subclasses should override if they have different output shapes
+        or need to save tensors for backward.
+        
+        Args:
+            input_info: TensorInfo describing input tensor
+            extra_inputs_info: TensorInfo for extra inputs (uses num_extra_inputs attr)
+            **kwargs: op-specific arguments
+            
+        Returns:
+            PseudoForwardResult with output shape, tensors_to_save shapes, and ctx data
+        """
+        # Lazy import to avoid circular dependency
+        from .compile_compat.tensor_info import TensorInfo, PseudoForwardResult
+        
+        # Default: output has same shape/dtype as input
+        output_info = TensorInfo(
+            shape=input_info.shape,
+            dtype=input_info.dtype,
+            requires_grad=input_info.requires_grad,
+        )
+        
+        return PseudoForwardResult(
+            output_info=output_info,
+            tensors_to_save_info=[],
+            extra_outputs_info=[],
+            ctx_data={},
+        )
+
     def fuser_forward(
         self,
         basic_op_ctxs: list[OperationContext],
@@ -507,7 +553,9 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 f"and {self.num_extra_outputs} extra tensor outputs. "
                 "It should override `fuser_backward` instead of `op_backward`."
             )
+        
         grad_input, grad_params = self.op_backward(basic_op_ctxs[0], grad_output)
+
         return grad_input, [grad_params], [()]
 
     def forward(


### PR DESCRIPTION
## [WIP] torch.compile Support for te.ops API

**This is an early draft - NOT ready for merge.** I'm sharing this to show progress and encourage discussion on the design approach.

### Overview

This PR introduces `torch.compile(fullgraph=True)` support for `te.ops` by wrapping fusion logic in custom operators. The key insight is to make fusion decisions **invisible to torch.compile** by encapsulating them inside opaque custom ops.

### What are Opaque Types?

PyTorch's `torch._library.opaque_object.register_opaque_type` allows passing custom Python objects through `torch.compile` without causing graph breaks. During tracing, the object becomes a `FakeScriptObject` - torch.compile doesn't see inside it.

Two variants:
- **Reference types** (`typ="reference"`) - for mutable/stateful objects, passed as graph inputs at runtime
- **Value types** (`typ="value"`) - for immutable data, baked into graph as constants

This lets us hide complex TE logic (fusion decisions, FP8 recipes, operation containers) from the compiler while still being fully compilable.

### Design Highlights

**Opaque Types Used:**
- `Recipe` - reference type (delayed scaling mutates internal state)
- `OpsContainer` - reference type, holds `BasicOperation` list, created outside compiled region
- `OpaqueKwargs` - value type (immutable, baked into graph)
- `TensorInfo` - value type for lightweight shape/dtype descriptors

**Key Abstraction - `pseudo_forward`:**
- New method on `BasicOperation` for shape inference without actual computation
- Called at compile time (via `register_fake`) for output shape prediction
- Called at backward time to reconstruct `ctx_data` from saved `TensorInfo`
- Eliminates need for mutable `CtxContainer` - deterministic reconstruction instead

### Custom Operators

**te_ops::fused_forward**
```python
def fused_forward_impl(
    x: torch.Tensor,
    ops_container: OpsContainer,
    recipe: Recipe,
    kwargs_opaque: OpaqueKwargs,
    params: list[torch.Tensor],
    extra_inputs: list[torch.Tensor],
) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
    """
    Perform fused forward pass.
    Fusion logic happens inside run_forward (invisible to torch.compile).
    
    Returns: (output, tensors_to_save, extra_outputs)
    """
```

**te_ops::fused_backward**
```python
def fused_backward_impl(
    grad_output: torch.Tensor,
    grad_extra_outputs: list[torch.Tensor],
    ops_container: OpsContainer,
    recipe: Recipe,
    kwargs_opaque: OpaqueKwargs,
    input_info: TensorInfo,
    extra_inputs_info: tuple[TensorInfo, ...],
    tensors_saved: list[torch.Tensor],
    params: list[torch.Tensor],
) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
    """
    Perform fused backward pass.
    Fusion logic happens inside run_backward (invisible to torch.compile).
    
    Returns: (grad_input, grad_params, grad_extra_inputs)
    """
```

### Integration with TE Sequential

`te.Sequential` groups consecutive `FusibleOperation`s and wraps each group in an `OperationFuser` (see `_make_module_groups()` in `sequential.py`). The `OperationFuser`:

1. Flattens `FusibleOperation`s into `BasicOperation`s 
2. Applies fusion passes in `maybe_fuse_ops()` (e.g., `fuse_forward_linear_bias_activation`, `fuse_backward_activation_bias`)
3. Runs forward/backward via `_OperationFuserAutogradFunction`

**Problem:** `OperationFuser` is not compile-friendly - fusion decisions, dynamic op lists, and complex autograd logic cause graph breaks.

**Solution:** `TorchCompileCompatibleFuser` is a drop-in replacement for `OperationFuser`:
- Wraps the same `BasicOperation` list in an `OpsContainer` (opaque to torch.compile)
- Fusion logic (`_fuse_forward_ops`, `_fuse_backward_ops`) moves inside `OpsContainer.run_forward/run_backward`
- Custom ops (`te_ops::fused_forward/backward`) expose a clean tensor-in-tensor-out interface
- All fusion complexity is hidden from the compiler while preserving TE optimizations
