### PR TITLE
Fix empty CUDA_ARCHITECTURES when SM120 is the only arch

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -79,6 +79,13 @@ if(NOT arch_120_index EQUAL -1)
   endif()
 endif()
 
+# If all architectures were moved to specific lists, set a placeholder
+# to avoid CMake's "CUDA_ARCHITECTURES is empty" error.
+# The actual arch flags are added per-source via COMPILE_OPTIONS.
+if(NOT CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES OFF)
+endif()
+
 # cuDNN frontend API
 set(CUDNN_FRONTEND_INCLUDE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/../../3rdparty/cudnn-frontend/include")


### PR DESCRIPTION
When SM120 (Blackwell) is the only architecture in the build and gets moved to per-source COMPILE_OPTIONS, CMAKE_CUDA_ARCHITECTURES becomes empty, causing CMake to error with "CUDA_ARCHITECTURES is empty".

Set CMAKE_CUDA_ARCHITECTURES to OFF as a placeholder when it's empty. The actual arch flags are still added per-source via COMPILE_OPTIONS.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
