### PR TITLE
[PyTorch] Skip `test_nvfp4_partial_cast_matches_full` test when NVFP4 is not available.

### DIFF
--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -1101,10 +1101,6 @@ def _test_nvfp4_partial_cast_matches_full(dp_group) -> None:
     WORLD_RANK = dist.get_rank(dp_group)
     WORLD_SIZE = dist.get_world_size(dp_group)
 
-    available, reason = is_nvfp4_available(return_reason=True)
-    if not available:
-        pytest.skip(reason)
-
     torch.manual_seed(1234)
     device = torch.device("cuda")
     # Shape must be divisible by WORLD_SIZE for even splitting
@@ -1196,6 +1192,11 @@ def _test_nvfp4_partial_cast_matches_full(dp_group) -> None:
 @pytest.mark.parametrize("world_size", [2])
 def test_nvfp4_partial_cast_matches_full(world_size: int) -> None:
     """Launch a distributed job for NVFP4 partial-cast equivalence test."""
+
+    available, reason = is_nvfp4_available(return_reason=True)
+    if not available:
+        pytest.skip(reason)
+
     python_exe = pathlib.Path(sys.executable).resolve()
     current_file = pathlib.Path(__file__).resolve()
     command = [


### PR DESCRIPTION
# Description

#2691 introduced this test but the NVFP4 condition wasn't checked properly.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Skip `test_nvfp4_partial_cast_matches_full` test when NVFP4 is not available.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
