### PR TITLE
add .claude to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ compile_commands.json
 tensor_dumps/
 artifacts/
 .DS_Store
+.claude/


### PR DESCRIPTION
Adds .claude/ folder to the .gitignore, claude code will dump stuff to this directory (session history, git worktrees, etc.) that we likely don't want to version-control