### PR TITLE
Add capture_time_hooks to make_graphed_callables for non-capturable per-callable hooks

### DIFF
--- a/tests/pytorch/test_cuda_graphs.py
+++ b/tests/pytorch/test_cuda_graphs.py
@@ -630,6 +630,72 @@ def test_make_graphed_callables_with_kwargs(
     assert_all_equal(outputs, graph_outputs)
 
 
+def _make_capture_time_hooks(
+    modules: Tuple[torch.nn.Module, ...],
+    records: List[Tuple[int, str]],
+) -> List[Dict[str, Dict[int, Callable]]]:
+    """Make capture-time hooks that record call order."""
+
+    def make_hook(module_idx: int, hook_name: str) -> Callable:
+        expected_module = modules[module_idx]
+
+        def hook(module: torch.nn.Module) -> None:
+            assert module is expected_module
+            assert not torch.cuda.is_current_stream_capturing()
+            records.append((module_idx, hook_name))
+
+        return hook
+
+    return [
+        {
+            "forward_pre_hooks": {0: make_hook(module_idx, "forward_pre_hooks")},
+            "forward_hooks": {0: make_hook(module_idx, "forward_hooks")},
+            "backward_pre_hooks": {0: make_hook(module_idx, "backward_pre_hooks")},
+            "backward_hooks": {0: make_hook(module_idx, "backward_hooks")},
+        }
+        for module_idx in range(len(modules))
+    ]
+
+
+@pytest.mark.parametrize("with_order", (False, True))
+def test_make_graphed_callables_with_capture_time_hooks(with_order: bool) -> None:
+    """Test capture-time hooks around warmup and graph capture."""
+    num_warmup_iters = 2
+    modules = (
+        torch.nn.Linear(8, 8, device="cuda"),
+        torch.nn.Linear(8, 8, device="cuda"),
+    )
+    sample_args = tuple((torch.ones(4, 8, device="cuda", requires_grad=True),) for _ in modules)
+    records = []
+    hook_order = [
+        (0, "forward_pre_hooks"),
+        (0, "forward_hooks"),
+        (1, "forward_pre_hooks"),
+        (1, "forward_hooks"),
+        (1, "backward_pre_hooks"),
+        (1, "backward_hooks"),
+        (0, "backward_pre_hooks"),
+        (0, "backward_hooks"),
+    ]
+
+    graphed_callables = make_graphed_callables(
+        modules,
+        sample_args,
+        num_warmup_iters=num_warmup_iters,
+        _order=[1, 2, -2, -1] if with_order else None,
+        capture_time_hooks=_make_capture_time_hooks(modules, records),
+    )
+
+    assert records == hook_order * (num_warmup_iters + 1)
+
+    for graphed in graphed_callables:
+        x = torch.randn(4, 8, device="cuda", requires_grad=True)
+        y = graphed(x)
+        y.backward(torch.ones_like(y))
+    assert records == hook_order * (num_warmup_iters + 1)
+    reset_graphs(graphed_callables)
+
+
 def _test_cuda_graphs_with_interleaved_pipeline_parallelism(
     *,
     with_graph: bool,

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -703,28 +703,34 @@ def _make_graphed_callables(
                     fwd_graph = fwd_graphs[per_callable_fwd_idx]
 
                     # Call pre_forward hooks before forward graph capture (outside capture context)
-                    if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
+                    if (
+                        capture_time_hooks is not None
+                        and capture_time_hooks[callable_idx] is not None
+                    ):
                         _hooks = capture_time_hooks[callable_idx]
                         _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
                         for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
                             if hook_id in _pre_fwd_with_kwargs:
                                 if hook(func, args, kwargs) is not None:
                                     raise RuntimeError(
-                                        "capture_time_hooks forward_pre_hooks must not return a value "
-                                        "(args/kwargs must not be modified via hook return)"
+                                        "capture_time_hooks forward_pre_hooks must not return a"
+                                        " value (args/kwargs must not be modified via hook return)"
                                     )
                             else:
                                 if hook(func, args) is not None:
                                     raise RuntimeError(
-                                        "capture_time_hooks forward_pre_hooks must not return a value "
-                                        "(args must not be modified via hook return)"
+                                        "capture_time_hooks forward_pre_hooks must not return a"
+                                        " value (args must not be modified via hook return)"
                                     )
 
                     with _graph_context_wrapper(fwd_graph, pool=mempool):
                         outputs = func(*args, **kwargs)
 
                     # Call forward hooks after forward graph capture (outside capture context)
-                    if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
+                    if (
+                        capture_time_hooks is not None
+                        and capture_time_hooks[callable_idx] is not None
+                    ):
                         _hooks = capture_time_hooks[callable_idx]
                         _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
                         for hook_id, hook in _hooks.get("forward_hooks", {}).items():
@@ -851,8 +857,8 @@ def _make_graphed_callables(
                             ].values():
                                 if hook(callable_module, static_grad_outputs) is not None:
                                     raise RuntimeError(
-                                        "capture_time_hooks backward_pre_hooks must not return a value "
-                                        "(grad_output must not be modified via hook return)"
+                                        "capture_time_hooks backward_pre_hooks must not return a"
+                                        " value (grad_output must not be modified via hook return)"
                                     )
 
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)
@@ -877,7 +883,10 @@ def _make_graphed_callables(
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
                             for hook in capture_time_hooks[callable_idx]["backward_hooks"].values():
-                                if hook(callable_module, grad_inputs, static_grad_outputs) is not None:
+                                if (
+                                    hook(callable_module, grad_inputs, static_grad_outputs)
+                                    is not None
+                                ):
                                     raise RuntimeError(
                                         "capture_time_hooks backward_hooks must not return a value "
                                         "(grad_input must not be modified via hook return)"

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -365,6 +365,12 @@ def _make_graphed_callables(
                 + "for each callable must contain only Tensors. Other types are not allowed."
             )
 
+    if capture_time_hooks is not None and len(capture_time_hooks) != len(callables):
+        raise ValueError(
+            f"capture_time_hooks has {len(capture_time_hooks)} entries but there are "
+            f"{len(callables)} callables"
+        )
+
     # If a callable is an nn.Module, its graph's full input surface is the args the user explicitly
     # passes to forward (ie, its sample_args) AND the module's parameter attributes.
     # Note: These per_callable_* variables are not actually
@@ -454,7 +460,7 @@ def _make_graphed_callables(
     visited_te_modules = {}
     need_bwd_dw_graph = {}
 
-    def _run_warmup_forward(func_idx, func):
+    def _run_warmup_forward(func_idx, func, callable_idx):
         """Run forward for one callable during warmup; returns flattened outputs."""
         args = sample_args[func_idx]
         kwargs = sample_kwargs[func_idx]
@@ -484,42 +490,44 @@ def _make_graphed_callables(
 
         if (
             capture_time_hooks is not None
-            and func_idx < len(capture_time_hooks)
-            and capture_time_hooks[func_idx] is not None
-            and "forward_pre" in capture_time_hooks[func_idx]
+            and capture_time_hooks[callable_idx] is not None
+            and "pre_forward" in capture_time_hooks[callable_idx]
         ):
-            for hook in capture_time_hooks[func_idx]["forward_pre"].values():
-                hook(func, args, kwargs)
+            for hook in capture_time_hooks[callable_idx]["pre_forward"].values():
+                result = hook(func, args, kwargs)
+                if result is not None:
+                    args, kwargs = result
 
         hooks = []
         for module in func.modules():
             hooks.append(module.register_forward_hook(hook_fn))
-        outputs, _ = _tree_flatten(func(*args, **kwargs))
+        outputs = func(*args, **kwargs)
         for hook in hooks:
             hook.remove()
 
         if (
             capture_time_hooks is not None
-            and func_idx < len(capture_time_hooks)
-            and capture_time_hooks[func_idx] is not None
-            and "forward" in capture_time_hooks[func_idx]
+            and capture_time_hooks[callable_idx] is not None
+            and "forward" in capture_time_hooks[callable_idx]
         ):
-            for hook in capture_time_hooks[func_idx]["forward"].values():
-                hook(func, args, outputs)
+            for hook in capture_time_hooks[callable_idx]["forward"].values():
+                result = hook(func, args, outputs)
+                if result is not None:
+                    outputs = result
 
+        outputs, _ = _tree_flatten(outputs)
         return outputs
 
-    def _run_warmup_backward(func_idx, func, outputs, warmup_iter):
+    def _run_warmup_backward(func_idx, func, outputs, warmup_iter, callable_idx):
         """Run dgrad backward for one callable during warmup."""
         static_input_surface = per_callable_static_input_surfaces[func_idx]
 
         if (
             capture_time_hooks is not None
-            and func_idx < len(capture_time_hooks)
-            and capture_time_hooks[func_idx] is not None
-            and "pre_backward" in capture_time_hooks[func_idx]
+            and capture_time_hooks[callable_idx] is not None
+            and "pre_backward" in capture_time_hooks[callable_idx]
         ):
-            for hook in capture_time_hooks[func_idx]["pre_backward"].values():
+            for hook in capture_time_hooks[callable_idx]["pre_backward"].values():
                 hook(func)
 
         inputs = tuple(i for i in static_input_surface if i.requires_grad)
@@ -533,11 +541,10 @@ def _make_graphed_callables(
 
         if (
             capture_time_hooks is not None
-            and func_idx < len(capture_time_hooks)
-            and capture_time_hooks[func_idx] is not None
-            and "backward" in capture_time_hooks[func_idx]
+            and capture_time_hooks[callable_idx] is not None
+            and "backward" in capture_time_hooks[callable_idx]
         ):
-            for hook in capture_time_hooks[func_idx]["backward"].values():
+            for hook in capture_time_hooks[callable_idx]["backward"].values():
                 hook(func)
 
         # Filter module params that get None grad from grad_inputs and remove them
@@ -594,11 +601,11 @@ def _make_graphed_callables(
                 # All forwards in order, then all backwards in reverse order.
                 warmup_outputs = []
                 for func_idx, func in zip(warmup_func_idx, warmup_func):
-                    outputs = _run_warmup_forward(func_idx, func)
+                    outputs = _run_warmup_forward(func_idx, func, func_idx)
                     warmup_outputs.append((func_idx, func, outputs))
                 if is_training:
                     for func_idx, func, outputs in reversed(warmup_outputs):
-                        _run_warmup_backward(func_idx, func, outputs, warmup_iter)
+                        _run_warmup_backward(func_idx, func, outputs, warmup_iter, func_idx)
             else:
                 # Follow _order exactly, mirroring the capture phase.
                 per_fwd_outputs = {}  # per_callable_fwd_idx -> flattened outputs
@@ -609,11 +616,12 @@ def _make_graphed_callables(
                         # Forward pass for chunk c_id.
                         m_chunk = c_id - 1
                         for l_no in range(_num_layers_per_chunk[m_chunk]):
+                            callable_idx = _prefix_num_layers[m_chunk] + l_no
                             per_callable_fwd_idx = (
                                 _prefix_num_layers[m_chunk] * num_microbatches
                             ) + (fwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no)
-                            func = callables[_prefix_num_layers[m_chunk] + l_no]
-                            outputs = _run_warmup_forward(per_callable_fwd_idx, func)
+                            func = callables[callable_idx]
+                            outputs = _run_warmup_forward(per_callable_fwd_idx, func, callable_idx)
                             per_fwd_outputs[per_callable_fwd_idx] = outputs
                         fwd_idx[m_chunk] += 1
                     elif ceil(c_id) == c_id:
@@ -621,13 +629,14 @@ def _make_graphed_callables(
                         if is_training:
                             m_chunk = -c_id - 1
                             for l_no in reversed(range(_num_layers_per_chunk[m_chunk])):
+                                callable_idx = _prefix_num_layers[m_chunk] + l_no
                                 per_callable_bwd_idx = (
                                     _prefix_num_layers[m_chunk] * num_microbatches
                                 ) + (bwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no)
-                                func = callables[_prefix_num_layers[m_chunk] + l_no]
+                                func = callables[callable_idx]
                                 outputs = per_fwd_outputs[per_callable_bwd_idx]
                                 _run_warmup_backward(
-                                    per_callable_bwd_idx, func, outputs, warmup_iter
+                                    per_callable_bwd_idx, func, outputs, warmup_iter, callable_idx
                                 )
                             bwd_idx[m_chunk] += 1
 
@@ -658,7 +667,8 @@ def _make_graphed_callables(
                 # Capture forward graph for model chunk c_id, microbatch fwd_idx[c_id-1]
                 m_chunk = c_id - 1
                 for l_no in range(_num_layers_per_chunk[m_chunk]):
-                    func = callables[_prefix_num_layers[m_chunk] + l_no]
+                    callable_idx = _prefix_num_layers[m_chunk] + l_no
+                    func = callables[callable_idx]
                     per_callable_fwd_idx = (_prefix_num_layers[m_chunk] * num_microbatches) + (
                         fwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no
                     )
@@ -666,19 +676,16 @@ def _make_graphed_callables(
                     kwargs = sample_kwargs[per_callable_fwd_idx]
                     fwd_graph = fwd_graphs[per_callable_fwd_idx]
 
-                    # Call forward_pre hooks before forward graph capture (outside capture context)
+                    # Call pre_forward hooks before forward graph capture (outside capture context)
                     if (
                         capture_time_hooks is not None
-                        and per_callable_fwd_idx < len(capture_time_hooks)
-                        and capture_time_hooks[per_callable_fwd_idx] is not None
-                        and "forward_pre" in capture_time_hooks[per_callable_fwd_idx]
+                        and capture_time_hooks[callable_idx] is not None
+                        and "pre_forward" in capture_time_hooks[callable_idx]
                     ):
-                        for hook in capture_time_hooks[per_callable_fwd_idx][
-                            "forward_pre"
-                        ].values():
-                            hook(
-                                func, args, kwargs
-                            )  # forward_pre hook signature: (module, args, kwargs)
+                        for hook in capture_time_hooks[callable_idx]["pre_forward"].values():
+                            result = hook(func, args, kwargs)
+                            if result is not None:
+                                args, kwargs = result
 
                     with _graph_context_wrapper(fwd_graph, pool=mempool):
                         outputs = func(*args, **kwargs)
@@ -686,14 +693,13 @@ def _make_graphed_callables(
                     # Call forward hooks after forward graph capture (outside capture context)
                     if (
                         capture_time_hooks is not None
-                        and per_callable_fwd_idx < len(capture_time_hooks)
-                        and capture_time_hooks[per_callable_fwd_idx] is not None
-                        and "forward" in capture_time_hooks[per_callable_fwd_idx]
+                        and capture_time_hooks[callable_idx] is not None
+                        and "forward" in capture_time_hooks[callable_idx]
                     ):
-                        for hook in capture_time_hooks[per_callable_fwd_idx]["forward"].values():
-                            hook(
-                                func, args, outputs
-                            )  # forward hook signature: (module, inputs, output)
+                        for hook in capture_time_hooks[callable_idx]["forward"].values():
+                            result = hook(func, args, outputs)
+                            if result is not None:
+                                outputs = result
 
                     flatten_outputs, spec = _tree_flatten(outputs)
                     per_callable_static_outputs[per_callable_fwd_idx] = tuple(flatten_outputs)
@@ -705,6 +711,7 @@ def _make_graphed_callables(
                 m_chunk = -ceil(c_id) - 1
                 previous_per_callable_bwd_idx = None
                 for l_no in list(reversed(range(_num_layers_per_chunk[m_chunk]))):
+                    callable_idx = _prefix_num_layers[m_chunk] + l_no
                     per_callable_bwd_idx = (_prefix_num_layers[m_chunk] * num_microbatches) + (
                         bwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no
                     )
@@ -794,17 +801,14 @@ def _make_graphed_callables(
                         # Call pre_backward hooks before backward graph capture (outside capture context)
                         if (
                             capture_time_hooks is not None
-                            and per_callable_bwd_idx < len(capture_time_hooks)
-                            and capture_time_hooks[per_callable_bwd_idx] is not None
-                            and "pre_backward" in capture_time_hooks[per_callable_bwd_idx]
+                            and capture_time_hooks[callable_idx] is not None
+                            and "pre_backward" in capture_time_hooks[callable_idx]
                         ):
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[per_callable_bwd_idx][
+                            for hook in capture_time_hooks[callable_idx][
                                 "pre_backward"
                             ].values():
-                                # During capture, call with the actual module (not None)
-                                # FSDP hooks need to access module attributes
                                 hook(callable_module)
 
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)
@@ -823,17 +827,12 @@ def _make_graphed_callables(
                         # Call backward hooks after backward graph capture (outside capture context)
                         if (
                             capture_time_hooks is not None
-                            and per_callable_bwd_idx < len(capture_time_hooks)
-                            and capture_time_hooks[per_callable_bwd_idx] is not None
-                            and "backward" in capture_time_hooks[per_callable_bwd_idx]
+                            and capture_time_hooks[callable_idx] is not None
+                            and "backward" in capture_time_hooks[callable_idx]
                         ):
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[per_callable_bwd_idx][
-                                "backward"
-                            ].values():
-                                # During capture, call with the actual module (not None)
-                                # FSDP hooks need to access module attributes
+                            for hook in capture_time_hooks[callable_idx]["backward"].values():
                                 hook(callable_module)
 
                     # Constructs a tuple suitable for returning from Graphed.backward:
@@ -893,15 +892,16 @@ def _make_graphed_callables(
         for func_idx, (func, args, kwargs, fwd_graph) in enumerate(
             zip(callables, sample_args, sample_kwargs, fwd_graphs)
         ):
-            # Call forward_pre hooks before forward graph capture (outside capture context)
+            # Call pre_forward hooks before forward graph capture (outside capture context)
             if (
                 capture_time_hooks is not None
-                and func_idx < len(capture_time_hooks)
                 and capture_time_hooks[func_idx] is not None
-                and "forward_pre" in capture_time_hooks[func_idx]
+                and "pre_forward" in capture_time_hooks[func_idx]
             ):
-                for hook in capture_time_hooks[func_idx]["forward_pre"].values():
-                    hook(func, args, kwargs)
+                for hook in capture_time_hooks[func_idx]["pre_forward"].values():
+                    result = hook(func, args, kwargs)
+                    if result is not None:
+                        args, kwargs = result
 
             with _graph_context_wrapper(fwd_graph, pool=mempool):
                 outputs = func(*args, **kwargs)
@@ -910,12 +910,13 @@ def _make_graphed_callables(
             # Call forward hooks after forward graph capture (outside capture context)
             if (
                 capture_time_hooks is not None
-                and func_idx < len(capture_time_hooks)
                 and capture_time_hooks[func_idx] is not None
                 and "forward" in capture_time_hooks[func_idx]
             ):
                 for hook in capture_time_hooks[func_idx]["forward"].values():
-                    hook(func, args, outputs)
+                    result = hook(func, args, outputs)
+                    if result is not None:
+                        outputs = result
 
             flatten_outputs, spec = _tree_flatten(outputs)
             per_callable_static_outputs.append(tuple(flatten_outputs))
@@ -940,7 +941,6 @@ def _make_graphed_callables(
                 # Call pre_backward hooks before backward graph capture (outside capture context)
                 if (
                     capture_time_hooks is not None
-                    and bwd_idx < len(capture_time_hooks)
                     and capture_time_hooks[bwd_idx] is not None
                     and "pre_backward" in capture_time_hooks[bwd_idx]
                 ):
@@ -962,7 +962,6 @@ def _make_graphed_callables(
                 # Call backward hooks after backward graph capture (outside capture context)
                 if (
                     capture_time_hooks is not None
-                    and bwd_idx < len(capture_time_hooks)
                     and capture_time_hooks[bwd_idx] is not None
                     and "backward" in capture_time_hooks[bwd_idx]
                 ):
@@ -1369,9 +1368,11 @@ def make_graphed_callables(
         when `_order` is provided. All callables in `modules` are assumed to have
         inputs and outputs with the same dtype and shape.
     pre_warmup_hook: callable, default = None
-                      A hook function that will be called before the warmup iterations.
+                      A hook function that will be called once before all warmup iterations
+                      (not once per callable).
     post_warmup_hook: callable, default = None
-                      A hook function that will be called after the warmup iterations.
+                      A hook function that will be called once after all warmup iterations
+                      (not once per callable).
     capture_time_hooks: list of dict, optional
                    Per-callable hooks invoked at capture time (during warmup iterations and
                    graph capture), but intentionally executed **outside** the CUDA graph
@@ -1381,7 +1382,7 @@ def make_graphed_callables(
                    CPU-side state updates.
                    Each element corresponds to one callable and is a dict with any subset
                    of the following keys:
-                   - ``"forward_pre"``: dict of hooks called *before* the forward pass.
+                   - ``"pre_forward"``: dict of hooks called *before* the forward pass.
                      Hook signature: ``hook(module, args, kwargs)``.
                    - ``"forward"``: dict of hooks called *after* the forward pass.
                      Hook signature: ``hook(module, args, output)``.

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -337,13 +337,18 @@ def _make_graphed_callables(
         if isinstance(c, torch.nn.Module):
             if not (
                 len(c._backward_hooks) == 0
+                and len(c._backward_pre_hooks) == 0
                 and len(c._forward_hooks) == 0
                 and len(c._forward_pre_hooks) == 0
             ):
                 raise RuntimeError(
                     "Modules must not have hooks registered at the time they are passed. "
                     + "However, registering hooks on modules after passing them "
-                    + "through make_graphed_callables is allowed."
+                    + "through make_graphed_callables is allowed. "
+                    + "If you have to use hooks during capture time, you can provide them "
+                    + "in the capture_time_hooks argument, and they will be executed outside "
+                    + "the CUDA graph capture context, meaning they will not be recorded into "
+                    + "the graph and will not be replayed."
                 )
             if not all(b.requires_grad is False for b in c.buffers()):
                 raise RuntimeError(
@@ -488,15 +493,22 @@ def _make_graphed_callables(
                 else:
                     visited_te_modules[func_idx].update(modules)
 
-        if (
-            capture_time_hooks is not None
-            and capture_time_hooks[callable_idx] is not None
-            and "pre_forward" in capture_time_hooks[callable_idx]
-        ):
-            for hook in capture_time_hooks[callable_idx]["pre_forward"].values():
-                result = hook(func, args, kwargs)
-                if result is not None:
-                    args, kwargs = result
+        if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
+            _hooks = capture_time_hooks[callable_idx]
+            _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
+            for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
+                if hook_id in _pre_fwd_with_kwargs:
+                    if hook(func, args, kwargs) is not None:
+                        raise RuntimeError(
+                            "capture_time_hooks forward_pre_hooks must not return a value "
+                            "(args/kwargs must not be modified via hook return)"
+                        )
+                else:
+                    if hook(func, args) is not None:
+                        raise RuntimeError(
+                            "capture_time_hooks forward_pre_hooks must not return a value "
+                            "(args must not be modified via hook return)"
+                        )
 
         hooks = []
         for module in func.modules():
@@ -505,15 +517,22 @@ def _make_graphed_callables(
         for hook in hooks:
             hook.remove()
 
-        if (
-            capture_time_hooks is not None
-            and capture_time_hooks[callable_idx] is not None
-            and "forward" in capture_time_hooks[callable_idx]
-        ):
-            for hook in capture_time_hooks[callable_idx]["forward"].values():
-                result = hook(func, args, outputs)
-                if result is not None:
-                    outputs = result
+        if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
+            _hooks = capture_time_hooks[callable_idx]
+            _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
+            for hook_id, hook in _hooks.get("forward_hooks", {}).items():
+                if hook_id in _fwd_with_kwargs:
+                    if hook(func, args, kwargs, outputs) is not None:
+                        raise RuntimeError(
+                            "capture_time_hooks forward_hooks must not return a value "
+                            "(output must not be modified via hook return)"
+                        )
+                else:
+                    if hook(func, args, outputs) is not None:
+                        raise RuntimeError(
+                            "capture_time_hooks forward_hooks must not return a value "
+                            "(output must not be modified via hook return)"
+                        )
 
         outputs, _ = _tree_flatten(outputs)
         return outputs
@@ -522,30 +541,37 @@ def _make_graphed_callables(
         """Run dgrad backward for one callable during warmup."""
         static_input_surface = per_callable_static_input_surfaces[func_idx]
 
+        inputs = tuple(i for i in static_input_surface if i.requires_grad)
+        outputs_requiring_grad = tuple(o for o in outputs if o is not None and o.requires_grad)
+        grad_outputs = tuple(torch.empty_like(o) for o in outputs_requiring_grad)
+
         if (
             capture_time_hooks is not None
             and capture_time_hooks[callable_idx] is not None
-            and "pre_backward" in capture_time_hooks[callable_idx]
+            and "backward_pre_hooks" in capture_time_hooks[callable_idx]
         ):
-            for hook in capture_time_hooks[callable_idx]["pre_backward"].values():
-                hook(func)
+            for hook in capture_time_hooks[callable_idx]["backward_pre_hooks"].values():
+                if hook(func, grad_outputs) is not None:
+                    raise RuntimeError(
+                        "capture_time_hooks backward_pre_hooks must not return a value "
+                        "(grad_output must not be modified via hook return)"
+                    )
 
-        inputs = tuple(i for i in static_input_surface if i.requires_grad)
         with _none_grad_context_wrapper(inputs):
-            outputs_requiring_grad = tuple(o for o in outputs if o is not None and o.requires_grad)
-            torch.autograd.backward(
-                outputs_requiring_grad,
-                grad_tensors=tuple(torch.empty_like(o) for o in outputs_requiring_grad),
-            )
+            torch.autograd.backward(outputs_requiring_grad, grad_tensors=grad_outputs)
             grad_inputs = tuple(input.grad for input in inputs)
 
         if (
             capture_time_hooks is not None
             and capture_time_hooks[callable_idx] is not None
-            and "backward" in capture_time_hooks[callable_idx]
+            and "backward_hooks" in capture_time_hooks[callable_idx]
         ):
-            for hook in capture_time_hooks[callable_idx]["backward"].values():
-                hook(func)
+            for hook in capture_time_hooks[callable_idx]["backward_hooks"].values():
+                if hook(func, grad_inputs, grad_outputs) is not None:
+                    raise RuntimeError(
+                        "capture_time_hooks backward_hooks must not return a value "
+                        "(grad_input must not be modified via hook return)"
+                    )
 
         # Filter module params that get None grad from grad_inputs and remove them
         # from static_input_surface. This is to ensure that the backward hooks
@@ -677,29 +703,43 @@ def _make_graphed_callables(
                     fwd_graph = fwd_graphs[per_callable_fwd_idx]
 
                     # Call pre_forward hooks before forward graph capture (outside capture context)
-                    if (
-                        capture_time_hooks is not None
-                        and capture_time_hooks[callable_idx] is not None
-                        and "pre_forward" in capture_time_hooks[callable_idx]
-                    ):
-                        for hook in capture_time_hooks[callable_idx]["pre_forward"].values():
-                            result = hook(func, args, kwargs)
-                            if result is not None:
-                                args, kwargs = result
+                    if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
+                        _hooks = capture_time_hooks[callable_idx]
+                        _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
+                        for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
+                            if hook_id in _pre_fwd_with_kwargs:
+                                if hook(func, args, kwargs) is not None:
+                                    raise RuntimeError(
+                                        "capture_time_hooks forward_pre_hooks must not return a value "
+                                        "(args/kwargs must not be modified via hook return)"
+                                    )
+                            else:
+                                if hook(func, args) is not None:
+                                    raise RuntimeError(
+                                        "capture_time_hooks forward_pre_hooks must not return a value "
+                                        "(args must not be modified via hook return)"
+                                    )
 
                     with _graph_context_wrapper(fwd_graph, pool=mempool):
                         outputs = func(*args, **kwargs)
 
                     # Call forward hooks after forward graph capture (outside capture context)
-                    if (
-                        capture_time_hooks is not None
-                        and capture_time_hooks[callable_idx] is not None
-                        and "forward" in capture_time_hooks[callable_idx]
-                    ):
-                        for hook in capture_time_hooks[callable_idx]["forward"].values():
-                            result = hook(func, args, outputs)
-                            if result is not None:
-                                outputs = result
+                    if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
+                        _hooks = capture_time_hooks[callable_idx]
+                        _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
+                        for hook_id, hook in _hooks.get("forward_hooks", {}).items():
+                            if hook_id in _fwd_with_kwargs:
+                                if hook(func, args, kwargs, outputs) is not None:
+                                    raise RuntimeError(
+                                        "capture_time_hooks forward_hooks must not return a value "
+                                        "(output must not be modified via hook return)"
+                                    )
+                            else:
+                                if hook(func, args, outputs) is not None:
+                                    raise RuntimeError(
+                                        "capture_time_hooks forward_hooks must not return a value "
+                                        "(output must not be modified via hook return)"
+                                    )
 
                     flatten_outputs, spec = _tree_flatten(outputs)
                     per_callable_static_outputs[per_callable_fwd_idx] = tuple(flatten_outputs)
@@ -802,12 +842,18 @@ def _make_graphed_callables(
                         if (
                             capture_time_hooks is not None
                             and capture_time_hooks[callable_idx] is not None
-                            and "pre_backward" in capture_time_hooks[callable_idx]
+                            and "backward_pre_hooks" in capture_time_hooks[callable_idx]
                         ):
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[callable_idx]["pre_backward"].values():
-                                hook(callable_module)
+                            for hook in capture_time_hooks[callable_idx][
+                                "backward_pre_hooks"
+                            ].values():
+                                if hook(callable_module, static_grad_outputs) is not None:
+                                    raise RuntimeError(
+                                        "capture_time_hooks backward_pre_hooks must not return a value "
+                                        "(grad_output must not be modified via hook return)"
+                                    )
 
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)
                         with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
@@ -826,12 +872,16 @@ def _make_graphed_callables(
                         if (
                             capture_time_hooks is not None
                             and capture_time_hooks[callable_idx] is not None
-                            and "backward" in capture_time_hooks[callable_idx]
+                            and "backward_hooks" in capture_time_hooks[callable_idx]
                         ):
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[callable_idx]["backward"].values():
-                                hook(callable_module)
+                            for hook in capture_time_hooks[callable_idx]["backward_hooks"].values():
+                                if hook(callable_module, grad_inputs, static_grad_outputs) is not None:
+                                    raise RuntimeError(
+                                        "capture_time_hooks backward_hooks must not return a value "
+                                        "(grad_input must not be modified via hook return)"
+                                    )
 
                     # Constructs a tuple suitable for returning from Graphed.backward:
                     # Pads out the actually-needed grads with Nones in gradient slots for inputs
@@ -891,30 +941,44 @@ def _make_graphed_callables(
             zip(callables, sample_args, sample_kwargs, fwd_graphs)
         ):
             # Call pre_forward hooks before forward graph capture (outside capture context)
-            if (
-                capture_time_hooks is not None
-                and capture_time_hooks[func_idx] is not None
-                and "pre_forward" in capture_time_hooks[func_idx]
-            ):
-                for hook in capture_time_hooks[func_idx]["pre_forward"].values():
-                    result = hook(func, args, kwargs)
-                    if result is not None:
-                        args, kwargs = result
+            if capture_time_hooks is not None and capture_time_hooks[func_idx] is not None:
+                _hooks = capture_time_hooks[func_idx]
+                _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
+                for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
+                    if hook_id in _pre_fwd_with_kwargs:
+                        if hook(func, args, kwargs) is not None:
+                            raise RuntimeError(
+                                "capture_time_hooks forward_pre_hooks must not return a value "
+                                "(args/kwargs must not be modified via hook return)"
+                            )
+                    else:
+                        if hook(func, args) is not None:
+                            raise RuntimeError(
+                                "capture_time_hooks forward_pre_hooks must not return a value "
+                                "(args must not be modified via hook return)"
+                            )
 
             with _graph_context_wrapper(fwd_graph, pool=mempool):
                 outputs = func(*args, **kwargs)
             graph_callables[func_idx] = func
 
             # Call forward hooks after forward graph capture (outside capture context)
-            if (
-                capture_time_hooks is not None
-                and capture_time_hooks[func_idx] is not None
-                and "forward" in capture_time_hooks[func_idx]
-            ):
-                for hook in capture_time_hooks[func_idx]["forward"].values():
-                    result = hook(func, args, outputs)
-                    if result is not None:
-                        outputs = result
+            if capture_time_hooks is not None and capture_time_hooks[func_idx] is not None:
+                _hooks = capture_time_hooks[func_idx]
+                _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
+                for hook_id, hook in _hooks.get("forward_hooks", {}).items():
+                    if hook_id in _fwd_with_kwargs:
+                        if hook(func, args, kwargs, outputs) is not None:
+                            raise RuntimeError(
+                                "capture_time_hooks forward_hooks must not return a value "
+                                "(output must not be modified via hook return)"
+                            )
+                    else:
+                        if hook(func, args, outputs) is not None:
+                            raise RuntimeError(
+                                "capture_time_hooks forward_hooks must not return a value "
+                                "(output must not be modified via hook return)"
+                            )
 
             flatten_outputs, spec = _tree_flatten(outputs)
             per_callable_static_outputs.append(tuple(flatten_outputs))
@@ -940,11 +1004,15 @@ def _make_graphed_callables(
                 if (
                     capture_time_hooks is not None
                     and capture_time_hooks[bwd_idx] is not None
-                    and "pre_backward" in capture_time_hooks[bwd_idx]
+                    and "backward_pre_hooks" in capture_time_hooks[bwd_idx]
                 ):
                     callable_module = graph_callables[bwd_idx]
-                    for hook in capture_time_hooks[bwd_idx]["pre_backward"].values():
-                        hook(callable_module)
+                    for hook in capture_time_hooks[bwd_idx]["backward_pre_hooks"].values():
+                        if hook(callable_module, static_grad_outputs) is not None:
+                            raise RuntimeError(
+                                "capture_time_hooks backward_pre_hooks must not return a value "
+                                "(grad_output must not be modified via hook return)"
+                            )
 
                 inputs = tuple(i for i in static_input_surface if i.requires_grad)
                 with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
@@ -961,11 +1029,15 @@ def _make_graphed_callables(
                 if (
                     capture_time_hooks is not None
                     and capture_time_hooks[bwd_idx] is not None
-                    and "backward" in capture_time_hooks[bwd_idx]
+                    and "backward_hooks" in capture_time_hooks[bwd_idx]
                 ):
                     callable_module = graph_callables[bwd_idx]
-                    for hook in capture_time_hooks[bwd_idx]["backward"].values():
-                        hook(callable_module)
+                    for hook in capture_time_hooks[bwd_idx]["backward_hooks"].values():
+                        if hook(callable_module, grad_inputs, static_grad_outputs) is not None:
+                            raise RuntimeError(
+                                "capture_time_hooks backward_hooks must not return a value "
+                                "(grad_input must not be modified via hook return)"
+                            )
 
                 if need_bwd_dw_graph[bwd_idx]:
                     with _graph_context_wrapper(bwd_dw_graph, pool=mempool):
@@ -1377,17 +1449,27 @@ def make_graphed_callables(
                    capture context so they are **not** recorded into the graph and will
                    **not** be replayed. Use this for operations that are inherently
                    non-capturable but essential for correct module execution, such as
-                   CPU-side state updates.
+                   CPU-side state updates. All the hooks must return None, meaning that
+                   modifying tensors is not supported. Any attempt to return a non-None
+                   value will raise ``RuntimeError``.
                    Each element corresponds to one callable and is a dict with any subset
-                   of the following keys:
-                   - ``"pre_forward"``: dict of hooks called *before* the forward pass.
-                     Hook signature: ``hook(module, args, kwargs)``.
-                   - ``"forward"``: dict of hooks called *after* the forward pass.
-                     Hook signature: ``hook(module, args, output)``.
-                   - ``"pre_backward"``: dict of hooks called *before* the backward pass.
-                     Hook signature: ``hook(module)``.
-                   - ``"backward"``: dict of hooks called *after* the backward pass.
-                     Hook signature: ``hook(module)``.
+                   of the following keys (names mirror PyTorch's ``nn.Module`` hook
+                   attributes):
+                   - ``"forward_pre_hooks"``: ``{hook_id: hook_fn}`` dict of *all* pre-forward
+                     hooks (both plain and with-kwargs). Plain signature: ``hook(module, args)``.
+                     With-kwargs signature: ``hook(module, args, kwargs)``.
+                   - ``"forward_pre_hooks_with_kwargs"``: ``{hook_id: True}`` flag set marking
+                     which entries in ``"forward_pre_hooks"`` should be called with kwargs.
+                   - ``"forward_hooks"``: ``{hook_id: hook_fn}`` dict of *all* post-forward
+                     hooks (both plain and with-kwargs). Plain signature:
+                     ``hook(module, args, output)``. With-kwargs signature:
+                     ``hook(module, args, kwargs, output)``.
+                   - ``"forward_hooks_with_kwargs"``: ``{hook_id: True}`` flag set marking
+                     which entries in ``"forward_hooks"`` should be called with kwargs.
+                   - ``"backward_pre_hooks"``: ``{hook_id: hook_fn}`` dict of hooks called
+                     *before* the backward pass. Signature: ``hook(module, grad_output)``.
+                   - ``"backward_hooks"``: ``{hook_id: hook_fn}`` dict of hooks called *after*
+                     the backward pass. Signature: ``hook(module, grad_input, grad_output)``.
 
     Quantization parameters
     -----------------------

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -110,6 +110,7 @@ def _make_graphed_callables(
     _reuse_graph_input_output_buffers: bool = False,
     pre_warmup_hook: Optional[Callable] = None,
     post_warmup_hook: Optional[Callable] = None,
+    capture_time_hooks: Optional[List[Optional[Dict[str, Dict]]]] = None,
 ) -> SingleOrTuple[Callable]:
     """
     Helper method for `make_graphed_callables`
@@ -453,111 +454,197 @@ def _make_graphed_callables(
     visited_te_modules = {}
     need_bwd_dw_graph = {}
 
+    def _run_warmup_forward(func_idx, func):
+        """Run forward for one callable during warmup; returns flattened outputs."""
+        args = sample_args[func_idx]
+        kwargs = sample_kwargs[func_idx]
+
+        def hook_fn(
+            module, inputs, outputs, func_idx=func_idx
+        ):  # pylint: disable=unused-argument
+            modules = set()
+            if isinstance(module, TransformerEngineBaseModule):
+                modules.add(module)
+            # If forward is called on a BasicOperation directly the hook will run
+            elif isinstance(module, BasicOperation):
+                modules.add(module)
+            # If forward is called on a te.ops.Sequential it is not called on its constituent ops
+            elif isinstance(module, Sequential):
+                if module._module_groups is None:
+                    raise RuntimeError(
+                        "module._module_groups should have been initialized by warmup"
+                    )
+                for module_group in module._module_groups:
+                    if isinstance(module_group, OperationFuser):
+                        for basic_op in module_group._basic_ops:
+                            modules.add(basic_op)
+            if modules:
+                if func_idx not in visited_te_modules:
+                    visited_te_modules[func_idx] = modules
+                else:
+                    visited_te_modules[func_idx].update(modules)
+
+        if (
+            capture_time_hooks is not None
+            and func_idx < len(capture_time_hooks)
+            and capture_time_hooks[func_idx] is not None
+            and "forward_pre" in capture_time_hooks[func_idx]
+        ):
+            for hook in capture_time_hooks[func_idx]["forward_pre"].values():
+                hook(func, args, kwargs)
+
+        hooks = []
+        for module in func.modules():
+            hooks.append(module.register_forward_hook(hook_fn))
+        outputs, _ = _tree_flatten(func(*args, **kwargs))
+        for hook in hooks:
+            hook.remove()
+
+        if (
+            capture_time_hooks is not None
+            and func_idx < len(capture_time_hooks)
+            and capture_time_hooks[func_idx] is not None
+            and "forward" in capture_time_hooks[func_idx]
+        ):
+            for hook in capture_time_hooks[func_idx]["forward"].values():
+                hook(func, args, outputs)
+
+        return outputs
+
+    def _run_warmup_backward(func_idx, func, outputs, warmup_iter):
+        """Run dgrad backward for one callable during warmup."""
+        static_input_surface = per_callable_static_input_surfaces[func_idx]
+
+        if (
+            capture_time_hooks is not None
+            and func_idx < len(capture_time_hooks)
+            and capture_time_hooks[func_idx] is not None
+            and "pre_backward" in capture_time_hooks[func_idx]
+        ):
+            for hook in capture_time_hooks[func_idx]["pre_backward"].values():
+                hook(func)
+
+        inputs = tuple(i for i in static_input_surface if i.requires_grad)
+        with _none_grad_context_wrapper(inputs):
+            outputs_requiring_grad = tuple(
+                o for o in outputs if o is not None and o.requires_grad
+            )
+            torch.autograd.backward(
+                outputs_requiring_grad,
+                grad_tensors=tuple(torch.empty_like(o) for o in outputs_requiring_grad),
+            )
+            grad_inputs = tuple(input.grad for input in inputs)
+
+        if (
+            capture_time_hooks is not None
+            and func_idx < len(capture_time_hooks)
+            and capture_time_hooks[func_idx] is not None
+            and "backward" in capture_time_hooks[func_idx]
+        ):
+            for hook in capture_time_hooks[func_idx]["backward"].values():
+                hook(func)
+
+        # Filter module params that get None grad from grad_inputs and remove them
+        # from static_input_surface. This is to ensure that the backward hooks
+        # registered to these params are not wrongly triggered.
+        num_required_grad_sample_args = sum(
+            arg.requires_grad for arg in flatten_sample_args[func_idx]
+        )
+        required_grad_input_idx = []
+        for i, arg in enumerate(static_input_surface):
+            if arg.requires_grad:
+                required_grad_input_idx.append(i)
+        module_params_with_grad = []
+        for grad_inputs_idx, inputs_idx in enumerate(required_grad_input_idx):
+            if (
+                grad_inputs[grad_inputs_idx] is None
+                and grad_inputs_idx < num_required_grad_sample_args
+            ):
+                if not allow_unused_input:
+                    raise RuntimeError(
+                        "The input tensor requires grad, but the grad is None after"
+                        " backward pass."
+                    )
+            elif (
+                grad_inputs[grad_inputs_idx] is not None
+                and grad_inputs_idx >= num_required_grad_sample_args
+            ):
+                module_params_with_grad.append(static_input_surface[inputs_idx])
+        if len(module_params_with_grad) != len(per_callable_module_params[func_idx]):
+            if warmup_iter != 0:
+                raise RuntimeError(
+                    "no-grad params should only be used as inputs in the first warmup"
+                    f" iteration, but found in iteration {warmup_iter}"
+                )
+            per_callable_module_params[func_idx] = tuple(module_params_with_grad)
+            static_input_surface = flatten_sample_args[func_idx] + tuple(
+                module_params_with_grad
+            )
+            per_callable_static_input_surfaces[func_idx] = static_input_surface
+
+        # Run wgrad. This is essential for some TE modules when they have
+        # delay_wgrad_compute enabled.
+        need_backward_dw = False
+        for module in visited_te_modules.get(func_idx, set()):
+            if hasattr(module, "need_backward_dw") and module.need_backward_dw():
+                need_backward_dw = True
+                module.backward_dw()
+        need_bwd_dw_graph[func_idx] = need_backward_dw
+
     # Run warmup and do the above filtering.
     with torch.cuda.stream(torch.cuda.Stream()):
-        for func_idx, func in zip(warmup_func_idx, warmup_func):
-            args = sample_args[func_idx]
-            kwargs = sample_kwargs[func_idx]
-            static_input_surface = per_callable_static_input_surfaces[func_idx]
+        if pre_warmup_hook is not None:
+            pre_warmup_hook()
 
-            def hook_fn(
-                module, inputs, outputs, func_idx=func_idx
-            ):  # pylint: disable=unused-argument
-                modules = set()
-                if isinstance(module, TransformerEngineBaseModule):
-                    modules.add(module)
-                # If forward is called on a BasicOperation directly the hook will run
-                elif isinstance(module, BasicOperation):
-                    modules.add(module)
-                # If forward is called on a te.ops.Sequential it is not called on its constituent ops
-                elif isinstance(module, Sequential):
-                    if module._module_groups is None:
-                        raise RuntimeError(
-                            "module._module_groups should have been initialized by warmup"
-                        )
-                    for module_group in module._module_groups:
-                        if isinstance(module_group, OperationFuser):
-                            for basic_op in module_group._basic_ops:
-                                modules.add(basic_op)
-                if modules:
-                    if func_idx not in visited_te_modules:
-                        visited_te_modules[func_idx] = modules
-                    else:
-                        visited_te_modules[func_idx].update(modules)
-
-            if pre_warmup_hook is not None:
-                pre_warmup_hook()
-            for warmup_iter in range(num_warmup_iters):
-                hooks = []
-                for module in func.modules():
-                    hook = module.register_forward_hook(hook_fn)
-                    hooks.append(hook)
-                outputs, _ = _tree_flatten(func(*args, **kwargs))
-                for hook in hooks:
-                    hook.remove()
+        for warmup_iter in range(num_warmup_iters):
+            if _order is None:
+                # All forwards in order, then all backwards in reverse order.
+                warmup_outputs = []
+                for func_idx, func in zip(warmup_func_idx, warmup_func):
+                    outputs = _run_warmup_forward(func_idx, func)
+                    warmup_outputs.append((func_idx, func, outputs))
                 if is_training:
-                    inputs = tuple(i for i in static_input_surface if i.requires_grad)
-                    with _none_grad_context_wrapper(inputs):
-                        outputs_requiring_grad = tuple(
-                            o for o in outputs if o is not None and o.requires_grad
-                        )
-                        torch.autograd.backward(
-                            outputs_requiring_grad,
-                            grad_tensors=tuple(torch.empty_like(o) for o in outputs_requiring_grad),
-                        )
-                        grad_inputs = tuple(input.grad for input in inputs)
-
-                    # Filter module params that get None grad from grad_inputs and remove them
-                    # from static_input_surface. This is to ensure that the backward hooks
-                    # registered to these params are not wrongly triggered.
-                    num_required_grad_sample_args = sum(
-                        arg.requires_grad for arg in flatten_sample_args[func_idx]
-                    )
-                    required_grad_input_idx = []
-                    for i, arg in enumerate(static_input_surface):
-                        if arg.requires_grad:
-                            required_grad_input_idx.append(i)
-                    module_params_with_grad = []
-                    for grad_inputs_idx, inputs_idx in enumerate(required_grad_input_idx):
-                        if (
-                            grad_inputs[grad_inputs_idx] is None
-                            and grad_inputs_idx < num_required_grad_sample_args
-                        ):
-                            if not allow_unused_input:
-                                raise RuntimeError(
-                                    "The input tensor requires grad, but the grad is None after"
-                                    " backward pass."
+                    for func_idx, func, outputs in reversed(warmup_outputs):
+                        _run_warmup_backward(func_idx, func, outputs, warmup_iter)
+            else:
+                # Follow _order exactly, mirroring the capture phase.
+                per_fwd_outputs = {}  # per_callable_fwd_idx -> flattened outputs
+                fwd_idx = [0] * num_model_chunks
+                bwd_idx = [0] * num_model_chunks
+                for c_id in _order:
+                    if c_id > 0:
+                        # Forward pass for chunk c_id.
+                        m_chunk = c_id - 1
+                        for l_no in range(_num_layers_per_chunk[m_chunk]):
+                            per_callable_fwd_idx = (
+                                _prefix_num_layers[m_chunk] * num_microbatches
+                            ) + (fwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no)
+                            func = callables[_prefix_num_layers[m_chunk] + l_no]
+                            outputs = _run_warmup_forward(per_callable_fwd_idx, func)
+                            per_fwd_outputs[per_callable_fwd_idx] = outputs
+                        fwd_idx[m_chunk] += 1
+                    elif ceil(c_id) == c_id:
+                        # Backward pass for chunk -c_id.
+                        if is_training:
+                            m_chunk = -c_id - 1
+                            for l_no in reversed(range(_num_layers_per_chunk[m_chunk])):
+                                per_callable_bwd_idx = (
+                                    _prefix_num_layers[m_chunk] * num_microbatches
+                                ) + (
+                                    bwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no
                                 )
-                        elif (
-                            grad_inputs[grad_inputs_idx] is not None
-                            and grad_inputs_idx >= num_required_grad_sample_args
-                        ):
-                            module_params_with_grad.append(static_input_surface[inputs_idx])
-                    if len(module_params_with_grad) != len(per_callable_module_params[func_idx]):
-                        if warmup_iter != 0:
-                            raise RuntimeError(
-                                "no-grad params should only be used as inputs in the first warmup"
-                                f" iteration, but found in iteration {warmup_iter}"
-                            )
-                        per_callable_module_params[func_idx] = tuple(module_params_with_grad)
-                        static_input_surface = flatten_sample_args[func_idx] + tuple(
-                            module_params_with_grad
-                        )
-                        per_callable_static_input_surfaces[func_idx] = static_input_surface
+                                func = callables[_prefix_num_layers[m_chunk] + l_no]
+                                outputs = per_fwd_outputs[per_callable_bwd_idx]
+                                _run_warmup_backward(
+                                    per_callable_bwd_idx,
+                                    func,
+                                    outputs,
+                                    warmup_iter
+                                )
+                            bwd_idx[m_chunk] += 1
 
-                    # Run wgrad. This is essential for some TE modules when they have
-                    # delay_wgrad_compute enabled.
-                    need_backward_dw = False
-                    for module in visited_te_modules.get(func_idx, set()):
-                        if hasattr(module, "need_backward_dw") and module.need_backward_dw():
-                            need_backward_dw = True
-                            module.backward_dw()
-                    need_bwd_dw_graph[func_idx] = need_backward_dw
-                else:
-                    grad_inputs = None
-                del outputs, grad_inputs
-            if post_warmup_hook is not None:
-                post_warmup_hook()
+        if post_warmup_hook is not None:
+            post_warmup_hook()
     torch.cuda.synchronize()
 
     # All captures here share a mempool. To avoid replays corrupting each other's memory,
@@ -590,8 +677,30 @@ def _make_graphed_callables(
                     args = sample_args[per_callable_fwd_idx]
                     kwargs = sample_kwargs[per_callable_fwd_idx]
                     fwd_graph = fwd_graphs[per_callable_fwd_idx]
+
+                    # Call forward_pre hooks before forward graph capture (outside capture context)
+                    if (
+                        capture_time_hooks is not None
+                        and per_callable_fwd_idx < len(capture_time_hooks)
+                        and capture_time_hooks[per_callable_fwd_idx] is not None
+                        and "forward_pre" in capture_time_hooks[per_callable_fwd_idx]
+                    ):
+                        for hook in capture_time_hooks[per_callable_fwd_idx]["forward_pre"].values():
+                            hook(func, args, kwargs)  # forward_pre hook signature: (module, args, kwargs)
+
                     with _graph_context_wrapper(fwd_graph, pool=mempool):
                         outputs = func(*args, **kwargs)
+
+                    # Call forward hooks after forward graph capture (outside capture context)
+                    if (
+                        capture_time_hooks is not None
+                        and per_callable_fwd_idx < len(capture_time_hooks)
+                        and capture_time_hooks[per_callable_fwd_idx] is not None
+                        and "forward" in capture_time_hooks[per_callable_fwd_idx]
+                    ):
+                        for hook in capture_time_hooks[per_callable_fwd_idx]["forward"].values():
+                            hook(func, args, outputs)  # forward hook signature: (module, inputs, output)
+
                     flatten_outputs, spec = _tree_flatten(outputs)
                     per_callable_static_outputs[per_callable_fwd_idx] = tuple(flatten_outputs)
                     per_callable_output_unflatten_spec[per_callable_fwd_idx] = spec
@@ -688,6 +797,22 @@ def _make_graphed_callables(
                             for o in static_outputs
                         )
                     if is_training:
+                        # Call pre_backward hooks before backward graph capture (outside capture context)
+                        if (
+                            capture_time_hooks is not None
+                            and per_callable_bwd_idx < len(capture_time_hooks)
+                            and capture_time_hooks[per_callable_bwd_idx] is not None
+                            and "pre_backward" in capture_time_hooks[per_callable_bwd_idx]
+                        ):
+                            # Get the callable module for this backward index
+                            callable_module = graph_callables[per_callable_bwd_idx]
+                            for hook in capture_time_hooks[per_callable_bwd_idx][
+                                "pre_backward"
+                            ].values():
+                                # During capture, call with the actual module (not None)
+                                # FSDP hooks need to access module attributes
+                                hook(callable_module)
+
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)
                         with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
                             bwd_graph, pool=mempool
@@ -700,6 +825,20 @@ def _make_graphed_callables(
                                 retain_graph=retain_graph_in_backward,
                             )
                             grad_inputs = tuple(input.grad for input in inputs)
+
+                        # Call backward hooks after backward graph capture (outside capture context)
+                        if (
+                            capture_time_hooks is not None
+                            and per_callable_bwd_idx < len(capture_time_hooks)
+                            and capture_time_hooks[per_callable_bwd_idx] is not None
+                            and "backward" in capture_time_hooks[per_callable_bwd_idx]
+                        ):
+                            # Get the callable module for this backward index
+                            callable_module = graph_callables[per_callable_bwd_idx]
+                            for hook in capture_time_hooks[per_callable_bwd_idx]["backward"].values():
+                                # During capture, call with the actual module (not None)
+                                # FSDP hooks need to access module attributes
+                                hook(callable_module)
 
                     # Constructs a tuple suitable for returning from Graphed.backward:
                     # Pads out the actually-needed grads with Nones in gradient slots for inputs
@@ -755,12 +894,32 @@ def _make_graphed_callables(
         # Capture forward graphs
         per_callable_static_outputs = []
         per_callable_output_unflatten_spec = []
-        graph_id = 0
-        for func, args, kwargs, fwd_graph in zip(callables, sample_args, sample_kwargs, fwd_graphs):
+        for func_idx, (func, args, kwargs, fwd_graph) in enumerate(
+            zip(callables, sample_args, sample_kwargs, fwd_graphs)
+        ):
+            # Call forward_pre hooks before forward graph capture (outside capture context)
+            if (
+                capture_time_hooks is not None
+                and func_idx < len(capture_time_hooks)
+                and capture_time_hooks[func_idx] is not None
+                and "forward_pre" in capture_time_hooks[func_idx]
+            ):
+                for hook in capture_time_hooks[func_idx]["forward_pre"].values():
+                    hook(func, args, kwargs)
+
             with _graph_context_wrapper(fwd_graph, pool=mempool):
                 outputs = func(*args, **kwargs)
-            graph_callables[graph_id] = func
-            graph_id += 1
+            graph_callables[func_idx] = func
+
+            # Call forward hooks after forward graph capture (outside capture context)
+            if (
+                capture_time_hooks is not None
+                and func_idx < len(capture_time_hooks)
+                and capture_time_hooks[func_idx] is not None
+                and "forward" in capture_time_hooks[func_idx]
+            ):
+                for hook in capture_time_hooks[func_idx]["forward"].values():
+                    hook(func, args, outputs)
 
             flatten_outputs, spec = _tree_flatten(outputs)
             per_callable_static_outputs.append(tuple(flatten_outputs))
@@ -782,6 +941,17 @@ def _make_graphed_callables(
                 for o in static_outputs
             )
             if is_training:
+                # Call pre_backward hooks before backward graph capture (outside capture context)
+                if (
+                    capture_time_hooks is not None
+                    and bwd_idx < len(capture_time_hooks)
+                    and capture_time_hooks[bwd_idx] is not None
+                    and "pre_backward" in capture_time_hooks[bwd_idx]
+                ):
+                    callable_module = graph_callables[bwd_idx]
+                    for hook in capture_time_hooks[bwd_idx]["pre_backward"].values():
+                        hook(callable_module)
+
                 inputs = tuple(i for i in static_input_surface if i.requires_grad)
                 with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
                     bwd_graph, pool=mempool
@@ -792,6 +962,17 @@ def _make_graphed_callables(
                         retain_graph=retain_graph_in_backward,
                     )
                     grad_inputs = tuple(input.grad for input in inputs)
+
+                # Call backward hooks after backward graph capture (outside capture context)
+                if (
+                    capture_time_hooks is not None
+                    and bwd_idx < len(capture_time_hooks)
+                    and capture_time_hooks[bwd_idx] is not None
+                    and "backward" in capture_time_hooks[bwd_idx]
+                ):
+                    callable_module = graph_callables[bwd_idx]
+                    for hook in capture_time_hooks[bwd_idx]["backward"].values():
+                        hook(callable_module)
 
                 if need_bwd_dw_graph[bwd_idx]:
                     with _graph_context_wrapper(bwd_dw_graph, pool=mempool):
@@ -1152,6 +1333,7 @@ def make_graphed_callables(
     _reuse_graph_input_output_buffers: bool = False,
     pre_warmup_hook: Optional[Callable] = None,
     post_warmup_hook: Optional[Callable] = None,
+    capture_time_hooks: Optional[List[Optional[Dict[str, Dict]]]] = None,
 ) -> Union[Callable, Tuple[Callable, ...]]:
     """
     Make CUDA graph version of Transformer Engine modules
@@ -1194,6 +1376,23 @@ def make_graphed_callables(
                       A hook function that will be called before the warmup iterations.
     post_warmup_hook: callable, default = None
                       A hook function that will be called after the warmup iterations.
+    capture_time_hooks: list of dict, optional
+                   Per-callable hooks invoked at capture time (during warmup iterations and
+                   graph capture), but intentionally executed **outside** the CUDA graph
+                   capture context so they are **not** recorded into the graph and will
+                   **not** be replayed. Use this for operations that are inherently
+                   non-capturable but essential for correct module execution, such as
+                   CPU-side state updates.
+                   Each element corresponds to one callable and is a dict with any subset
+                   of the following keys:
+                   - ``"forward_pre"``: dict of hooks called *before* the forward pass.
+                     Hook signature: ``hook(module, args, kwargs)``.
+                   - ``"forward"``: dict of hooks called *after* the forward pass.
+                     Hook signature: ``hook(module, args, output)``.
+                   - ``"pre_backward"``: dict of hooks called *before* the backward pass.
+                     Hook signature: ``hook(module)``.
+                   - ``"backward"``: dict of hooks called *after* the backward pass.
+                     Hook signature: ``hook(module)``.
 
     Quantization parameters
     -----------------------
@@ -1387,6 +1586,7 @@ def make_graphed_callables(
         _reuse_graph_input_output_buffers=_reuse_graph_input_output_buffers,
         pre_warmup_hook=pre_warmup_hook,
         post_warmup_hook=post_warmup_hook,
+        capture_time_hooks=capture_time_hooks,
     )
 
     # Ensures warmup does not affect numerics for ops such as dropout.

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -806,9 +806,7 @@ def _make_graphed_callables(
                         ):
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[callable_idx][
-                                "pre_backward"
-                            ].values():
+                            for hook in capture_time_hooks[callable_idx]["pre_backward"].values():
                                 hook(callable_module)
 
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -459,9 +459,7 @@ def _make_graphed_callables(
         args = sample_args[func_idx]
         kwargs = sample_kwargs[func_idx]
 
-        def hook_fn(
-            module, inputs, outputs, func_idx=func_idx
-        ):  # pylint: disable=unused-argument
+        def hook_fn(module, inputs, outputs, func_idx=func_idx):  # pylint: disable=unused-argument
             modules = set()
             if isinstance(module, TransformerEngineBaseModule):
                 modules.add(module)
@@ -526,9 +524,7 @@ def _make_graphed_callables(
 
         inputs = tuple(i for i in static_input_surface if i.requires_grad)
         with _none_grad_context_wrapper(inputs):
-            outputs_requiring_grad = tuple(
-                o for o in outputs if o is not None and o.requires_grad
-            )
+            outputs_requiring_grad = tuple(o for o in outputs if o is not None and o.requires_grad)
             torch.autograd.backward(
                 outputs_requiring_grad,
                 grad_tensors=tuple(torch.empty_like(o) for o in outputs_requiring_grad),
@@ -562,8 +558,7 @@ def _make_graphed_callables(
             ):
                 if not allow_unused_input:
                     raise RuntimeError(
-                        "The input tensor requires grad, but the grad is None after"
-                        " backward pass."
+                        "The input tensor requires grad, but the grad is None after backward pass."
                     )
             elif (
                 grad_inputs[grad_inputs_idx] is not None
@@ -577,9 +572,7 @@ def _make_graphed_callables(
                     f" iteration, but found in iteration {warmup_iter}"
                 )
             per_callable_module_params[func_idx] = tuple(module_params_with_grad)
-            static_input_surface = flatten_sample_args[func_idx] + tuple(
-                module_params_with_grad
-            )
+            static_input_surface = flatten_sample_args[func_idx] + tuple(module_params_with_grad)
             per_callable_static_input_surfaces[func_idx] = static_input_surface
 
         # Run wgrad. This is essential for some TE modules when they have
@@ -630,16 +623,11 @@ def _make_graphed_callables(
                             for l_no in reversed(range(_num_layers_per_chunk[m_chunk])):
                                 per_callable_bwd_idx = (
                                     _prefix_num_layers[m_chunk] * num_microbatches
-                                ) + (
-                                    bwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no
-                                )
+                                ) + (bwd_idx[m_chunk] * _num_layers_per_chunk[m_chunk] + l_no)
                                 func = callables[_prefix_num_layers[m_chunk] + l_no]
                                 outputs = per_fwd_outputs[per_callable_bwd_idx]
                                 _run_warmup_backward(
-                                    per_callable_bwd_idx,
-                                    func,
-                                    outputs,
-                                    warmup_iter
+                                    per_callable_bwd_idx, func, outputs, warmup_iter
                                 )
                             bwd_idx[m_chunk] += 1
 
@@ -685,8 +673,12 @@ def _make_graphed_callables(
                         and capture_time_hooks[per_callable_fwd_idx] is not None
                         and "forward_pre" in capture_time_hooks[per_callable_fwd_idx]
                     ):
-                        for hook in capture_time_hooks[per_callable_fwd_idx]["forward_pre"].values():
-                            hook(func, args, kwargs)  # forward_pre hook signature: (module, args, kwargs)
+                        for hook in capture_time_hooks[per_callable_fwd_idx][
+                            "forward_pre"
+                        ].values():
+                            hook(
+                                func, args, kwargs
+                            )  # forward_pre hook signature: (module, args, kwargs)
 
                     with _graph_context_wrapper(fwd_graph, pool=mempool):
                         outputs = func(*args, **kwargs)
@@ -699,7 +691,9 @@ def _make_graphed_callables(
                         and "forward" in capture_time_hooks[per_callable_fwd_idx]
                     ):
                         for hook in capture_time_hooks[per_callable_fwd_idx]["forward"].values():
-                            hook(func, args, outputs)  # forward hook signature: (module, inputs, output)
+                            hook(
+                                func, args, outputs
+                            )  # forward hook signature: (module, inputs, output)
 
                     flatten_outputs, spec = _tree_flatten(outputs)
                     per_callable_static_outputs[per_callable_fwd_idx] = tuple(flatten_outputs)
@@ -835,7 +829,9 @@ def _make_graphed_callables(
                         ):
                             # Get the callable module for this backward index
                             callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[per_callable_bwd_idx]["backward"].values():
+                            for hook in capture_time_hooks[per_callable_bwd_idx][
+                                "backward"
+                            ].values():
                                 # During capture, call with the actual module (not None)
                                 # FSDP hooks need to access module attributes
                                 hook(callable_module)

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -806,6 +806,7 @@ def _make_graphed_callables(
                             torch.empty_like(o) if o is not None and o.requires_grad else None
                             for o in static_outputs
                         )
+                    grad_inputs: Tuple[Optional[torch.Tensor], ...] = ()
                     if is_training:
                         _run_capture_time_hooks(
                             capture_time_hooks,
@@ -917,6 +918,7 @@ def _make_graphed_callables(
                 torch.empty_like(o) if o is not None and o.requires_grad else None
                 for o in static_outputs
             )
+            grad_inputs: Tuple[Optional[torch.Tensor], ...] = ()
             if is_training:
                 _run_capture_time_hooks(
                     capture_time_hooks,

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -36,6 +36,12 @@ _IS_GRAPH_CAPTURING = False
 
 _T = TypeVar("_T")
 SingleOrTuple = Union[_T, Tuple[_T, ...]]
+_CAPTURE_TIME_HOOK_NAMES = (
+    "forward_pre_hooks",
+    "forward_hooks",
+    "backward_pre_hooks",
+    "backward_hooks",
+)
 
 
 def set_capture_start() -> None:
@@ -96,9 +102,50 @@ def _graph_context_wrapper(*args, **kwargs):
         gc.enable()
 
 
+def _canonicalize_capture_time_hooks(
+    num_callables: int,
+    capture_time_hooks: Optional[List[Optional[Dict[str, Dict]]]],
+) -> List[Dict[str, Dict]]:
+    """Fill defaults in capture_time_hooks."""
+    if capture_time_hooks is None:
+        capture_time_hooks = [None] * num_callables
+    if len(capture_time_hooks) != num_callables:
+        raise ValueError(
+            f"capture_time_hooks has {len(capture_time_hooks)} entries, "
+            f"but there are {num_callables} callables."
+        )
+
+    canonicalized = []
+    for callable_idx in range(num_callables):
+        hooks = capture_time_hooks[callable_idx]
+        if hooks is None:
+            hooks = {}
+        unexpected_keys = set(hooks.keys()) - set(_CAPTURE_TIME_HOOK_NAMES)
+        if unexpected_keys:
+            raise ValueError(f"Found unexpected keys in capture_time_hooks ({unexpected_keys}).")
+        canonicalized.append(
+            {hook_name: hooks.get(hook_name, {}) for hook_name in _CAPTURE_TIME_HOOK_NAMES}
+        )
+
+    return canonicalized
+
+
+def _run_capture_time_hooks(
+    capture_time_hooks: List[Dict[str, Dict]],
+    callable_idx: int,
+    hook_name: str,
+    module: torch.nn.Module,
+) -> None:
+    """Run non-capturable hooks outside CUDA graph capture."""
+    for hook in capture_time_hooks[callable_idx][hook_name].values():
+        if hook(module) is not None:
+            raise RuntimeError(f"capture_time_hooks {hook_name} must not return a value.")
+
+
 def _make_graphed_callables(
     callables: SingleOrTuple[Callable],
     sample_args: SingleOrTuple[Tuple[torch.Tensor, ...]],
+    *,
     num_warmup_iters: int = 3,
     allow_unused_input: bool = False,
     cache_quantized_params: bool = False,
@@ -110,7 +157,7 @@ def _make_graphed_callables(
     _reuse_graph_input_output_buffers: bool = False,
     pre_warmup_hook: Optional[Callable] = None,
     post_warmup_hook: Optional[Callable] = None,
-    capture_time_hooks: Optional[List[Optional[Dict[str, Dict]]]] = None,
+    capture_time_hooks: List[Dict[str, Dict]],
 ) -> SingleOrTuple[Callable]:
     """
     Helper method for `make_graphed_callables`
@@ -370,12 +417,6 @@ def _make_graphed_callables(
                 + "for each callable must contain only Tensors. Other types are not allowed."
             )
 
-    if capture_time_hooks is not None and len(capture_time_hooks) != len(callables):
-        raise ValueError(
-            f"capture_time_hooks has {len(capture_time_hooks)} entries but there are "
-            f"{len(callables)} callables"
-        )
-
     # If a callable is an nn.Module, its graph's full input surface is the args the user explicitly
     # passes to forward (ie, its sample_args) AND the module's parameter attributes.
     # Note: These per_callable_* variables are not actually
@@ -493,22 +534,7 @@ def _make_graphed_callables(
                 else:
                     visited_te_modules[func_idx].update(modules)
 
-        if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
-            _hooks = capture_time_hooks[callable_idx]
-            _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
-            for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
-                if hook_id in _pre_fwd_with_kwargs:
-                    if hook(func, args, kwargs) is not None:
-                        raise RuntimeError(
-                            "capture_time_hooks forward_pre_hooks must not return a value "
-                            "(args/kwargs must not be modified via hook return)"
-                        )
-                else:
-                    if hook(func, args) is not None:
-                        raise RuntimeError(
-                            "capture_time_hooks forward_pre_hooks must not return a value "
-                            "(args must not be modified via hook return)"
-                        )
+        _run_capture_time_hooks(capture_time_hooks, callable_idx, "forward_pre_hooks", func)
 
         hooks = []
         for module in func.modules():
@@ -517,22 +543,7 @@ def _make_graphed_callables(
         for hook in hooks:
             hook.remove()
 
-        if capture_time_hooks is not None and capture_time_hooks[callable_idx] is not None:
-            _hooks = capture_time_hooks[callable_idx]
-            _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
-            for hook_id, hook in _hooks.get("forward_hooks", {}).items():
-                if hook_id in _fwd_with_kwargs:
-                    if hook(func, args, kwargs, outputs) is not None:
-                        raise RuntimeError(
-                            "capture_time_hooks forward_hooks must not return a value "
-                            "(output must not be modified via hook return)"
-                        )
-                else:
-                    if hook(func, args, outputs) is not None:
-                        raise RuntimeError(
-                            "capture_time_hooks forward_hooks must not return a value "
-                            "(output must not be modified via hook return)"
-                        )
+        _run_capture_time_hooks(capture_time_hooks, callable_idx, "forward_hooks", func)
 
         outputs, _ = _tree_flatten(outputs)
         return outputs
@@ -545,33 +556,13 @@ def _make_graphed_callables(
         outputs_requiring_grad = tuple(o for o in outputs if o is not None and o.requires_grad)
         grad_outputs = tuple(torch.empty_like(o) for o in outputs_requiring_grad)
 
-        if (
-            capture_time_hooks is not None
-            and capture_time_hooks[callable_idx] is not None
-            and "backward_pre_hooks" in capture_time_hooks[callable_idx]
-        ):
-            for hook in capture_time_hooks[callable_idx]["backward_pre_hooks"].values():
-                if hook(func, grad_outputs) is not None:
-                    raise RuntimeError(
-                        "capture_time_hooks backward_pre_hooks must not return a value "
-                        "(grad_output must not be modified via hook return)"
-                    )
+        _run_capture_time_hooks(capture_time_hooks, callable_idx, "backward_pre_hooks", func)
 
         with _none_grad_context_wrapper(inputs):
             torch.autograd.backward(outputs_requiring_grad, grad_tensors=grad_outputs)
             grad_inputs = tuple(input.grad for input in inputs)
 
-        if (
-            capture_time_hooks is not None
-            and capture_time_hooks[callable_idx] is not None
-            and "backward_hooks" in capture_time_hooks[callable_idx]
-        ):
-            for hook in capture_time_hooks[callable_idx]["backward_hooks"].values():
-                if hook(func, grad_inputs, grad_outputs) is not None:
-                    raise RuntimeError(
-                        "capture_time_hooks backward_hooks must not return a value "
-                        "(grad_input must not be modified via hook return)"
-                    )
+        _run_capture_time_hooks(capture_time_hooks, callable_idx, "backward_hooks", func)
 
         # Filter module params that get None grad from grad_inputs and remove them
         # from static_input_surface. This is to ensure that the backward hooks
@@ -702,50 +693,22 @@ def _make_graphed_callables(
                     kwargs = sample_kwargs[per_callable_fwd_idx]
                     fwd_graph = fwd_graphs[per_callable_fwd_idx]
 
-                    # Call pre_forward hooks before forward graph capture (outside capture context)
-                    if (
-                        capture_time_hooks is not None
-                        and capture_time_hooks[callable_idx] is not None
-                    ):
-                        _hooks = capture_time_hooks[callable_idx]
-                        _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
-                        for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
-                            if hook_id in _pre_fwd_with_kwargs:
-                                if hook(func, args, kwargs) is not None:
-                                    raise RuntimeError(
-                                        "capture_time_hooks forward_pre_hooks must not return a"
-                                        " value (args/kwargs must not be modified via hook return)"
-                                    )
-                            else:
-                                if hook(func, args) is not None:
-                                    raise RuntimeError(
-                                        "capture_time_hooks forward_pre_hooks must not return a"
-                                        " value (args must not be modified via hook return)"
-                                    )
+                    _run_capture_time_hooks(
+                        capture_time_hooks,
+                        callable_idx,
+                        "forward_pre_hooks",
+                        func,
+                    )
 
                     with _graph_context_wrapper(fwd_graph, pool=mempool):
                         outputs = func(*args, **kwargs)
 
-                    # Call forward hooks after forward graph capture (outside capture context)
-                    if (
-                        capture_time_hooks is not None
-                        and capture_time_hooks[callable_idx] is not None
-                    ):
-                        _hooks = capture_time_hooks[callable_idx]
-                        _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
-                        for hook_id, hook in _hooks.get("forward_hooks", {}).items():
-                            if hook_id in _fwd_with_kwargs:
-                                if hook(func, args, kwargs, outputs) is not None:
-                                    raise RuntimeError(
-                                        "capture_time_hooks forward_hooks must not return a value "
-                                        "(output must not be modified via hook return)"
-                                    )
-                            else:
-                                if hook(func, args, outputs) is not None:
-                                    raise RuntimeError(
-                                        "capture_time_hooks forward_hooks must not return a value "
-                                        "(output must not be modified via hook return)"
-                                    )
+                    _run_capture_time_hooks(
+                        capture_time_hooks,
+                        callable_idx,
+                        "forward_hooks",
+                        func,
+                    )
 
                     flatten_outputs, spec = _tree_flatten(outputs)
                     per_callable_static_outputs[per_callable_fwd_idx] = tuple(flatten_outputs)
@@ -844,22 +807,12 @@ def _make_graphed_callables(
                             for o in static_outputs
                         )
                     if is_training:
-                        # Call pre_backward hooks before backward graph capture (outside capture context)
-                        if (
-                            capture_time_hooks is not None
-                            and capture_time_hooks[callable_idx] is not None
-                            and "backward_pre_hooks" in capture_time_hooks[callable_idx]
-                        ):
-                            # Get the callable module for this backward index
-                            callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[callable_idx][
-                                "backward_pre_hooks"
-                            ].values():
-                                if hook(callable_module, static_grad_outputs) is not None:
-                                    raise RuntimeError(
-                                        "capture_time_hooks backward_pre_hooks must not return a"
-                                        " value (grad_output must not be modified via hook return)"
-                                    )
+                        _run_capture_time_hooks(
+                            capture_time_hooks,
+                            callable_idx,
+                            "backward_pre_hooks",
+                            callables[callable_idx],
+                        )
 
                         inputs = tuple(i for i in static_input_surface if i.requires_grad)
                         with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
@@ -874,23 +827,12 @@ def _make_graphed_callables(
                             )
                             grad_inputs = tuple(input.grad for input in inputs)
 
-                        # Call backward hooks after backward graph capture (outside capture context)
-                        if (
-                            capture_time_hooks is not None
-                            and capture_time_hooks[callable_idx] is not None
-                            and "backward_hooks" in capture_time_hooks[callable_idx]
-                        ):
-                            # Get the callable module for this backward index
-                            callable_module = graph_callables[per_callable_bwd_idx]
-                            for hook in capture_time_hooks[callable_idx]["backward_hooks"].values():
-                                if (
-                                    hook(callable_module, grad_inputs, static_grad_outputs)
-                                    is not None
-                                ):
-                                    raise RuntimeError(
-                                        "capture_time_hooks backward_hooks must not return a value "
-                                        "(grad_input must not be modified via hook return)"
-                                    )
+                        _run_capture_time_hooks(
+                            capture_time_hooks,
+                            callable_idx,
+                            "backward_hooks",
+                            callables[callable_idx],
+                        )
 
                     # Constructs a tuple suitable for returning from Graphed.backward:
                     # Pads out the actually-needed grads with Nones in gradient slots for inputs
@@ -949,45 +891,13 @@ def _make_graphed_callables(
         for func_idx, (func, args, kwargs, fwd_graph) in enumerate(
             zip(callables, sample_args, sample_kwargs, fwd_graphs)
         ):
-            # Call pre_forward hooks before forward graph capture (outside capture context)
-            if capture_time_hooks is not None and capture_time_hooks[func_idx] is not None:
-                _hooks = capture_time_hooks[func_idx]
-                _pre_fwd_with_kwargs = _hooks.get("forward_pre_hooks_with_kwargs", {})
-                for hook_id, hook in _hooks.get("forward_pre_hooks", {}).items():
-                    if hook_id in _pre_fwd_with_kwargs:
-                        if hook(func, args, kwargs) is not None:
-                            raise RuntimeError(
-                                "capture_time_hooks forward_pre_hooks must not return a value "
-                                "(args/kwargs must not be modified via hook return)"
-                            )
-                    else:
-                        if hook(func, args) is not None:
-                            raise RuntimeError(
-                                "capture_time_hooks forward_pre_hooks must not return a value "
-                                "(args must not be modified via hook return)"
-                            )
+            _run_capture_time_hooks(capture_time_hooks, func_idx, "forward_pre_hooks", func)
 
             with _graph_context_wrapper(fwd_graph, pool=mempool):
                 outputs = func(*args, **kwargs)
             graph_callables[func_idx] = func
 
-            # Call forward hooks after forward graph capture (outside capture context)
-            if capture_time_hooks is not None and capture_time_hooks[func_idx] is not None:
-                _hooks = capture_time_hooks[func_idx]
-                _fwd_with_kwargs = _hooks.get("forward_hooks_with_kwargs", {})
-                for hook_id, hook in _hooks.get("forward_hooks", {}).items():
-                    if hook_id in _fwd_with_kwargs:
-                        if hook(func, args, kwargs, outputs) is not None:
-                            raise RuntimeError(
-                                "capture_time_hooks forward_hooks must not return a value "
-                                "(output must not be modified via hook return)"
-                            )
-                    else:
-                        if hook(func, args, outputs) is not None:
-                            raise RuntimeError(
-                                "capture_time_hooks forward_hooks must not return a value "
-                                "(output must not be modified via hook return)"
-                            )
+            _run_capture_time_hooks(capture_time_hooks, func_idx, "forward_hooks", func)
 
             flatten_outputs, spec = _tree_flatten(outputs)
             per_callable_static_outputs.append(tuple(flatten_outputs))
@@ -1003,25 +913,17 @@ def _make_graphed_callables(
             reversed(bwd_dw_graphs),
             reversed(range(len(per_callable_static_input_surfaces))),
         ):
-            # For now, assumes all static_outputs require grad
             static_grad_outputs = tuple(
                 torch.empty_like(o) if o is not None and o.requires_grad else None
                 for o in static_outputs
             )
             if is_training:
-                # Call pre_backward hooks before backward graph capture (outside capture context)
-                if (
-                    capture_time_hooks is not None
-                    and capture_time_hooks[bwd_idx] is not None
-                    and "backward_pre_hooks" in capture_time_hooks[bwd_idx]
-                ):
-                    callable_module = graph_callables[bwd_idx]
-                    for hook in capture_time_hooks[bwd_idx]["backward_pre_hooks"].values():
-                        if hook(callable_module, static_grad_outputs) is not None:
-                            raise RuntimeError(
-                                "capture_time_hooks backward_pre_hooks must not return a value "
-                                "(grad_output must not be modified via hook return)"
-                            )
+                _run_capture_time_hooks(
+                    capture_time_hooks,
+                    bwd_idx,
+                    "backward_pre_hooks",
+                    callables[bwd_idx],
+                )
 
                 inputs = tuple(i for i in static_input_surface if i.requires_grad)
                 with _none_grad_context_wrapper(inputs), _graph_context_wrapper(
@@ -1034,19 +936,12 @@ def _make_graphed_callables(
                     )
                     grad_inputs = tuple(input.grad for input in inputs)
 
-                # Call backward hooks after backward graph capture (outside capture context)
-                if (
-                    capture_time_hooks is not None
-                    and capture_time_hooks[bwd_idx] is not None
-                    and "backward_hooks" in capture_time_hooks[bwd_idx]
-                ):
-                    callable_module = graph_callables[bwd_idx]
-                    for hook in capture_time_hooks[bwd_idx]["backward_hooks"].values():
-                        if hook(callable_module, grad_inputs, static_grad_outputs) is not None:
-                            raise RuntimeError(
-                                "capture_time_hooks backward_hooks must not return a value "
-                                "(grad_input must not be modified via hook return)"
-                            )
+                _run_capture_time_hooks(
+                    capture_time_hooks,
+                    bwd_idx,
+                    "backward_hooks",
+                    callables[bwd_idx],
+                )
 
                 if need_bwd_dw_graph[bwd_idx]:
                     with _graph_context_wrapper(bwd_dw_graph, pool=mempool):
@@ -1458,27 +1353,13 @@ def make_graphed_callables(
                    capture context so they are **not** recorded into the graph and will
                    **not** be replayed. Use this for operations that are inherently
                    non-capturable but essential for correct module execution, such as
-                   CPU-side state updates. All the hooks must return None, meaning that
-                   modifying tensors is not supported. Any attempt to return a non-None
-                   value will raise ``RuntimeError``.
+                   CPU-side state updates. All hooks must have signature ``hook(module)``
+                   and must return ``None``. Any non-``None`` return value raises
+                   ``RuntimeError``.
                    Each element corresponds to one callable and is a dict with any subset
-                   of the following keys (names mirror PyTorch's ``nn.Module`` hook
-                   attributes):
-                   - ``"forward_pre_hooks"``: ``{hook_id: hook_fn}`` dict of *all* pre-forward
-                     hooks (both plain and with-kwargs). Plain signature: ``hook(module, args)``.
-                     With-kwargs signature: ``hook(module, args, kwargs)``.
-                   - ``"forward_pre_hooks_with_kwargs"``: ``{hook_id: True}`` flag set marking
-                     which entries in ``"forward_pre_hooks"`` should be called with kwargs.
-                   - ``"forward_hooks"``: ``{hook_id: hook_fn}`` dict of *all* post-forward
-                     hooks (both plain and with-kwargs). Plain signature:
-                     ``hook(module, args, output)``. With-kwargs signature:
-                     ``hook(module, args, kwargs, output)``.
-                   - ``"forward_hooks_with_kwargs"``: ``{hook_id: True}`` flag set marking
-                     which entries in ``"forward_hooks"`` should be called with kwargs.
-                   - ``"backward_pre_hooks"``: ``{hook_id: hook_fn}`` dict of hooks called
-                     *before* the backward pass. Signature: ``hook(module, grad_output)``.
-                   - ``"backward_hooks"``: ``{hook_id: hook_fn}`` dict of hooks called *after*
-                     the backward pass. Signature: ``hook(module, grad_input, grad_output)``.
+                   of these keys: ``"forward_pre_hooks"``, ``"forward_hooks"``,
+                   ``"backward_pre_hooks"``, and ``"backward_hooks"``. Each value is a
+                   ``{hook_id: hook_fn}`` dict.
 
     Quantization parameters
     -----------------------
@@ -1608,6 +1489,12 @@ def make_graphed_callables(
     elif not any(enabled):
         recipe = None
     module_uses_fp8 = dict(zip((id(m) for m in modules), enabled))
+
+    # Canonicalize capture_time_hooks kwarg.
+    capture_time_hooks = _canonicalize_capture_time_hooks(
+        len(modules),
+        capture_time_hooks,
+    )
 
     # Store FP8 tensors to reset later.
     saved_fp8_tensors = save_fp8_tensors(modules, recipe=recipe)


### PR DESCRIPTION
# Description

## Summary

This PR adds `capture_time_hooks` to `make_graphed_callables` for per-callable work that must run during warmup and CUDA Graph construction but remain outside the CUDA Graph capture context. This is needed for non-capturable operations such as CPU-side state updates and FSDP parameter un-shard/re-shard work that may allocate memory.

These callbacks are graph-construction hooks, not PyTorch `Module` hooks: they receive only the original callable/module, must return `None`, are not recorded into the graph, and are not replayed.

## Changes

- Add one `capture_time_hooks` entry per callable, with support for `forward_pre_hooks`, `forward_hooks`, `backward_pre_hooks`, and `backward_hooks`.
- Run the hooks around each callable's forward and backward during warmup and graph construction, outside the corresponding CUDA Graph capture context.
- Support both capture paths: no-order warmup runs all forwards followed by backwards in reverse order, while ordered warmup follows `_order` across chunks and microbatches. Existing `backward_dw()` warmup behavior is unchanged.
- Call the existing `pre_warmup_hook` and `post_warmup_hook` once around the complete warmup phase rather than once per callable.
- Reject modules with registered backward pre-hooks consistently with the existing checks for other pre-registered `Module` hooks.
- Add parameterized CUDA coverage for both `_order=None` and `_order=[1, 2, -2, -1]`.

## Hook contract

`capture_time_hooks` is a list with one entry per callable. Each entry may be `None` or a dictionary containing any subset of the four supported hook groups. Each group is a `{hook_id: hook_fn}` dictionary, and every hook has signature `hook(module) -> None`.

The list length must match the number of callables. Missing hook groups are treated as empty, unsupported group names raise `ValueError`, and a non-`None` hook return raises `RuntimeError`. The hooks cannot replace inputs, outputs, `grad_inputs`, or `grad_outputs`.

Normal PyTorch `Module` hooks may still be registered after graph construction.

## Execution order

For each callable, the order is:

1. `forward_pre_hooks`
2. forward execution
3. `forward_hooks`
4. `backward_pre_hooks` (training only)
5. backward execution (training only)
6. `backward_hooks` (training only)

During graph construction, pre-hooks run before entering the corresponding capture context and post-hooks run after leaving it.

## Tests and validation

The CUDA test verifies:

- exact forward/backward hook order;
- original module identity;
- execution outside CUDA Graph capture;
- invocation during every warmup iteration and graph construction;
- no invocation during graph replay.

Validation performed:

- focused capture-time hook test on H100: `2 passed`;
- full `tests/pytorch/test_cuda_graphs.py` on H100: `412 passed, 423 skipped`;
- `pylint==3.3.1`, pre-commit, Python compilation, and diff checks passed.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
