### PR TITLE
Optimize naive top-k masking in fused router

### DIFF
--- a/transformer_engine/common/fused_router/utils.h
+++ b/transformer_engine/common/fused_router/utils.h
@@ -203,50 +203,69 @@ __device__ inline void apply_softmax_on_float(float *scores, int data_size, int 
   __syncwarp();
 }
 
-__device__ inline void naive_topk_and_mask(CompType *scores, int data_size, int topk,
-                                           int *topk_indices, CompType *topk_scores, int lane_id) {
-  // Check if the index is masked by the later iteration
-  auto is_masked = [&topk_indices](int k, int index) {
-    if (k == 0) return false;
-    for (int i = 0; i < k; i++) {
-      if (topk_indices[i] == index) return true;
-    }
-    return false;
-  };
-  // Topk Times: Find the max value and its index
-  // Then mask it, and record the index in the topk_indices
-  // After looping topk times, the topk_indices will be the topk indices
+template <typename T>
+__device__ inline void naive_topk_and_mask(T *scores, int data_size, int topk, int *topk_indices,
+                                          T *topk_scores, int lane_id) {
+  // Bit i indicates whether the i-th local element (lane_id + i * warp_size) was selected.
+  uint32_t local_mask = 0;
+
   for (int k = 0; k < topk; k++) {
-    // Find the max value and its index
-    CompType val = (lane_id < data_size && !is_masked(k, lane_id))
-                       ? scores[lane_id]
-                       : -std::numeric_limits<CompType>::infinity();
-    int index = (lane_id < data_size) ? lane_id : 0;
-    // Some value is hanlded in local thread
-    // Thread 0 is responsible for the: 0-th, 32-th, 64-th, 96-th ...
-    // Reduce the value in local thread
-    for (int i = lane_id + kThreadsPerWarp; i < data_size; i += kThreadsPerWarp) {
-      CompType cur_val = (is_masked(k, i)) ? -std::numeric_limits<CompType>::infinity() : scores[i];
-      if (cur_val > val) {
-        val = cur_val;
-        index = i;
+    CompType local_max_val = -std::numeric_limits<CompType>::infinity();
+    int local_max_idx = -1;
+
+    // 1) Per-lane local max on unmasked elements.
+    int bit_idx = 0;
+    for (int i = lane_id; i < data_size; i += kThreadsPerWarp) {
+      CompType cur_val = 0.0f;
+      if constexpr (std::is_same_v<CompType, double>) {
+        uint64_t mask = -(uint64_t)((local_mask >> bit_idx) & 1u);
+        uint64_t x_bits = __double_as_longlong(static_cast<CompType>(scores[i]));
+        uint64_t result_bits =
+          (~mask & x_bits) | (mask & 0xFFF0000000000000ULL);
+        cur_val = __longlong_as_double(result_bits);  
+      } else {
+        uint32_t full_mask = -(uint32_t)((local_mask >> bit_idx) & 1u);
+        uint32_t x_bits = __float_as_uint(static_cast<CompType>(scores[i]));
+        uint32_t result_bits =
+            (~full_mask & x_bits) | (full_mask & 0xFF800000u);
+        cur_val = __uint_as_float(result_bits);
+      }
+      if (cur_val > local_max_val) {
+        local_max_val = cur_val;
+        local_max_idx = i;
+      }
+      bit_idx++;
+    }
+
+    // 2) Warp reduction to find global max and index.
+    CompType global_max_val = local_max_val;
+    int global_max_idx = local_max_idx;
+    for (int s = kThreadsPerWarp / 2; s > 0; s /= 2) {
+      CompType shuffled_val = __shfl_down_sync(0xffffffff, global_max_val, s);
+      int shuffled_idx = __shfl_down_sync(0xffffffff, global_max_idx, s);
+      if (shuffled_val > global_max_val) {
+        global_max_val = shuffled_val;
+        global_max_idx = shuffled_idx;
       }
     }
-    // Warp shuffle between threads
-    for (int s = 16; s > 0; s /= 2) {
-      auto shuffled_val = __shfl_xor_sync(0xffffffff, val, s);
-      auto shuffled_index = __shfl_xor_sync(0xffffffff, index, s);
-      if (shuffled_val > val) {
-        val = shuffled_val;
-        index = shuffled_index;
-      }
-    }
+    global_max_idx = __shfl_sync(0xffffffff, global_max_idx, 0);
+    global_max_val = __shfl_sync(0xffffffff, global_max_val, 0);
+
+    // 3) Write top-k result.
     if (lane_id == 0) {
-      topk_indices[k] = index;
-      topk_scores[k] = val;
+      topk_indices[k] = global_max_idx;
+      topk_scores[k] = static_cast<T>(global_max_val);
     }
-    __syncwarp();
+
+    // 4) Mark selected element in owning lane's local mask.
+    if (global_max_idx >= 0 && (global_max_idx % kThreadsPerWarp) == lane_id) {
+      int local_bit_pos = global_max_idx / kThreadsPerWarp;
+      if (local_bit_pos < 32) {
+        local_mask |= (1u << local_bit_pos);
+      }
+    }
   }
+  __syncwarp();
 }
 
 // Current TE only support float32/bf16/fp16, float64 probs should be considered in the future

--- a/transformer_engine/common/fused_router/utils.h
+++ b/transformer_engine/common/fused_router/utils.h
@@ -217,17 +217,10 @@ __device__ inline void naive_topk_and_mask(T *scores, int data_size, int topk, i
     int bit_idx = 0;
     for (int i = lane_id; i < data_size; i += kThreadsPerWarp) {
       CompType cur_val = 0.0f;
-      if constexpr (std::is_same_v<CompType, double>) {
-        uint64_t mask = -(uint64_t)((local_mask >> bit_idx) & 1u);
-        uint64_t x_bits = __double_as_longlong(static_cast<CompType>(scores[i]));
-        uint64_t result_bits = (~mask & x_bits) | (mask & 0xFFF0000000000000ULL);
-        cur_val = __longlong_as_double(result_bits);
-      } else {
-        uint32_t full_mask = -(uint32_t)((local_mask >> bit_idx) & 1u);
-        uint32_t x_bits = __float_as_uint(static_cast<CompType>(scores[i]));
-        uint32_t result_bits = (~full_mask & x_bits) | (full_mask & 0xFF800000u);
-        cur_val = __uint_as_float(result_bits);
-      }
+      uint32_t full_mask = -(uint32_t)((local_mask >> bit_idx) & 1u);
+      uint32_t x_bits = __float_as_uint(static_cast<CompType>(scores[i]));
+      uint32_t result_bits = (~full_mask & x_bits) | (full_mask & 0xFF800000u);
+      cur_val = __uint_as_float(result_bits);
       if (cur_val > local_max_val) {
         local_max_val = cur_val;
         local_max_idx = i;

--- a/transformer_engine/common/fused_router/utils.h
+++ b/transformer_engine/common/fused_router/utils.h
@@ -7,6 +7,8 @@
 #ifndef TRANSFORMER_ENGINE_FUSED_ROUTER_UTILS_H_
 #define TRANSFORMER_ENGINE_FUSED_ROUTER_UTILS_H_
 
+#include <cassert>
+
 #include "transformer_engine/transformer_engine.h"
 
 namespace transformer_engine {
@@ -208,6 +210,8 @@ __device__ inline void naive_topk_and_mask(T *scores, int data_size, int topk, i
                                            T *topk_scores, int lane_id) {
   // Bit i indicates whether the i-th local element (lane_id + i * warp_size) was selected.
   uint32_t local_mask = 0;
+  assert(data_size <= static_cast<int>(sizeof(local_mask) * 8 * kThreadsPerWarp) &&
+         "local_mask too small for data_size > 1024");
 
   for (int k = 0; k < topk; k++) {
     CompType local_max_val = -std::numeric_limits<CompType>::infinity();

--- a/transformer_engine/common/fused_router/utils.h
+++ b/transformer_engine/common/fused_router/utils.h
@@ -205,7 +205,7 @@ __device__ inline void apply_softmax_on_float(float *scores, int data_size, int 
 
 template <typename T>
 __device__ inline void naive_topk_and_mask(T *scores, int data_size, int topk, int *topk_indices,
-                                          T *topk_scores, int lane_id) {
+                                           T *topk_scores, int lane_id) {
   // Bit i indicates whether the i-th local element (lane_id + i * warp_size) was selected.
   uint32_t local_mask = 0;
 
@@ -220,14 +220,12 @@ __device__ inline void naive_topk_and_mask(T *scores, int data_size, int topk, i
       if constexpr (std::is_same_v<CompType, double>) {
         uint64_t mask = -(uint64_t)((local_mask >> bit_idx) & 1u);
         uint64_t x_bits = __double_as_longlong(static_cast<CompType>(scores[i]));
-        uint64_t result_bits =
-          (~mask & x_bits) | (mask & 0xFFF0000000000000ULL);
-        cur_val = __longlong_as_double(result_bits);  
+        uint64_t result_bits = (~mask & x_bits) | (mask & 0xFFF0000000000000ULL);
+        cur_val = __longlong_as_double(result_bits);
       } else {
         uint32_t full_mask = -(uint32_t)((local_mask >> bit_idx) & 1u);
         uint32_t x_bits = __float_as_uint(static_cast<CompType>(scores[i]));
-        uint32_t result_bits =
-            (~full_mask & x_bits) | (full_mask & 0xFF800000u);
+        uint32_t result_bits = (~full_mask & x_bits) | (full_mask & 0xFF800000u);
         cur_val = __uint_as_float(result_bits);
       }
       if (cur_val > local_max_val) {


### PR DESCRIPTION
# Description

Refactor the fused router's naive top-k selection path to track already-selected entries with a per-lane mask

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Refactor `naive_topk_and_mask` in `transformer_engine/common/fused_router/utils.h` to track per-lane selections with a local bitmask
- Preserve the existing function interface and current fused router call sites

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
