### PR TITLE
[PyTorch] Avoid autograd's gradient accumulation in grouped MLP if possible

### DIFF
--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -1045,7 +1045,7 @@ class GroupedLinear(BasicOperation):
                     grad_weight = torch.stack(grad_weights, dim=0)
             final_weight_grads = [grad_weight]
         else:
-            if delay_wgrad and ctx.weight_requires_grad:
+            if delay_wgrad and ctx.weight_requires_grad and not accumulate_into_main_grad:
                 final_weight_grads = [None] * num_groups
             else:
                 final_weight_grads = grad_weights

--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -155,8 +155,8 @@ def _compute_grad_params(
                 )
             w_list = [packed_wgrad]
         else:
-            if delay_wgrad:
-                w_list = list(w_list) if accumulate_into_main_grad else [None] * num_groups
+            if delay_wgrad or accumulate_into_main_grad:
+                w_list = [None] * num_groups
             if accumulate_into_main_grad:
                 for idx in range(num_groups):
                     wp = getattr(fc_op, f"weight{idx}")


### PR DESCRIPTION
# Description

If `.grad` field of a param is not `None` (many cases such as externally maintained grads for various optimizations, multiple microbatches etc.), pytorch by default accumulates gradients resulting in expensive copy and adds.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [x] Performance

## Changes

- Return `None` gradient when possible in grouped MLP backward.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
