### PR TITLE
fix(CP, MLA): CP works fine with MLA in a2a cp_comm_type

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -4072,6 +4072,7 @@ def attn_forward_func_with_cp(
     enable_mla = k.shape[-1] != v.shape[-1]
     assert not enable_mla or cp_comm_type in [
         "p2p",
+        "a2a",
         "a2a+p2p",
     ], f"Context parallelism does not support MLA with {cp_comm_type=}!"
 


### PR DESCRIPTION
# Description

I think CP works fine with MLA in a2a cp_comm_type, we can just open it. And I conducted some relevant experiments, and the results were consistent with expectations. If my understanding is incorrect, please point it out. Thank you.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Just context_parallel.py file

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
