### PR TITLE
Reduce number of C++ test cases for MXFP8 cast and activation kernels

### DIFF
--- a/tests/cpp/operator/test_act.cu
+++ b/tests/cpp/operator/test_act.cu
@@ -394,19 +394,31 @@ std::vector<std::pair<size_t, size_t>> act_test_cases = {{2048, 12288},
                                                          {257, 259},
                                                          {128, 128+1}};
 
+std::string test_name_generator(
+    const testing::TestParamInfo<ActTestSuite::ParamType>& info) {
+    std::string name = test::typeName(std::get<0>(info.param)) + "X" +
+                       test::typeName(std::get<1>(info.param)) + "X" +
+                       std::to_string(std::get<2>(info.param).first) + "X" +
+                       std::to_string(std::get<2>(info.param).second);
+    return name;
+}
+
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
-    OperatorTest,
+    OperatorTest_ActTestSuite_BF16,
+    ActTestSuite,
+    ::testing::Combine(
+        ::testing::Values(DType::kBFloat16),
+        ::testing::ValuesIn(test::all_fp_types),
+        ::testing::ValuesIn(act_test_cases)),
+    test_name_generator);
+
+INSTANTIATE_TEST_SUITE_P(
+    OperatorTest_ActTestSuite_DType,
     ActTestSuite,
     ::testing::Combine(
         ::testing::Values(DType::kFloat32, DType::kBFloat16, DType::kFloat16),
         ::testing::ValuesIn(test::all_fp_types),
-        ::testing::ValuesIn(act_test_cases)),
-    [](const testing::TestParamInfo<ActTestSuite::ParamType>& info) {
-      std::string name = test::typeName(std::get<0>(info.param)) + "X" +
-                         test::typeName(std::get<1>(info.param)) + "X" +
-                         std::to_string(std::get<2>(info.param).first) + "X" +
-                         std::to_string(std::get<2>(info.param).second);
-      return name;
-    });
+        ::testing::Values(std::pair<size_t, size_t>{768, 2816})),
+    test_name_generator);

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -524,14 +524,8 @@ void performTest_x2(const ProcessingMethod processing_method,
 std::vector<std::vector<size_t>> matrix_sizes = {
     {1, 16},
     {16, 48},
-    {65, 96},
     {128, 128},
-    {256, 256},
     {993, 512},
-    {511, 6144},
-    {8192, 128},
-    {2048, 160},
-    {577, 1632},
     {1024},
     {8, 32, 1024},
     {16, 8, 4, 512},
@@ -569,8 +563,6 @@ std::vector<ActivationType> Activation_types = {
     // ActivationType::QGeLU,
     // ActivationType::SReLU,
 };
-
-}  // namespace
 
 class FusedCastMXFP8TestSuite : public ::testing::TestWithParam
     <std::tuple<ProcessingMethod,
@@ -684,28 +676,62 @@ std::string to_string(const ActivationType Act_type) {
     }
 }
 
