### PR TITLE
[Core] Gate NVTE_WITH_CUBLASMP build flag behind NCCL version 2.29.3+

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -287,17 +287,41 @@ endif()
 
 option(NVTE_WITH_CUBLASMP "Use cuBLASMp for tensor parallel GEMMs" OFF)
 if (NVTE_WITH_CUBLASMP)
-    target_compile_definitions(transformer_engine PRIVATE NVTE_WITH_CUBLASMP)
-    target_include_directories(transformer_engine PRIVATE ${CUBLASMP_DIR}/include)
-    find_library(CUBLASMP_LIB
-                 NAMES cublasmp libcublasmp
-                 PATHS ${CUBLASMP_DIR}
-                 PATH_SUFFIXES lib
-                 REQUIRED)
-    find_library(NCCL_LIB
-                 NAMES nccl libnccl
-                 PATH_SUFFIXES lib
-                 REQUIRED)
+  # Check NCCL version for cuBLASMp compatibility
+  if(NOT DEFINED NCCL_VERSION)
+    message(FATAL_ERROR "NCCL_VERSION environment variable not set. NCCL 2.29.3+ is required for cuBLASMp support.")
+  endif()
+
+  # Parse semantic version from NCCL_VERSION
+  string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" NCCL_VERSION_MATCH "${NCCL_VERSION}")
+  if(NOT NCCL_VERSION_MATCH)
+    message(FATAL_ERROR "Invalid NCCL_VERSION format: ${NCCL_VERSION}. Expected format: X.Y.Z")
+  endif()
+
+  set(NCCL_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(NCCL_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(NCCL_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+  # Check if version is >= 2.29.3
+  if(NCCL_VERSION_MAJOR LESS 2 OR
+     (NCCL_VERSION_MAJOR EQUAL 2 AND NCCL_VERSION_MINOR LESS 29) OR
+     (NCCL_VERSION_MAJOR EQUAL 2 AND NCCL_VERSION_MINOR EQUAL 29 AND NCCL_VERSION_PATCH LESS 3))
+    message(FATAL_ERROR "NCCL 2.29.3+ is required for cuBLASMp tensor-parallel GEMMs, but found NCCL ${NCCL_VERSION}")
+  endif()
+
+  message(STATUS "NCCL version check passed: ${NCCL_VERSION}")
+
+  target_compile_definitions(transformer_engine PRIVATE NVTE_WITH_CUBLASMP)
+  target_include_directories(transformer_engine PRIVATE ${CUBLASMP_DIR}/include)
+  find_library(CUBLASMP_LIB
+               NAMES cublasmp libcublasmp
+               PATHS ${CUBLASMP_DIR}
+               PATH_SUFFIXES lib
+               REQUIRED)
+  find_library(NCCL_LIB
+               NAMES nccl libnccl
+               PATH_SUFFIXES lib
+               REQUIRED)
   target_link_libraries(transformer_engine PUBLIC ${NCCL_LIB} ${CUBLASMP_LIB})
   message(STATUS "Using cuBLASMp at: ${CUBLASMP_DIR}")
 endif()


### PR DESCRIPTION
# Description

Currently using older NCCL versions with the NVTE_WITH_CUBLASMP build flag lead to an unclear linker error. This PR addes a guard to the CMake setup to check that the NCCL version is sufficient before trying to link with cublasMp. If the user's NCCL version is not sufficient, this gives a clear error from CMake instead of a linker error.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Check NCCL version for cuBLASMp

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
