### PR TITLE
[JAX] Fix cb.CUDAOptions usage for Triton 3.6.0

### DIFF
--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -33,9 +33,10 @@ Environment Variables:
 import hashlib
 import os
 import warnings
-from packaging import version
 from typing import Any, Callable, Mapping
 import zlib
+
+from packaging import version
 
 from jax import core
 import jax
@@ -276,7 +277,7 @@ def compile_triton(
 
     # Compile kernel
     cuda_option_kwargs = {}
-    if version.parse(triton.__version__) < version.parse("3.6.0"):
+    if version.parse(_TRITON_VERSION) < version.parse("3.6.0"):
         cuda_option_kwargs["cluster_dims"] = (1, 1, 1)
     options = cb.CUDAOptions(
         num_warps=num_warps,


### PR DESCRIPTION
# Description

Fix Triton extension issue now that `cluster_dims` does not exist on `cb.CUDAOptions`

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- When Triton >= 3.6.0, don't pass in `cluster_dims` to `CUDAOptions` as it is now computed internally

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
