### PR TITLE
Fix vermin pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,4 @@ repos:
     rev: c75aca72f4e85c6e47252139e8695f1c8b5f9ae3
     hooks:
       - id: vermin
-        args: ['-t=3.10', '--violations']
+        args: ['-t=3.10-', '--violations']


### PR DESCRIPTION
Fix the `vermin` pre-commit hook when running on a sub-set of changed files. We need to specify `3.10-`, so that if a change supports a minimum version _less_ than 3.10, we don't error.

From the vermin [docs](https://pypi.org/project/vermin/#examples)
> If you’re using the vermin-all hook, you can specify any target as you usually would. However, if you’re using the vermin hook, your target must be in the form of x.y- (as opposed to x.y), otherwise you will run into issues when your staged changes meet a minimum version that is lower than your target.