### PR TITLE
[Common][PyTorch] Add z_loss_weight to parallel_cross_entropy

### DIFF
--- a/tests/pytorch/test_parallel_cross_entropy.py
+++ b/tests/pytorch/test_parallel_cross_entropy.py
@@ -15,18 +15,31 @@ class TestParallelCrossEntropy:
     def generate_iters(self, iters: int):
         self.iters = iters
 
-    def generate_infra(self, reduce_loss: bool, label_smoothing: float, z_loss_weight: float = 0.0, ignore_idx: int = -100):
+    def generate_infra(
+        self,
+        reduce_loss: bool,
+        label_smoothing: float,
+        z_loss_weight: float = 0.0,
+        ignore_idx: int = -100,
+    ):
         self.test_loss_func = parallel_cross_entropy
         if z_loss_weight == 0.0:
             self.ref_loss_func = torch.nn.CrossEntropyLoss(
-                label_smoothing=label_smoothing, reduction="mean" if reduce_loss else "none",
+                label_smoothing=label_smoothing,
+                reduction="mean" if reduce_loss else "none",
                 ignore_index=ignore_idx,
             )
         else:
 
             def ref_with_zloss(inp, tar):
                 inp = inp.float()
-                ce = F.cross_entropy(inp, tar, reduction="none", label_smoothing=label_smoothing, ignore_index=ignore_idx)
+                ce = F.cross_entropy(
+                    inp,
+                    tar,
+                    reduction="none",
+                    label_smoothing=label_smoothing,
+                    ignore_index=ignore_idx,
+                )
                 z_pen = z_loss_weight * torch.square(torch.logsumexp(inp, dim=-1))
                 z_pen[tar == ignore_idx] = 0.0
                 loss = ce + z_pen
@@ -90,16 +103,18 @@ class TestParallelCrossEntropy:
         if check_lse:
             ref_lse = torch.logsumexp(self.input_test.float(), dim=-1)
 
-            loss_only = self.test_loss_func(self.input_test.clone().detach(), self.tar_test,
-                                            z_loss_weight=z_loss_weight)
+            loss_only = self.test_loss_func(
+                self.input_test.clone().detach(), self.tar_test, z_loss_weight=z_loss_weight
+            )
 
             inp_lse = self.input_test.clone().detach().requires_grad_(True)
-            loss_lse, lse = self.test_loss_func(inp_lse, self.tar_test,
-                                                z_loss_weight=z_loss_weight, return_log_sum_exp=True)
+            loss_lse, lse = self.test_loss_func(
+                inp_lse, self.tar_test, z_loss_weight=z_loss_weight, return_log_sum_exp=True
+            )
 
             torch.testing.assert_close(loss_lse, loss_only)
 
-            non_ignored = (self.tar_test != -100)
+            non_ignored = self.tar_test != -100
             torch.testing.assert_close(lse[non_ignored], ref_lse[non_ignored], atol=1e-5, rtol=1e-5)
 
             if ignore_idx:

--- a/tests/pytorch/test_parallel_cross_entropy.py
+++ b/tests/pytorch/test_parallel_cross_entropy.py
@@ -80,10 +80,34 @@ class TestParallelCrossEntropy:
         reduce_loss: bool,
         ignore_idx: bool = False,
         z_loss_weight: float = 0.0,
+        check_lse: bool = False,
     ):
 
         # Random data
         self.generate_input(dtype, swap_dim, ignore_idx)
