### PR TITLE
[JAX] Add bias support for v2 grouped GEMM path

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -1799,6 +1799,22 @@ class TestGroupedDense:
 
         self._assert_grouped_gemm_output(prim_out, group_sizes, ref_out, dtype)
 
+    @pytest_parametrize_wrapper("layout", ["NN"])
+    def test_grouped_gemm_fp16_with_bias(self, input_shape, layout):
+        """Directly exercises the v2 grouped GEMM path with bias (bfloat16 only, since v2 is
+        only active for bfloat16 no-scaling inputs)."""
+        dtype = jnp.bfloat16
+        lhs, rhs, group_sizes, contracting_dims, bias = self._generate_grouped_dense_input(
+            dtype, input_shape, layout, with_bias=True
+        )
+        ref_out = self._ref_grouped_dense(lhs, rhs, bias, group_sizes, contracting_dims)
+
+        prim_out = jax.jit(tex.grouped_gemm, static_argnames=("contracting_dims",))(
+            lhs, rhs, group_sizes, contracting_dims, bias=bias
+        )
+
+        self._assert_grouped_gemm_output(prim_out, group_sizes, ref_out, dtype)
+
     @pytest.mark.skipif(not is_fp8_supported, reason=fp8_unsupported_reason)
     @pytest.mark.parametrize("fwd_bwd_dtype", fwd_bwd_dtypes)
     @pytest_parametrize_wrapper("scaling_mode", non_fp4_supported_scaling_modes)

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -1685,6 +1685,17 @@ class GroupedGemmPrimitive(BasePrimitive):
             use_async_d2h_group_sizes=use_async_d2h_group_sizes,
             use_v2_ffi=use_v2_ffi,
         )
+        if use_v2_ffi and has_bias:
+            # The C++ FFI for v2 grouped GEMM does not support bias, so we apply it here in
+            # pure JAX. Groups are contiguous, so we build a per-token expert index via
+            # jnp.repeat and gather the corresponding bias row for each token.
+            num_groups = group_sizes.shape[0]
+            segment_ids = jnp.repeat(
+                jnp.arange(num_groups, dtype=jnp.int32),
+                group_sizes,
+                total_repeat_length=M,
+            )
+            out = out + bias[segment_ids].astype(out.dtype)
         return (out,)
 
 
@@ -2008,18 +2019,17 @@ def grouped_gemm_copy_group_sizes(
 def _can_use_v2_grouped_gemm(
     scaling_mode: ScalingMode,
     dtype: jnp.dtype,
-    has_bias: bool,
 ) -> bool:
     """Determine whether the cuda-graphable grouped GEMM implementation can be used based on the input parameters."""
     # Use the cuda-graphable path for plain BF16 non-quantized inputs; fall back to the legacy
     # nvte_multi_tensor_gemm path for all other cases (FP8, MXFP8, etc.) to stay
     # feature-compatible with the main branch.
-    # Bias can be supported in a kernel or in pure-JAX in the future.
+    # Bias is applied in pure JAX after the GEMM in GroupedGemmPrimitive.impl.
 
     if not _v2_grouped_gemm_available:
         return False
 
-    return scaling_mode == ScalingMode.NO_SCALING and dtype == jnp.bfloat16 and not has_bias
+    return scaling_mode == ScalingMode.NO_SCALING and dtype == jnp.bfloat16
 
 
 def grouped_gemm(
@@ -2205,7 +2215,7 @@ def grouped_gemm(
         " and padded with zeros to not affect the result of the MoE block."
     )
 
-    use_v2_ffi = _can_use_v2_grouped_gemm(scaling_mode, lhs_data.dtype, has_bias)
+    use_v2_ffi = _can_use_v2_grouped_gemm(scaling_mode, lhs_data.dtype)
     if use_v2_ffi:
         num_gemms = group_sizes.shape[0]
         additional_arg_0 = jnp.ones((num_gemms,), jnp.float32)  # alpha


### PR DESCRIPTION
# Description

The cuda-graphable (v2) grouped GEMM FFI does not natively support bias. This change applies bias in pure JAX after the GEMM in GroupedGemmPrimitive.impl, using a per-token expert index built from group_sizes to gather the correct bias row for each token.

A dedicated unit test (test_grouped_gemm_fp16_with_bias) is added to directly exercise the v2 path with a non-None bfloat16 bias.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Update gemm.py to support pure-JAX bias computation
- Add new dedicated test for grouped GEMM with bias. Grouped Dense already included bias testing

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
