### PR TITLE
Refactor Amax Kernel ldmatrix loads, TMA/compute barriers,  swizzle_idx

### DIFF
--- a/transformer_engine/common/hadamard_transform/graph_safe_group_hadamard_transform.cu
+++ b/transformer_engine/common/hadamard_transform/graph_safe_group_hadamard_transform.cu
@@ -90,9 +90,8 @@ __device__ __forceinline__ void ComputeKernel(uint32_t b_frag_i[4], uint32_t b_f
   if (kReturnTransposedAmax) {
     if (!kReturnIdentityAmax) {
       ldmatrix_x4_m8n8_shared_b16<true>(a_frag[0], a_frag[1], a_frag[2], a_frag[3],
-                                         reinterpret_cast<uint4*>(in_sh_ptr) + swizzle_idx);
-    }
-    else {
+                                        reinterpret_cast<uint4*>(in_sh_ptr) + swizzle_idx);
+    } else {
       matrix_transpose_m8_n8_b16_inplace(a_frag[0]);
       matrix_transpose_m8_n8_b16_inplace(a_frag[1]);
       matrix_transpose_m8_n8_b16_inplace(a_frag[2]);
@@ -100,11 +99,11 @@ __device__ __forceinline__ void ComputeKernel(uint32_t b_frag_i[4], uint32_t b_f
     }
 
     mma_m16_n16_k16_b16_b16_b16_noacc<kReturnTransposedAmax>(
-      a_frag[0], a_frag[2], a_frag[1], a_frag[3], b_frag_t[0], b_frag_t[1], b_frag_t[2],
-      b_frag_t[3], c_frag[0], c_frag[1], c_frag[2], c_frag[3], temp_amax_t_reg);
-    asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;\n\t" 
-                : "=r"(local_amax_t_reg)
-                : "r"(local_amax_t_reg), "r"(temp_amax_t_reg));
+        a_frag[0], a_frag[2], a_frag[1], a_frag[3], b_frag_t[0], b_frag_t[1], b_frag_t[2],
+        b_frag_t[3], c_frag[0], c_frag[1], c_frag[2], c_frag[3], temp_amax_t_reg);
+    asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;\n\t"
+                 : "=r"(local_amax_t_reg)
+                 : "r"(local_amax_t_reg), "r"(temp_amax_t_reg));
   }
 
   if (kReturnPreRhtAmax) {

--- a/transformer_engine/common/hadamard_transform/group_hadamard_transform.cu
+++ b/transformer_engine/common/hadamard_transform/group_hadamard_transform.cu
@@ -66,9 +66,8 @@ __device__ __forceinline__ void ComputeKernel(uint32_t b_frag_i[4], uint32_t b_f
   if (kReturnTransposedAmax) {
     if (!kReturnIdentityAmax) {
       ldmatrix_x4_m8n8_shared_b16<true>(a_frag[0], a_frag[1], a_frag[2], a_frag[3],
-                                         reinterpret_cast<uint4*>(in_sh_ptr) + swizzle_idx);
-    }
-    else {
+                                        reinterpret_cast<uint4*>(in_sh_ptr) + swizzle_idx);
+    } else {
       matrix_transpose_m8_n8_b16_inplace(a_frag[0]);
       matrix_transpose_m8_n8_b16_inplace(a_frag[1]);
       matrix_transpose_m8_n8_b16_inplace(a_frag[2]);
@@ -76,11 +75,11 @@ __device__ __forceinline__ void ComputeKernel(uint32_t b_frag_i[4], uint32_t b_f
     }
 
     mma_m16_n16_k16_b16_b16_b16_noacc<kReturnTransposedAmax>(
-      a_frag[0], a_frag[2], a_frag[1], a_frag[3], b_frag_t[0], b_frag_t[1], b_frag_t[2],
-      b_frag_t[3], c_frag[0], c_frag[1], c_frag[2], c_frag[3], temp_amax_t_reg);
-    asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;\n\t" 
-                : "=r"(local_amax_t_reg)
-                : "r"(local_amax_t_reg), "r"(temp_amax_t_reg));
+        a_frag[0], a_frag[2], a_frag[1], a_frag[3], b_frag_t[0], b_frag_t[1], b_frag_t[2],
+        b_frag_t[3], c_frag[0], c_frag[1], c_frag[2], c_frag[3], temp_amax_t_reg);
+    asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;\n\t"
+                 : "=r"(local_amax_t_reg)
+                 : "r"(local_amax_t_reg), "r"(temp_amax_t_reg));
   }
 
   if (kReturnPreRhtAmax) {

--- a/transformer_engine/common/hadamard_transform/hadamard_transform.cu
+++ b/transformer_engine/common/hadamard_transform/hadamard_transform.cu
@@ -51,9 +51,8 @@ __device__ __forceinline__ void ComputeKernel(uint32_t b_frag_i[4], uint32_t b_f
   if (kReturnTransposedAmax) {
     if (!kReturnIdentityAmax) {
       ldmatrix_x4_m8n8_shared_b16<true>(a_frag[0], a_frag[1], a_frag[2], a_frag[3],
-                                         reinterpret_cast<uint4*>(in_sh_ptr) + swizzle_idx);
-    }
-    else {
+                                        reinterpret_cast<uint4*>(in_sh_ptr) + swizzle_idx);
+    } else {
       matrix_transpose_m8_n8_b16_inplace(a_frag[0]);
       matrix_transpose_m8_n8_b16_inplace(a_frag[1]);
       matrix_transpose_m8_n8_b16_inplace(a_frag[2]);
@@ -61,11 +60,11 @@ __device__ __forceinline__ void ComputeKernel(uint32_t b_frag_i[4], uint32_t b_f
     }
 
     mma_m16_n16_k16_b16_b16_b16_noacc<kReturnTransposedAmax>(
-      a_frag[0], a_frag[2], a_frag[1], a_frag[3], b_frag_t[0], b_frag_t[1], b_frag_t[2],
-      b_frag_t[3], c_frag[0], c_frag[1], c_frag[2], c_frag[3], temp_amax_t_reg);
-    asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;\n\t" 
-                : "=r"(local_amax_t_reg)
-                : "r"(local_amax_t_reg), "r"(temp_amax_t_reg));
+        a_frag[0], a_frag[2], a_frag[1], a_frag[3], b_frag_t[0], b_frag_t[1], b_frag_t[2],
+        b_frag_t[3], c_frag[0], c_frag[1], c_frag[2], c_frag[3], temp_amax_t_reg);
+    asm volatile("max.xorsign.abs.bf16x2 %0, %1, %2;\n\t"
+                 : "=r"(local_amax_t_reg)
+                 : "r"(local_amax_t_reg), "r"(temp_amax_t_reg));
   }
 
   if (kReturnPreRhtAmax) {


### PR DESCRIPTION
# Description

To improve the efficiency of Amax kernel for nvFP4 quantization, the following code-refactoring are applied:

1. Transposed path
The transposed path uses ldmatrix_x4_m8n8_shared_b16 instead of row-major loads plus four in-register transposes before the same WMMA operand pattern, cutting instructions and warp-synchronous work on the hot path.

2. TMA + compute pipeline barrier
__syncthreads() barrier is moved to after the full nested (stage_y, stage_x) compute for the current stage pair: one __syncthreads(), then ptx::fence_proxy_async_shared_cta(), so generic shared visibility is established before the next async TMA reuses the buffer. Fewer barriers, lower overhead, same “no readers left before reuse” semantics.

3. swizzle_idx
GroupHadamardAmaxTmaKernel now computes swizzle_idx once per thread before the for (stage_y) loop and passes it into ComputeKernel, avoiding redundant work in the hot nested loops. Behavior unchanged; small micro-optimization and clearer split between loop-invariant mapping and per-tile pointer math.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