+
+        # Check return_log_sum_exp before the main forward (which modifies input in-place)
+        if check_lse:
+            ref_lse = torch.logsumexp(self.input_test.float(), dim=-1)
+
+            loss_only = self.test_loss_func(self.input_test.clone().detach(), self.tar_test,
+                                            z_loss_weight=z_loss_weight)
+
+            inp_lse = self.input_test.clone().detach().requires_grad_(True)
+            loss_lse, lse = self.test_loss_func(inp_lse, self.tar_test,
+                                                z_loss_weight=z_loss_weight, return_log_sum_exp=True)
+
+            torch.testing.assert_close(loss_lse, loss_only)
+
+            non_ignored = (self.tar_test != -100)
+            torch.testing.assert_close(lse[non_ignored], ref_lse[non_ignored], atol=1e-5, rtol=1e-5)
+
+            if ignore_idx:
+                assert torch.all(lse[~non_ignored] == 0.0), "LSE should be zero for ignored tokens"
+
+            loss_lse.sum().backward()
+            assert inp_lse.grad is not None
+            assert inp_lse.grad.shape == self.input_test.shape
 
         # Forward pass — default return is a single tensor (backward compatible)
         test_loss = self.test_loss_func(
@@ -288,6 +312,44 @@ class TestParallelCrossEntropy:
                 label_smoothing=0,
                 reduce_loss=False,
                 z_loss_weight=0.001,
+            )
+
+    def test_return_log_sum_exp(self):
+        self.generate_iters(5)
+        self.generate_infra(False, 0)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=False,
+                check_lse=True,
+            )
+
+    def test_return_log_sum_exp_with_z_loss(self):
+        self.generate_iters(5)
+        self.generate_infra(False, 0, z_loss_weight=0.01)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=False,
+                z_loss_weight=0.01,
+                check_lse=True,
+            )
+
+    def test_return_log_sum_exp_with_ignore_idx(self):
+        self.generate_iters(5)
+        self.generate_infra(False, 0)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=False,
+                ignore_idx=True,
+                check_lse=True,
             )
 
 

--- a/tests/pytorch/test_parallel_cross_entropy.py
+++ b/tests/pytorch/test_parallel_cross_entropy.py
@@ -4,6 +4,7 @@
 
 import random
 import torch
+import torch.nn.functional as F
 from transformer_engine.pytorch import parallel_cross_entropy
 
 from utils import dtype_tols
@@ -14,11 +15,26 @@ class TestParallelCrossEntropy:
     def generate_iters(self, iters: int):
         self.iters = iters
 
-    def generate_infra(self, reduce_loss: bool, label_smoothing: float):
+    def generate_infra(self, reduce_loss: bool, label_smoothing: float, z_loss_weight: float = 0.0, ignore_idx: int = -100):
         self.test_loss_func = parallel_cross_entropy
-        self.ref_loss_func = torch.nn.CrossEntropyLoss(
-            label_smoothing=label_smoothing, reduction="mean" if reduce_loss else "none"
-        )
+        if z_loss_weight == 0.0:
+            self.ref_loss_func = torch.nn.CrossEntropyLoss(
+                label_smoothing=label_smoothing, reduction="mean" if reduce_loss else "none",
+                ignore_index=ignore_idx,
+            )
+        else:
+
+            def ref_with_zloss(inp, tar):
+                inp = inp.float()
+                ce = F.cross_entropy(inp, tar, reduction="none", label_smoothing=label_smoothing, ignore_index=ignore_idx)
+                z_pen = z_loss_weight * torch.square(torch.logsumexp(inp, dim=-1))
+                z_pen[tar == ignore_idx] = 0.0
+                loss = ce + z_pen
+                if reduce_loss:
+                    loss = loss.sum() / (tar != ignore_idx).sum()
+                return loss
+
+            self.ref_loss_func = ref_with_zloss
 
     def generate_input(
         self,
@@ -63,14 +79,20 @@ class TestParallelCrossEntropy:
         label_smoothing: float,
         reduce_loss: bool,
         ignore_idx: bool = False,
+        z_loss_weight: float = 0.0,
     ):
 
         # Random data
         self.generate_input(dtype, swap_dim, ignore_idx)
 
-        # Forward pass
+        # Forward pass — default return is a single tensor (backward compatible)
         test_loss = self.test_loss_func(
-            self.input_test, self.tar_test, label_smoothing, reduce_loss, None
+            self.input_test,
+            self.tar_test,
+            label_smoothing,
+            reduce_loss,
+            None,
+            z_loss_weight=z_loss_weight,
         )
         ref_loss = self.ref_loss_func(self.input_ref, self.tar_ref)
 
@@ -166,6 +188,106 @@ class TestParallelCrossEntropy:
                 label_smoothing=0,
                 reduce_loss=True,
                 ignore_idx=True,
