### PR TITLE
[JAX] Tighten Triton autotuning version gate + autotuning enforce env var

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -443,6 +443,21 @@ JAX-Specific Variables
    :Default: None
    :Description: Test level for JAX unit tests (``"L0"``, ``"L1"``, ``"L2"``). Used internally by the test suite.
 
+JAX Triton Extensions
+^^^^^^^^^^^^^^^^^^^^^
+
+.. envvar:: NVTE_USE_PYTORCH_TRITON
+
+   :Type: ``int`` (0 or 1)
+   :Default: ``0``
+   :Description: Explicitly acknowledge using ``pytorch-triton`` for JAX Triton kernels. When both JAX and PyTorch are installed in the same environment, PyTorch's ``pytorch-triton`` package may be imported instead of the standard ``triton`` package from OpenAI. Setting this to ``1`` suppresses the compatibility warning emitted in that situation. ``pytorch-triton`` (the real package from PyTorch's package index, not the placeholder on PyPI) is compatible with JAX Triton kernels.
+
+.. envvar:: NVTE_JAX_ENFORCE_TRITON_AUTOTUNING
+
+   :Type: ``int`` (0 or 1)
+   :Default: ``0``
+   :Description: Raise a ``RuntimeError`` when the installed JAX is too old to safely run ``TritonAutotunedKernelCall`` (`jax-ml/jax#35218 <https://github.com/jax-ml/jax/pull/35218>`_) instead of silently falling back to non-autotuned dispatch. Useful for CI or debugging to ensure Triton autotuning is active. When set to ``0`` (default), old JAX versions silently fall back to single-config (non-autotuned) kernel dispatch for compatibility.
+
 Examples
 --------
 

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -433,8 +433,12 @@ def triton_call_lowering(
     num_ctas = 1
     kernel_constexprs = constexprs if constexprs is not None else {}
 
-    # Handle autotuned kernels - compile all configs
-    is_autotuned = isinstance(kernel_fn, autotuner.Autotuner)
+    # Handle autotuned kernels - compile all configs.
+    # Set NVTE_DISABLE_TRITON_AUTOTUNING=1 to skip TritonAutotunedKernelCall and use a
+    # single fixed config instead (useful for measuring autotuning overhead or for JAX
+    # versions that do not support input_output_aliases on autotuned calls).
+    _disable_autotuning = os.environ.get("NVTE_DISABLE_TRITON_AUTOTUNING", "0") == "1"
+    is_autotuned = isinstance(kernel_fn, autotuner.Autotuner) and not _disable_autotuning
     if is_autotuned:
         # Compile all configs for runtime selection
         kernel_calls = []
@@ -446,8 +450,10 @@ def triton_call_lowering(
             config_num_stages = config.num_stages if config.num_stages is not None else num_stages
             config_num_ctas = config.num_ctas if config.num_ctas is not None else num_ctas
 
-            # Merge config kwargs with user constexprs
-            config_constexprs = {**config.kwargs, **(constexprs if constexprs else {})}
+            # Config kwargs (e.g. BLOCK_SIZE) take priority over caller constexprs so that
+            # each autotuning candidate actually compiles with its own BLOCK_SIZE rather than
+            # having the caller-supplied grid BLOCK_SIZE override every config.
+            config_constexprs = {**(constexprs if constexprs else {}), **config.kwargs}
 
             # Compile this config
             config_kernel = compile_triton(
@@ -504,7 +510,28 @@ def triton_call_lowering(
         )
 
     else:
-        # Regular kernel: compile single config
+        # Regular kernel: compile single config.
+        # If the kernel is an Autotuner but autotuning is disabled, unwrap it and use
+        # the first config's kwargs (user constexprs still take priority via dict merge).
+        if isinstance(kernel_fn, autotuner.Autotuner):
+            actual_kernel_fn = kernel_fn.fn
+            if kernel_fn.configs:
+                first_cfg = kernel_fn.configs[0]
+                # user constexprs override config kwargs (so stride / size scalars win)
+                kernel_constexprs = {**first_cfg.kwargs, **(constexprs or {})}
+                num_warps = first_cfg.num_warps if first_cfg.num_warps is not None else num_warps
+                num_stages = (
+                    first_cfg.num_stages if first_cfg.num_stages is not None else num_stages
+                )
+                num_ctas = first_cfg.num_ctas if first_cfg.num_ctas is not None else num_ctas
+
+                # NVTE_TRITON_BLOCK_SIZE lets benchmarks pin a specific BLOCK_SIZE candidate
+                # without changing any other constexpr.  Only applied when the kernel has a
+                # BLOCK_SIZE constant and the env var is explicitly set.
+                _bs_env = os.environ.get("NVTE_TRITON_BLOCK_SIZE", "")
+                if _bs_env and "BLOCK_SIZE" in kernel_constexprs:
+                    kernel_constexprs["BLOCK_SIZE"] = int(_bs_env)
+
         kernel = compile_triton(
             actual_kernel_fn,
             signature,

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -538,19 +538,6 @@ def triton_call_lowering(
                 )
                 num_ctas = first_cfg.num_ctas if first_cfg.num_ctas is not None else num_ctas
 
-                # NVTE_TRITON_BLOCK_SIZE lets benchmarks pin a specific BLOCK_SIZE candidate
-                # without changing any other constexpr.  Only applied when the kernel has a
-                # BLOCK_SIZE constant and the env var is explicitly set.
-                _bs_env = os.environ.get("NVTE_TRITON_BLOCK_SIZE", "")
-                if _bs_env and "BLOCK_SIZE" in kernel_constexprs:
-                    try:
-                        kernel_constexprs["BLOCK_SIZE"] = int(_bs_env)
-                    except ValueError as exc:
-                        raise ValueError(
-                            f"NVTE_TRITON_BLOCK_SIZE={_bs_env!r} is not a valid integer. "
-                            "Set it to a plain integer, e.g. NVTE_TRITON_BLOCK_SIZE=128."
-                        ) from exc
-
         kernel = compile_triton(
             actual_kernel_fn,
             signature,

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -463,8 +463,7 @@ def triton_call_lowering(
             enforce = bool(int(val))
         except ValueError as e:
             raise ValueError(
-                "NVTE_JAX_ENFORCE_TRITON_AUTOTUNING must be an integer (0 or 1),"
-                f" got: {val!r}"
+                f"NVTE_JAX_ENFORCE_TRITON_AUTOTUNING must be an integer (0 or 1), got: {val!r}"
             ) from e
         if enforce:
             raise RuntimeError(

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -136,7 +136,13 @@ def _check_triton_compatibility():
             "If you don't need Triton, use transformer_engine.jax.cpp_extensions instead."
         )
 
-    use_pytorch_triton_explicit = bool(int(os.environ.get("NVTE_USE_PYTORCH_TRITON", "0")))
+    val = os.environ.get("NVTE_USE_PYTORCH_TRITON", "0")
+    try:
+        use_pytorch_triton_explicit = bool(int(val))
+    except ValueError as e:
+        raise ValueError(
+            f"NVTE_USE_PYTORCH_TRITON must be an integer (0 or 1), got: {val!r}"
+        ) from e
 
     if is_pytorch_triton:
         if use_pytorch_triton_explicit:
@@ -214,7 +220,13 @@ def get_triton_info():
         if info['is_pytorch_triton']:
              print("Using pytorch-triton - compatible with both PyTorch and JAX")
     """
-    env_acknowledged = bool(int(os.environ.get("NVTE_USE_PYTORCH_TRITON", "0")))
+    val = os.environ.get("NVTE_USE_PYTORCH_TRITON", "0")
+    try:
+        env_acknowledged = bool(int(val))
+    except ValueError as e:
+        raise ValueError(
+            f"NVTE_USE_PYTORCH_TRITON must be an integer (0 or 1), got: {val!r}"
+        ) from e
 
     return {
         "version": _TRITON_VERSION,
@@ -446,7 +458,15 @@ def triton_call_lowering(
     # user to upgrade JAX for improved performance.
     is_autotuned = isinstance(kernel_fn, autotuner.Autotuner)
     if is_autotuned and not is_triton_autotuned_alias_safe():
-        if os.environ.get("NVTE_JAX_ENFORCE_TRITON_AUTOTUNING", "0") == "1":
+        val = os.environ.get("NVTE_JAX_ENFORCE_TRITON_AUTOTUNING", "0")
+        try:
+            enforce = bool(int(val))
+        except ValueError as e:
+            raise ValueError(
+                "NVTE_JAX_ENFORCE_TRITON_AUTOTUNING must be an integer (0 or 1),"
+                f" got: {val!r}"
+            ) from e
+        if enforce:
             raise RuntimeError(
                 "NVTE_JAX_ENFORCE_TRITON_AUTOTUNING=1 requires JAX >= "
                 f"{TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION} (stable) or a "

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -544,7 +544,13 @@ def triton_call_lowering(
                 # BLOCK_SIZE constant and the env var is explicitly set.
                 _bs_env = os.environ.get("NVTE_TRITON_BLOCK_SIZE", "")
                 if _bs_env and "BLOCK_SIZE" in kernel_constexprs:
-                    kernel_constexprs["BLOCK_SIZE"] = int(_bs_env)
+                    try:
+                        kernel_constexprs["BLOCK_SIZE"] = int(_bs_env)
+                    except ValueError as exc:
+                        raise ValueError(
+                            f"NVTE_TRITON_BLOCK_SIZE={_bs_env!r} is not a valid integer. "
+                            "Set it to a plain integer, e.g. NVTE_TRITON_BLOCK_SIZE=128."
+                        ) from exc
 
         kernel = compile_triton(
             actual_kernel_fn,

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -28,6 +28,11 @@ Environment Variables:
         pytorch-triton for JAX Triton kernels (suppresses warnings). This is
         useful when both JAX and PyTorch are installed in the same environment.
         Default is "0".
+    NVTE_JAX_ENFORCE_TRITON_AUTOTUNING: If set to "1", raise a RuntimeError when
+        the installed JAX is too old to safely run TritonAutotunedKernelCall
+        (jax-ml/jax#35218) instead of silently falling back to non-autotuned
+        dispatch. Useful for CI or debugging to ensure autotuning is active.
+        Default is "0" (silent compatibility fallback).
 """
 
 import hashlib
@@ -434,11 +439,27 @@ def triton_call_lowering(
     kernel_constexprs = constexprs if constexprs is not None else {}
 
     # Handle autotuned kernels - compile all configs.
-    # Set NVTE_DISABLE_TRITON_AUTOTUNING=1 to skip TritonAutotunedKernelCall and use a
-    # single fixed config instead (useful for measuring autotuning overhead or for JAX
-    # versions that do not support input_output_aliases on autotuned calls).
-    _disable_autotuning = os.environ.get("NVTE_DISABLE_TRITON_AUTOTUNING", "0") == "1"
-    is_autotuned = isinstance(kernel_fn, autotuner.Autotuner) and not _disable_autotuning
+    # On JAX < TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION the save/restore
+    # loop in TritonAutotunedKernelCall is buggy (jax-ml/jax#35218).  Fall back to a
+    # single non-autotuned dispatch for compatibility.  Set
+    # NVTE_JAX_ENFORCE_TRITON_AUTOTUNING=1 to raise an error instead, prompting the
+    # user to upgrade JAX for improved performance.
+    is_autotuned = isinstance(kernel_fn, autotuner.Autotuner)
+    if is_autotuned and not jax_version_meet_requirement(
+        TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION
+    ):
+        if os.environ.get("NVTE_JAX_ENFORCE_TRITON_AUTOTUNING", "0") == "1":
+            raise RuntimeError(
+                "NVTE_JAX_ENFORCE_TRITON_AUTOTUNING=1 requires JAX >= "
+                f"{TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION} for safe "
+                "Triton autotuning (jax-ml/jax#35218). "
+                f"Current JAX version: {jax.__version__}. "
+                "Upgrade: pip install --upgrade jax jaxlib"
+            )
+        # Compatibility fallback: disable autotuning on old JAX to avoid
+        # CUDA_ERROR_INVALID_VALUE from the unfixed save/restore loop.
+        is_autotuned = False
+
     if is_autotuned:
         # Compile all configs for runtime selection
         kernel_calls = []
@@ -484,24 +505,17 @@ def triton_call_lowering(
 
         input_output_aliases_with_sizes = ()
         if input_output_aliases:
-            if jax_version_meet_requirement(TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION):
-                num_inputs = len(ctx.avals_in)
-                aliases = []
-                for input_idx, output_idx in input_output_aliases.items():
-                    aval = ctx.avals_in[input_idx]
-                    size_bytes = aval.size * jnp.dtype(aval.dtype).itemsize
-                    # AutotunedKernelCall expects buffer indices (inputs + outputs).
-                    buffer_output_idx = num_inputs + output_idx
-                    aliases.append((input_idx, buffer_output_idx, size_bytes))
-                input_output_aliases_with_sizes = tuple(aliases)
-            else:
-                warnings.warn(
-                    f"JAX >= {TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION} is required "
-                    "to safely pass input_output_aliases to TritonAutotunedKernelCall. "
-                    "Passing empty aliases as a workaround (jax-ml/jax#35218).",
-                    UserWarning,
-                    stacklevel=2,
-                )
+            # JAX version is guaranteed >= TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION
+            # here — verified by the upfront check that set is_autotuned.
+            num_inputs = len(ctx.avals_in)
+            aliases = []
+            for input_idx, output_idx in input_output_aliases.items():
+                aval = ctx.avals_in[input_idx]
+                size_bytes = aval.size * jnp.dtype(aval.dtype).itemsize
+                # AutotunedKernelCall expects buffer indices (inputs + outputs).
+                buffer_output_idx = num_inputs + output_idx
+                aliases.append((input_idx, buffer_output_idx, size_bytes))
+            input_output_aliases_with_sizes = tuple(aliases)
 
         kernel_call = gpu_triton.TritonAutotunedKernelCall(
             f"{actual_kernel_fn.__name__}_autotuned",
@@ -511,8 +525,8 @@ def triton_call_lowering(
 
     else:
         # Regular kernel: compile single config.
-        # If the kernel is an Autotuner but autotuning is disabled, unwrap it and use
-        # the first config's kwargs (user constexprs still take priority via dict merge).
+        # If the kernel is an Autotuner but JAX is too old for safe autotuning, unwrap
+        # it and use the first config's kwargs (user constexprs take priority via dict merge).
         if isinstance(kernel_fn, autotuner.Autotuner):
             actual_kernel_fn = kernel_fn.fn
             if kernel_fn.configs:

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -52,7 +52,6 @@ from ..version_utils import (
     TRITON_EXTENSION_MIN_JAX_VERSION,
     is_triton_autotuned_alias_safe,
     is_triton_extension_supported,
-    jax_version_meet_requirement,
 )
 
 

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -50,6 +50,7 @@ import jax.numpy as jnp
 from ..version_utils import (
     TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION,
     TRITON_EXTENSION_MIN_JAX_VERSION,
+    is_triton_autotuned_alias_safe,
     is_triton_extension_supported,
     jax_version_meet_requirement,
 )
@@ -445,14 +446,12 @@ def triton_call_lowering(
     # NVTE_JAX_ENFORCE_TRITON_AUTOTUNING=1 to raise an error instead, prompting the
     # user to upgrade JAX for improved performance.
     is_autotuned = isinstance(kernel_fn, autotuner.Autotuner)
-    if is_autotuned and not jax_version_meet_requirement(
-        TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION
-    ):
+    if is_autotuned and not is_triton_autotuned_alias_safe():
         if os.environ.get("NVTE_JAX_ENFORCE_TRITON_AUTOTUNING", "0") == "1":
             raise RuntimeError(
                 "NVTE_JAX_ENFORCE_TRITON_AUTOTUNING=1 requires JAX >= "
-                f"{TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION} for safe "
-                "Triton autotuning (jax-ml/jax#35218). "
+                f"{TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION} (stable) or a "
+                "post-2026-03-17 nightly for safe Triton autotuning (jax-ml/jax#35218). "
                 f"Current JAX version: {jax.__version__}. "
                 "Upgrade: pip install --upgrade jax jaxlib"
             )

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -30,9 +30,13 @@ TRITON_EXTENSION_MIN_JAX_VERSION = "0.8.0"
 # it iterated over all declared aliases unconditionally, but input_copies only
 # contains entries for aliases where XLA actually shared buffers at runtime.
 # Accessing a missing entry produced a null vector → CUDA_ERROR_INVALID_VALUE.
-# Fixed by: https://github.com/jax-ml/jax/pull/35218 (merged 2026-03-17, main).
-# Ships in JAX 0.9.3 (not yet released as of 2026-03-31).
-TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION = "0.9.3"
+# Fixed by: https://github.com/jax-ml/jax/pull/35218 (committed 2026-03-10 on jax-ml/jax main;
+# first published nightly container: jax-2026-03-17). Ships in JAX 0.9.3 (stable).
+# Nightly containers report "0.9.2devYYYYMMDD", which packaging.version treats as a
+# pre-release of 0.9.2 (less than 0.9.2 stable, greater than any 0.9.2.devN).
+# Using "0.9.2.dev20260317" as the floor accepts post-fix nightlies while correctly
+# rejecting pre-fix builds (0.9.2.dev20260316 and earlier).
+TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION = "0.9.2.dev20260317"
 
 
 def is_triton_extension_supported() -> bool:

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -25,18 +25,40 @@ def jax_version_meet_requirement(version: str):
 # Minimum JAX version required for Triton kernel dispatch (jaxlib < 0.8.0 segfaults).
 TRITON_EXTENSION_MIN_JAX_VERSION = "0.8.0"
 
-# Minimum JAX version for safe input_output_aliases in TritonAutotunedKernelCall.
+# Nightly and stable floors for safe input_output_aliases in TritonAutotunedKernelCall.
 # jaxlib/gpu/triton_kernels.cc had a bug in the autotuning save/restore loop:
 # it iterated over all declared aliases unconditionally, but input_copies only
 # contains entries for aliases where XLA actually shared buffers at runtime.
 # Accessing a missing entry produced a null vector → CUDA_ERROR_INVALID_VALUE.
 # Fixed by: https://github.com/jax-ml/jax/pull/35218 (committed 2026-03-10 on jax-ml/jax main;
 # first published nightly container: jax-2026-03-17). Ships in JAX 0.9.3 (stable).
-# Nightly containers report "0.9.2devYYYYMMDD", which packaging.version treats as a
-# pre-release of 0.9.2 (less than 0.9.2 stable, greater than any 0.9.2.devN).
-# Using "0.9.2.dev20260317" as the floor accepts post-fix nightlies while correctly
-# rejecting pre-fix builds (0.9.2.dev20260316 and earlier).
-TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION = "0.9.2.dev20260317"
+#
+# Two separate floors are required because packaging.version always ranks a stable
+# release above any pre-release of the same series: PkgVersion("0.9.2") >
+# PkgVersion("0.9.2.dev20260317"), so a single ">= 0.9.2.dev20260317" check would
+# incorrectly accept 0.9.2 stable, which does NOT contain the fix.
+#
+#   nightly build  (v.dev is not None): safe if >= 0.9.2.dev20260317
+#   stable release (v.dev is None):     safe if >= 0.9.3
+_TRITON_AUTOTUNED_ALIAS_NIGHTLY_FLOOR = "0.9.2.dev20260317"
+_TRITON_AUTOTUNED_ALIAS_STABLE_FLOOR = "0.9.3"
+
+# Legacy single-constant kept for external callers; reflects the stable floor.
+TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION = _TRITON_AUTOTUNED_ALIAS_STABLE_FLOOR
+
+
+@lru_cache(maxsize=None)
+def is_triton_autotuned_alias_safe() -> bool:
+    """Return True if the installed JAX safely supports input_output_aliases on autotuned calls.
+
+    Uses two separate floors (jax-ml/jax#35218):
+    - nightly builds: >= 0.9.2.dev20260317 (first container with the fix)
+    - stable releases: >= 0.9.3 (0.9.2 stable does not contain the fix)
+    """
+    v = PkgVersion(get_pkg_version("jax"))
+    if v.dev is not None:
+        return v >= PkgVersion(_TRITON_AUTOTUNED_ALIAS_NIGHTLY_FLOOR)
+    return v >= PkgVersion(_TRITON_AUTOTUNED_ALIAS_STABLE_FLOOR)
 
 
 def is_triton_extension_supported() -> bool:
@@ -51,6 +73,7 @@ def is_triton_extension_supported() -> bool:
 
 __all__ = [
     "jax_version_meet_requirement",
+    "is_triton_autotuned_alias_safe",
     "is_triton_extension_supported",
     "TRITON_EXTENSION_MIN_JAX_VERSION",
     "TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION",


### PR DESCRIPTION
Tighten the version checking for JAX version for passing input_output_alias to TritonAutotunedKernelCall. Also disable triton autotuning to prevent  bug 6060962 from reproducing with any version of JAX

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes


# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
