### PR TITLE
Fix flash attention version check.

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -936,14 +936,14 @@ class FlashAttention(torch.nn.Module):
                         batch_size * context_len,
                     )
 
-        use_flash_attn_4 = False
-        if flash_attention_backend is not None and flash_attention_backend > PkgVersion("4.0.0b"):
-            use_flash_attn_4 = True
-        use_flash_attn_3 = False
-        if flash_attention_backend is not None and PkgVersion(
-            "3.0.0b"
-        ) < flash_attention_backend < PkgVersion("4.0.0"):
-            use_flash_attn_3 = True
+        # FA4 prereleases such as 4.0.0b8 sort below 4.0.0, so key off the major
+        # version instead of a stable-version range check when selecting the API.
+        use_flash_attn_4 = (
+            flash_attention_backend is not None and flash_attention_backend.major == 4
+        )
+        use_flash_attn_3 = (
+            flash_attention_backend is not None and flash_attention_backend.major == 3
+        )
         if context_parallel and all(
             not isinstance(x, Float8Tensor) for x in [query_layer, key_layer, value_layer]
         ):


### PR DESCRIPTION
# Description

The current FA4 beta release 4.0.0b9 sorts below version 4.0.0 according to [PEP 440](https://peps.python.org/pep-0440/), causing 4.0.0b9 to incorrectly enable both `use_flash_attn_3` and `use_flash_attn_4`.

Related to #2432 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `backends.py` checking flash attention major version directly now

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
