### PR TITLE
[PyTorch] Pad V when Q/V head dims differ (MLA) for THD

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -182,14 +182,21 @@ _dpa_fp8ds_reduce_amax = os.getenv("NVTE_DPA_FP8DS_REDUCE_AMAX", "1") == "1"
 __all__ = ["DotProductAttention"]
 
 
-def _pad_value_layer(value_layer, head_dim_qk):
-    """Pad V for FlashAttention when Q/K and V head dimensions differ."""
+def _pad_qkv_head_dim(query_layer, key_layer, value_layer):
+    """Pad Q/K/V to the same head dimension for FlashAttention 2 MLA."""
+    orig_head_dim_qk = query_layer.shape[-1]
     orig_head_dim_v = value_layer.shape[-1]
-    return F.pad(value_layer, (0, head_dim_qk - orig_head_dim_v)), orig_head_dim_v
+    padded_head_dim = max(orig_head_dim_qk, orig_head_dim_v)
+    if orig_head_dim_qk < padded_head_dim:
+        query_layer = F.pad(query_layer, (0, padded_head_dim - orig_head_dim_qk))
+        key_layer = F.pad(key_layer, (0, padded_head_dim - key_layer.shape[-1]))
+    if orig_head_dim_v < padded_head_dim:
+        value_layer = F.pad(value_layer, (0, padded_head_dim - orig_head_dim_v))
+    return query_layer, key_layer, value_layer, orig_head_dim_qk, orig_head_dim_v
 
 
 def _trim_output(attn_out, num_attention_heads, padded_head_dim_v, orig_head_dim_v):
-    """Trim FlashAttention output after padding V to the Q/K head dimension."""
+    """Trim FlashAttention output after padding V to a larger head dimension."""
     out_shape = attn_out.shape[:-1]
     attn_out = attn_out.reshape(*out_shape, num_attention_heads, padded_head_dim_v)
     return attn_out[..., :orig_head_dim_v].reshape(*out_shape, -1)
@@ -1645,14 +1652,20 @@ class DotProductAttention(TransformerEngineBaseModule):
             )
 
             if use_flash_attention:
+                orig_qk_dim = None
                 orig_v_dim = None
                 if (
                     flash_attention_backend == FlashAttentionUtils.version
                     and not isinstance(value_layer, Float8TensorStorage)
                     and head_dim_qk != head_dim_v
-                    and value_layer.shape[-1] < head_dim_qk
                 ):
-                    value_layer, orig_v_dim = _pad_value_layer(value_layer, head_dim_qk)
+                    (
+                        query_layer,
+                        key_layer,
+                        value_layer,
+                        orig_qk_dim,
+                        orig_v_dim,
+                    ) = _pad_qkv_head_dim(query_layer, key_layer, value_layer)
 
                 if core_attention_bias_type == "alibi":
                     alibi_slopes, _ = dpa_utils.get_alibi(
@@ -1690,8 +1703,8 @@ class DotProductAttention(TransformerEngineBaseModule):
                     cu_seqlens_q_padded=cu_seqlens_q_padded,
                     cu_seqlens_kv_padded=cu_seqlens_kv_padded,
                 )
-                if orig_v_dim is not None:
-                    return _trim_output(attn_out, num_attention_heads, head_dim_qk, orig_v_dim)
+                if orig_qk_dim is not None and orig_qk_dim > orig_v_dim:
+                    return _trim_output(attn_out, num_attention_heads, orig_qk_dim, orig_v_dim)
                 return attn_out
 
             if use_fused_attention:

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -11,6 +11,7 @@ import warnings
 import logging
 
 import torch
+import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
 import transformer_engine_torch as tex
@@ -178,6 +179,18 @@ _dpa_fp8ds_reduce_amax = os.getenv("NVTE_DPA_FP8DS_REDUCE_AMAX", "1") == "1"
 
 
 __all__ = ["DotProductAttention"]