+            )
+
+    def test_z_loss(self):
+        self.generate_iters(5)
+        self.generate_infra(False, 0, z_loss_weight=0.001)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=False,
+                z_loss_weight=0.001,
+            )
+
+    def test_z_loss_zero_weight(self):
+        self.generate_infra(False, 0)
+        self.generate_input(torch.float32, False, False)
+
+        inp_base = self.input_test.clone().detach().requires_grad_(True)
+        inp_zero = self.input_test.clone().detach().requires_grad_(True)
+
+        loss_base = self.test_loss_func(inp_base, self.tar_test)
+        loss_zero = self.test_loss_func(inp_zero, self.tar_test, z_loss_weight=0.0)
+
+        assert torch.equal(
+            loss_base, loss_zero
+        ), "z_loss_weight=0.0 must be bit-identical to the default"
+
+        loss_base.sum().backward()
+        loss_zero.sum().backward()
+
+        assert torch.equal(
+            inp_base.grad, inp_zero.grad
+        ), "Gradients with z_loss_weight=0.0 must be bit-identical to the default"
+
+        self.input_test = None
+        self.input_ref = None
+        self.tar_test = None
+        self.tar_ref = None
+
+    def test_z_loss_with_ignore_idx(self):
+        self.generate_iters(5)
+        self.generate_infra(False, 0, z_loss_weight=0.001)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=False,
+                ignore_idx=True,
+                z_loss_weight=0.001,
+            )
+
+    def test_z_loss_reduced(self):
+        self.generate_iters(5)
+        self.generate_infra(True, 0, z_loss_weight=0.001)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=True,
+                z_loss_weight=0.001,
+            )
+
+    def test_z_loss_reduced_with_ignore_idx(self):
+        self.generate_iters(5)
+        self.generate_infra(True, 0, z_loss_weight=0.001)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=True,
+                ignore_idx=True,
+                z_loss_weight=0.001,
+            )
+
+    def test_z_loss_label_smoothing(self):
+        self.generate_iters(3)
+        self.generate_infra(False, 0.1, z_loss_weight=0.001)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.float32,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0.1,
+                reduce_loss=False,
+                z_loss_weight=0.001,
+            )
+
+    def test_z_loss_bfloat16(self):
+        self.generate_iters(3)
+        self.generate_infra(False, 0, z_loss_weight=0.001)
+        for i in range(self.iters):
+            self.one_iteration_test(
+                dtype=torch.bfloat16,
+                swap_dim=random.choice([True, False]),
+                label_smoothing=0,
+                reduce_loss=False,
+                z_loss_weight=0.001,
             )
 
 

