### PR TITLE
[PyTorch] Minor optimizations in fused grouped MLP

### DIFF
--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -69,20 +69,17 @@ def _cudnn_compute_wgrad(
     sfb_tensor = grouped_x.columnwise_scale_inv.view(in_features, -1).view(
         dtype=torch.float8_e8m0fnu
     )
-    offsets_tensor = offsets.to(dtype=torch.int32)
 
     # Prepare wgrad output
     if single_grouped_weight:
         # Dense mode: single (num_groups, out_features, in_features) tensor
-        wgrad_tensor = wgrad_output.rowwise_data.view(
-            offsets_tensor.shape[0], out_features, in_features
-        )
+        wgrad_tensor = wgrad_output.rowwise_data.view(offsets.shape[0], out_features, in_features)
         wgrad_kernel_fn(
             a_tensor=a_tensor,
             b_tensor=b_tensor,
             sfa_tensor=sfa_tensor,
             sfb_tensor=sfb_tensor,
-            offsets_tensor=offsets_tensor,
+            offsets_tensor=offsets,
             output_mode="dense",
             wgrad_tensor=wgrad_tensor,
             acc_dtype=torch.float32,
@@ -99,7 +96,7 @@ def _cudnn_compute_wgrad(
             b_tensor=b_tensor,
             sfa_tensor=sfa_tensor,
             sfb_tensor=sfb_tensor,
-            offsets_tensor=offsets_tensor,
+            offsets_tensor=offsets,
             output_mode="discrete",
             wgrad_ptrs=wgrad_ptrs,
             acc_dtype=torch.float32,
@@ -210,6 +207,7 @@ def _compute_grad_params(
         # Launch or defer the GEMM
         delay_wgrad = fc_op.wgrad_store is not None and fc_op.wgrad_store.delay_wgrad_compute()
         if cudnn_wgrad_kernel_fn is not None:
+            offsets = offsets if offsets.dtype == torch.int32 else offsets.to(dtype=torch.int32)
             gemm_fn = functools.partial(
                 _cudnn_compute_wgrad,
                 weight_shape=weight_shape,
@@ -424,8 +422,6 @@ class BackwardGroupedMLP_CuTeGEMMDSwiGLU_MXFP8(FusedOperation):
         # Group splits
         if int(split_sizes.numel()) != num_groups:
             raise ValueError(f"Expected {num_groups} splits, but got {int(split_sizes.numel())}.")
-        split_sizes = split_sizes.to(dtype=torch.int64, device=device)
-        split_points = split_points.to(dtype=torch.int, device=device)
         scale_bias = fc2_op._scale_bias and fc2_op.has_bias
 
         grouped_fc1_x = None
@@ -516,7 +512,8 @@ class BackwardGroupedMLP_CuTeGEMMDSwiGLU_MXFP8(FusedOperation):
         norm_const_tensor = get_cached_ones_tensor(1, dtype, device)
         current_stream = torch.cuda.current_stream().cuda_stream
 
-        scales_tensor = scales.detach().to(dtype=torch.float32).reshape(-1, 1, 1)
+        scales_f32 = scales.detach().to(dtype=torch.float32)
+        scales_tensor = scales_f32.reshape(-1, 1, 1)
         dscales_tensor = torch.zeros_like(scales_tensor)
 
         fc2_dglu_kwargs = {
@@ -594,7 +591,6 @@ class BackwardGroupedMLP_CuTeGEMMDSwiGLU_MXFP8(FusedOperation):
         if scale_bias:
             fc2_biases = fc2_op._get_bias_tensors(dtype)
             bias_packed = torch.stack(fc2_biases)
-            scales_f32 = scales.detach().to(dtype=torch.float32)
             fc2_dbias_packed_result, grad_scales = _compute_grouped_dbias_dscales(
                 fc2_dy,
                 scales_f32,
@@ -608,12 +604,11 @@ class BackwardGroupedMLP_CuTeGEMMDSwiGLU_MXFP8(FusedOperation):
             else:
                 fc2_bias_grads = [fc2_dbias_packed_result[idx] for idx in range(num_groups)]
         elif fc2_dbias_packed is not None:
+            fc2_dbias_packed = fc2_dbias_packed.to(dtype=dtype)
             if fc2_op.single_grouped_bias:
-                fc2_bias_grad_packed = fc2_dbias_packed.to(dtype=dtype)
+                fc2_bias_grad_packed = fc2_dbias_packed
             else:
-                fc2_bias_grads = [
-                    fc2_dbias_packed[idx].to(dtype=dtype) for idx in range(num_groups)
-                ]
+                fc2_bias_grads = [fc2_dbias_packed[idx] for idx in range(num_groups)]
 
         grad_scales = grad_scales.to(dtype=dtype)
 
@@ -622,13 +617,11 @@ class BackwardGroupedMLP_CuTeGEMMDSwiGLU_MXFP8(FusedOperation):
         if fc1_op.has_bias:
             dbias_t = fc2_dgrad_kernel_out["dbias_tensor"]
             if dbias_t is not None:
-                dbias_2d = dbias_t.squeeze(-1)
+                dbias_2d = dbias_t.squeeze(-1).to(dtype=dtype)
                 if fc1_op.single_grouped_bias:
-                    fc1_bias_grad_packed = dbias_2d.to(dtype=dtype)
+                    fc1_bias_grad_packed = dbias_2d
                 else:
-                    fc1_bias_grads = [
-                        dbias_2d[group_idx].to(dtype=dtype) for group_idx in range(num_groups)
-                    ]
+                    fc1_bias_grads = [dbias_2d[group_idx] for group_idx in range(num_groups)]
 
         # FC1 grad output for dgrad and wgrad GEMMs
         fc1_dy_tensor_offsets = fc1_ctx.base_split_offsets * fc1_weight_shape[0]

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -194,14 +194,8 @@ class ForwardGroupedMLP_CuTeGEMMSwiGLU_MXFP8(FusedOperation):
         if int(split_sizes.numel()) != num_groups:
             raise ValueError(f"Expected {num_groups} splits, but got {int(split_sizes.numel())}.")
         split_sizes = split_sizes.to(dtype=torch.int64, device=device)
-        split_points = torch.cumsum(split_sizes, 0, dtype=torch.int)
-        split_points_offsets = torch.cumsum(split_sizes, 0)
-        base_offsets = torch.cat(
-            [
-                torch.zeros(1, device=split_sizes.device, dtype=split_sizes.dtype),
-                split_points_offsets,
-            ]
-        )
+        base_offsets = tex.splits_to_offsets(split_sizes, 1)
+        split_points = base_offsets[1:].to(dtype=torch.int)
         fc1_x_tensor_offsets = base_offsets * fc1_weight_shape[1]
         fc2_x_tensor_offsets = base_offsets * fc2_weight_shape[1]
 


### PR DESCRIPTION
# Description

Small perf/cpu overhead improvements in fused grouped MLP

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [x] Performance

## Changes

- Reduce number of casts via torch `.to` wherever possible.
- Use fused kernel to calculate offsets from splits.
- Calculate split points by indexing into offsets to remove an additional `cumsum`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
