### PR TITLE
[PyTorch] Fix bug with PR 2677

### DIFF
--- a/transformer_engine/pytorch/cpp_extensions/fused_attn.py
+++ b/transformer_engine/pytorch/cpp_extensions/fused_attn.py
@@ -365,8 +365,8 @@ def fused_attn_fwd(
 
         if qkv_format == "thd":
             if max_tensor.ndim == 4:
-                # For THD on older cuDNN runtimes or THD on sm120, stats can be [b, h, sq, 1] with padded
-                # sequence positions. Exclude those padded positions when computing max_logit.
+                # For THD on cuDNN <= 9.6 or THD on sm120, Max tensor can be [b, h, sq, 1]
+                # with padded sequence positions. Exclude those padded positions when computing max_logit.
                 seqlens_q = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).to(device=max_tensor.device)
                 sq_idx = torch.arange(max_tensor.shape[2], device=max_tensor.device).view(
                     1, 1, -1, 1
@@ -375,8 +375,9 @@ def fused_attn_fwd(
                 max_tensor = max_tensor.masked_fill(~valid, float("-inf"))
             elif max_tensor.ndim == 3:
                 if cu_seqlens_q_padded is not None:
-                    # For THD on newer cuDNN runtimes (non-sm120), Max is [tq, h, 1] with
-                    # padded positions containing junk. Mask them out with -inf.
+                    # For THD + pad_between_seqs=True + non-sm120 + cuDNN>9.6, Max tensor is [tq, h, 1]
+                    # and padding positions could be uninitialized. Exclude those padded positions when
+                    # computing max_logit.
                     actual_seqlens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).to(
                         device=max_tensor.device
                     )


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/2677 didn't run L1 tests and the downstream CIs failed since there was a bug where padding tokens were not ignored while returning max_logit. This PR fixes it. 

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- When THD and `return_max_logit=True`, ignore the padding tokens correctly before calculating `max_logit`

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