--- a/transformer_engine/common/triton/cross_entropy.py
+++ b/transformer_engine/common/triton/cross_entropy.py
@@ -92,6 +92,8 @@ def cross_entropy_kernel(
     loss_stride,
     m_d_X_y_ptr,
     m_d_X_y_stride,
+    log_sum_exp_ptr,
+    log_sum_exp_stride,
     rank,
     world_size,
     ignore_idx,
@@ -115,6 +117,8 @@ def cross_entropy_kernel(
     loss_stride (int): The stride of the loss tensor.
     m_d_X_y_ptr: Pointer to m/d/X_y tensor.
     m_d_X_y_stride: The stride of m/d/X_y tensor.
+    log_sum_exp_ptr: Pointer to tensor to store log(sum(exp(logits))) per row.
+    log_sum_exp_stride (int): The stride of the log_sum_exp tensor.
     rank (int): The rank of this device in the TP group.
     world_size (int): The size of world involved in this distributed loss calculation.
     ignore_idx (int): Tokens to be ignored for loss and gradient calculation.
@@ -165,6 +169,7 @@ def cross_entropy_kernel(
 
     # lse = log(Z): free to compute (m, d already in registers).
     lse = m + tl.log(d)
+    tl.store(log_sum_exp_ptr + program_id * log_sum_exp_stride, lse)
 
     # Label smoothing is a general case of normal cross entropy
     scaled_x_sum = 0.0

--- a/transformer_engine/common/triton/cross_entropy.py
+++ b/transformer_engine/common/triton/cross_entropy.py
@@ -100,6 +100,7 @@ def cross_entropy_kernel(
     n_non_ignore,
     reduce_loss: tl.constexpr,
     label_smoothing: tl.constexpr,
+    z_loss_weight: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -121,6 +122,8 @@ def cross_entropy_kernel(
     n_rows (int): The number of rows in the batch (B * SQ), used for buffer indexing.
     n_non_ignore: The number of non-ignored elements in the batch.
     label_smoothing (float): The amount of smoothing when computing the loss, where 0.0 means no smoothing.
+    z_loss_weight (float): Weight for z-loss regularization. Adds z_loss_weight * log(Z)^2 per token.
+        Compile-time constant (tl.constexpr); varying it across calls triggers kernel recompilation.
     BLOCK_SIZE (int): The block size for Triton operations.
     """
 
@@ -160,6 +163,9 @@ def cross_entropy_kernel(
         m = tl.maximum(m, m_new)
         ori_X_y = tl.maximum(ori_X_y, X_y_new)
 
+    # lse = log(Z): free to compute (m, d already in registers).
+    lse = m + tl.log(d)
+
     # Label smoothing is a general case of normal cross entropy
     scaled_x_sum = 0.0
     eps = label_smoothing / (n_cols * world_size)
@@ -180,13 +186,16 @@ def cross_entropy_kernel(
         if label_smoothing > 0:
             # scale X beforehand to avoid overflow
             scaled_x_sum += tl.sum(tl.where(X_offsets < n_cols, -eps * X_block, 0.0))
+        # Softmax gradient
+        X_block = tl.exp(X_block - m) / d
+        # Z-loss gradient: d/dx_i[z_loss_weight * lse^2] = 2 * z_loss_weight * lse * softmax(x_i).
+        # Applied before eps subtraction so only pure softmax is scaled.
+        if z_loss_weight > 0:
+            X_block = X_block * (1.0 + 2.0 * z_loss_weight * lse)
+        X_block = X_block - eps
         # Scale gradients based on reduction mode
-        # For reduce_loss=True: PyTorch will scale by 1/n_rows, so we need to scale by n_rows/n_non_ignore
-        # For reduce_loss=False: No additional scaling from PyTorch, so we don't scale here
         if reduce_loss:
-            X_block = (tl.exp(X_block - m) / d - eps) / (n_non_ignore)
-        else:
-            X_block = tl.exp(X_block - m) / d - eps
+            X_block = X_block / n_non_ignore
         tl.store(X_ptr + X_offsets, X_block.to(grad_dtype), mask=X_offsets < n_cols)
 
     # We need tl.debug_barrier() to ensure the new result of X_ptr is written
@@ -196,7 +205,8 @@ def cross_entropy_kernel(
 
     # loss = log (softmax(X_y)) = log ((e ^ (X_y - max(X)) / sum(e ^ (X - max(X))))
     #      = (X_y - max(X)) - log(sum(e ^ (X - max(X))))
-    loss = -(ori_X_y - m - tl.log(d))
+    #      = lse - ori_X_y  (reusing lse = m + log(d) already computed above)
+    loss = lse - ori_X_y
 
     # Orginal loss = H(q, p),  with label smoothing regularization = H(q', p) and (label_smoothing / V) = eps
     # H(q', p) = (1 - label_smoothing) * H(q, p) + label_smoothing * H(u, p)
@@ -205,8 +215,12 @@ def cross_entropy_kernel(
     #          = (1 - label_smoothing) * H(q, p) + (-sum(x_i * eps) + label_smoothing * (m + logd))
     # Refer to H(q', p) in section 7 of the paper: https://arxiv.org/pdf/1512.00567
     if label_smoothing > 0:
-        smooth_loss = scaled_x_sum + label_smoothing * (m + tl.log(d))
+        smooth_loss = scaled_x_sum + label_smoothing * lse
         loss = loss * (1 - label_smoothing) + smooth_loss
+
+    # Z-loss regularization: adds z_loss_weight * log(Z)^2 per token.
+    if z_loss_weight > 0:
+        loss += z_loss_weight * lse * lse
 
     # 6. Specially handle the i==y case where `dx_y = (softmax(x_y) - (1 - label_smoothing) / N`
     vocab_start_idx = rank * n_cols

--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -33,6 +33,7 @@ class CrossEntropyFunction(torch.autograd.Function):
         dist_process_group=None,
         ignore_idx=-100,
         is_cg_capturable=False,
+        z_loss_weight=0.0,
     ):
         """
         The forward pass of the Cross Entropy loss. If dist_process_group is passed for distributed loss calculation, the input to each
@@ -45,7 +46,8 @@ class CrossEntropyFunction(torch.autograd.Function):
         label_smoothing (float): The amount of smoothing when computing the loss, where 0.0 means no smoothing.
         reduce_loss (bool): If true, returns the averaged loss across the B*SQ dimension.
         dist_process_group (torch.dist.ProcessGroup): The distributed process group the loss computation is split across, None if on 1 device.
-        ignore_idx (int): The index for which loss and gradients are made to zero
+        ignore_idx (int): The index for which loss and gradients are made to zero.
+        z_loss_weight (float): Weight for z-loss regularization. Adds z_loss_weight * log(Z)^2 per token.
 
         Returns:
         tensor: The computed loss.
@@ -57,6 +59,7 @@ class CrossEntropyFunction(torch.autograd.Function):
             reduce_loss,
             dist_process_group,
             ignore_idx,
+            z_loss_weight,
         )
 
         ctx.save_for_backward(inp.detach())
@@ -85,6 +88,7 @@ class CrossEntropyFunction(torch.autograd.Function):
             None,
             None,
             None,
+            None,
         )
 
 
@@ -96,11 +100,12 @@ def parallel_cross_entropy(
     dist_process_group: Optional[torch.distributed.ProcessGroup] = None,
     ignore_idx: int = -100,
     is_cg_capturable: bool = False,
+    z_loss_weight: float = 0.0,
     *,
     _input: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
-    Cross Entropy loss with optional distributed reduction.
+    Cross Entropy loss with optional distributed reduction and z-loss regularization.
 
     The input tensor can be in BF16/FP32, the loss and gradient calculation happens in
     FP32 only. The returned loss is always in FP32, the input gradients are upcasted
@@ -127,6 +132,9 @@ def parallel_cross_entropy(
         The index for which loss and gradients are made to zero.
     is_cg_capturable : bool, default = False
         Whether the operation is CUDA graph capturable.
+    z_loss_weight : float, default = 0.0
+        Weight for z-loss regularization. Adds ``z_loss_weight * log(Z)^2`` per token.
+        This value is a Triton compile-time constant; use a fixed value during training.
 
     Returns
     -------
@@ -141,6 +149,9 @@ def parallel_cross_entropy(
         )
         inp = _input
 
+    if not (z_loss_weight >= 0.0 and z_loss_weight != float("inf")):
+        raise ValueError(f"z_loss_weight must be a finite non-negative number, got {z_loss_weight}")
+
     return CrossEntropyFunction.apply(
         inp,
         target,
@@ -149,4 +160,5 @@ def parallel_cross_entropy(
         dist_process_group,
         ignore_idx,
         is_cg_capturable,
+        z_loss_weight,
     )

--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -57,8 +57,13 @@ class CrossEntropyFunction(torch.autograd.Function):
             log_sum_exp is non-differentiable.
         """
         loss, inp, log_sum_exp = triton_cross_entropy.cross_entropy_forward(
-            inp, target, label_smoothing, reduce_loss, dist_process_group,
-            ignore_idx, z_loss_weight,
+            inp,
+            target,
+            label_smoothing,
+            reduce_loss,
+            dist_process_group,
+            ignore_idx,
+            z_loss_weight,
         )
 
         ctx.save_for_backward(inp.detach())

--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -4,7 +4,7 @@
 
 """Cross Entropy Loss API"""
 
-from typing import Optional
+from typing import Optional, Tuple, Union
 import warnings
 
 import torch
@@ -34,6 +34,7 @@ class CrossEntropyFunction(torch.autograd.Function):
         ignore_idx=-100,
         is_cg_capturable=False,
         z_loss_weight=0.0,
+        return_log_sum_exp=False,
     ):
         """
         The forward pass of the Cross Entropy loss. If dist_process_group is passed for distributed loss calculation, the input to each
@@ -48,32 +49,35 @@ class CrossEntropyFunction(torch.autograd.Function):
         dist_process_group (torch.dist.ProcessGroup): The distributed process group the loss computation is split across, None if on 1 device.
         ignore_idx (int): The index for which loss and gradients are made to zero.
         z_loss_weight (float): Weight for z-loss regularization. Adds z_loss_weight * log(Z)^2 per token.
+        return_log_sum_exp (bool): If True, also returns log(sum(exp(logits))) per token.
 
         Returns:
-        tensor: The computed loss.
+        tensor: The computed loss (when return_log_sum_exp=False).
+        tuple[tensor, tensor]: (loss, log_sum_exp) when return_log_sum_exp=True.
+            log_sum_exp is non-differentiable.
         """
-        loss, inp = triton_cross_entropy.cross_entropy_forward(
-            inp,
-            target,
-            label_smoothing,
-            reduce_loss,
-            dist_process_group,
-            ignore_idx,
-            z_loss_weight,
+        loss, inp, log_sum_exp = triton_cross_entropy.cross_entropy_forward(
+            inp, target, label_smoothing, reduce_loss, dist_process_group,
+            ignore_idx, z_loss_weight,
         )
 
         ctx.save_for_backward(inp.detach())
         ctx.is_cg_capturable = is_cg_capturable
+
+        if return_log_sum_exp:
+            ctx.mark_non_differentiable(log_sum_exp)
+            return loss, log_sum_exp
         return loss
 
     @staticmethod
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, grad_log_sum_exp=None):
         """
         The backward pass of the Cross Entropy loss.
 
         Parameters:
         ctx : The context object with saved tensors.
         grad_output (tensor): The tensor containing the gradient of the loss with respect to the output.
+        grad_log_sum_exp: None when return_log_sum_exp=True (log_sum_exp is non-differentiable).
 
         Returns:
         tuple: A tuple with the gradients with respect to the inputs. The elements are tensors or None.
@@ -82,6 +86,7 @@ class CrossEntropyFunction(torch.autograd.Function):
         inp = triton_cross_entropy.cross_entropy_backward(inp, grad_output, ctx.is_cg_capturable)
         return (
             inp,
+            None,
             None,
             None,
             None,
@@ -103,7 +108,8 @@ def parallel_cross_entropy(
     z_loss_weight: float = 0.0,
     *,
     _input: Optional[torch.Tensor] = None,
-) -> torch.Tensor:
+    return_log_sum_exp: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Cross Entropy loss with optional distributed reduction and z-loss regularization.
 
@@ -135,11 +141,19 @@ def parallel_cross_entropy(
     z_loss_weight : float, default = 0.0
         Weight for z-loss regularization. Adds ``z_loss_weight * log(Z)^2`` per token.
         This value is a Triton compile-time constant; use a fixed value during training.
+    return_log_sum_exp : bool, default = False
+        If True, returns a ``(loss, log_sum_exp)`` tuple. If False (default), returns only
+        ``loss`` as a single tensor, preserving backward compatibility.
 
     Returns
     -------
     torch.Tensor
-        The computed loss.
+        The computed loss. Shape is ``(B, SQ)`` (or scalar if ``reduce_loss=True``).
+        Returned when ``return_log_sum_exp=False`` (default).
+    tuple[torch.Tensor, torch.Tensor]
+        ``(loss, log_sum_exp)`` when ``return_log_sum_exp=True``.
+        ``log_sum_exp`` has shape ``(B, SQ)``: ``log(sum(exp(logits)))`` per token,
+        useful as a training metric. Non-differentiable; zero for ignored tokens.
     """
     # Handle backward compatibility with _input parameter
     if _input is not None:
@@ -161,4 +175,5 @@ def parallel_cross_entropy(
         ignore_idx,
         is_cg_capturable,
         z_loss_weight,
+        return_log_sum_exp,
     )

--- a/transformer_engine/pytorch/triton/cross_entropy.py
+++ b/transformer_engine/pytorch/triton/cross_entropy.py
@@ -44,6 +44,9 @@ def cross_entropy_forward(
     # unreduced loss
     loss_1d = torch.zeros(n_rows, dtype=torch.float32, device=_input.device)
 
+    # log(sum(exp(logits))) per row — free byproduct of online softmax
+    log_sum_exp_1d = torch.zeros(n_rows, dtype=torch.float32, device=_input.device)
+
     # tensor to hold this rank's m/d/X_y values
     m_d_X_y = torch.zeros(n_rows * 3, dtype=torch.float32, device=_input.device)
 
@@ -93,6 +96,8 @@ def cross_entropy_forward(
         loss_stride=loss_1d.stride(-1),
         m_d_X_y_ptr=m_d_X_y_gathered,
         m_d_X_y_stride=m_d_X_y_gathered.stride(-1),
+        log_sum_exp_ptr=log_sum_exp_1d,
+        log_sum_exp_stride=log_sum_exp_1d.stride(-1),
         rank=rank,
         world_size=world_size,
         ignore_idx=ignore_idx,
@@ -110,7 +115,9 @@ def cross_entropy_forward(
         torch.reshape(loss_1d, (B, SQ)) if not reduce_loss else (torch.sum(loss_1d) / n_non_ignore)
     )
 
-    return loss, _input
+    log_sum_exp = torch.reshape(log_sum_exp_1d, (B, SQ))
+
+    return loss, _input, log_sum_exp
 
 
 def cross_entropy_backward(

--- a/transformer_engine/pytorch/triton/cross_entropy.py
+++ b/transformer_engine/pytorch/triton/cross_entropy.py
@@ -30,6 +30,7 @@ def cross_entropy_forward(
     reduce_loss: bool,
     dist_process_group: Union[dist.ProcessGroup, None],
     ignore_idx: int,
+    z_loss_weight: float = 0.0,
 ):
     """Forward implementation of Cross Entropy kernel"""
 
@@ -100,6 +101,7 @@ def cross_entropy_forward(
         n_non_ignore=n_non_ignore,
         reduce_loss=reduce_loss,
         label_smoothing=label_smoothing,
+        z_loss_weight=z_loss_weight,
         BLOCK_SIZE=BLOCK_SIZE,
         num_warps=32,
     )


### PR DESCRIPTION
# PR Draft — NVIDIA/TransformerEngine#2707

**Title:** `[Common][PyTorch] Add z_loss_weight to parallel_cross_entropy`

---

# Description

Adds z-loss regularization to `parallel_cross_entropy`. Z-loss penalizes large logit magnitudes by adding `z_loss_weight * log(Z)^2` per token to the loss, where `log(Z) = log(sum(exp(logits)))` is the log-sum-exp. This stabilizes training by keeping logits in a numerically well-behaved range (see [ST-MoE](https://arxiv.org/abs/2202.08906) and [PaLM](https://arxiv.org/abs/2204.02311)).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes

The Triton kernel already computes `m` (running max) and `d` (sum of shifted exponentials) as part of the online softmax. `lse = m + log(d)` is a free byproduct which means no extra data movement required.

- **Forward**: compute `lse = m + log(d)` using existing variables and add  `z_loss_weight * lse^2` to the per-token loss. Reuse `lse` in the  label-smoothing path (`smooth_loss` previously recomputed `m + log(d)`).
- **Backward**: scale the softmax gradient by `(1 + 2 * z_loss_weight * lse)`, derived from `d/dx_i[z_loss_weight * lse^2] = 2 * z_loss_weight * lse * softmax(x_i)`.
- **Dead-code elimination**: `z_loss_weight` is `tl.constexpr`, enabling Triton to eliminate all z-loss branches at compile time when `z_loss_weight=0.0`.
- **API**: `parallel_cross_entropy(..., z_loss_weight=0.0, return_log_sum_exp=False)` is backward compatible and the default behavior unchanged. When `return_log_sum_exp=True`, returns `(loss, log_sum_exp)` tuple instead of `loss`.## Tests

Z-loss tests extend the existing test infrastructure rather than introducing separate helpers. `generate_infra` accepts an optional `z_loss_weight` parameter: when `> 0`, it builds a PyTorch reference function that computes `F.cross_entropy + z_loss_weight * lse^2` in FP32. `one_iteration_test` passes `z_loss_weight` through to `parallel_cross_entropy`. This keeps all z-loss tests in the same pattern as the existing suite.

The `z_loss_weight == 0.0` path in `generate_infra` uses `torch.nn.CrossEntropyLoss` with `ignore_index` forwarded, keeping it consistent with the z-loss reference path.

**7 new tests, 15 total pass** (A40, single GPU):

| Test | What it verifies |
|------|-----------------|
| `test_z_loss` | FP32 loss and gradients match PyTorch reference (5 random iterations, random swap_dim) |
| `test_z_loss_bfloat16` | Same as above with BF16 input (3 iterations) |
| `test_z_loss_with_ignore_idx` | Z-loss + ignored tokens: loss and gradients correct (5 iterations) |
| `test_z_loss_zero_weight` | `z_loss_weight=0.0` produces bit-identical results to the default (no z-loss) |
| `test_z_loss_reduced` | Z-loss + `reduce_loss=True`: reduced loss and gradients correct (5 iterations) |
| `test_z_loss_reduced_with_ignore_idx` | Z-loss + `reduce_loss=True` + ignored tokens: correct (5 iterations) |
| `test_z_loss_label_smoothing` | Z-loss + `label_smoothing=0.1`: both features interact correctly (3 iterations) |

Additionally validated in a Megatron-LM integration across tp1/tp2/tp8 on 8×A40 and 8×H100.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes