### PR TITLE
[PyTorch][Flash Attn] Add fallback import for FA3 

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -6,6 +6,7 @@
 from contextlib import nullcontext
 from importlib.metadata import version as get_pkg_version
 from importlib.metadata import PackageNotFoundError
+import importlib.util
 import os
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
@@ -138,7 +139,7 @@ except PackageNotFoundError:
     flash_attn_with_kvcache_v3 = None
     # pass  # only print warning if use_flash_attention_3 = True in get_attention_backend
 else:
-    try:
+    if importlib.util.find_spec("flash_attn_3.flash_attn_interface") is not None:
         from flash_attn_3.flash_attn_interface import flash_attn_func as flash_attn_func_v3
         from flash_attn_3.flash_attn_interface import (
             flash_attn_varlen_func as flash_attn_varlen_func_v3,
@@ -148,7 +149,11 @@ else:
         )
         from flash_attn_3.flash_attn_interface import _flash_attn_forward as _flash_attn_fwd_v3
         from flash_attn_3.flash_attn_interface import _flash_attn_backward as _flash_attn_bwd_v3
-    except ModuleNotFoundError:
+    elif importlib.util.find_spec("flash_attn_interface") is not None:
+        warnings.warn(
+            "flash_attn_interface found outside flash_attn_3 package. "
+            "Importing directly from flash_attn_interface."
+        )
         from flash_attn_interface import flash_attn_func as flash_attn_func_v3
         from flash_attn_interface import (
             flash_attn_varlen_func as flash_attn_varlen_func_v3,
@@ -158,6 +163,11 @@ else:
         )
         from flash_attn_interface import _flash_attn_forward as _flash_attn_fwd_v3
         from flash_attn_interface import _flash_attn_backward as _flash_attn_bwd_v3
+    else:
+        raise ModuleNotFoundError(
+            "flash-attn-3 package is installed but flash_attn_interface module "
+            "could not be found in flash_attn_3/ or site-packages/."
+        )
 
     fa_utils.set_flash_attention_3_params()
 


### PR DESCRIPTION
Add fallback import for FA3  when flash_attn_interface.py is outside flash_attn_3 package

# Description
Some FA3 installations (e.g. via wheel built from the https://github.com/Dao-AILab/flash-attention repo) place
  flash_attn_interface.py directly under site-packages/ rather than inside the flash_attn_3/ folder:

  site-packages/
  ├── flash_attn_interface.py
  └── flash_attn_3/
      ├── __init__.py
      └── _C.abi3.so

  This causes a ModuleNotFoundError when TE tries to import from flash_attn_3.flash_attn_interface, even though FA3 is
  correctly installed and detected via importlib.metadata.

  This PR adds a try/except ModuleNotFoundError fallback so both layouts are supported:
  1. flash_attn_interface.py inside flash_attn_3/ (existing behavior)
  2. flash_attn_interface.py directly in site-packages/

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add try/except ModuleNotFoundError around FA3 imports in backends.py to fall back to from flash_attn_interface
import ... when from flash_attn_3.flash_attn_interface import ... fails

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
