### PR TITLE
[PyTorch debug] Fix issue with tp_group=None

### DIFF
--- a/transformer_engine/debug/features/api.py
+++ b/transformer_engine/debug/features/api.py
@@ -479,7 +479,12 @@ class TransformerEngineAPI(BaseNamespaceAPI):
         """
         if call.__name__ == "inspect_tensor":
             kwargs_copy = kwargs.copy()
-            for k in ["quantizer", "columnwise_quantized_tensor", "rowwise_quantized_tensor"]:
+            for k in [
+                "quantizer",
+                "columnwise_quantized_tensor",
+                "rowwise_quantized_tensor",
+                "tp_size",
+            ]:
                 if k not in call.__code__.co_varnames:
                     kwargs_copy.pop(k)
         else:
@@ -490,6 +495,10 @@ class TransformerEngineAPI(BaseNamespaceAPI):
                 "inspect_tensor_postquantize is deprecated, use inspect_tensor instead.",
                 DeprecationWarning,
             )
+            kwargs_copy = kwargs.copy()
+            for k in ["tp_size"]:
+                if k not in call.__code__.co_varnames:
+                    kwargs_copy.pop(k, None)
 
         return call(feat_config, layer_name, **kwargs_copy)
 

--- a/transformer_engine/debug/features/log_fp8_tensor_stats.py
+++ b/transformer_engine/debug/features/log_fp8_tensor_stats.py
@@ -311,6 +311,7 @@ class LogFp8TensorStats(BaseLogTensorStats):
         rowwise_quantized_tensor: Optional[torch.Tensor | QuantizedTensor] = None,
         columnwise_quantized_tensor: Optional[torch.Tensor | QuantizedTensor] = None,
         quantizer: Optional[Quantizer] = None,
+        tp_size: int = 1,
     ):
         """
         API call used to collect the data about the tensor after process_tensor()/quantization.
