### PR TITLE
Check numerics in MXFP8 C++ tests by dequantizing to FP32

### DIFF
--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -36,121 +36,50 @@ enum ActivationType {
     SReLU
 };
 
-template <typename InputType, typename OutputType>
+// Compute the pre-quantization float values that the GPU kernel processes before
+// casting to FP8. These are used as the reference for dequantized output comparison.
+template <typename InputType>
 void compute_ref(const ProcessingMethod processing_method,
                  float (*OP)(const float),
-                 const bool rowwise,
-                 const bool colwise,
                  const InputType* input,
                  const InputType* grad,
-                 OutputType* output_rowwise,
-                 OutputType* output_colwise,
-                 fp8e8m0* output_scales_rowwise,
-                 fp8e8m0* output_scales_colwise,
+                 float* ref_output,
                  InputType* output_dbias,
                  const size_t rows,
-                 const size_t cols,
-                 const size_t scales_stride_rowwise,
-                 const size_t scales_stride_colwise)
+                 const size_t cols)
 {
-    const size_t tile_size_Y = 32;
-    const size_t tile_size_X = 32;
-    const size_t tiles_num_Y = (rows + tile_size_Y - 1) / tile_size_Y;
-    const size_t tiles_num_X = (cols + tile_size_X - 1) / tile_size_X;
-
     std::vector<float> output_dbias_fp32(cols, 0);
     #pragma omp parallel proc_bind(spread)
     {
-        // Buffers to cache intermediate computations
-        std::vector<float> cache_buffer(tile_size_Y * tile_size_X);
-
         std::vector<float> thread_dbias(cols, 0);
-        #pragma omp for schedule(static)
-        for (size_t t = 0; t < tiles_num_Y * tiles_num_X; ++t) {
-            const size_t tile_Y = t / tiles_num_X;
-            const size_t tile_X = t % tiles_num_X;
-            const size_t tile_offset_Y = tile_Y * tile_size_Y;
-            const size_t tile_offset_X = tile_X * tile_size_X;
-
-            const size_t i_min = tile_offset_Y;
-            const size_t i_max = std::min(i_min + tile_size_Y, rows);
-
-            const size_t j_min = tile_offset_X;
-            const size_t j_max = std::min(j_min + tile_size_X, cols);
-
-            // Cache computations
-            for (size_t i = i_min; i < i_max; ++i) {
-                for (size_t j = j_min; j < j_max; ++j) {
-
-                    const size_t idx = i * cols + j;
-                    const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-
-                    float elt = static_cast<float>(input[idx]);
-                    if (processing_method == ProcessingMethod::CAST_DBIAS) {
-                        // grad is the input
-                        elt = static_cast<float>(grad[idx]);
+        #pragma omp for schedule(static) collapse(2)
+        for (size_t i = 0; i < rows; ++i) {
+            for (size_t j = 0; j < cols; ++j) {
+                const size_t idx = i * cols + j;
+                const float in = static_cast<float>(input[idx]);
+                float out;
+                switch (processing_method) {
+                case ProcessingMethod::CAST_ONLY:
+                case ProcessingMethod::CAST_DBIAS:
+                    out = in;
+                    break;
+                case ProcessingMethod::CAST_ACT:
+                    out = OP(in);
+                    break;
+                case ProcessingMethod::CAST_DBIAS_DACT:
+                case ProcessingMethod::CAST_DACT:
+                    {
+                        const float g = static_cast<float>(grad[idx]);
+                        out = OP(in) * g;
                     }
-                    if (processing_method != ProcessingMethod::CAST_ONLY
-                        && processing_method != ProcessingMethod::CAST_DBIAS) {
-                        elt = OP(elt);
-                    }
-                    if (processing_method == ProcessingMethod::CAST_DACT ||
-                        processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
-                        elt *= static_cast<float>(grad[idx]);
-                    }
-                    thread_dbias[j] += elt;
-
-                    // Numerical truncation: after downcast to InputType (BF16/FP16), upcast it back to FP32
-                    elt = static_cast<float>(static_cast<InputType>(elt));
-
-                    cache_buffer[cache_idx] = elt;
-                    if (isinf(elt) || isnan(elt)) {
-                        continue;
-                    }
+                    break;
+                default:
+                    NVTE_ERROR("Invalid processing mode (",
+                               static_cast<int>(processing_method), ").");
                 }
-            }
-
-            if (rowwise) {
-                for (size_t i = i_min; i < i_max; ++i) {
-                    float block_amax = 0.0f;
-
-                    for (size_t j = j_min; j < j_max; ++j) {
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        block_amax = std::max(block_amax, std::abs(cache_buffer[cache_idx]));
-                    }
-
-                    const fp8e8m0 biased_exponent = float_to_e8m0(block_amax * Quantized_Limits<OutputType>::max_reciprocal());
-                    const size_t scale_idx = i * scales_stride_rowwise + tile_X;
-                    output_scales_rowwise[scale_idx] = biased_exponent;
-                    const float scale_reciprocal = exp2f_rcp(biased_exponent);
-
-                    for (size_t j = j_min; j < j_max; ++j) {
-                        const size_t idx = i * cols + j;
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        output_rowwise[idx] = static_cast<OutputType>(cache_buffer[cache_idx] * scale_reciprocal);
-                    }
-                }
-            }
-            if (colwise) {
-                for (size_t j = j_min; j < j_max; ++j) {
-                    float block_amax = 0.0f;
-
-                    for (size_t i = i_min; i < i_max; ++i) {
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        block_amax = std::max(block_amax, std::abs(cache_buffer[cache_idx]));
-                    }
-
-                    const fp8e8m0 biased_exponent = float_to_e8m0(block_amax * Quantized_Limits<OutputType>::max_reciprocal());
-                    const size_t scale_idx = tile_Y * scales_stride_colwise + j;
-                    output_scales_colwise[scale_idx] = biased_exponent;
-                    const float scale_reciprocal = exp2f_rcp(biased_exponent);
-
-                    for (size_t i = i_min; i < i_max; ++i) {
-                        const size_t idx = i * cols + j;
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        output_colwise[idx] = static_cast<OutputType>(cache_buffer[cache_idx] * scale_reciprocal);
-                    }
-                }
+                thread_dbias[j] += out;
+                // Match GPU: downcast to InputType then back to float before quantization.
+                ref_output[idx] = static_cast<float>(static_cast<InputType>(out));
             }
         }
         #pragma omp critical
@@ -181,39 +110,32 @@ void performTest_x1(const ProcessingMethod processing_method,
                     const bool colwise,
                     InputsFillCase fill_case) {
     using namespace test;
-    using EncodingType = fp32;
     DType itype = TypeInfo<InputType>::dtype;
     DType otype = TypeInfo<OutputType>::dtype;
 
     const size_t rows = first_dimension(shape);
     const size_t cols = last_dimension(shape);
 
+    NVTE_CHECK(rowwise != colwise,
+               "Expected either rowwise or columnwise scaling (rowwise=", rowwise,
+               ", colwise=", colwise, ").");
     if (shape.size() < 2 && colwise) {
-      GTEST_SKIP();
+        GTEST_SKIP();
     }
 
     const size_t block_size_rows = rowwise ? 1 : 32;
     const size_t block_size_cols = colwise ? 1 : 32;
-
-    const std::array<size_t,4> scale_dims = get_scale_tensor_dims(rows, cols, block_size_rows,
-                                                                  block_size_cols);
-
-    const size_t unpadded_blocks_Y = scale_dims[0];
-    const size_t unpadded_blocks_X = scale_dims[1];
-    const size_t blocks_Y = scale_dims[2];
-    const size_t blocks_X = scale_dims[3];
-    const size_t scales_stride = blocks_X;
+    const size_t scales_stride = get_scale_tensor_dims(rows, cols, block_size_rows, block_size_cols)[3];
 
     Tensor input("input", shape, itype);
     Tensor grad("grad", shape, itype);
     Tensor output_c("output_c", shape, otype, rowwise, colwise, NVTE_MXFP8_1D_SCALING);
     Tensor output_dbias("output_dbias", std::vector<size_t>{ cols }, itype);
 
-    std::unique_ptr<OutputType[]> ref_output_c = std::make_unique<OutputType[]>(rows * cols);
+    std::vector<float> ref_output(rows * cols);
     std::unique_ptr<InputType[]> ref_output_dbias = std::make_unique<InputType[]>(cols);
-    std::unique_ptr<fp8e8m0[]> ref_output_scales = std::make_unique<fp8e8m0[]>(blocks_Y * blocks_X);
 
-    fillCase<EncodingType>(&input, fill_case);
+    fillCase<fp32>(&input, fill_case);
     fillUniform(&grad);
 
     Tensor workspace;
@@ -223,18 +145,11 @@ void performTest_x1(const ProcessingMethod processing_method,
             break;
         }
         case ProcessingMethod::CAST_DBIAS: {
-            nvte_quantize_dbias(grad.data(),
-                                output_c.data(),
-                                output_dbias.data(),
-                                workspace.data(),
-                                0);
+            nvte_quantize_dbias(grad.data(), output_c.data(), output_dbias.data(),
+                                workspace.data(), 0);
             workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
-
-            nvte_quantize_dbias(grad.data(),
-                                output_c.data(),
-                                output_dbias.data(),
-                                workspace.data(),
-                                0);
+            nvte_quantize_dbias(grad.data(), output_c.data(), output_dbias.data(),
+                                workspace.data(), 0);
             break;
         }
         case ProcessingMethod::CAST_DBIAS_DACT: {
@@ -243,21 +158,11 @@ void performTest_x1(const ProcessingMethod processing_method,
             else if (OP == &drelu)  { nvte_quantize_dbias_dact = &nvte_quantize_dbias_drelu; }
             else if (OP == &dqgelu) { nvte_quantize_dbias_dact = &nvte_quantize_dbias_dqgelu; }
             else if (OP == &dsrelu) { nvte_quantize_dbias_dact = &nvte_quantize_dbias_dsrelu; }
-
-            nvte_quantize_dbias_dact(grad.data(),
-                                     input.data(),
-                                     output_c.data(),
-                                     output_dbias.data(),
-                                     workspace.data(),
-                                     0);
+            nvte_quantize_dbias_dact(grad.data(), input.data(), output_c.data(),
+                                     output_dbias.data(), workspace.data(), 0);
             workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
-
-            nvte_quantize_dbias_dact(grad.data(),
-                                     input.data(),
-                                     output_c.data(),
-                                     output_dbias.data(),
-                                     workspace.data(),
-                                     0);
+            nvte_quantize_dbias_dact(grad.data(), input.data(), output_c.data(),
+                                     output_dbias.data(), workspace.data(), 0);
             break;
         }
         case ProcessingMethod::CAST_DACT: {
@@ -266,7 +171,6 @@ void performTest_x1(const ProcessingMethod processing_method,
             else if (OP == &drelu)  { nvte_dact = &nvte_drelu; }
             else if (OP == &dqgelu) { nvte_dact = &nvte_dqgelu; }
             else if (OP == &dsrelu) { nvte_dact = &nvte_dsrelu; }
-
             nvte_dact(grad.data(), input.data(), output_c.data(), 0);
             break;
         }
@@ -276,7 +180,6 @@ void performTest_x1(const ProcessingMethod processing_method,
             else if (OP == &relu)  { nvte_act = &nvte_relu; }
             else if (OP == &qgelu) { nvte_act = &nvte_qgelu; }
             else if (OP == &srelu) { nvte_act = &nvte_srelu; }
-
             nvte_act(input.data(), output_c.data(), 0);
             break;
         }
@@ -286,54 +189,43 @@ void performTest_x1(const ProcessingMethod processing_method,
     auto err = cudaGetLastError();
     ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
 
-    compute_ref<InputType, OutputType>(processing_method,
-                                       OP,
-                                       rowwise,
-                                       colwise,
-                                       input.rowwise_cpu_dptr<InputType>(),
-                                       grad.rowwise_cpu_dptr<InputType>(),
-                                       ref_output_c.get(),
-                                       ref_output_c.get(),
-                                       ref_output_scales.get(),
-                                       ref_output_scales.get(),
-                                       ref_output_dbias.get(),
-                                       rows,
-                                       cols,
-                                       scales_stride,
-                                       scales_stride);
+    // CPU reference: pre-quantization float values that the GPU kernel operates on.
+    compute_ref<InputType>(processing_method, OP,
+                           input.rowwise_cpu_dptr<InputType>(),
+                           grad.rowwise_cpu_dptr<InputType>(),
+                           ref_output.data(), ref_output_dbias.get(),
+                           rows, cols);
 
-    const uint8_t * const gpu_scales_ptr = rowwise
-                                           ? output_c.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
-                                           : output_c.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
+    // Dequantize GPU output using the GPU's own scales, then compare to the
+    // pre-quantization reference.  This is valid regardless of whether the GPU
+    // and reference rounded a near-power-of-2 amax to the same E8M0 exponent.
+    std::vector<float> dequant_output(rows * cols);
+    if (rowwise) {
+        dequantize_mxfp8_rowwise(
+            output_c.rowwise_cpu_dptr<OutputType>(),
+            output_c.rowwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_output.data(), rows, cols, scales_stride);
+    } else {
+        dequantize_mxfp8_colwise(
+            output_c.columnwise_cpu_dptr<OutputType>(),
+            output_c.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_output.data(), rows, cols, scales_stride);
+    }
 
-    const size_t scale_diff_abs_tolerance = 0;
-    const double abs_tolerable_mismatches_limit = 0.0;
-    const double rel_tolerable_mismatches_limit = 0.0;
-
-    size_t mismatches_scales = 0;
-
-    compare_scaling_factors("scales", gpu_scales_ptr, ref_output_scales.get(),
-                            unpadded_blocks_Y, unpadded_blocks_X, scales_stride,
-                            mismatches_scales,
-                            scale_diff_abs_tolerance,
-                            abs_tolerable_mismatches_limit,
-                            rel_tolerable_mismatches_limit);
-
-    const size_t mismatches_elts = 32 * mismatches_scales;
     auto [atol, rtol] = getTolerances(otype);
-    compareResults("output_c", output_c, ref_output_c.get(), rowwise, atol, rtol, true, mismatches_elts);
+    compareResults("output_c", dequant_output.data(), ref_output.data(), rows * cols, atol, rtol);
 
     if (processing_method == ProcessingMethod::CAST_DBIAS
-        || processing_method == ProcessingMethod::CAST_DBIAS_DACT)
-    {
+        || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);
         if (itype == DType::kFloat32) {
             atol_dbias = 1e-4;
-            rtol_dbias *= sqrt(static_cast<double>(rows)) ;
+            rtol_dbias *= sqrt(static_cast<double>(rows));
         } else {
             rtol_dbias *= 4;
         }
-        compareResults("output_dbias", output_dbias, ref_output_dbias.get(), true, atol_dbias, rtol_dbias);
+        compareResults("output_dbias", output_dbias, ref_output_dbias.get(), true,
+                       atol_dbias, rtol_dbias);
     }
 }
 
@@ -352,44 +244,30 @@ void performTest_x2(const ProcessingMethod processing_method,
                     const size_t block_size_cols,
                     InputsFillCase fill_case) {
     using namespace test;
-    using EncodingType = fp32;
     DType itype = TypeInfo<InputType>::dtype;
     DType otype = TypeInfo<OutputType>::dtype;
 
     if (shape.size() < 2) {
-      GTEST_SKIP();
+        GTEST_SKIP();
     }
 
     const size_t rows = first_dimension(shape);
     const size_t cols = last_dimension(shape);
 
-    const std::array<size_t,4> scale_dims_rowwise = get_scale_tensor_dims(rows, cols, 1, 32);
-    const std::array<size_t,4> scale_dims_colwise = get_scale_tensor_dims(rows, cols, 32, 1);
-
-    const size_t unpadded_blocks_Y_rowwise = scale_dims_rowwise[0];
-    const size_t unpadded_blocks_X_rowwise = scale_dims_rowwise[1];
-    const size_t blocks_Y_rowwise = scale_dims_rowwise[2];
-    const size_t blocks_X_rowwise = scale_dims_rowwise[3];
-    const size_t scales_stride_rowwise = blocks_X_rowwise;
-
-    const size_t unpadded_blocks_Y_colwise = scale_dims_colwise[0];
-    const size_t unpadded_blocks_X_colwise = scale_dims_colwise[1];
-    const size_t blocks_Y_colwise = scale_dims_colwise[2];
-    const size_t blocks_X_colwise = scale_dims_colwise[3];
-    const size_t scales_stride_colwise = blocks_X_colwise;
+    const size_t scales_stride_rowwise = get_scale_tensor_dims(rows, cols, 1, 32)[3];
+    const size_t scales_stride_colwise = get_scale_tensor_dims(rows, cols, 32, 1)[3];
 
     Tensor input("input", shape, itype);
     Tensor grad("grad", shape, itype);
     Tensor output("output", shape, otype, true, true, NVTE_MXFP8_1D_SCALING);
     Tensor output_dbias("output_dbias", std::vector<size_t>{ cols }, itype);
 
-    std::unique_ptr<OutputType[]> ref_output_c_rowwise = std::make_unique<OutputType[]>(rows * cols);
-    std::unique_ptr<OutputType[]> ref_output_c_colwise = std::make_unique<OutputType[]>(rows * cols);
-    std::unique_ptr<fp8e8m0[]> ref_scales_rowwise = std::make_unique<fp8e8m0[]>(blocks_Y_rowwise * blocks_X_rowwise);
-    std::unique_ptr<fp8e8m0[]> ref_scales_colwise = std::make_unique<fp8e8m0[]>(blocks_Y_colwise * blocks_X_colwise);
+    // Single reference array serves both rowwise and colwise comparisons: the
+    // pre-quantization float values are independent of the scaling direction.
+    std::vector<float> ref_output(rows * cols);
     std::unique_ptr<InputType[]> ref_output_dbias = std::make_unique<InputType[]>(cols);
 
-    fillCase<EncodingType>(&input, fill_case);
+    fillCase<fp32>(&input, fill_case);
     fillUniform(&grad);
 
     Tensor workspace;
@@ -399,18 +277,11 @@ void performTest_x2(const ProcessingMethod processing_method,
             break;
         }
         case ProcessingMethod::CAST_DBIAS: {
-            nvte_quantize_dbias(grad.data(),
-                                output.data(),
-                                output_dbias.data(),
-                                workspace.data(),
-                                0);
+            nvte_quantize_dbias(grad.data(), output.data(), output_dbias.data(),
+                                workspace.data(), 0);
             workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
-
-            nvte_quantize_dbias(grad.data(),
-                                output.data(),
-                                output_dbias.data(),
-                                workspace.data(),
-                                0);
+            nvte_quantize_dbias(grad.data(), output.data(), output_dbias.data(),
+                                workspace.data(), 0);
             break;
         }
         case ProcessingMethod::CAST_DBIAS_DACT: {
@@ -419,21 +290,11 @@ void performTest_x2(const ProcessingMethod processing_method,
             else if (OP == &drelu)  { nvte_quantize_dbias_dact = &nvte_quantize_dbias_drelu; }
             else if (OP == &dqgelu) { nvte_quantize_dbias_dact = &nvte_quantize_dbias_dqgelu; }
             else if (OP == &dsrelu) { nvte_quantize_dbias_dact = &nvte_quantize_dbias_dsrelu; }
-
-            nvte_quantize_dbias_dact(grad.data(),
-                                     input.data(),
-                                     output.data(),
-                                     output_dbias.data(),
-                                     workspace.data(),
-                                     0);
+            nvte_quantize_dbias_dact(grad.data(), input.data(), output.data(),
+                                     output_dbias.data(), workspace.data(), 0);
             workspace = Tensor("workspace", workspace.rowwise_shape(), workspace.dtype());
-
-            nvte_quantize_dbias_dact(grad.data(),
-                                     input.data(),
-                                     output.data(),
-                                     output_dbias.data(),
-                                     workspace.data(),
-                                     0);
+            nvte_quantize_dbias_dact(grad.data(), input.data(), output.data(),
+                                     output_dbias.data(), workspace.data(), 0);
             break;
         }
         case ProcessingMethod::CAST_DACT: {
@@ -442,7 +303,6 @@ void performTest_x2(const ProcessingMethod processing_method,
             else if (OP == &drelu)  { nvte_dact = &nvte_drelu; }
             else if (OP == &dqgelu) { nvte_dact = &nvte_dqgelu; }
             else if (OP == &dsrelu) { nvte_dact = &nvte_dsrelu; }
-
             nvte_dact(grad.data(), input.data(), output.data(), 0);
             break;
         }
@@ -452,7 +312,6 @@ void performTest_x2(const ProcessingMethod processing_method,
             else if (OP == &relu)  { nvte_act = &nvte_relu; }
             else if (OP == &qgelu) { nvte_act = &nvte_qgelu; }
             else if (OP == &srelu) { nvte_act = &nvte_srelu; }
-
             nvte_act(input.data(), output.data(), 0);
             break;
         }
@@ -462,62 +321,47 @@ void performTest_x2(const ProcessingMethod processing_method,
     auto err = cudaGetLastError();
     ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
 
-    compute_ref<InputType, OutputType>(processing_method,
-                                       OP,
-                                       true,
-                                       true,
-                                       input.rowwise_cpu_dptr<InputType>(),
-                                       grad.rowwise_cpu_dptr<InputType>(),
-                                       ref_output_c_rowwise.get(),
-                                       ref_output_c_colwise.get(),
-                                       ref_scales_rowwise.get(),
-                                       ref_scales_colwise.get(),
-                                       ref_output_dbias.get(),
-                                       rows,
-                                       cols,
-                                       scales_stride_rowwise,
-                                       scales_stride_colwise);
-
-    const size_t scale_diff_abs_tolerance = 0;
-    const double abs_tolerable_mismatches_limit = 0.0;
-    const double rel_tolerable_mismatches_limit = 0.0;
-
-    size_t mismatches_scales_rowwise = 0;
-    compare_scaling_factors("scales_rowwise", output.rowwise_cpu_scale_inv_ptr<fp8e8m0>(),
-                            ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise,
-                            unpadded_blocks_X_rowwise, scales_stride_rowwise,
-                            mismatches_scales_rowwise,
-                            scale_diff_abs_tolerance,
-                            abs_tolerable_mismatches_limit,
-                            rel_tolerable_mismatches_limit);
-
-    size_t mismatches_scales_colwise = 0;
-    compare_scaling_factors("scales_colwise", output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
-                            ref_scales_colwise.get(), unpadded_blocks_Y_colwise,
-                            unpadded_blocks_X_colwise, scales_stride_colwise,
-                            mismatches_scales_colwise,
-                            scale_diff_abs_tolerance,
-                            abs_tolerable_mismatches_limit,
-                            rel_tolerable_mismatches_limit);
-
-    const size_t mismatches_elts_rowwise = 32 * mismatches_scales_rowwise;
-    const size_t mismatches_elts_colwise = 32 * mismatches_scales_colwise;
+    compute_ref<InputType>(processing_method, OP,
+                           input.rowwise_cpu_dptr<InputType>(),
+                           grad.rowwise_cpu_dptr<InputType>(),
+                           ref_output.data(), ref_output_dbias.get(),
+                           rows, cols);
 
     auto [atol, rtol] = getTolerances(otype);
-    compareResults("output_c_rowwise", output, ref_output_c_rowwise.get(), true, atol, rtol, true, mismatches_elts_rowwise);
-    compareResults("output_c_colwise", output, ref_output_c_colwise.get(), false, atol, rtol, true, mismatches_elts_colwise);
+
+    // Dequantize rowwise GPU output and compare to reference.
+    {
+        std::vector<float> dequant_rowwise(rows * cols);
+        dequantize_mxfp8_rowwise(
+            output.rowwise_cpu_dptr<OutputType>(),
+            output.rowwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_rowwise.data(), rows, cols, scales_stride_rowwise);
+        compareResults("output_rowwise", dequant_rowwise.data(), ref_output.data(),
+                       rows * cols, atol, rtol);
+    }
+
+    // Dequantize colwise GPU output and compare to reference.
+    {
+        std::vector<float> dequant_colwise(rows * cols);
+        dequantize_mxfp8_colwise(
+            output.columnwise_cpu_dptr<OutputType>(),
+            output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_colwise.data(), rows, cols, scales_stride_colwise);
+        compareResults("output_colwise", dequant_colwise.data(), ref_output.data(),
+                       rows * cols, atol, rtol);
+    }
 
     if (processing_method == ProcessingMethod::CAST_DBIAS
-        || processing_method == ProcessingMethod::CAST_DBIAS_DACT)
-    {
+        || processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
         auto [atol_dbias, rtol_dbias] = getTolerances(itype);
         if (itype == DType::kFloat32) {
             atol_dbias = 1e-4;
-            rtol_dbias *= sqrt(static_cast<double>(rows)) ;
+            rtol_dbias *= sqrt(static_cast<double>(rows));
         } else {
             rtol_dbias *= 4;
         }
-        compareResults("output_dbias", output_dbias, ref_output_dbias.get(), true, atol_dbias, rtol_dbias);
+        compareResults("output_dbias", output_dbias, ref_output_dbias.get(), true,
+                       atol_dbias, rtol_dbias);
     }
 }
 
@@ -569,8 +413,6 @@ std::vector<ActivationType> Activation_types = {
     // ActivationType::QGeLU,
     // ActivationType::SReLU,
 };
-
-}  // namespace
 
 class FusedCastMXFP8TestSuite : public ::testing::TestWithParam
     <std::tuple<ProcessingMethod,
@@ -683,6 +525,8 @@ std::string to_string(const ActivationType Act_type) {
         default: return "";
     }
 }
+
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     OperatorTest,

--- a/tests/cpp/operator/test_cast_mxfp8.cu
+++ b/tests/cpp/operator/test_cast_mxfp8.cu
@@ -57,18 +57,21 @@ void compute_ref(const ProcessingMethod processing_method,
             for (size_t j = 0; j < cols; ++j) {
                 const size_t idx = i * cols + j;
                 const float in = static_cast<float>(input[idx]);
+                const float g = static_cast<float>(grad[idx]);
                 float out;
                 switch (processing_method) {
                 case ProcessingMethod::CAST_ONLY:
-                case ProcessingMethod::CAST_DBIAS:
                     out = in;
+                    break;
+                case ProcessingMethod::CAST_DBIAS:
+                    out = g;
                     break;
                 case ProcessingMethod::CAST_ACT:
                     out = OP(in);
                     break;
                 case ProcessingMethod::CAST_DBIAS_DACT:
                 case ProcessingMethod::CAST_DACT:
-                    out = OP(in) * static_cast<float>(grad[idx]);
+                    out = OP(in) * g;
                     break;
                 default:
                     NVTE_ERROR("Invalid processing mode (",

--- a/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_gated_swiglu.cu
@@ -18,165 +18,47 @@ using namespace test;
 
 namespace {
 
-template <typename IType, typename OType>
+// Compute the pre-quantization float values for the gated-SwiGLU kernel.
+// Output layout: rows × output_cols, where output_cols = IS_DGATED ? 2*cols : cols.
+// For IS_DGATED, the act part occupies [0, cols) and the gate part [cols, 2*cols).
+template <typename IType>
 void compute_ref(const IType* grad,
                  const IType* input,
-                 OType* output_rowwise,
-                 OType* output_colwise,
-                 fp8e8m0* output_scales_rowwise,
-                 fp8e8m0* output_scales_colwise,
-                 float& ref_amax,
+                 float* ref_output,
                  const bool IS_DGATED,
                  const size_t rows,
-                 const size_t cols,
-                 const size_t scales_stride_rowwise,
-                 const size_t scales_stride_colwise,
-                 const bool is_rowwise,
-                 const bool is_colwise) {
-    constexpr size_t tile_size_Y = 32;
-    constexpr size_t tile_size_X = 32;
-    const size_t tiles_num_Y = (rows + tile_size_Y - 1) / tile_size_Y;
-    const size_t tiles_num_X = (cols + tile_size_X - 1) / tile_size_X;
-    float amax = 0;
-    #pragma omp parallel reduction(max: amax) proc_bind(spread)
-    {
-        // Buffers to cache intermediate computations
-        std::vector<float> cache_buffer_act(tile_size_Y * tile_size_X);
-        std::vector<float> cache_buffer_gate(tile_size_Y * tile_size_X);
-        float thread_amax = 0.0f;
-        #pragma omp for schedule(static)
-        for (size_t t = 0; t < tiles_num_Y * tiles_num_X; ++t) {
-            const size_t tile_Y = t / tiles_num_X;
-            const size_t tile_X = t % tiles_num_X;
-            const size_t tile_offset_Y = tile_Y * tile_size_Y;
-            const size_t tile_offset_X = tile_X * tile_size_X;
+                 const size_t cols)   // "half" cols (before gating)
+{
+    const size_t output_cols = IS_DGATED ? 2 * cols : cols;
+    const size_t input_stride = cols * 2;  // input has shape [rows, 2*cols]
 
-            const size_t stride = cols * 2;
+    #pragma omp parallel for proc_bind(spread) schedule(static) collapse(2)
+    for (size_t i = 0; i < rows; ++i) {
+        for (size_t j = 0; j < cols; ++j) {
+            const float silu_elt = static_cast<float>(input[i * input_stride + j]);
+            const float gate_elt = static_cast<float>(input[i * input_stride + cols + j]);
 
-            const size_t i_min = tile_offset_Y;
-            const size_t i_max = std::min(rows, tile_offset_Y + tile_size_Y);
-            const size_t j_min = tile_offset_X;
-            const size_t j_max = std::min(cols, tile_offset_X + tile_size_X);
+            if (IS_DGATED) {
+                const float s = sigmoid(silu_elt);
+                const float dact = silu_elt * s * (1 - s) + s;  // dsilu
+                const float grad_elt = static_cast<float>(grad[i * cols + j]);
 
-            // Compute and cache activations for the entire tile
-            for (size_t i = i_min; i < i_max; ++i) {
-                for (size_t j = j_min; j < j_max; ++j) {
-                    float silu_elt = static_cast<float>(input[i * stride + j]);
-                    float gate_elt = static_cast<float>(input[i * stride + cols + j]);
+                float after_dsilu = dact * grad_elt * gate_elt;
+                float after_dgate = silu(silu_elt) * grad_elt;
 
-                    const size_t cached_idx = (i - i_min) * tile_size_X + (j - j_min);
+                // Match GPU: downcast to IType then back to float before quantization.
+                after_dsilu = static_cast<float>(static_cast<IType>(after_dsilu));
+                after_dgate = static_cast<float>(static_cast<IType>(after_dgate));
 
-                    if (IS_DGATED) {
-                        const float x = silu_elt;
-                        const float s = sigmoid(x);
-                        const float act_x = x * s;
-                        const float dact_x = x * s * (1 - s) + s;
-
-                        const float grad_elt = static_cast<float>(grad[i * cols + j]);
-                        float after_dsilu = dact_x * grad_elt * gate_elt;
-                        float after_dgate = act_x * grad_elt;
-
-                        // Numerical truncation: after downcast to IType (BF16/FP16), upcast it back to FP32
-                        after_dsilu = static_cast<float>(static_cast<IType>(after_dsilu));
-                        after_dgate = static_cast<float>(static_cast<IType>(after_dgate));
-
-                        cache_buffer_act[cached_idx] = after_dsilu;
-                        cache_buffer_gate[cached_idx] = after_dgate;
-                        thread_amax = std::max(thread_amax, std::abs(after_dsilu));
-                        thread_amax = std::max(thread_amax, std::abs(after_dgate));
-                    } else {
-                        float after_silu = silu(silu_elt) * gate_elt;
-
-                        // Numerical truncation: after downcast to IType (BF16/FP16), upcast it back to FP32
-                        after_silu = static_cast<float>(static_cast<IType>(after_silu));
-
-                        cache_buffer_act[cached_idx] = after_silu;
-                        thread_amax = std::max(thread_amax, std::abs(after_silu));
-                    }
-                }
+                ref_output[i * output_cols + j]        = after_dsilu;
+                ref_output[i * output_cols + cols + j] = after_dgate;
+            } else {
+                float after_silu = silu(silu_elt) * gate_elt;
+                after_silu = static_cast<float>(static_cast<IType>(after_silu));
+                ref_output[i * cols + j] = after_silu;
             }
-
-            if (is_rowwise) {
-                for (size_t i = i_min; i < i_max; ++i) {
-                    float block_amax_act = 0.0f;
-                    float block_amax_gate = 0.0f;
-                    for (size_t j = j_min; j < j_max; ++j) {
-                        const size_t cached_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        block_amax_act = std::max(block_amax_act, std::abs(cache_buffer_act[cached_idx]));
-                        if (IS_DGATED) {
-                            block_amax_gate = std::max(block_amax_gate, std::abs(cache_buffer_gate[cached_idx]));
-                        }
-                    }
-                    const fp8e8m0 biased_exponent_act = float_to_e8m0(block_amax_act * Quantized_Limits<OType>::max_reciprocal());
-                    const float scale_reciprocal_act = exp2f_rcp(biased_exponent_act);
-                    const size_t scale_idx_act = i * scales_stride_rowwise + tile_X;
-                    output_scales_rowwise[scale_idx_act] = biased_exponent_act;
-
-                    float scale_reciprocal_gate;
-                    if (IS_DGATED) {
-                        const fp8e8m0 biased_exponent_gate = float_to_e8m0(block_amax_gate * Quantized_Limits<OType>::max_reciprocal());
-                        scale_reciprocal_gate = exp2f_rcp(biased_exponent_gate);
-                        const size_t scale_idx_gate = scale_idx_act + (cols + 32 - 1) / 32;
-                        output_scales_rowwise[scale_idx_gate] = biased_exponent_gate;
-                    }
-                    for (size_t j = j_min; j < j_max; ++j) {
-                        const size_t cached_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        const float after_act = cache_buffer_act[cached_idx] * scale_reciprocal_act;
-
-                        if (IS_DGATED) {
-                            const float after_gate = cache_buffer_gate[cached_idx] * scale_reciprocal_gate;
-                            output_rowwise[i * stride + j] = static_cast<OType>(after_act);
-                            output_rowwise[i * stride + cols + j] = static_cast<OType>(after_gate);
-                        } else {
-                            output_rowwise[i * cols + j] = static_cast<OType>(after_act);
-                        }
-                    }
-                }
-            }
-
-            if (is_colwise) {
-                for (size_t j = j_min; j < j_max; ++j) {
-                    float block_amax_act = 0.0f;
-                    float block_amax_gate = 0.0f;
-                    for (size_t i = i_min; i < i_max; ++i) {
-                        const size_t cached_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        block_amax_act = std::max(block_amax_act, std::abs(cache_buffer_act[cached_idx]));
-                        if (IS_DGATED) {
-                            block_amax_gate = std::max(block_amax_gate, std::abs(cache_buffer_gate[cached_idx]));
-                        }
-                    }
-                    const fp8e8m0 biased_exponent_act = float_to_e8m0(block_amax_act * Quantized_Limits<OType>::max_reciprocal());
-                    const float scale_reciprocal_act = exp2f_rcp(biased_exponent_act);
-                    const size_t scale_idx_act = tile_Y * scales_stride_colwise + j;
-                    output_scales_colwise[scale_idx_act] = biased_exponent_act;
-
-                    float scale_reciprocal_gate;
-                    if (IS_DGATED) {
-                        const fp8e8m0 biased_exponent_gate = float_to_e8m0(block_amax_gate * Quantized_Limits<OType>::max_reciprocal());
-                        const size_t scale_idx_gate = scale_idx_act + cols;
-                        scale_reciprocal_gate = exp2f_rcp(biased_exponent_gate);
-                        output_scales_colwise[scale_idx_gate] = biased_exponent_gate;
-                    }
-                    for (size_t i = i_min; i < i_max; ++i) {
-                        const size_t cached_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        const float after_act = cache_buffer_act[cached_idx] * scale_reciprocal_act;
-
-                        if (IS_DGATED) {
-                            const float after_gate = cache_buffer_gate[cached_idx] * scale_reciprocal_gate;
-                            output_colwise[i * stride + j] = static_cast<OType>(after_act);
-                            output_colwise[i * stride + cols + j] = static_cast<OType>(after_gate);
-                        } else {
-                            output_colwise[i * cols + j] = static_cast<OType>(after_act);
-                        }
-                    }
-                }
-            }
-        }
-        if (thread_amax > amax) {
-            amax = thread_amax;
         }
     }
-    ref_amax = amax;
 }
 
 /**
@@ -194,39 +76,26 @@ void performTest_x1(const size_t rows,
                     InputsFillCase fill_case,
                     const bool IS_DGATED) {
     using namespace test;
-    using EncodingType = fp32;
     DType itype = TypeInfo<IType>::dtype;
     DType otype = TypeInfo<OType>::dtype;
 
     const bool rowwise = (block_size_rows == 1) && (block_size_cols == 32);
     const bool colwise = (block_size_rows == 32) && (block_size_cols == 1);
-    NVTE_CHECK(rowwise || colwise);
+    NVTE_CHECK(rowwise != colwise,
+               "Expected either rowwise or columnwise scaling (rowwise=", rowwise,
+               ", colwise=", colwise, ").");
+
+    const size_t output_cols = (IS_DGATED ? 2 : 1) * cols;
+    const size_t scales_stride = get_scale_tensor_dims(rows, output_cols,
+                                                       block_size_rows, block_size_cols)[3];
 
     Tensor grad("grad", std::vector<size_t>{ rows, cols }, itype);
     Tensor input("input", std::vector<size_t>{ rows, cols * 2 }, itype);
-
-    const size_t output_cols = (IS_DGATED ? 2 : 1) * cols;
-
-    const std::array<size_t,4> scale_dims = get_scale_tensor_dims(rows, output_cols, block_size_rows,
-                                                                  block_size_cols);
-
-    const size_t unpadded_blocks_Y = scale_dims[0];
-    const size_t unpadded_blocks_X = scale_dims[1];
-    const size_t blocks_Y = scale_dims[2];
-    const size_t blocks_X = scale_dims[3];
-    const size_t scales_stride = blocks_X;
-
     Tensor output("output", std::vector<size_t>{ rows, output_cols }, otype,
                   rowwise, colwise, NVTE_MXFP8_1D_SCALING);
 
-    std::unique_ptr<OType[]> ref_output = std::make_unique<OType[]>(rows * output_cols);
-    std::unique_ptr<fp8e8m0[]> ref_output_scales = std::make_unique<fp8e8m0[]>(blocks_Y * blocks_X);
+    std::vector<float> ref_output(rows * output_cols);
 
-    for (size_t i = 0; i < blocks_Y * blocks_X; ++i) {
-      ref_output_scales[i] = 0;
-    }
-
-    // fillCase<EncodingType>(&grad, fill_case);
     if (IS_DGATED) {
         fillUniform(&grad);
     }
@@ -238,54 +107,29 @@ void performTest_x1(const size_t rows,
         nvte_swiglu(input.data(), output.data(), 0);
     }
     cudaDeviceSynchronize();
-
     auto err = cudaGetLastError();
     ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
 
-    float ref_amax = 0;
-    compute_ref<IType, OType>(grad.rowwise_cpu_dptr<IType>(),
-                              input.rowwise_cpu_dptr<IType>(),
-                              ref_output.get(),
-                              ref_output.get(),
-                              ref_output_scales.get(),
-                              ref_output_scales.get(),
-                              ref_amax,
-                              IS_DGATED,
-                              rows,
-                              cols,
-                              scales_stride,
-                              scales_stride,
-                              rowwise,
-                              colwise);
+    compute_ref<IType>(grad.rowwise_cpu_dptr<IType>(),
+                       input.rowwise_cpu_dptr<IType>(),
+                       ref_output.data(), IS_DGATED, rows, cols);
 
-    size_t mismatches_scales = 0;
-    const size_t scale_diff_abs_tolerance = 0;
-    const double abs_tolerable_mismatches_limit = 1.0;
-    const double rel_tolerable_mismatches_limit = 1.0e-4;
-
-    const uint8_t * const gpu_scales_ptr = rowwise
-                                           ? output.rowwise_cpu_scale_inv_ptr<fp8e8m0>()
-                                           : output.columnwise_cpu_scale_inv_ptr<fp8e8m0>();
+    std::vector<float> dequant_output(rows * output_cols);
     if (rowwise) {
-      compare_scaling_factors("rowwise scales", gpu_scales_ptr, ref_output_scales.get(),
-                              unpadded_blocks_Y, unpadded_blocks_X, scales_stride,
-                              mismatches_scales,
-                              scale_diff_abs_tolerance,
-                              abs_tolerable_mismatches_limit,
-                              rel_tolerable_mismatches_limit);
+        dequantize_mxfp8_rowwise(
+            output.rowwise_cpu_dptr<OType>(),
+            output.rowwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_output.data(), rows, output_cols, scales_stride);
     } else {
-      compare_scaling_factors("colwise scales", gpu_scales_ptr, ref_output_scales.get(),
-                              unpadded_blocks_Y, unpadded_blocks_X, scales_stride,
-                              mismatches_scales,
-                              scale_diff_abs_tolerance,
-                              abs_tolerable_mismatches_limit,
-                              rel_tolerable_mismatches_limit);
-
+        dequantize_mxfp8_colwise(
+            output.columnwise_cpu_dptr<OType>(),
+            output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_output.data(), rows, output_cols, scales_stride);
     }
 
-    const size_t mismatches_elts = 32 * mismatches_scales;
     auto [atol, rtol] = getTolerances(otype);
-    compareResults("output", output, ref_output.get(), rowwise, atol, rtol, true, mismatches_elts);
+    compareResults("output", dequant_output.data(), ref_output.data(),
+                   rows * output_cols, atol, rtol);
 }
 
 /**
@@ -303,46 +147,21 @@ void performTest_x2(const size_t rows,
                     InputsFillCase fill_case,
                     const bool IS_DGATED) {
     using namespace test;
-    using EncodingType = fp32;
     DType itype = TypeInfo<IType>::dtype;
     DType otype = TypeInfo<OType>::dtype;
 
+    const size_t output_cols = (IS_DGATED ? 2 : 1) * cols;
+    const size_t scales_stride_rowwise = get_scale_tensor_dims(rows, output_cols, 1, 32)[3];
+    const size_t scales_stride_colwise = get_scale_tensor_dims(rows, output_cols, 32, 1)[3];
+
     Tensor grad("grad", std::vector<size_t>{ rows, cols }, itype);
     Tensor input("input", std::vector<size_t>{ rows, cols * 2 }, itype);
-
-    const size_t output_cols = (IS_DGATED ? 2 : 1) * cols;
-
-    const std::array<size_t,4> scale_dims_rowwise = get_scale_tensor_dims(rows, output_cols, 1, 32);
-    const std::array<size_t,4> scale_dims_colwise = get_scale_tensor_dims(rows, output_cols, 32, 1);
-
-    const size_t unpadded_blocks_Y_rowwise = scale_dims_rowwise[0];
-    const size_t unpadded_blocks_X_rowwise = scale_dims_rowwise[1];
-    const size_t blocks_Y_rowwise = scale_dims_rowwise[2];
-    const size_t blocks_X_rowwise = scale_dims_rowwise[3];
-    const size_t scales_stride_rowwise = blocks_X_rowwise;
-
-    const size_t unpadded_blocks_Y_colwise = scale_dims_colwise[0];
-    const size_t unpadded_blocks_X_colwise = scale_dims_colwise[1];
-    const size_t blocks_Y_colwise = scale_dims_colwise[2];
-    const size_t blocks_X_colwise = scale_dims_colwise[3];
-    const size_t scales_stride_colwise = blocks_X_colwise;
-
     Tensor output("output", std::vector<size_t>{ rows, output_cols }, otype,
                   true, true, NVTE_MXFP8_1D_SCALING);
 
-    std::unique_ptr<OType[]> ref_output_rowwise = std::make_unique<OType[]>(rows * output_cols);
-    std::unique_ptr<OType[]> ref_output_colwise = std::make_unique<OType[]>(rows * output_cols);
-    std::unique_ptr<fp8e8m0[]> ref_scales_rowwise = std::make_unique<fp8e8m0[]>(blocks_Y_rowwise * blocks_X_rowwise);
-    std::unique_ptr<fp8e8m0[]> ref_scales_colwise = std::make_unique<fp8e8m0[]>(blocks_Y_colwise * blocks_X_colwise);
+    // Pre-quantization float reference (scale-direction independent).
+    std::vector<float> ref_output(rows * output_cols);
 
-    for (size_t i = 0; i < blocks_Y_rowwise * blocks_X_rowwise; ++i) {
-      ref_scales_rowwise[i] = 0;
-    }
-    for (size_t i = 0; i < blocks_Y_colwise * blocks_X_colwise; ++i) {
-      ref_scales_colwise[i] = 0;
-    }
-
-    // fillCase<EncodingType>(&grad, fill_case);
     if (IS_DGATED) {
         fillUniform(&grad);
     }
@@ -354,55 +173,36 @@ void performTest_x2(const size_t rows,
         nvte_swiglu(input.data(), output.data(), 0);
     }
     cudaDeviceSynchronize();
-
     auto err = cudaGetLastError();
     ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
 
-    float ref_amax = 0;
-    compute_ref<IType, OType>(grad.rowwise_cpu_dptr<IType>(),
-                              input.rowwise_cpu_dptr<IType>(),
-                              ref_output_rowwise.get(),
-                              ref_output_colwise.get(),
-                              ref_scales_rowwise.get(),
-                              ref_scales_colwise.get(),
-                              ref_amax,
-                              IS_DGATED,
-                              rows,
-                              cols,
-                              scales_stride_rowwise,
-                              scales_stride_colwise,
-                              true,
-                              true);
-
-    const size_t scale_diff_abs_tolerance = 0;
-    const double abs_tolerable_mismatches_limit = 1.0;
-    const double rel_tolerable_mismatches_limit = 1.0e-4;
-
-    size_t mismatches_scales_rowwise = 0;
-    compare_scaling_factors("scales_rowwise", output.rowwise_cpu_scale_inv_ptr<fp8e8m0>(),
-                            ref_scales_rowwise.get(), unpadded_blocks_Y_rowwise,
-                            unpadded_blocks_X_rowwise, scales_stride_rowwise,
-                            mismatches_scales_rowwise,
-                            scale_diff_abs_tolerance,
-                            abs_tolerable_mismatches_limit,
-                            rel_tolerable_mismatches_limit);
-    size_t mismatches_scales_colwise = 0;
-    compare_scaling_factors("scales_colwise", output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
-                            ref_scales_colwise.get(), unpadded_blocks_Y_colwise,
-                            unpadded_blocks_X_colwise, scales_stride_colwise,
-                            mismatches_scales_colwise,
-                            scale_diff_abs_tolerance,
-                            abs_tolerable_mismatches_limit,
-                            rel_tolerable_mismatches_limit);
-
-
-    const size_t mismatches_elts_rowwise = 32 * mismatches_scales_rowwise;
-    const size_t mismatches_elts_colwise = 32 * mismatches_scales_colwise;
+    compute_ref<IType>(grad.rowwise_cpu_dptr<IType>(),
+                       input.rowwise_cpu_dptr<IType>(),
+                       ref_output.data(), IS_DGATED, rows, cols);
 
     auto [atol, rtol] = getTolerances(otype);
-    auto [atol_amax, rtol_amax] = getTolerances(DType::kFloat32);
-    compareResults("output_c_rowwise", output, ref_output_rowwise.get(), true, atol, rtol, true, mismatches_elts_rowwise);
-    compareResults("output_c_colwise", output, ref_output_colwise.get(), false, atol, rtol, true, mismatches_elts_colwise);
+
+    // Dequantize rowwise GPU output and compare to reference.
+    {
+        std::vector<float> dequant_rowwise(rows * output_cols);
+        dequantize_mxfp8_rowwise(
+            output.rowwise_cpu_dptr<OType>(),
+            output.rowwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_rowwise.data(), rows, output_cols, scales_stride_rowwise);
+        compareResults("output_rowwise", dequant_rowwise.data(), ref_output.data(),
+                       rows * output_cols, atol, rtol);
+    }
+
+    // Dequantize colwise GPU output and compare to reference.
+    {
+        std::vector<float> dequant_colwise(rows * output_cols);
+        dequantize_mxfp8_colwise(
+            output.columnwise_cpu_dptr<OType>(),
+            output.columnwise_cpu_scale_inv_ptr<fp8e8m0>(),
+            dequant_colwise.data(), rows, output_cols, scales_stride_colwise);
+        compareResults("output_colwise", dequant_colwise.data(), ref_output.data(),
+                       rows * output_cols, atol, rtol);
+    }
 }
 
 std::vector<std::pair<size_t, size_t>> matrix_sizes = {
@@ -435,8 +235,6 @@ std::vector<bool> is_bwd_op = {
     false,
     true
 };
-
-}  // namespace
 
 class CastMXFP8_GatedActTestSuite : public ::testing::TestWithParam
     <std::tuple<std::pair<size_t, size_t>,
@@ -474,6 +272,8 @@ TEST_P(CastMXFP8_GatedActTestSuite, TestCastMXFP8Swiglu) {
         );
     );
 }
+
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     OperatorTest,

--- a/tests/cpp/operator/test_cast_mxfp8_grouped.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_grouped.cu
@@ -64,18 +64,21 @@ void compute_ref(const ProcessingMethod processing_method,
             for (size_t j = 0; j < cols; ++j) {
                 const size_t idx = i * cols + j;
                 const float in = static_cast<float>(input[idx]);
+                const float g = static_cast<float>(grad[idx]);
                 float out;
                 switch (processing_method) {
                 case ProcessingMethod::CAST_ONLY:
-                case ProcessingMethod::CAST_DBIAS:
                     out = in;
+                    break;
+                case ProcessingMethod::CAST_DBIAS:
+                    out = g;
                     break;
                 case ProcessingMethod::CAST_ACT:
                     out = OP(in);
                     break;
                 case ProcessingMethod::CAST_DBIAS_DACT:
                 case ProcessingMethod::CAST_DACT:
-                    out = OP(in) * static_cast<float>(grad[idx]);
+                    out = OP(in) * g;
                     break;
                 default:
                     NVTE_ERROR("Invalid processing mode (",

--- a/tests/cpp/operator/test_cast_mxfp8_grouped.cu
+++ b/tests/cpp/operator/test_cast_mxfp8_grouped.cu
@@ -43,121 +43,49 @@ enum ShapeRepresentation {
   VARYING_BOTH_DIMS = 3
 };
 
-template <typename InputType, typename OutputType>
+// Compute the pre-quantization float values that the GPU kernel processes before
+// casting to FP8. These are used as the reference for dequantized output comparison.
+template <typename InputType>
 void compute_ref(const ProcessingMethod processing_method,
                  float (*OP)(const float),
-                 const bool rowwise,
-                 const bool colwise,
                  const InputType* input,
                  const InputType* grad,
-                 OutputType* output_rowwise,
-                 OutputType* output_colwise,
-                 fp8e8m0* output_scales_rowwise,
-                 fp8e8m0* output_scales_colwise,
+                 float* ref_output,
                  InputType* output_dbias,
                  const size_t rows,
-                 const size_t cols,
-                 const size_t scales_stride_rowwise,
-                 const size_t scales_stride_colwise)
+                 const size_t cols)
 {
-    const size_t tile_size_Y = 32;
-    const size_t tile_size_X = 32;
-    const size_t tiles_num_Y = (rows + tile_size_Y - 1) / tile_size_Y;
-    const size_t tiles_num_X = (cols + tile_size_X - 1) / tile_size_X;
-
     std::vector<float> output_dbias_fp32(cols, 0);
     #pragma omp parallel proc_bind(spread)
     {
-        // Buffers to cache intermediate computations
-        std::vector<float> cache_buffer(tile_size_Y * tile_size_X);
-
         std::vector<float> thread_dbias(cols, 0);
-        #pragma omp for schedule(static)
-        for (size_t t = 0; t < tiles_num_Y * tiles_num_X; ++t) {
-            const size_t tile_Y = t / tiles_num_X;
-            const size_t tile_X = t % tiles_num_X;
-            const size_t tile_offset_Y = tile_Y * tile_size_Y;
-            const size_t tile_offset_X = tile_X * tile_size_X;
-
-            const size_t i_min = tile_offset_Y;
-            const size_t i_max = std::min(i_min + tile_size_Y, rows);
-
-            const size_t j_min = tile_offset_X;
-            const size_t j_max = std::min(j_min + tile_size_X, cols);
-
-            // Cache computations
-            for (size_t i = i_min; i < i_max; ++i) {
-                for (size_t j = j_min; j < j_max; ++j) {
-
-                    const size_t idx = i * cols + j;
-                    const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-
-                    float elt = static_cast<float>(input[idx]);
-                    if (processing_method == ProcessingMethod::CAST_DBIAS) {
-                        // grad is the input
-                        elt = static_cast<float>(grad[idx]);
+        #pragma omp for schedule(static) collapse(2)
+        for (size_t i = 0; i < rows; ++i) {
+            for (size_t j = 0; j < cols; ++j) {
+                const size_t idx = i * cols + j;
+                const float in = static_cast<float>(input[idx]);
+                float out;
+                switch (processing_method) {
+                case ProcessingMethod::CAST_ONLY:
+                case ProcessingMethod::CAST_DBIAS:
+                    out = in;
+                    break;
+                case ProcessingMethod::CAST_ACT:
+                    out = OP(in);
+                    break;
+                case ProcessingMethod::CAST_DBIAS_DACT:
+                case ProcessingMethod::CAST_DACT:
+                    {
+                        out = OP(in) * static_cast<float>(grad[idx]);
                     }
-                    if (processing_method != ProcessingMethod::CAST_ONLY
-                        && processing_method != ProcessingMethod::CAST_DBIAS) {
-                        elt = OP(elt);
-                    }
-                    if (processing_method == ProcessingMethod::CAST_DACT ||
-                        processing_method == ProcessingMethod::CAST_DBIAS_DACT) {
-                        elt *= static_cast<float>(grad[idx]);
-                    }
-                    thread_dbias[j] += elt;
-
-                    // Numerical truncation: after downcast to InputType (BF16/FP16), upcast it back to FP32
-                    elt = static_cast<float>(static_cast<InputType>(elt));
-
-                    cache_buffer[cache_idx] = elt;
-                    if (isinf(elt) || isnan(elt)) {
-                        continue;
-                    }
+                    break;
+                default:
+                    NVTE_ERROR("Invalid processing mode (",
+                               static_cast<int>(processing_method), ").");
                 }
-            }
-
-            if (rowwise) {
-                for (size_t i = i_min; i < i_max; ++i) {
-                    float block_amax = 0.0f;
-
-                    for (size_t j = j_min; j < j_max; ++j) {
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        block_amax = std::max(block_amax, std::abs(cache_buffer[cache_idx]));
-                    }
-
-                    const fp8e8m0 biased_exponent = float_to_e8m0(block_amax * Quantized_Limits<OutputType>::max_reciprocal());
-                    const size_t scale_idx = i * scales_stride_rowwise + tile_X;
-                    output_scales_rowwise[scale_idx] = biased_exponent;
-                    const float scale_reciprocal = exp2f_rcp(biased_exponent);
-
-                    for (size_t j = j_min; j < j_max; ++j) {
-                        const size_t idx = i * cols + j;
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        output_rowwise[idx] = static_cast<OutputType>(cache_buffer[cache_idx] * scale_reciprocal);
-                    }
-                }
-            }
-            if (colwise) {
-                for (size_t j = j_min; j < j_max; ++j) {
-                    float block_amax = 0.0f;
-
-                    for (size_t i = i_min; i < i_max; ++i) {
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        block_amax = std::max(block_amax, std::abs(cache_buffer[cache_idx]));
-                    }
-
-                    const fp8e8m0 biased_exponent = float_to_e8m0(block_amax * Quantized_Limits<OutputType>::max_reciprocal());
-                    const size_t scale_idx = tile_Y * scales_stride_colwise + j;
-                    output_scales_colwise[scale_idx] = biased_exponent;
-                    const float scale_reciprocal = exp2f_rcp(biased_exponent);
-
-                    for (size_t i = i_min; i < i_max; ++i) {
-                        const size_t idx = i * cols + j;
-                        const size_t cache_idx = (i - i_min) * tile_size_X + (j - j_min);
-                        output_colwise[idx] = static_cast<OutputType>(cache_buffer[cache_idx] * scale_reciprocal);
-                    }
-                }
+                thread_dbias[j] += out;
+                // Match GPU: downcast to InputType then back to float before quantization.
+                ref_output[idx] = static_cast<float>(static_cast<InputType>(out));
             }
         }
         #pragma omp critical
@@ -167,60 +95,8 @@ void compute_ref(const ProcessingMethod processing_method,
             }
         }
     }
-
     for (size_t j = 0; j < cols; ++j) {
         output_dbias[j] = static_cast<InputType>(output_dbias_fp32[j]);
-    }
-}
-
-template <typename T>
-void compare_scaled_elts(const std::string &name,
-                         const T* ref_data,
-                         const T* test_data,
-                         const size_t rows,
-                         const size_t cols,
-                         const bool rowwise,
-                         const size_t tolerable_mismatches_limit = 0,
-                         const double atol = 1e-5,
-                         const double rtol = 1e-8) {
-    size_t mismatches_num = 0;
-    int first_mismatch_idx = -1;
-
-    for (size_t i = 0; i < rows * cols; ++i) {
-        double t = static_cast<double>(test_data[i]);
-        double r = static_cast<double>(ref_data[i]);
-        bool mismatch = fabs(t - r) > atol && (r == 0 || fabs((t - r) / r) > rtol);
-        /* For Float32 the floating point comparison is enough to error out */
-        bool assertion = false;
-        if (mismatch && !assertion) {
-            /* Check if it is just a failure of round to nearest choosing different
-                side of the real value */
-            const double mean = (t + r) / 2;
-            const double mean_p = mean >= 0 ? mean * (1 + 1e-6) : mean * (1 - 1e-6);
-            const double mean_m = mean >= 0 ? mean * (1 - 1e-6) : mean * (1 + 1e-6);
-            const double cast_mean_p = static_cast<double>(static_cast<T>(mean_p));
-            const double cast_mean_m = static_cast<double>(static_cast<T>(mean_m));
-            assertion = !(cast_mean_m == std::min(t,r) && cast_mean_p == std::max(t,r));
-        }
-        std::string direction = rowwise ? "rowwise" : "columnwise";
-        if (assertion) {
-            mismatches_num++;
-            if (first_mismatch_idx == -1) {
-                first_mismatch_idx = i;
-            }
-        }
-        if (mismatches_num > tolerable_mismatches_limit) {
-            const double first_mismatch_t = static_cast<double>(test_data[first_mismatch_idx]);
-            const double first_mismatch_r = static_cast<double>(ref_data[first_mismatch_idx]);
-
-            GTEST_FAIL() << mismatches_num << " mismatche(s) which is more than tolerable mismatch limit of "
-                        << tolerable_mismatches_limit << "." << std::endl
-                        << "Error in tensor " << name << " in "
-                        << direction << " direction." << std::endl
-                        << "First mismatch at place " << first_mismatch_idx
-                        << " (" << std::to_string(first_mismatch_idx) << "): "
-                        << first_mismatch_t << " vs " << first_mismatch_r;
-        }
     }
 }
 
@@ -308,32 +184,14 @@ void performTest(const ProcessingMethod processing_method,
     std::vector<fp8e8m0> out_scales_rowwise_h(rowwise ? rowwise_sfs_num : 0);
     std::vector<fp8e8m0> out_scales_colwise_h(colwise ? colwise_sfs_num : 0);
 
-    std::vector<OutputType> out_data_rowwise_ref(rowwise ? elts_num : 0);
-    std::vector<OutputType> out_data_colwise_ref(colwise ? elts_num : 0);
-    std::vector<fp8e8m0> out_scales_rowwise_ref(rowwise ? rowwise_sfs_num : 0);
-    std::vector<fp8e8m0> out_scales_colwise_ref(colwise ? colwise_sfs_num : 0);
-
+    // Pre-quantization float reference (scale-direction independent).
+    std::vector<float> ref_output_float(elts_num, 0.0f);
     std::vector<InputType> ref_output_dbias(sum_of_last_dims, static_cast<InputType>(0.0f));
 
     for (size_t i = 0; i < elts_num; ++i) {
         const float val = dis(gen);
         grad_data[i] = static_cast<InputType>(val);
         in_data[i] = static_cast<InputType>(val);
-    }
-
-    const OutputType zero_elt = static_cast<OutputType>(0.0f);
-    const fp8e8m0 zero_SF = static_cast<fp8e8m0>(0.0f);
-    if (rowwise) {
-        std::fill(out_data_rowwise_h.begin(), out_data_rowwise_h.end(), zero_elt);
-        std::fill(out_data_rowwise_ref.begin(), out_data_rowwise_ref.end(), zero_elt);
-        std::fill(out_scales_rowwise_h.begin(), out_scales_rowwise_h.end(), zero_SF);
-        std::fill(out_scales_rowwise_ref.begin(), out_scales_rowwise_ref.end(), zero_SF);
-    }
-    if (colwise) {
-        std::fill(out_data_colwise_h.begin(), out_data_colwise_h.end(), zero_elt);
-        std::fill(out_data_colwise_ref.begin(), out_data_colwise_ref.end(), zero_elt);
-        std::fill(out_scales_colwise_h.begin(), out_scales_colwise_h.end(), zero_SF);
-        std::fill(out_scales_colwise_ref.begin(), out_scales_colwise_ref.end(), zero_SF);
     }
 
     const size_t in_data_size = elts_num * sizeof(InputType);
@@ -475,28 +333,16 @@ void performTest(const ProcessingMethod processing_method,
         const size_t M = first_dims_h[t];
         const size_t K = last_dims_h[t];
 
-        const size_t scales_stride_rowwise = rowwise_scales_last_dim[t];
-        const size_t scales_stride_colwise = colwise_scales_last_dim[t];
         const size_t data_offset = offsets_h[t];
-        const size_t rowwise_sfs_offset = rowwise_scales_offset[t];
-        const size_t colwise_sfs_offset = colwise_scales_offset[t];
         const size_t dbias_offset = dbias_offsets[t];
 
-        const InputType* const grad_ptr = grad_data.data() + data_offset;
-        const InputType* const in_ptr = in_data.data() + data_offset;
-        OutputType* const out_data_rowwise_ptr = out_data_rowwise_ref.data() + data_offset;
-        OutputType* const out_data_colwise_ptr = out_data_colwise_ref.data() + data_offset;
-        fp8e8m0* const out_scales_rowwise_ptr = out_scales_rowwise_ref.data() + rowwise_sfs_offset;
-        fp8e8m0* const out_scales_colwise_ptr = out_scales_colwise_ref.data() + colwise_sfs_offset;
-        InputType* const ref_output_dbias_ptr = ref_output_dbias.data() + dbias_offset;
-
-        compute_ref<InputType, OutputType>(
-            processing_method, OP, rowwise, colwise, in_ptr, grad_ptr,
-            out_data_rowwise_ptr, out_data_colwise_ptr,
-            out_scales_rowwise_ptr, out_scales_colwise_ptr,
-            ref_output_dbias_ptr, M, K,
-            scales_stride_rowwise,
-            scales_stride_colwise);
+        compute_ref<InputType>(
+            processing_method, OP,
+            in_data.data() + data_offset,
+            grad_data.data() + data_offset,
+            ref_output_float.data() + data_offset,
+            ref_output_dbias.data() + dbias_offset,
+            M, K);
     }
 
     QuantizationConfigWrapper quant_config;
@@ -552,45 +398,43 @@ void performTest(const ProcessingMethod processing_method,
     ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
 
     auto [atol, rtol] = getTolerances(otype);
-    const size_t scale_diff_abs_tolerance = 0;
-    const double abs_tolerable_mismatches_limit = 0.0;
-    const double rel_tolerable_mismatches_limit = 0.0;
 
-    // Compare only allocated contiguous output range.
-    // In graph-safe mode logical shape may include trailing garbage beyond offsets_h.back().
-    const size_t compare_rows = 1;
-    const size_t compare_cols = elts_num;
-
+    // Dequantize each sub-tensor using its own GPU scales, then compare to the
+    // pre-quantization float reference.  Each sub-tensor has its own scale stride.
     if (rowwise) {
         cudaMemcpy(out_data_rowwise_h.data(), out_data_rowwise_d, out_data_size, cudaMemcpyDeviceToHost);
         cudaMemcpy(out_scales_rowwise_h.data(), out_scales_rowwise_d, rowwise_scales_size, cudaMemcpyDeviceToHost);
 
-        size_t mismatches_scales = 0;
-        compare_scaling_factors("rowwise_scales", out_scales_rowwise_h.data(), out_scales_rowwise_ref.data(),
-                                1, rowwise_sfs_num, rowwise_sfs_num, mismatches_scales, scale_diff_abs_tolerance,
-                                abs_tolerable_mismatches_limit, rel_tolerable_mismatches_limit);
-
-        const size_t mismatches_elts = 32 * mismatches_scales;
-
-        compare_scaled_elts<OutputType>("rowwise_output", out_data_rowwise_ref.data(),
-                                        out_data_rowwise_h.data(), compare_rows, compare_cols,
-                                        true, mismatches_elts);
+        std::vector<float> dequant_rowwise(elts_num);
+        for (size_t t = 0; t < num_tensors; ++t) {
+            const size_t M = first_dims_h[t];
+            const size_t K = last_dims_h[t];
+            dequantize_mxfp8_rowwise(
+                out_data_rowwise_h.data() + offsets_h[t],
+                out_scales_rowwise_h.data() + rowwise_scales_offset[t],
+                dequant_rowwise.data() + offsets_h[t],
+                M, K, rowwise_scales_last_dim[t]);
+        }
+        compareResults("rowwise_output", dequant_rowwise.data(), ref_output_float.data(),
+                       elts_num, atol, rtol);
     }
 
     if (colwise) {
         cudaMemcpy(out_data_colwise_h.data(), out_data_colwise_d, out_data_size, cudaMemcpyDeviceToHost);
         cudaMemcpy(out_scales_colwise_h.data(), out_scales_colwise_d, colwise_scales_size, cudaMemcpyDeviceToHost);
 
-        size_t mismatches_scales = 0;
-        compare_scaling_factors("colwise_scales", out_scales_colwise_h.data(), out_scales_colwise_ref.data(),
-                                1, colwise_sfs_num, colwise_sfs_num, mismatches_scales, scale_diff_abs_tolerance,
-                                abs_tolerable_mismatches_limit, rel_tolerable_mismatches_limit);
-
-        const size_t mismatches_elts = 32 * mismatches_scales;
-
-        compare_scaled_elts<OutputType>("colwise_output", out_data_colwise_ref.data(),
-                                        out_data_colwise_h.data(), compare_rows, compare_cols,
-                                        false, mismatches_elts);
+        std::vector<float> dequant_colwise(elts_num);
+        for (size_t t = 0; t < num_tensors; ++t) {
+            const size_t M = first_dims_h[t];
+            const size_t K = last_dims_h[t];
+            dequantize_mxfp8_colwise(
+                out_data_colwise_h.data() + offsets_h[t],
+                out_scales_colwise_h.data() + colwise_scales_offset[t],
+                dequant_colwise.data() + offsets_h[t],
+                M, K, colwise_scales_last_dim[t]);
+        }
+        compareResults("colwise_output", dequant_colwise.data(), ref_output_float.data(),
+                       elts_num, atol, rtol);
     }
 
     if (compute_dbias) {
@@ -669,8 +513,6 @@ std::vector<std::vector<size_t>> input_config = {
     {VARYING_FIRST_DIM,     4,      512,160,                    128,0,0,256},
     {VARYING_BOTH_DIMS,     3,      1,(128*128)+(128*128),      128,0,128,      128,0,128},
 };
-
-}  // namespace
 
 class GroupedFusedCastMXFP8TestSuite : public ::testing::TestWithParam
     <std::tuple<ProcessingMethod,
@@ -851,6 +693,8 @@ std::string MakeGroupedFusedCastMXFP8TestName(
 
     return name;
 }
+
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     OperatorTest,

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -883,8 +883,6 @@ std::pair<double, double> getTolerances(const DType type) {
       return {0.0675, 0.125};
     case DType::kFloat8E5M2:
       return {0.125, 0.25};
-    case DType::kFloat8E8M0:
-      return {1e-2, 1e-2};
     default:
       NVTE_CHECK("Invalid type!");
   }

--- a/tests/cpp/test_common.cu
+++ b/tests/cpp/test_common.cu
@@ -648,7 +648,7 @@ void compareResults_sequential(const std::string &name, const Tensor &test,
         const double first_mismatch_t = static_cast<double>(test_data[first_mismatch_idx]);
         const double first_mismatch_r = static_cast<double>(ref_data[first_mismatch_idx]);
 
-        GTEST_FAIL() << mismatches_num << " mismatche(s) which is more than tolerable mismatch limit of "
+        GTEST_FAIL() << mismatches_num << " mismatch(es) which is more than tolerable mismatch limit of "
                     << tolerable_mismatches_limit << "." << std::endl
                     << "Error in tensor " << name << " in "
                     << direction << " direction." << std::endl
@@ -716,7 +716,7 @@ void compareResults_parallel(const std::string &name, const Tensor &test, const 
       const double r = static_cast<double>(ref_data[i]);
       std::string direction = rowwise ? "rowwise" : "columnwise";
 
-      GTEST_FAIL() << mismatches << " mismatche(s) which is more than tolerable mismatch limit of "
+      GTEST_FAIL() << mismatches << " mismatch(es) which is more than tolerable mismatch limit of "
                    << tolerable_mismatches_limit << "." << std::endl
                    << "Error in tensor " << name << " in "
                    << direction << " direction." << std::endl
@@ -748,6 +748,17 @@ void compareResults(const std::string &name, const float test, const float ref,
 }
 
 
+void compareResults(const std::string &name, const float *test, const float *ref,
+                    const size_t N, const double atol, const double rtol) {
+  size_t mismatches = 0;
+  const size_t first_idx = getFirstMismatchIdx<float>(DType::kFloat32, test, ref, N, atol, rtol, mismatches);
+  if (first_idx != N) {
+    GTEST_FAIL() << mismatches << " mismatch(es) in \"" << name << "\"."
+                 << " First at index " << first_idx << ": "
+                 << test[first_idx] << " vs " << ref[first_idx];
+  }
+}
+
 void compareResults(const std::string &name, const uint8_t *test, const uint8_t *ref,
                     size_t N, float mismatch_rate_tol) {
   size_t max_mismatches = std::ceil(N * mismatch_rate_tol);
@@ -764,7 +775,7 @@ void compareResults(const std::string &name, const uint8_t *test, const uint8_t 
       for (auto &index : mismatch_indices)
         std::cout << "Mismatch at (" << index << "):" << static_cast<int>(test[i]) << " vs "
         << static_cast<int>(ref[i]) << std::endl;
-      GTEST_FAIL() << n_mismatches << " mismatche(s) which is more than mismatch tol.";
+      GTEST_FAIL() << n_mismatches << " mismatch(es) which is more than mismatch tol.";
     }
   }
 }
@@ -837,7 +848,7 @@ void compare_scaling_factors(const std::string &name, const T *test, const T *re
                     << static_cast<UpcastType>(test[index]) << " vs "
                     << static_cast<UpcastType>(ref[index]) << std::endl;
         }
-        GTEST_FAIL() << mismatches_num << " mismatche(s) which is more than tolerable mismatch limit of "
+        GTEST_FAIL() << mismatches_num << " mismatch(es) which is more than tolerable mismatch limit of "
                      << tolerable_mismatches_limit << ".";
       }
     }
@@ -869,7 +880,9 @@ std::pair<double, double> getTolerances(const DType type) {
     case DType::kBFloat16:
       return {1e-5, 1e-2};
     case DType::kFloat8E4M3:
+      return {0.0675, 0.125};
     case DType::kFloat8E5M2:
+      return {0.125, 0.25};
     case DType::kFloat8E8M0:
       return {1e-2, 1e-2};
     default:

--- a/tests/cpp/test_common.h
+++ b/tests/cpp/test_common.h
@@ -437,6 +437,40 @@ inline float exp2f_rcp(fp8e8m0 biased_exp) {
   return fp32_val;
 }
 
+// Dequantize MXFP8 (rowwise): one E8M0 scale per 32-element row segment.
+// scale_stride: number of scale entries per row (padded column-block count).
+// Scale for element (i, j) is at scales[i * scale_stride + j / 32].
+template <typename FP8Type>
+inline void dequantize_mxfp8_rowwise(const FP8Type* fp8_data, const fp8e8m0* scales,
+                                      float* out, size_t rows, size_t cols,
+                                      size_t scale_stride) {
+  #pragma omp parallel for proc_bind(spread) schedule(static)
+  for (size_t i = 0; i < rows; ++i) {
+    for (size_t j = 0; j < cols; ++j) {
+      const size_t scale_idx = i * scale_stride + j / 32;
+      const float scale = std::exp2f(static_cast<float>(scales[scale_idx]) - FP32_EXPONENT_BIAS);
+      out[i * cols + j] = static_cast<float>(fp8_data[i * cols + j]) * scale;
+    }
+  }
+}
+
+// Dequantize MXFP8 (colwise): one E8M0 scale per 32-element column segment.
+// scale_stride: number of scale entries per row-of-blocks (padded column count).
+// Scale for element (i, j) is at scales[(i / 32) * scale_stride + j].
+template <typename FP8Type>
+inline void dequantize_mxfp8_colwise(const FP8Type* fp8_data, const fp8e8m0* scales,
+                                      float* out, size_t rows, size_t cols,
+                                      size_t scale_stride) {
+  #pragma omp parallel for proc_bind(spread) schedule(static)
+  for (size_t i = 0; i < rows; ++i) {
+    for (size_t j = 0; j < cols; ++j) {
+      const size_t scale_idx = (i / 32) * scale_stride + j;
+      const float scale = std::exp2f(static_cast<float>(scales[scale_idx]) - FP32_EXPONENT_BIAS);
+      out[i * cols + j] = static_cast<float>(fp8_data[i * cols + j]) * scale;
+    }
+  }
+}
+
 inline float identity(const float x) { return x; }
 inline float gelu(const float x)     { return x * (0.5f + 0.5f * tanhf(x * (0.79788456f + 0.03567741f * x * x))); }
 inline float dgelu(const float x) {
@@ -472,6 +506,8 @@ void compareResults(const std::string &name, const float test, const float ref,
                     double atol = 1e-5, double rtol = 1e-8);
 void compareResults(const std::string &name, const uint8_t *test, const uint8_t *ref,
                     size_t N, float mismatch_rate_tol = 0.);
+void compareResults(const std::string &name, const float *test, const float *ref,
+                    size_t N, double atol, double rtol);
 template <typename T>
 void compare_scaling_factors(const std::string &name, const T *test, const T *ref,
                              const size_t row_blocks, const size_t col_blocks, const size_t stride,


### PR DESCRIPTION
# Description

We have experienced some failures in the MXFP8 C++ tests because of expected numerical errors. In particular, FP32 numerical errors will sometimes cause the MXFP8 scales to differ by one. However, our current tests assume that MXFP8 scales are bit-wise exact between the TE implementation and reference implementation. This PR changes the MXFP8 tests so that we dequantize MXFP8 values and compare against an FP32 reference implementation.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add MXFP8 dequantization function to test utilities
- Change FP8 tolerances to match machine epsilon
- Change MXFP8 tests to use FP32 reference implementation
- Change MXFP8 tests to check that dequantized MXFP8 values and FP32 reference values are within FP8 tolerances

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
