### PR TITLE
WAR sort_chunks_by_index intermittent failures in L0 JAX unitttest

### DIFF
--- a/transformer_engine/common/triton/permutation.py
+++ b/transformer_engine/common/triton/permutation.py
@@ -599,6 +599,10 @@ def _sort_chunks_by_map_kernel(
     input_ptr,
     row_id_map_ptr,
     probs_ptr,
+    # Pre-allocated output buffer for JAX input_output_aliases.
+    # Aliased to output_ptr in JAX so they point to the same memory.
+    # In PyTorch, pass the same tensor as output_ptr.
+    output_buf_ptr,  # pylint: disable=unused-argument
     # strides
     stride_input_token,
     stride_input_hidden,

--- a/transformer_engine/jax/triton_extensions/permutation.py
+++ b/transformer_engine/jax/triton_extensions/permutation.py
@@ -1666,10 +1666,19 @@ class SortChunksByMapPrimitive(BasePrimitive):
 
     @staticmethod
     def abstract(
-        inp_aval, row_id_map_aval, probs_aval, *, num_tokens, hidden_size, is_forward, with_probs
+        inp_aval,
+        row_id_map_aval,
+        probs_aval,
+        output_buf_aval=None,  # Pre-allocated output buffer (inner primitive only)
+        *,
+        num_tokens,
+        hidden_size,
+        is_forward,
+        with_probs,
     ):
         """Shape/dtype inference."""
         del row_id_map_aval, is_forward
+        del output_buf_aval  # Used for input_output_aliases only
 
         output_aval = jax.core.ShapedArray((num_tokens, hidden_size), inp_aval.dtype)
 
@@ -1684,10 +1693,14 @@ class SortChunksByMapPrimitive(BasePrimitive):
     def impl(inp, row_id_map, probs, num_tokens, hidden_size, is_forward, with_probs):
         """Forward to inner primitive."""
         assert SortChunksByMapPrimitive.inner_primitive is not None
+
+        output_buf = jnp.empty((num_tokens, hidden_size), dtype=inp.dtype)
+
         return SortChunksByMapPrimitive.inner_primitive.bind(
             inp,
             row_id_map,
             probs,
+            output_buf,
             num_tokens=num_tokens,
             hidden_size=hidden_size,
             is_forward=is_forward,
@@ -1695,7 +1708,9 @@ class SortChunksByMapPrimitive(BasePrimitive):
         )
 
     @staticmethod
-    def lowering(ctx, inp, row_id_map, probs, *, num_tokens, hidden_size, is_forward, with_probs):
+    def lowering(
+        ctx, inp, row_id_map, probs, output_buf, *, num_tokens, hidden_size, is_forward, with_probs
+    ):
         """MLIR lowering using triton_call_lowering."""
         # Compute strides
         inp_stride_token = hidden_size
@@ -1709,13 +1724,22 @@ class SortChunksByMapPrimitive(BasePrimitive):
         block_size = _get_min_block_size(_sort_chunks_by_map_kernel)
         grid = (num_tokens, triton.cdiv(hidden_size, block_size))
 
+        # Declare input_output_aliases so XLA knows output slot 0 is claimed by
+        # input 3 (output_buf). This prevents XLA from implicitly aliasing any
+        # other input (like output_grad in backward) to the output buffer.
+        # Input indices: 0=inp, 1=row_id_map, 2=probs, 3=output_buf
+        # Output indices: 0=output, 1=permuted_probs
+        input_output_aliases = {3: 0}
+
         return triton_call_lowering(
             ctx,
             _sort_chunks_by_map_kernel,
             inp,
             row_id_map,
             probs,
+            output_buf,
             grid=grid,
+            input_output_aliases=input_output_aliases,
             constexprs={
                 "stride_input_token": inp_stride_token,
                 "stride_input_hidden": inp_stride_hidden,

--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -427,6 +427,7 @@ def sort_chunks_by_map(
         inp,
         row_id_map,
         probs,
+        output,  # no use in Pytorch side, serves as WAR for JAX side
         inp.stride(0),
         inp.stride(1),
         output.stride(0),


### PR DESCRIPTION
 WAR intermittent mismatch failures in sort_chunks_by_index sort_chunk_by_map bwd function (part 1/2)

# Description

There is a bug in our CI where the following symptoms were observed:
- ~50% element mismatch in **backward pass gradients** (`computed_grad != ref_grad`)
- Forward pass and `row_id_map` are correct
- Fails ~30% overall across systems, but **deterministically** when running the full L0 test suite via `stress_test.sh` (all `tests/jax/` in one pytest process)
- **Never** fails when running `pytest test_permutation.py` in isolation

After benig able to reproduce this on B200, only when running the whole L0_jax_unittest/test.sh, I found 3 
interacting factors combine to produce the corruption:

### 1. XLA implicit buffer aliasing

XLA's buffer assignment (`xla/service/buffer_assignment.cc`) can assign the **same GPU memory** to the **input** (`output_grad`) and **output** (`inp_grad`) of the backward `sort_chunks_by_map` custom call. This happens because:

- They have the same shape
- XLA determines the input is dead after the operation

(*) We don't know if this is XLA fault or Python yet.

### 2. Permutation kernels cannot operate in-place

`_sort_chunks_by_map_kernel` (in `transformer_engine/common/triton/permutation.py`) reads from `src_row` and writes to `dst_row` where `src_row != dst_row`. When input and output share the same buffer, GPU thread blocks execute in waves — early blocks overwrite data that later blocks haven't read yet, causing corruption.

### 3. Triton autotuning amplifies corruption

`TritonAutotunedKernelCall` (in `jaxlib/gpu/triton_kernels.cc`) runs the kernel multiple times with different configs. It normally saves/restores aliased buffers between runs using `input_output_aliases_with_sizes`. But since no explicit aliases are declared for `sort_chunks_by_map`, the save/restore is inactive, and each autotuning trial corrupts the shared buffer further.

Some questions to answer/ponder:

### Why only `sort_chunks_by_map`?

Other permutation kernels in TE (e.g., `_permute_with_mask_map_kernel` in the same file) already declare explicit `input_output_aliases`, which **claims** the output buffer slot and prevents XLA from implicitly aliasing a different input to that output. `_sort_chunks_by_map_kernel` lacked this explicit alias, leaving the output slot "unclaimed."

### Why only in the full test suite?

Running all tests in a single pytest process changes XLA's buffer assignment decisions compared to an isolated run — likely due to different memory pressure, compilation caches, or HLO graph differences. The exact mechanism was investigated but not conclusively determined. TODO: I am currently trying to dump out VLOG prints in `buffer_assignment.cc` in XLA for this kernel specifically while running all tests (the reproducing set up), to determine whether the buffer reuse was intentional by XLA in some specific HLO graph, or was it a rare error somewhere in the Python stack. The answer to this is still TBD


Fixes # (issue) 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
(Part 1/2)
Pass a pre-allocated output buffer as an additional input and declare an explicit `input_output_alias` in `sort_chunks_by_map_kernel` ( Mirror what `PermuteWithMaskMapPrimitive` already does )

By declaring `input_output_aliases={3: 0}`, XLA knows output slot 0  (dummy output) is claimed by input 3 (`output_buf`). XLA/Python will not implicitly assign any other input (like `output_grad`) to that output buffer. Input and output are guaranteed separate memory. Therefore, no corruption leading to mismatch will happen.

(Part 2/2) is still needed to complete this fix and guarantee we will not see this issue again.
There is currently this bug: [bug 5810384](https://nvbugspro.nvidia.com/bug/5810384) that prevents `triton_extension/utils.py` from passing  the correct `input_output_alias` to our `TritonAutotunedKernel` call, therefore this WAR in part 1/2 will not take effect for the autotuning passes if part 2/2 is not submitted, and mismatches will still be observed in our CI

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