+std::string test_name_generator(
+    const testing::TestParamInfo<FusedCastMXFP8TestSuite::ParamType>& info) {
+    std::string name = to_string(std::get<0>(info.param)) + "X" +
+        to_string(std::get<1>(info.param));
+    const auto& shape = std::get<2>(info.param);
+    for ( const auto& s: shape) {
+        name += "X" + std::to_string(s);
+    }
+    name += "X" + std::to_string(std::get<3>(info.param).first) +
+            "X" + std::to_string(std::get<3>(info.param).second) +
+            "X" + test::typeName(std::get<4>(info.param)) +
+            "X" + test::typeName(std::get<5>(info.param)) +
+            "X" + test::caseName(std::get<6>(info.param));
+    return name;
+}
+
+}  // namespace
+
+// Test cases with only cast kernels
 INSTANTIATE_TEST_SUITE_P(
-    OperatorTest,
+    OperatorTest_FusedCastMXFP8_CastOnly,
+    FusedCastMXFP8TestSuite,
+    ::testing::Combine(
+        ::testing::Values(ProcessingMethod::CAST_ONLY),
+        ::testing::Values(ActivationType::Identity),
+        ::testing::ValuesIn(matrix_sizes),
+        ::testing::ValuesIn(block_sizes),
+        ::testing::Values(DType::kFloat32, DType::kBFloat16, DType::kFloat16),
+        ::testing::Values(DType::kFloat8E4M3, DType::kFloat8E5M2),
+        ::testing::ValuesIn(input_scenarios)),
+    test_name_generator);
+
+// Test cases with varying matrix shapes and block shapes
+INSTANTIATE_TEST_SUITE_P(
+    OperatorTest_FusedCastMXFP8_Sizes,
     FusedCastMXFP8TestSuite,
     ::testing::Combine(
         ::testing::ValuesIn(processing_methods),
         ::testing::ValuesIn(Activation_types),
         ::testing::ValuesIn(matrix_sizes),
         ::testing::ValuesIn(block_sizes),
+        ::testing::Values(DType::kBFloat16),
+        ::testing::Values(DType::kFloat8E4M3),
+        ::testing::ValuesIn(input_scenarios)),
+    test_name_generator);
+
+// Test cases with varying dtypes
+INSTANTIATE_TEST_SUITE_P(
+    OperatorTest_FusedCastMXFP8_Dtypes,
+    FusedCastMXFP8TestSuite,
+    ::testing::Combine(
+        ::testing::ValuesIn(processing_methods),
+        ::testing::ValuesIn(Activation_types),
+        ::testing::Values(std::vector<size_t>{256, 384}),
+        ::testing::Values(std::pair<size_t, size_t>{32, 32}),
         ::testing::Values(DType::kFloat32, DType::kBFloat16, DType::kFloat16),
         ::testing::Values(DType::kFloat8E4M3, DType::kFloat8E5M2),
         ::testing::ValuesIn(input_scenarios)),
-    [](const testing::TestParamInfo<FusedCastMXFP8TestSuite::ParamType>& info) {
-        std::string name = to_string(std::get<0>(info.param)) + "X" +
-                           to_string(std::get<1>(info.param));
-      const auto& shape = std::get<2>(info.param);
-      for ( const auto& s: shape) {
-        name += "X" + std::to_string(s);
-      }
-      name += "X" + std::to_string(std::get<3>(info.param).first) +
-              "X" + std::to_string(std::get<3>(info.param).second) +
-              "X" + test::typeName(std::get<4>(info.param)) +
-              "X" + test::typeName(std::get<5>(info.param)) +
-              "X" + test::caseName(std::get<6>(info.param));
-        return name;
-    });
+    test_name_generator);

--- a/tests/cpp/operator/test_cast_mxfp8_grouped.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_grouped.cu
@@ -669,8 +669,13 @@ std::vector<std::vector<size_t>> input_config = {
     {VARYING_FIRST_DIM,     4,      512,160,                    128,0,0,256},
     {VARYING_BOTH_DIMS,     3,      1,(128*128)+(128*128),      128,0,128,      128,0,128},
 };
-
-}  // namespace
+std::vector<std::vector<size_t>> input_config_small = {
+    {SAME_BOTH_DIMS,        2,      256,128},
+    {VARYING_FIRST_DIM,     4,      1536,160,                   128,384,512,512},
+    {VARYING_LAST_DIM,      3,      256,896,                    128,256,512},
+    {VARYING_BOTH_DIMS,     2,      1,(256*128)+(512*640),      256,512,        128,640},
+    {VARYING_FIRST_DIM,     4,      512,160,                    128,0,0,256},
+};
 
 class GroupedFusedCastMXFP8TestSuite : public ::testing::TestWithParam
     <std::tuple<ProcessingMethod,
@@ -852,14 +857,40 @@ std::string MakeGroupedFusedCastMXFP8TestName(
     return name;
 }
 
