### PR TITLE
Fix exp2f_rcp to properly handle nan and 0xFE cases

### DIFF
--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -425,10 +425,14 @@ inline fp8e8m0 float_to_e8m0(float val) {
 }
 
 inline float exp2f_rcp(fp8e8m0 biased_exp) {
-  if (biased_exp == 0) {
-    return 1.0f;
+  int32_t int_val = 0;
+  if (biased_exp == 255) {
+    int_val = 0x7fffffff;
+  } else if (biased_exp == 254) {
+    int_val = 0x00400000;
+  } else {
+    int_val = (254 - biased_exp) << FP32_MANTISSA_BITS;   // 127 - (biased_exp - 127)
   }
-  int32_t int_val = (254 - biased_exp) << FP32_MANTISSA_BITS;   // 127 - (biased_exp - 127)
   float fp32_val = *reinterpret_cast<float*>(&int_val);
   return fp32_val;
 }


### PR DESCRIPTION
# Description

Fix the implementation of `exp2f_rcp`

Fixes #2408

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

Our previous implementation of `exp2f_rcp` is not accurate. After some discussion we decide to
- If biased_exp is nan, return nan
- Otherwise, return the reciprocal using the fast math trick
  - If biased_exp == 254 (2^127), this is the only case where we have to use the mantissa bits to represent its reciprocal 2^-127, so we directly return the hardcoded result here
  - Otherwise we use a bits shifting trick to obtain the float reciprocal result

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