+
+
+def _pad_thd_value_layer(value_layer, head_dim_qk):
+    """Pad V for THD FlashAttention when Q/K and V head dimensions differ."""
+    orig_head_dim_v = value_layer.shape[-1]
+    return F.pad(value_layer, (0, head_dim_qk - orig_head_dim_v)), orig_head_dim_v
+
+
+def _trim_thd_output(attn_out, num_attention_heads, padded_head_dim_v, orig_head_dim_v):
+    """Trim FlashAttention THD output after padding V to the Q/K head dimension."""
+    attn_out = attn_out.reshape(attn_out.shape[0], num_attention_heads, padded_head_dim_v)
+    return attn_out[..., :orig_head_dim_v].reshape(attn_out.shape[0], -1)
 
 
 class DotProductAttention(TransformerEngineBaseModule):
@@ -1630,6 +1643,16 @@ class DotProductAttention(TransformerEngineBaseModule):
             )
 
             if use_flash_attention:
+                orig_v_dim = None
+                if (
+                    q_format == "thd"
+                    and kv_format == "thd"
+                    and not isinstance(value_layer, Float8TensorStorage)
+                    and head_dim_qk != head_dim_v
+                    and value_layer.shape[-1] < head_dim_qk
+                ):
+                    value_layer, orig_v_dim = _pad_thd_value_layer(value_layer, head_dim_qk)
+
                 if core_attention_bias_type == "alibi":
                     alibi_slopes, _ = dpa_utils.get_alibi(
                         _alibi_cache,
@@ -1638,7 +1661,7 @@ class DotProductAttention(TransformerEngineBaseModule):
                         max_seqlen_kv,
                         alibi_slopes=alibi_slopes,
                     )
