### PR TITLE
Fix nvshmem build

### DIFF
--- a/transformer_engine/common/nvshmem_api/CMakeLists.txt
+++ b/transformer_engine/common/nvshmem_api/CMakeLists.txt
@@ -16,7 +16,8 @@ set(NVSHMEMAPI_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PARENT_SCOPE)
 target_link_directories(nvshmemapi PUBLIC ${NVSHMEM_HOME}/lib)
 target_link_libraries(nvshmemapi PUBLIC -static-libstdc++ nvshmem_device nvshmem_host CUDA::nvml CUDA::cublas CUDA::cuda_driver)
 target_include_directories(nvshmemapi PRIVATE
-                           ${NVSHMEM_HOME}/include/)
+                           ${NVSHMEM_HOME}/include/
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_include_directories(nvshmemapi PUBLIC
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
                            "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/transformer_engine/common/nvshmem_api/nvshmem_waitkernel.cu
+++ b/transformer_engine/common/nvshmem_api/nvshmem_waitkernel.cu
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <string>
 
+#include "../util/cuda_driver.h"
 #include "../util/logging.h"
 #include "nvshmem_waitkernel.h"
 


### PR DESCRIPTION
# Description

When building TE with `NVTE_ENABLE_NVSHMEM=1`, the build fails with:
```
FAILED: [code=2] nvshmem_api/CMakeFiles/nvshmemapi.dir/nvshmem_waitkernel.cu.o
/nix/store/8j41syz9cbh1l74k2283q14ghpap7nfx-cuda12.9-cuda_nvcc-12.9.86/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/nix/store/bn3mhkpnh7zrf0sb65jalb7dg76ycl42-gcc-wrapper-14.3.0/bin/c++  -I/build/source/transformer_eng>
/build/source/transformer_engine/common/nvshmem_api/nvshmem_waitkernel.cu(42): error: identifier "NVTE_CHECK_CUDA_DRIVER" is undefined
        NVTE_CHECK_CUDA_DRIVER(
        ^
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add missing include in `transformer_engine/common/nvshmem_api/nvshmem_waitkernel.cu`
- Add `${CMAKE_CURRENT_SOURCE_DIR}/../include` to `target_include_directories` in `transformer_engine/common/nvshmem_api/CMakeLists.txt`

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/nvidia/transformerengine/blob/main/contributing.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
