### PR TITLE
Fix CP crash with GQA + asymmetric KV head dims (#2868)

### DIFF
--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -51,6 +51,12 @@ model_configs_flash_attn = {
         2, 4096, 12, 192, attn_mask_type="causal", window_size=(512, 0), head_dim_v=128
     ),  # MLA
     "cp_3_3": ModelConfig(2, 4096, 12, 192, window_size=(512, 512), head_dim_v=128),  # MLA
+    "cp_3_4": ModelConfig(
+        2, 4096, 12, 192, num_gqa_groups=2, attn_mask_type="causal", head_dim_v=128
+    ),  # GQA + asymmetric qk/v
+    "cp_3_5": ModelConfig(
+        2, 4096, 12, 192, num_gqa_groups=2, head_dim_v=128
+    ),  # GQA + asymmetric qk/v
 }
 
 
@@ -73,7 +79,7 @@ dtypes = ["bf16", "fp16"]
 qkv_formats = ["bshd", "sbhd", "thd"]
 cp_comm_types = ["p2p", "all_gather", "a2a", "a2a+p2p"]
 if test_essential:
-    configs = ["cp_1_0", "cp_1_2", "cp_2_1", "cp_3_2", "cp_3_3"]
+    configs = ["cp_1_0", "cp_1_2", "cp_2_1", "cp_3_2", "cp_3_3", "cp_3_4"]
     model_configs_flash_attn = {k: model_configs_flash_attn[k] for k in configs}
     dtypes = ["bf16"]
     qkv_formats = ["sbhd", "thd"]
@@ -197,6 +203,12 @@ model_configs_fused_attn = {
     "cp_3_4": ModelConfig(
         2, 4096, 12, 128, attn_bias_type="post_scale_bias", bias_shape="b1ss", head_dim_v=64
     ),  # MLA
+    "cp_3_5": ModelConfig(
+        2, 4096, 12, 128, num_gqa_groups=2, attn_mask_type="causal", head_dim_v=64
+    ),  # GQA + asymmetric qk/v
+    "cp_3_6": ModelConfig(
+        2, 4096, 12, 128, num_gqa_groups=2, head_dim_v=64
+    ),  # GQA + asymmetric qk/v
     "cp_4_0": ModelConfig(
         2, 4096, 64, 64, num_gqa_groups=8, attn_mask_type="causal", softmax_type="vanilla"
     ),  # GQA
@@ -224,6 +236,7 @@ if test_essential:
         "cp_2_4",
         "cp_3_2",
         "cp_3_4",
+        "cp_3_5",
         "cp_4_2",
     ]
     model_configs_fused_attn = {k: model_configs_fused_attn[k] for k in configs}

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -1561,6 +1561,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         k_shape = k.shape
         k_numel = k.numel()
         v_shape = v.shape
+        mla_out_shape = (*q.shape[:-1], v.shape[-1])
         p2p_comm_buffers[0] = torch.cat((k.view(-1), v.view(-1)), dim=-1)
         send_recv_reqs = [[], []]
 
@@ -1795,9 +1796,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         softmax_lse = torch.clone(softmax_lse_per_step[0])
                         if qkv_format == "thd":
                             if enable_mla:
-                                out = torch.zeros_like(v if not fp8 else out_per_step[0]).view(
-                                    v_shape
-                                )
+                                out = (v if not fp8 else out_per_step[0]).new_zeros(mla_out_shape)
                             else:
                                 # MHA or GQA
                                 out = torch.zeros_like(q if not fp8 else out_per_step[0]).view(
@@ -1851,7 +1850,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             seq_dim,
                         )
                         if enable_mla:
-                            out = out.view(v_shape)
+                            out = out.view(mla_out_shape)
                         else:
                             out = out.view(q.shape)
                     else:
@@ -2023,6 +2022,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         ctx.use_flash_attn_3 = use_flash_attn_3
 
         ctx.enable_mla = enable_mla
+        ctx.mla_out_shape = mla_out_shape
         ctx.k_numel = k_numel
         ctx.k_shape = k_shape
         ctx.v_shape = v_shape
@@ -2266,8 +2266,8 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
             )
 
         if ctx.enable_mla:
-            out = out.view(*ctx.v_shape)
-            dout = dout.view(*ctx.v_shape)
+            out = out.view(*ctx.mla_out_shape)
+            dout = dout.view(*ctx.mla_out_shape)
         else:
             # MHA or GQA
             out = out.view(*q.shape)


### PR DESCRIPTION
# Description

`AttnFuncWithCPAndKVP2P` treats `k.shape[-1] != v.shape[-1]` as "MLA mode" and
  assumes the attention output shares V's shape. That holds for strict MLA
  (h_q == h_kv) but not when MLA-style attention is combined with GQA
  (h_q != h_kv), e.g. MiMo-V2-Flash with `num_attention_heads=64,                                                                               
  num_kv_heads=4, head_dim_qk=192, head_dim_v=128`.
                                                                                                                                                
  In that case `out.view(v_shape)` and `zeros_like(v).view(v_shape)` fail with a                                                                
  size/shape mismatch because the attention output has `h_q` heads while V has                                                                  
  `h_kv` heads.  

Fixes #2868 

Distinguish V's shape from the attention-output shape:
                                                                                                                                                
  - `v_shape` (unchanged): used for views of V and dV — `[..., h_kv, d_v]`.
  - `mla_out_shape = (*q.shape[:-1], v.shape[-1])` (new): used for views of                                                                     
    out / dout — `[..., h_q, d_v]`.           
                                                                                                                                                
  Computed after the causal reshape so it parallels `v_shape`'s 5D layout when
  causal. Under strict MLA (h_q == h_kv) `mla_out_shape == v_shape`, so the                                                                     
  existing MLA path is unchanged.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

 - Introduce `mla_out_shape` in `AttnFuncWithCPAndKVP2P.forward` and save it on
    `ctx`, separate from the existing `v_shape` which continues to describe V/dV.                                                               
  - Use `mla_out_shape` for out/dout views in forward (init zeros, post-correction
    reshape) and backward (out/dout rehydration).                                                                                               
  - Allocate the first-step output with `.new_zeros(mla_out_shape)` instead of
    `torch.zeros_like(v).view(v_shape)`, so allocation size matches `h_q * d_v`                                                                 
    instead of `h_kv * d_v`.                                                                                                                    
  - Add tests in `tests/pytorch/attention/test_attention_with_cp.py`                                                                 
    combining GQA + asymmetric qk/v head dims:                                                                                                  
    - `model_configs_flash_attn`: `cp_3_4` (causal), `cp_3_5` (non-causal).                                                                     
    - `model_configs_fused_attn`: `cp_3_5` (causal), `cp_3_6` (non-causal).                                                                     
    - Causal cases added to the `test_essential` CI subset as regression                                                                        
      sentinels.                                                                                                                                
  - Clarify in the code and test-config comments that this path covers both                                                                     
    strict MLA and MLA-style attention combined with GQA.  

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