+}  // namespace
+
 INSTANTIATE_TEST_SUITE_P(
-    OperatorTest,
+    OperatorTest_GroupedFusedCastMXFP8_CastOnly,
+    GroupedFusedCastMXFP8TestSuite,
+    ::testing::Combine(
+        ::testing::Values(ProcessingMethod::CAST_ONLY),
+        ::testing::Values(ActivationKind::Identity),
+        ::testing::ValuesIn(scaling_directions),
+        ::testing::ValuesIn(input_config),
+        ::testing::Values(DType::kFloat32, DType::kBFloat16, DType::kFloat16),
+        ::testing::Values(DType::kFloat8E4M3, DType::kFloat8E5M2)),
+    MakeGroupedFusedCastMXFP8TestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    OperatorTest_GroupedFusedCastMXFP8_Shapes,
     GroupedFusedCastMXFP8TestSuite,
     ::testing::Combine(
         ::testing::ValuesIn(processing_methods),
         ::testing::ValuesIn(activation_kinds),
         ::testing::ValuesIn(scaling_directions),
         ::testing::ValuesIn(input_config),
+        ::testing::Values(DType::kBFloat16),
+        ::testing::Values(DType::kFloat8E4M3)),
+    MakeGroupedFusedCastMXFP8TestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    OperatorTest_GroupedFusedCastMXFP8_Dtypes,
+    GroupedFusedCastMXFP8TestSuite,
+    ::testing::Combine(
+        ::testing::ValuesIn(processing_methods),
+        ::testing::ValuesIn(activation_kinds),
+        ::testing::Values(ScalingDirection::BOTH),
+        ::testing::ValuesIn(input_config_small),
         ::testing::Values(DType::kFloat32, DType::kBFloat16, DType::kFloat16),
         ::testing::Values(DType::kFloat8E4M3, DType::kFloat8E5M2)),
     MakeGroupedFusedCastMXFP8TestName);

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -1020,9 +1020,12 @@ bool isFp4Type(DType type) {
 }
 
 int32_t getDeviceComputeCapability() {
-  cudaDeviceProp deviceProp;
-  cudaGetDeviceProperties(&deviceProp, 0);
-  return 10 * deviceProp.major + deviceProp.minor;
+  static int32_t compute_capability = [] () -> int32_t {
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, 0);
+    return 10 * deviceProp.major + deviceProp.minor;
+  }();
+  return compute_capability;
 }
 
 size_t first_dimension(const std::vector<size_t> &shape) {


### PR DESCRIPTION
# Description

We have been experiencing test timeouts in the C++ unit tests on Blackwell. The biggest culprits are the tests for the MXFP8 cast kernels and grouped MXFP8 cast kernels, which take nearly half of our testing budget.

<details> <summary> Test times on GB200 </summary>

```
Test Suite                          Passed  Failed  Skipped  Not Run    Total Time    Avg Time  % of Total
----------------------------------------------------------------------------------------------------------
FusedCastMXFP8TestSuite               1198       2     1320        -     42m 43.9s        1.0s       26.0%
GroupedFusedCastMXFP8TestSuite        1026       -     1314        -     36m 28.2s        0.9s       22.2%
ActTestSuite                          1050       -        -        -      23m 2.9s        1.3s       14.0%
NormTestSuite                          448       -     1088        -     18m 59.5s        0.7s       11.5%
CastMXFP8_GatedActTestSuite            324       -        -        -      8m 23.6s        1.6s        5.1%
FusedCastFloat8VectorwiseTestSuite     252       -      276        -      5m 24.6s        0.6s        3.3%
FusedCastFloat8BlockwiseTestSuite      252       -      276        -      5m 12.0s        0.6s        3.2%
CTCSTestSuite                          150       -        -        -      3m 11.1s        1.3s        1.9%
CTTestSuite                            150       -        -        -      2m 53.3s        1.2s        1.8%
CastDBiasTestSuite                      84       -        -        -       2m 4.7s        1.5s        1.3%
CastCSTestSuite                         96       -        -        -       2m 4.7s        1.3s        1.3%
CTDBiasDGeluTestSuite                   90       -        -        -       2m 2.1s        1.4s        1.2%
CastTestSuite                           96       -        -        -      1m 57.3s        1.2s        1.2%
CTDBiasTestSuite                        90       -        -        -      1m 55.6s        1.3s        1.2%
CastDBiasDGeluTestSuite                 84       -        -        -      1m 52.0s        1.3s        1.1%
QDQTestSuite                            72       -        -        -      1m 30.3s        1.3s        0.9%
DequantizeMXFP8TestSuite                48       -       36        -       1m 9.6s        0.8s        0.7%
TTestSuite                              50       -        -        -       1m 2.8s        1.3s        0.6%
CastSwiGLUTestSuite                     48       -        6        -         58.9s        1.1s        0.6%
DGeGLUCTTestSuite                       36       -        -        -         42.5s        1.2s        0.4%
MxNormTestSuite                         21       -        -        -         36.4s        1.7s        0.4%
FusedCastTransposeNVFP4TestSuite        16       -        -        -         22.7s        1.4s        0.2%
----------------------------------------------------------------------------------------------------------
TOTAL                                 5681       2     4316        0    164m 38.5s
```

</details>

This PR reduces the number of test cases, mostly by disentangling the parametrization for activations, tensor sizes, and dtypes.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [x] Testing

## Changes

- Reduce number of test cases for MXFP8 cast kernels
- Reduce number of test cases for group MXFP8 cast kernels
- Reduce number of test cases for activation kernels

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