-                return self.flash_attention(
+                attn_out = self.flash_attention(
                     query_layer,
                     key_layer,
                     value_layer,
@@ -1666,6 +1689,9 @@ class DotProductAttention(TransformerEngineBaseModule):
                     cu_seqlens_q_padded=cu_seqlens_q_padded,
                     cu_seqlens_kv_padded=cu_seqlens_kv_padded,
                 )
+                if orig_v_dim is not None:
+                    return _trim_thd_output(attn_out, num_attention_heads, head_dim_qk, orig_v_dim)
+                return attn_out
 
             if use_fused_attention:
                 fu_core_attention_bias_type = core_attention_bias_type

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -56,6 +56,7 @@ from transformer_engine.pytorch.attention.inference import InferenceParams
 import transformer_engine.pytorch.attention.dot_product_attention.utils as dpa_utils
 from transformer_engine.pytorch.attention.dot_product_attention.utils import (
     AttentionLogging as attn_log,
+    FlashAttentionUtils,
 )
 
 from transformer_engine.pytorch.attention.dot_product_attention.backends import (
@@ -181,16 +182,17 @@ _dpa_fp8ds_reduce_amax = os.getenv("NVTE_DPA_FP8DS_REDUCE_AMAX", "1") == "1"
 __all__ = ["DotProductAttention"]
 
 
-def _pad_thd_value_layer(value_layer, head_dim_qk):
-    """Pad V for THD FlashAttention when Q/K and V head dimensions differ."""
+def _pad_value_layer(value_layer, head_dim_qk):
+    """Pad V for FlashAttention when Q/K and V head dimensions differ."""
     orig_head_dim_v = value_layer.shape[-1]
     return F.pad(value_layer, (0, head_dim_qk - orig_head_dim_v)), orig_head_dim_v
 
 
-def _trim_thd_output(attn_out, num_attention_heads, padded_head_dim_v, orig_head_dim_v):
-    """Trim FlashAttention THD output after padding V to the Q/K head dimension."""
-    attn_out = attn_out.reshape(attn_out.shape[0], num_attention_heads, padded_head_dim_v)
-    return attn_out[..., :orig_head_dim_v].reshape(attn_out.shape[0], -1)
+def _trim_output(attn_out, num_attention_heads, padded_head_dim_v, orig_head_dim_v):
+    """Trim FlashAttention output after padding V to the Q/K head dimension."""
+    out_shape = attn_out.shape[:-1]
+    attn_out = attn_out.reshape(*out_shape, num_attention_heads, padded_head_dim_v)
+    return attn_out[..., :orig_head_dim_v].reshape(*out_shape, -1)
 
 
 class DotProductAttention(TransformerEngineBaseModule):
@@ -1645,13 +1647,12 @@ class DotProductAttention(TransformerEngineBaseModule):
             if use_flash_attention:
                 orig_v_dim = None
                 if (
-                    q_format == "thd"
-                    and kv_format == "thd"
+                    flash_attention_backend == FlashAttentionUtils.version
                     and not isinstance(value_layer, Float8TensorStorage)
                     and head_dim_qk != head_dim_v
                     and value_layer.shape[-1] < head_dim_qk
                 ):
-                    value_layer, orig_v_dim = _pad_thd_value_layer(value_layer, head_dim_qk)
+                    value_layer, orig_v_dim = _pad_value_layer(value_layer, head_dim_qk)
 
                 if core_attention_bias_type == "alibi":
                     alibi_slopes, _ = dpa_utils.get_alibi(
@@ -1690,7 +1691,7 @@ class DotProductAttention(TransformerEngineBaseModule):
                     cu_seqlens_kv_padded=cu_seqlens_kv_padded,
                 )
                 if orig_v_dim is not None:
-                    return _trim_thd_output(attn_out, num_attention_heads, head_dim_qk, orig_v_dim)
+                    return _trim_output(attn_out, num_attention_heads, head_dim_qk, orig_v_dim)
                 return attn_out
 
             if use_fused_attention:

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -722,10 +722,6 @@ def get_attention_backend(
 
     # Filter: Head dimension
     if head_dim_qk != head_dim_v:
-        if use_flash_attention_2 and FlashAttentionUtils.is_installed:
-            logger.debug("Disabling FlashAttention 2 as it does not support MLA.")
-            use_flash_attention_2 = False
-
         qkv_layout_group = qkv_layout.replace("b", "").replace("s", "").replace("t", "")
         if use_fused_attention and qkv_layout_group != "hd_hd_hd":
             logger.debug(

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -743,18 +743,27 @@ def get_attention_backend(
                 )
             use_fused_attention = False
 
+    fa2_padded_head_dim = max(head_dim_qk, head_dim_v)
     if (  # pylint: disable=too-many-boolean-expressions
         use_flash_attention_2
         and FlashAttentionUtils.is_installed
-        and (head_dim_qk > 256 or head_dim_qk % 8 != 0)
+        and (
+            fa2_padded_head_dim > 256
+            or fa2_padded_head_dim % 8 != 0
+            or (
+                fa2_padded_head_dim > 192
+                and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (12, 0))
+            )
+        )
     ):
         logger.debug(
             "Disabling FlashAttention 2 due to unsupported head_dim_qk and head_dim_v. "
-            "Supported: head_dim_qk = head_dim_v, head_dim_qk %%8 = 0, "
-            "head_dim_qk <= 256. "
-            "Found: head_dim_qk = %s, head_dim_v = %s, on sm%s.",
+            "Supported after padding: padded head_dim %%8 = 0, padded head_dim <= 256 "
+            "(>192 requires sm80/90/100+). "
+            "Found: head_dim_qk = %s, head_dim_v = %s, padded head_dim = %s, on sm%s.",
             head_dim_qk,
             head_dim_v,
+            fa2_padded_head_dim,
             ".".join([str(i) for i in device_compute_capability]),
         )
         use_flash_attention_2 = False


### PR DESCRIPTION
# Description

For MLA, we shall pad V when Q/V head dims differ for THD

Similar to https://github.com/NVIDIA/Megatron-LM/pull/3003

Fixes https://github.com/nvidia/megatron-lm/issues/1698

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- pad V when Q/V head dims differ for THD

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
