### PR TITLE
Pass input_output_alias to TritonAutotunedKernelCall

### DIFF
--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -43,8 +43,10 @@ import jax
 import jax.numpy as jnp
 
 from ..version_utils import (
+    TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION,
     TRITON_EXTENSION_MIN_JAX_VERSION,
     is_triton_extension_supported,
+    jax_version_meet_requirement,
 )
 
 
@@ -476,15 +478,24 @@ def triton_call_lowering(
 
         input_output_aliases_with_sizes = ()
         if input_output_aliases:
-            num_inputs = len(ctx.avals_in)
-            aliases = []
-            for input_idx, output_idx in input_output_aliases.items():
-                aval = ctx.avals_in[input_idx]
-                size_bytes = aval.size * jnp.dtype(aval.dtype).itemsize
-                # AutotunedKernelCall expects buffer indices (inputs + outputs).
-                buffer_output_idx = num_inputs + output_idx
-                aliases.append((input_idx, buffer_output_idx, size_bytes))
-            input_output_aliases_with_sizes = tuple(aliases)
+            if jax_version_meet_requirement(TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION):
+                num_inputs = len(ctx.avals_in)
+                aliases = []
+                for input_idx, output_idx in input_output_aliases.items():
+                    aval = ctx.avals_in[input_idx]
+                    size_bytes = aval.size * jnp.dtype(aval.dtype).itemsize
+                    # AutotunedKernelCall expects buffer indices (inputs + outputs).
+                    buffer_output_idx = num_inputs + output_idx
+                    aliases.append((input_idx, buffer_output_idx, size_bytes))
+                input_output_aliases_with_sizes = tuple(aliases)
+            else:
+                warnings.warn(
+                    f"JAX >= {TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION} is required "
+                    "to safely pass input_output_aliases to TritonAutotunedKernelCall. "
+                    "Passing empty aliases as a workaround (jax-ml/jax#35218).",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         kernel_call = gpu_triton.TritonAutotunedKernelCall(
             f"{actual_kernel_fn.__name__}_autotuned",

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -25,6 +25,15 @@ def jax_version_meet_requirement(version: str):
 # Minimum JAX version required for Triton kernel dispatch (jaxlib < 0.8.0 segfaults).
 TRITON_EXTENSION_MIN_JAX_VERSION = "0.8.0"
 
+# Minimum JAX version for safe input_output_aliases in TritonAutotunedKernelCall.
+# jaxlib/gpu/triton_kernels.cc had a bug in the autotuning save/restore loop:
+# it iterated over all declared aliases unconditionally, but input_copies only
+# contains entries for aliases where XLA actually shared buffers at runtime.
+# Accessing a missing entry produced a null vector → CUDA_ERROR_INVALID_VALUE.
+# Fixed by: https://github.com/jax-ml/jax/pull/35218 (merged 2026-03-17, main).
+# Ships in JAX 0.9.3 (not yet released as of 2026-03-31).
+TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION = "0.9.3"
+
 
 def is_triton_extension_supported() -> bool:
     """Return True if the current JAX version supports Triton kernel dispatch.
@@ -40,4 +49,5 @@ __all__ = [
     "jax_version_meet_requirement",
     "is_triton_extension_supported",
     "TRITON_EXTENSION_MIN_JAX_VERSION",
+    "TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION",
 ]


### PR DESCRIPTION
# Description
https://nvbugspro.nvidia.com/bug/5810384
To remove the WAR that was put in place for this bug.

This should also serves as part 2 to WAR to the intermittent sort_chunks_by_index bug seen before in https://github.com/NVIDIA/TransformerEngine/pull/2730

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

if JAX version >= 0.9.3, which contains the fix to restore all aliased input buffers that was saved away during autotuning: we pass the input_output_alias tuples to TritonAutotunedKernelCall

If JAX version < 0.9.3, which does not contain the fix, we pass an empty dict to the call.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