@@ -357,7 +358,7 @@ class LogFp8TensorStats(BaseLogTensorStats):
         )
 
         skip_reduction, reduction_group, reduce_within_microbatch = get_reduction_params(
-            tensor_name, tp_group
+            tensor_name, tp_group, tp_size
         )
 
         STATS_BUFFERS.try_add_buffer(

--- a/transformer_engine/debug/features/log_nvfp4_tensor_stats.py
+++ b/transformer_engine/debug/features/log_nvfp4_tensor_stats.py
@@ -148,6 +148,7 @@ class LogNvfp4TensorStats(BaseLogTensorStats):
         rowwise_quantized_tensor: Optional[QuantizedTensor] = None,
         columnwise_quantized_tensor: Optional[QuantizedTensor] = None,
         quantizer: Optional[Quantizer] = None,
+        tp_size: int = 1,
     ):
         """
         API call used to collect the data about the tensor after process_tensor()/quantization.
@@ -199,7 +200,7 @@ class LogNvfp4TensorStats(BaseLogTensorStats):
         )
 
         skip_reduction, reduction_group, reduce_within_microbatch = get_reduction_params(
-            tensor_name, tp_group
+            tensor_name, tp_group, tp_size
         )
 
         # Add nvfp4_ prefix to all stats for internal use

--- a/transformer_engine/debug/features/log_tensor_stats.py
+++ b/transformer_engine/debug/features/log_tensor_stats.py
@@ -184,6 +184,7 @@ class LogTensorStats(BaseLogTensorStats):
         rowwise_quantized_tensor: Optional[torch.Tensor | QuantizedTensor] = None,
         columnwise_quantized_tensor: Optional[torch.Tensor | QuantizedTensor] = None,
         quantizer: Optional[Quantizer] = None,
+        tp_size: int = 1,
     ):  # pylint: disable=unused-argument
         """API call used to collect the data about the tensor before process_tensor()/quantization."""
 
@@ -214,7 +215,7 @@ class LogTensorStats(BaseLogTensorStats):
         )
 
         skip_reduction, reduction_group, reduce_within_microbatch = get_reduction_params(
-            tensor_name, tp_group
+            tensor_name, tp_group, tp_size
         )
 
         for stat in config["stats"]:

--- a/transformer_engine/debug/features/utils/__init__.py
+++ b/transformer_engine/debug/features/utils/__init__.py
@@ -12,7 +12,9 @@ import nvdlfw_inspect.api as debug_api
 from transformer_engine.debug.pytorch.debug_state import TEDebugState
 
 
-def get_reduction_params(tensor_name: str, tp_group: torch.distributed.ProcessGroup):
+def get_reduction_params(
+    tensor_name: str, tp_group: torch.distributed.ProcessGroup, tp_size: int
+):
     """
     Returns the statistics reduction parameters for the tensor.
     """
@@ -20,7 +22,7 @@ def get_reduction_params(tensor_name: str, tp_group: torch.distributed.ProcessGr
     reduction_group = debug_api.get_tensor_reduction_group()
     reduce_within_microbatch = tensor_name != "weight"
     if tensor_name == "weight":
-        if TEDebugState.weight_tensor_tp_group_reduce:
+        if TEDebugState.weight_tensor_tp_group_reduce and tp_size > 1:
             # Do not overwrite with `None`: in torch.distributed collectives
             # group=None means the default/world process group.
             if tp_group is not None:

--- a/transformer_engine/debug/features/utils/__init__.py
+++ b/transformer_engine/debug/features/utils/__init__.py
@@ -12,9 +12,7 @@ import nvdlfw_inspect.api as debug_api
 from transformer_engine.debug.pytorch.debug_state import TEDebugState
 
 
-def get_reduction_params(
-    tensor_name: str, tp_group: torch.distributed.ProcessGroup, tp_size: int
-):
+def get_reduction_params(tensor_name: str, tp_group: torch.distributed.ProcessGroup, tp_size: int):
     """
     Returns the statistics reduction parameters for the tensor.
     """

--- a/transformer_engine/debug/features/utils/__init__.py
+++ b/transformer_engine/debug/features/utils/__init__.py
@@ -21,7 +21,13 @@ def get_reduction_params(tensor_name: str, tp_group: torch.distributed.ProcessGr
     reduce_within_microbatch = tensor_name != "weight"
     if tensor_name == "weight":
         if TEDebugState.weight_tensor_tp_group_reduce:
-            reduction_group = tp_group
+            # Do not overwrite with `None`: in torch.distributed collectives
+            # group=None means the default/world process group.
+            if tp_group is not None:
+                reduction_group = tp_group
+            else:
+                # "Reduce in TP group" requested, but TP group is missing.
+                skip_reduction = True
         else:
             skip_reduction = True
     return skip_reduction, reduction_group, reduce_within_microbatch

--- a/transformer_engine/debug/pytorch/debug_quantization.py
+++ b/transformer_engine/debug/pytorch/debug_quantization.py
@@ -53,6 +53,7 @@ class DebugQuantizer(Quantizer):
         tensor_name: str,
         parent_quantizer: Optional[Quantizer],
         tp_group: torch.distributed.ProcessGroup,
+        tp_size: int,
     ):
 
         super().__init__(rowwise=True, columnwise=True)
@@ -60,6 +61,7 @@ class DebugQuantizer(Quantizer):
         self.tensor_name = tensor_name
         self.parent_quantizer = parent_quantizer
         self.tp_group = tp_group  # used in inspect_tensor calls
+        self.tp_size = tp_size
         self.iteration = TEDebugState.get_iteration()
 
         # Configure parent quantizer
@@ -263,6 +265,7 @@ class DebugQuantizer(Quantizer):
             "tensor_name": self.tensor_name,
             "iteration": TEDebugState.get_iteration(),
             "tp_group": self.tp_group,
+            "tp_size": self.tp_size,
             "columnwise_quantized_tensor": columnwise_gemm_tensor,
             "rowwise_quantized_tensor": rowwise_gemm_tensor,
             "quantizer": self.parent_quantizer,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -1082,7 +1082,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         names = ["activation", "weight", "output", "dgrad", "wgrad", "gradient"]
         return tuple(
             [
-                DebugQuantizer(self.name + f".gemm_{q_id}", name, q, self.tp_group)
+                DebugQuantizer(self.name + f".gemm_{q_id}", name, q, self.tp_group, self.tp_size)
                 for q_id, q in enumerate(qs)
             ]
             for name, qs in zip(names, original_quantizers)

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1646,7 +1646,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
 
         names = ["activation", "weight", "output", "dgrad", "wgrad", "gradient"]
         return tuple(
-            DebugQuantizer(self.name, name, q, self.tp_group)
+            DebugQuantizer(self.name, name, q, self.tp_group, self.tp_size)
             for name, q in zip(names, original_quantizers)
         )
 

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -2373,6 +2373,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
                     label,
                     None if label in ("dgrad", "wgrad") else base_quantizers[i + offset],
                     self.tp_group,
+                    self.tp_size,
                 )
                 for i, label in enumerate(labels)
             ]

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -1513,7 +1513,7 @@ class Linear(TransformerEngineBaseModule):
 
         names = ["activation", "weight", "output", "dgrad", "wgrad", "gradient"]
         return tuple(
-            DebugQuantizer(self.name, name, q, self.tp_group)
+            DebugQuantizer(self.name, name, q, self.tp_group, self.tp_size)
             for name, q in zip(names, original_quantizers)
         )
 


### PR DESCRIPTION
# Description

If no TP is used, then `tp_size=1` and `tp_group=None` inside TE modules.  
In the debug feature utility `get_reduction_params()`, when `TEDebugState.weight_tensor_tp_group_reduce=True`, we previously set `reduction_group = tp_group` unconditionally. With `tp_group=None`, downstream distributed collectives interpret this as the default/world group, which can cause unintended cross-rank reduction for weight stats.

This PR fixes that behavior by making TP-group reduction explicit and safe:

- `tp_size` is now passed to `DebugQuantizer` at creation time (from all module call sites: `Linear`, `LayerNormLinear`, `LayerNormMLP`, `GroupedLinear`) and forwarded through the `inspect_tensor` API args;
- `get_reduction_params()` now takes `tp_size` and uses `tp_size > 1` (instead of `tp_group is not None`) to determine whether tensor parallelism is active — this is the correct check since `tp_group=None` is ambiguous (it means the world process group in `torch.distributed`);
- if `weight_tensor_tp_group_reduce=True` and `tp_size > 1` but `tp_group is None`, skip reduction for weight stats;
- if `weight_tensor_tp_group_reduce=True` and `tp_size > 1` and `tp_group` is available, reduce in that TP group;
- `tp_size` is added to the backward-compat kwargs filtering in `call_feature` (`api.py`), so custom user features whose `inspect_tensor` / `inspect_tensor_postquantize` signatures do not include `tp_size` continue to work without modification.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes