### PR TITLE
[Common] Remove volatile keyword in fused router kernel utils

### DIFF
--- a/transformer_engine/common/fused_router/utils.h
+++ b/transformer_engine/common/fused_router/utils.h
@@ -184,8 +184,8 @@ __device__ inline void naive_topk_and_mask(T *scores, int data_size, int topk, i
   for (int k = 0; k < topk; k++) {
     // Find the max value and its index
     double val = (lane_id < data_size && !is_masked(k, lane_id))
-                    ? static_cast<double>(scores[lane_id])
-                    : -std::numeric_limits<double>::infinity();
+                     ? static_cast<double>(scores[lane_id])
+                     : -std::numeric_limits<double>::infinity();
     int index = (lane_id < data_size) ? lane_id : 0;
     // Some value is hanlded in local thread
     // Thread 0 is responsible for the: 0-th, 32-th, 64-th, 96-th ...


### PR DESCRIPTION
# Description

Per recommendation from the compiler team, this helps avoid local memory loads/stores on SM100 and significantly improves performance of fused router kernels.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
