### PR TITLE
[PyTorch][CP] Reduce P2P forward peak memory: O(C) _ O(1)

### DIFF
--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -51,6 +51,8 @@ model_configs_flash_attn = {
         2, 4096, 12, 192, attn_mask_type="causal", window_size=(512, 0), head_dim_v=128
     ),  # MLA
     "cp_3_3": ModelConfig(2, 4096, 12, 192, window_size=(512, 512), head_dim_v=128),  # MLA
+    "bariamis_4k": ModelConfig(2, 4096, 16, 128, attn_mask_type="causal"),  # bariamis default
+    "bariamis_8k": ModelConfig(2, 8192, 16, 128, attn_mask_type="causal"),
 }
 
 

--- a/transformer_engine/common/fused_attn/context_parallel.cu
+++ b/transformer_engine/common/fused_attn/context_parallel.cu
@@ -555,10 +555,10 @@ void thd_read_second_half_lse(const Tensor &lse, const Tensor &cu_seqlens, Tenso
  **************************************************************************************************/
 
 template <typename dtype, int only_second_half>
-static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step,
-                                      const Tensor &old_lse, const Tensor &lse,
-                                      const Tensor &lse_per_step, const Tensor &cu_seqlens,
-                                      bool lse_packed, cudaStream_t stream) {
+static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step, const Tensor &old_lse,
+                                      const Tensor &lse, const Tensor &lse_per_step,
+                                      const Tensor &cu_seqlens, bool lse_packed,
+                                      cudaStream_t stream) {
   using namespace transformer_engine;
   NVTE_CHECK(out.dtype() == out_per_step.dtype());
   NVTE_CHECK(old_lse.dtype() == DType::kFloat32);
@@ -616,8 +616,7 @@ static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step,
         <<<grid, block, sizeof(int) * (batch + 1), stream>>>(
             reinterpret_cast<dtype *>(out.data.dptr),
             reinterpret_cast<dtype *>(out_per_step.data.dptr),
-            reinterpret_cast<float *>(old_lse.data.dptr),
-            reinterpret_cast<float *>(lse.data.dptr),
+            reinterpret_cast<float *>(old_lse.data.dptr), reinterpret_cast<float *>(lse.data.dptr),
             reinterpret_cast<float *>(lse_per_step.data.dptr),
             reinterpret_cast<int *>(cu_seqlens.data.dptr), batch, num_heads, dim_per_head,
             lse_seqlen, lse_per_step_seqlen);
@@ -627,8 +626,7 @@ static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step,
         <<<grid, block, sizeof(int) * (batch + 1), stream>>>(
             reinterpret_cast<dtype *>(out.data.dptr),
             reinterpret_cast<dtype *>(out_per_step.data.dptr),
-            reinterpret_cast<float *>(old_lse.data.dptr),
-            reinterpret_cast<float *>(lse.data.dptr),
+            reinterpret_cast<float *>(old_lse.data.dptr), reinterpret_cast<float *>(lse.data.dptr),
             reinterpret_cast<float *>(lse_per_step.data.dptr),
             reinterpret_cast<int *>(cu_seqlens.data.dptr), batch, num_heads, dim_per_head,
             lse_seqlen, lse_per_step_seqlen);
@@ -897,8 +895,8 @@ void nvte_cp_thd_out_correction(NVTETensor out, const NVTETensor &out_per_step,
   context_parallel::thd_out_correction(
       *convertNVTETensorCheck(out), *convertNVTETensorCheck(out_per_step),
       *convertNVTETensorCheck(old_lse), *convertNVTETensorCheck(lse),
-      *convertNVTETensorCheck(lse_per_step),
-      *convertNVTETensorCheck(cu_seqlens), only_second_half, lse_packed, stream);
+      *convertNVTETensorCheck(lse_per_step), *convertNVTETensorCheck(cu_seqlens), only_second_half,
+      lse_packed, stream);
 }
 
 void nvte_cp_thd_grad_correction(NVTETensor grad, const NVTETensor &grad_per_step,

--- a/transformer_engine/common/fused_attn/context_parallel.cu
+++ b/transformer_engine/common/fused_attn/context_parallel.cu
@@ -273,10 +273,10 @@ __global__ void thd_lse_kernel(float *lse, float *half_lse, int *cu_seqlens, int
  **************************************************************************************************/
 
 template <typename dtype, int only_second_half, int tile_size, bool lse_packed>
-__global__ void thd_out_correction_kernel(dtype *out, dtype *out_per_step, float *lse,
-                                          float *lse_per_step, int *cu_seqlens, int batch,
-                                          int num_heads, int dim_per_head, int lse_seqlen,
-                                          int lse_per_step_seqlen) {
+__global__ void thd_out_correction_kernel(dtype *out, dtype *out_per_step, float *old_lse,
+                                          float *lse, float *lse_per_step, int *cu_seqlens,
+                                          int batch, int num_heads, int dim_per_head,
+                                          int lse_seqlen, int lse_per_step_seqlen) {
   extern __shared__ int cu_seqlens_s[];
   for (int i = threadIdx.x; i <= batch; i += blockDim.x) {
     cu_seqlens_s[i] = cu_seqlens[i] / (only_second_half + 1);
@@ -304,6 +304,7 @@ __global__ void thd_out_correction_kernel(dtype *out, dtype *out_per_step, float
         idx = row * lse_seqlen + col + seq_len * only_second_half;
         idx_per_step = row * lse_per_step_seqlen + col;
       }
+      float old_lse_corrected_exp = expf(old_lse[idx] - lse[idx]);
       float lse_corrected_exp = expf(lse_per_step[idx_per_step] - lse[idx]);
 
       idx = token_id + cu_seqlens_s[seq_id + 1] * only_second_half;
@@ -318,10 +319,13 @@ __global__ void thd_out_correction_kernel(dtype *out, dtype *out_per_step, float
         dtype *p_per_step = reinterpret_cast<dtype *>(&data_per_step);
         dtype *p = reinterpret_cast<dtype *>(&data);
         for (int k = 0; k < sizeof(float4) / sizeof(dtype); k++) {
-          p[k] = p[k] +
-                 (p_per_step[k] == static_cast<dtype>(0.f)
-                      ? static_cast<dtype>(0.f)
-                      : static_cast<dtype>(static_cast<float>(p_per_step[k]) * lse_corrected_exp));
+          float old_out = p[k] == static_cast<dtype>(0.f)
+                              ? 0.f
+                              : static_cast<float>(p[k]) * old_lse_corrected_exp;
+          float out_per_step = p_per_step[k] == static_cast<dtype>(0.f)
+                                   ? 0.f
+                                   : static_cast<float>(p_per_step[k]) * lse_corrected_exp;
+          p[k] = static_cast<dtype>(old_out + out_per_step);
         }
         reinterpret_cast<float4 *>(cur_out)[j] = data;
       }
@@ -551,20 +555,25 @@ void thd_read_second_half_lse(const Tensor &lse, const Tensor &cu_seqlens, Tenso
  **************************************************************************************************/
 
 template <typename dtype, int only_second_half>
-static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step, const Tensor &lse,
+static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step,
+                                      const Tensor &old_lse, const Tensor &lse,
                                       const Tensor &lse_per_step, const Tensor &cu_seqlens,
                                       bool lse_packed, cudaStream_t stream) {
   using namespace transformer_engine;
   NVTE_CHECK(out.dtype() == out_per_step.dtype());
+  NVTE_CHECK(old_lse.dtype() == DType::kFloat32);
   NVTE_CHECK(lse.dtype() == DType::kFloat32);
   NVTE_CHECK(lse_per_step.dtype() == DType::kFloat32);
   NVTE_CHECK(cu_seqlens.dtype() == DType::kInt32);
 
   auto out_shape = out.shape();
+  auto old_lse_shape = old_lse.shape();
   auto lse_shape = lse.shape();
   auto out_per_step_shape = out_per_step.shape();
   auto lse_per_step_shape = lse_per_step.shape();
   auto cu_seqlens_shape = cu_seqlens.shape();
+
+  NVTE_CHECK(old_lse_shape == lse_shape);
 
   int total_tokens = out_shape[0];
   int num_heads = out_shape[1];
@@ -607,6 +616,7 @@ static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step, co
         <<<grid, block, sizeof(int) * (batch + 1), stream>>>(
             reinterpret_cast<dtype *>(out.data.dptr),
             reinterpret_cast<dtype *>(out_per_step.data.dptr),
+            reinterpret_cast<float *>(old_lse.data.dptr),
             reinterpret_cast<float *>(lse.data.dptr),
             reinterpret_cast<float *>(lse_per_step.data.dptr),
             reinterpret_cast<int *>(cu_seqlens.data.dptr), batch, num_heads, dim_per_head,
@@ -617,6 +627,7 @@ static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step, co
         <<<grid, block, sizeof(int) * (batch + 1), stream>>>(
             reinterpret_cast<dtype *>(out.data.dptr),
             reinterpret_cast<dtype *>(out_per_step.data.dptr),
+            reinterpret_cast<float *>(old_lse.data.dptr),
             reinterpret_cast<float *>(lse.data.dptr),
             reinterpret_cast<float *>(lse_per_step.data.dptr),
             reinterpret_cast<int *>(cu_seqlens.data.dptr), batch, num_heads, dim_per_head,
@@ -625,20 +636,20 @@ static void thd_out_correction_helper(Tensor out, const Tensor &out_per_step, co
   }
 }
 
-void thd_out_correction(Tensor out, const Tensor &out_per_step, const Tensor &lse,
-                        const Tensor &lse_per_step, const Tensor &cu_seqlens, bool only_second_half,
-                        bool lse_packed, cudaStream_t stream) {
+void thd_out_correction(Tensor out, const Tensor &out_per_step, const Tensor &old_lse,
+                        const Tensor &lse, const Tensor &lse_per_step, const Tensor &cu_seqlens,
+                        bool only_second_half, bool lse_packed, cudaStream_t stream) {
   using namespace transformer_engine;
   if (only_second_half) {
     TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(
         out.dtype(), dtype,
-        thd_out_correction_helper<dtype, 1>(out, out_per_step, lse, lse_per_step, cu_seqlens,
-                                            lse_packed, stream););
+        thd_out_correction_helper<dtype, 1>(out, out_per_step, old_lse, lse, lse_per_step,
+                                            cu_seqlens, lse_packed, stream););
   } else {
     TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(
         out.dtype(), dtype,
-        thd_out_correction_helper<dtype, 0>(out, out_per_step, lse, lse_per_step, cu_seqlens,
-                                            lse_packed, stream););
+        thd_out_correction_helper<dtype, 0>(out, out_per_step, old_lse, lse, lse_per_step,
+                                            cu_seqlens, lse_packed, stream););
   }
 }
 
@@ -877,15 +888,16 @@ void nvte_cp_thd_read_second_half_lse(const NVTETensor &lse, const NVTETensor &c
 }
 
 void nvte_cp_thd_out_correction(NVTETensor out, const NVTETensor &out_per_step,
-                                const NVTETensor &lse, const NVTETensor &lse_per_step,
-                                const NVTETensor &cu_seqlens, int only_second_half, int lse_packed,
-                                cudaStream_t stream) {
+                                const NVTETensor &old_lse, const NVTETensor &lse,
+                                const NVTETensor &lse_per_step, const NVTETensor &cu_seqlens,
+                                int only_second_half, int lse_packed, cudaStream_t stream) {
   NVTE_API_CALL(nvte_thd_out_correction);
   using namespace transformer_engine;
 
   context_parallel::thd_out_correction(
       *convertNVTETensorCheck(out), *convertNVTETensorCheck(out_per_step),
-      *convertNVTETensorCheck(lse), *convertNVTETensorCheck(lse_per_step),
+      *convertNVTETensorCheck(old_lse), *convertNVTETensorCheck(lse),
+      *convertNVTETensorCheck(lse_per_step),
       *convertNVTETensorCheck(cu_seqlens), only_second_half, lse_packed, stream);
 }
 

--- a/transformer_engine/common/include/transformer_engine/fused_attn.h
+++ b/transformer_engine/common/include/transformer_engine/fused_attn.h
@@ -490,7 +490,8 @@ void nvte_cp_thd_read_second_half_lse(const NVTETensor &lse, const NVTETensor &c
  *
  *  \param[out]    out                   Output tensor.
  *  \param[in]     out_per_step          THD format output of context parallelism in forward pass.
- *  \param[in]     lse                   Softmax LSE.
+ *  \param[in]     old_lse               Softmax LSE before adding this step.
+ *  \param[in]     lse                   Softmax LSE after adding this step.
  *  \param[in]     lse_per_step          Softmax LSE per step.
  *  \param[in]     cu_seqlens            Cumulative sequence lengths, [batch_size + 1].
  *  \param[in]     only_second_half      Whether or not to correct only second half.
@@ -498,9 +499,9 @@ void nvte_cp_thd_read_second_half_lse(const NVTETensor &lse, const NVTETensor &c
  *  \param[in]     stream                CUDA stream used for this operation.
  */
 void nvte_cp_thd_out_correction(NVTETensor out, const NVTETensor &out_per_step,
-                                const NVTETensor &lse, const NVTETensor &lse_per_step,
-                                const NVTETensor &cu_seqlens, int only_second_half, int lse_packed,
-                                cudaStream_t stream);
+                                const NVTETensor &old_lse, const NVTETensor &lse,
+                                const NVTETensor &lse_per_step, const NVTETensor &cu_seqlens,
+                                int only_second_half, int lse_packed, cudaStream_t stream);
 
 /*!  \brief Update the two halves of each packed THD sequence during context-parallel backward.
  *

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -173,6 +173,41 @@ def flash_attn_fwd_second_half_softmax_lse_correction(
 
 
 @jit_fuser
+def flash_attn_fwd_incremental_out_correction(
+    out: torch.Tensor,
+    out_per_step: torch.Tensor,
+    old_softmax_lse: torch.Tensor,
+    new_softmax_lse: torch.Tensor,
+    softmax_lse_per_step: torch.Tensor,
+    seq_dim: int,
+):
+    """Online softmax merge: rescale accumulated output and add new step's contribution."""
+    scale_old = torch.exp(old_softmax_lse - new_softmax_lse).movedim(2, seq_dim).unsqueeze(-1)
+    scale_new = torch.exp(softmax_lse_per_step - new_softmax_lse).movedim(2, seq_dim).unsqueeze(-1)
+    out.mul_(scale_old)
+    out.addcmul_(out_per_step, scale_new)
+
+
+@jit_fuser
+def flash_attn_fwd_incremental_second_half_out_correction(
+    out: torch.Tensor,
+    out_per_step: torch.Tensor,
+    old_softmax_lse: torch.Tensor,
+    new_softmax_lse: torch.Tensor,
+    softmax_lse_per_step: torch.Tensor,
+    seq_dim: int,
+):
+    """Online softmax merge for second-half tokens only (causal upper-triangle steps)."""
+    out_ = out.select(seq_dim, 1)
+    old_lse_ = old_softmax_lse.view(*old_softmax_lse.shape[:-1], 2, -1)[..., 1, :]
+    new_lse_ = new_softmax_lse.view(*new_softmax_lse.shape[:-1], 2, -1)[..., 1, :]
+    scale_old = torch.exp(old_lse_ - new_lse_).movedim(2, seq_dim).unsqueeze(-1)
+    scale_new = torch.exp(softmax_lse_per_step - new_lse_).movedim(2, seq_dim).unsqueeze(-1)
+    out_.mul_(scale_old)
+    out_.addcmul_(out_per_step, scale_new)
+
+
+@jit_fuser
 def get_cu_seqlens_on_cp_rank(
     cu_seqlens: torch.Tensor,
     cu_seqlens_padded_on_cp_rank: torch.Tensor,
@@ -1347,7 +1382,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         amax_per_step = None
         S_quantizer_per_step = [None for _ in range(cp_size)]
         O_quantizer_per_step = [None for _ in range(cp_size)]
-        max_logit_per_step = [None for _ in range(cp_size)]
+        max_logit_per_step = [None, None]
         max_logit = None
 
         assert isinstance(k, q.__class__) and isinstance(
@@ -1439,7 +1474,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 fused_attn_backend = FusedAttnBackend["F16_arbitrary_seqlen"]
             if return_max_logit:
                 max_logit_per_step = [
-                    torch.empty(q.shape[-2], dtype=q.dtype, device=q.device) for _ in range(cp_size)
+                    torch.empty(q.shape[-2], dtype=q.dtype, device=q.device) for _ in range(2)
                 ]
 
         # split qkv to two halves and prepare for load balancing
@@ -1547,8 +1582,8 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # set up inputs for forward
         q_inputs = [None, None]
         kv_inputs = [None, None]
-        out_per_step = [None for _ in range(cp_size)]
-        softmax_lse_per_step = [None for _ in range(cp_size)]
+        out_per_step = [None, None]
+        softmax_lse_per_step = [None, None]
         rng_states = [None for _ in range(cp_size)]
         attn_biases = [None for _ in range(cp_size)]
 
@@ -1568,6 +1603,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # f16 attention:    q, k, v: torch.Tensor, dtype=fwd_nominal_dtype
         # fp8 attention:    q, k, v: torch.Tensor, dtype=torch.uint8
         out = None
+        second_half_lse_seqlen = None
         for i in range(cp_size + 1):
             if i < cp_size:
                 with torch.cuda.stream(flash_attn_streams[i % 2]):
@@ -1676,16 +1712,16 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             q_inputs[i % 2] = q_part
                             if use_fused_attention:
                                 (
-                                    out_per_step[i],
-                                    softmax_lse_per_step[i],
+                                    out_per_step[i % 2],
+                                    softmax_lse_per_step[i % 2],
                                     rng_states[i],
                                     attn_biases[i],
-                                    max_logit_per_step[i],
+                                    max_logit_per_step[i % 2],
                                 ) = cp_p2p_fwd_fused_attn(
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                                out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                     cp_p2p_fwd_flash_attn(
                                         *flash_attn_inputs, *prepare_outputs, section
                                     )
@@ -1703,16 +1739,16 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             q_inputs[i % 2] = q_part
                             if use_fused_attention:
                                 (
-                                    out_per_step[i],
-                                    softmax_lse_per_step[i],
+                                    out_per_step[i % 2],
+                                    softmax_lse_per_step[i % 2],
                                     rng_states[i],
                                     attn_biases[i],
-                                    max_logit_per_step[i],
+                                    max_logit_per_step[i % 2],
                                 ) = cp_p2p_fwd_fused_attn(
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                                out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                     cp_p2p_fwd_flash_attn(
                                         *flash_attn_inputs, *prepare_outputs, section
                                     )
@@ -1730,16 +1766,16 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             q_inputs[i % 2] = q_part
                             if use_fused_attention:
                                 (
-                                    out_per_step[i],
-                                    softmax_lse_per_step[i],
+                                    out_per_step[i % 2],
+                                    softmax_lse_per_step[i % 2],
                                     rng_states[i],
                                     attn_biases[i],
-                                    max_logit_per_step[i],
+                                    max_logit_per_step[i % 2],
                                 ) = cp_p2p_fwd_fused_attn(
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                                out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                     cp_p2p_fwd_flash_attn(
                                         *flash_attn_inputs, *prepare_outputs, section
                                     )
@@ -1758,18 +1794,18 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         q_inputs[i % 2] = q_part
                         if use_fused_attention:
                             (
-                                out_per_step[i],
-                                softmax_lse_per_step[i],
+                                out_per_step[i % 2],
+                                softmax_lse_per_step[i % 2],
                                 rng_states[i],
                                 attn_biases[i],
-                                max_logit_per_step[i],
+                                max_logit_per_step[i % 2],
                             ) = cp_p2p_fwd_fused_attn(*fused_attn_inputs, *prepare_outputs, section)
                         else:
-                            out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                            out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                 cp_p2p_fwd_flash_attn(*flash_attn_inputs, *prepare_outputs, section)
                             )
 
-            # softmax_lse correction
+            # Incremental softmax_lse + output correction (online softmax merge)
             if i > 0:
                 # wait until fwd results correction of last step is done
                 if i > 1:
@@ -1779,54 +1815,143 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                     if use_fused_attention:
                         # [b, h, sq, 1] -> [b, h, sq] or
                         # [t, h, 1] -> [t, np]
-                        softmax_lse_per_step[i - 1].squeeze_(-1)
+                        softmax_lse_per_step[(i - 1) % 2].squeeze_(-1)
                         if softmax_lse_in_packed_format:
-                            softmax_lse_per_step[i - 1] = (
-                                softmax_lse_per_step[i - 1].transpose(0, 1).contiguous()
+                            softmax_lse_per_step[(i - 1) % 2] = (
+                                softmax_lse_per_step[(i - 1) % 2].transpose(0, 1).contiguous()
                             )
                     if fp8:
                         # dequantize out_per_step to torch.float32
                         if fp8_recipe.delayed():
-                            out_per_step[i - 1] = out_per_step[i - 1].dequantize(
+                            out_per_step[(i - 1) % 2] = out_per_step[(i - 1) % 2].dequantize(
                                 dtype=torch.float32
                             )
                         if fp8_recipe.float8_current_scaling():
-                            out_per_step[i - 1] = out_per_step[i - 1].to(dtype=torch.float32)
+                            out_per_step[(i - 1) % 2] = out_per_step[(i - 1) % 2].to(
+                                dtype=torch.float32
+                            )
 
                     if i == 1:
                         softmax_lse = torch.clone(softmax_lse_per_step[0])
                         if qkv_format == "thd":
+                            out = out_per_step[0].to(torch.float32)
                             if enable_mla:
-                                out = torch.zeros_like(v if not fp8 else out_per_step[0]).view(
-                                    v_shape
-                                )
+                                out = out.view(v_shape)
                             else:
-                                # MHA or GQA
-                                out = torch.zeros_like(q if not fp8 else out_per_step[0]).view(
-                                    q.shape
-                                )
+                                out = out.view(q.shape)
+                        elif qkv_format in ["bshd", "sbhd"]:
+                            out = out_per_step[0].to(torch.float32)
+                            if enable_mla:
+                                out = out.view(v_shape)
+                            else:
+                                out = out.view(q.shape)
                     elif (i - 1) <= rank or not causal:
+                        old_softmax_lse = softmax_lse.clone()
                         flash_attn_fwd_softmax_lse_correction(
-                            softmax_lse, softmax_lse_per_step[i - 1]
+                            softmax_lse, softmax_lse_per_step[(i - 1) % 2]
                         )
+                        if qkv_format in ["bshd", "sbhd"]:
+                            flash_attn_fwd_incremental_out_correction(
+                                out.view(*out_per_step[(i - 1) % 2].shape),
+                                out_per_step[(i - 1) % 2],
+                                old_softmax_lse,
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                seq_dim,
+                            )
+                        elif qkv_format == "thd":
+                            if softmax_lse_in_packed_format:
+                                # LSE is [h, t], out is [t, h, d]
+                                scale = torch.exp(
+                                    old_softmax_lse - softmax_lse
+                                ).transpose(0, 1).unsqueeze(-1)
+                                out.mul_(scale)
+                            else:
+                                # LSE is [b*h, s_padded] — zero out and reconstruct
+                                # via two thd_out_correction calls
+                                out_backup = out.clone()
+                                out.zero_()
+                                tex.thd_out_correction(
+                                    out,
+                                    out_backup,
+                                    softmax_lse,
+                                    old_softmax_lse,
+                                    cu_seqlens_q_padded,
+                                    False,
+                                    softmax_lse_in_packed_format,
+                                )
+                            tex.thd_out_correction(
+                                out,
+                                out_per_step[(i - 1) % 2],
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                cu_seqlens_q_padded,
+                                False,
+                                softmax_lse_in_packed_format,
+                            )
                     else:
+                        old_softmax_lse = softmax_lse.clone()
                         if qkv_format == "thd":
                             tex.thd_second_half_lse_correction(
                                 softmax_lse,
-                                softmax_lse_per_step[i - 1],
+                                softmax_lse_per_step[(i - 1) % 2],
                                 cu_seqlens_q_padded,
+                                softmax_lse_in_packed_format,
+                            )
+                            # Rescale out for affected (second-half) tokens;
+                            # first-half tokens have old==new so scale=1.0
+                            if softmax_lse_in_packed_format:
+                                scale = torch.exp(
+                                    old_softmax_lse - softmax_lse
+                                ).transpose(0, 1).unsqueeze(-1)
+                                out.mul_(scale)
+                            else:
+                                # Zero out and reconstruct; use only_second_half=False
+                                # because first-half has old==new so scale=1.0
+                                out_backup = out.clone()
+                                out.zero_()
+                                tex.thd_out_correction(
+                                    out,
+                                    out_backup,
+                                    softmax_lse,
+                                    old_softmax_lse,
+                                    cu_seqlens_q_padded,
+                                    False,
+                                    softmax_lse_in_packed_format,
+                                )
+                            tex.thd_out_correction(
+                                out,
+                                out_per_step[(i - 1) % 2],
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                cu_seqlens_q_padded,
+                                True,
                                 softmax_lse_in_packed_format,
                             )
                         else:
                             flash_attn_fwd_second_half_softmax_lse_correction(
                                 softmax_lse.view(*softmax_lse.shape[:-1], 2, -1),
-                                softmax_lse_per_step[i - 1],
+                                softmax_lse_per_step[(i - 1) % 2],
+                            )
+                            flash_attn_fwd_incremental_second_half_out_correction(
+                                out,
+                                out_per_step[(i - 1) % 2],
+                                old_softmax_lse,
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                seq_dim,
                             )
                     if return_max_logit:
                         if i == 1:
                             max_logit = torch.clone(max_logit_per_step[0])
                         else:
-                            max_logit = torch.maximum(max_logit, max_logit_per_step[i - 1])
+                            max_logit = torch.maximum(max_logit, max_logit_per_step[(i - 1) % 2])
+
+                    # Capture second_half_lse_seqlen from the last step's LSE
+                    if i == cp_size and causal and rank < (cp_size - 1):
+                        second_half_lse_seqlen = (
+                            softmax_lse_per_step[(cp_size - 1) % 2].shape[-1]
+                        )
 
                 if i < cp_size:
                     flash_attn_streams[(i - 1) % 2].record_event(fwd_results_correction_done)
@@ -1836,63 +1961,6 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
             torch.distributed.all_reduce(
                 max_logit, op=torch.distributed.ReduceOp.MAX, group=cp_group
             )
-
-        second_half_lse_seqlen = None
-        if causal and rank < (cp_size - 1):
-            second_half_lse_seqlen = softmax_lse_per_step[-1].shape[-1]
-
-        # fwd output correction: out in torch.float32
-        for i in range(cp_size):
-            if i <= rank or not causal:
-                if qkv_format in ["bshd", "sbhd"]:
-                    if i == 0:
-                        out = flash_attn_fwd_out_correction_init(
-                            out_per_step[0],
-                            softmax_lse,
-                            softmax_lse_per_step[0],
-                            seq_dim,
-                        )
-                        if enable_mla:
-                            out = out.view(v_shape)
-                        else:
-                            out = out.view(q.shape)
-                    else:
-                        flash_attn_fwd_out_correction(
-                            out.view(*out_per_step[i].shape),
-                            out_per_step[i],
-                            softmax_lse,
-                            softmax_lse_per_step[i],
-                            seq_dim,
-                        )
-                elif qkv_format == "thd":
-                    tex.thd_out_correction(
-                        out,
-                        out_per_step[i],
-                        softmax_lse,
-                        softmax_lse_per_step[i],
-                        cu_seqlens_q_padded,
-                        False,
-                        softmax_lse_in_packed_format,
-                    )
-            else:
-                if qkv_format in ["bshd", "sbhd"]:
-                    flash_attn_fwd_second_half_out_correction(
-                        out,
-                        out_per_step[i],
-                        softmax_lse,
-                        softmax_lse_per_step[i],
-                        seq_dim,
-                    )
-                elif qkv_format == "thd":
-                    tex.thd_out_correction(
-                        out,
-                        out_per_step[i],
-                        softmax_lse,
-                        softmax_lse_per_step[i],
-                        cu_seqlens_q_padded,
-                        True,
-                        softmax_lse_in_packed_format,
-                    )
 
         if qkv_format == "bshd":
             out = out.view(out.shape[0], -1, *out.shape[-2:])

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -1557,7 +1557,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # synchronize fwd results correction across steps
         fwd_results_correction_done = torch.cuda.Event()
 
-        p2p_comm_buffers = [None for _ in range(cp_size)]
+        p2p_comm_buffers = [None, None]
         k_shape = k.shape
         k_numel = k.numel()
         v_shape = v.shape
@@ -1576,18 +1576,20 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         req.wait()
 
                     if i < (cp_size - 1):
-                        p2p_comm_buffers[i + 1] = torch.empty_like(p2p_comm_buffers[i])
+                        p2p_comm_buffers[(i + 1) % 2] = torch.empty_like(
+                            p2p_comm_buffers[i % 2]
+                        )
                         send_recv_reqs[i % 2] = flash_attn_p2p_communicate(
                             rank,
-                            p2p_comm_buffers[i],
+                            p2p_comm_buffers[i % 2],
                             send_dst,
-                            p2p_comm_buffers[i + 1],
+                            p2p_comm_buffers[(i + 1) % 2],
                             recv_src,
                             cp_group,
                             batch_p2p_comm,
                         )
 
-                    kv_inputs[i % 2] = p2p_comm_buffers[i]
+                    kv_inputs[i % 2] = p2p_comm_buffers[i % 2]
                     k_part = kv_inputs[i % 2][:k_numel].view(*k_shape)
                     v_part = kv_inputs[i % 2][k_numel:].view(*v_shape)
                     q_part = q
@@ -1952,7 +1954,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         ctx.fp8 = fp8 and is_bwd_fp8
 
         kv_fp8 = None
-        kv = p2p_comm_buffers[-1]
+        kv = p2p_comm_buffers[(cp_size - 1) % 2]
         if fp8:
             q_fp8, kv_fp8 = [
                 Float8Tensor.make_like(x, data=y, dtype=fwd_nominal_dtype)

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -1834,7 +1834,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                     if i == 1:
                         softmax_lse = torch.clone(softmax_lse_per_step[0])
                         if qkv_format == "thd":
-                            out = out_per_step[0].to(torch.float32)
+                            out = out_per_step[0].clone()
                             if enable_mla:
                                 out = out.view(v_shape)
                             else:

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -1921,10 +1921,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # synchronize fwd results correction across steps
         fwd_results_correction_done = torch.cuda.Event()
 
-        # q, k, v, o:
-        # causal: [b, 2, s//2, h, d] or [2, s//2, b, h, d]
-        # non-causal: [b, s, h, d] or [s, b, h, d]
-        p2p_comm_buffers = [None for _ in range(cp_size)]
+        p2p_comm_buffers = [None, None]
         k_shape = k.shape
         k_numel = k.numel()
         v_shape = v.shape
@@ -1945,18 +1942,20 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         req.wait()
 
                     if i < (cp_size - 1):
-                        p2p_comm_buffers[i + 1] = torch.empty_like(p2p_comm_buffers[i])
+                        p2p_comm_buffers[(i + 1) % 2] = torch.empty_like(
+                            p2p_comm_buffers[i % 2]
+                        )
                         send_recv_reqs[i % 2] = flash_attn_p2p_communicate(
                             rank,
-                            p2p_comm_buffers[i],
+                            p2p_comm_buffers[i % 2],
                             send_dst,
-                            p2p_comm_buffers[i + 1],
+                            p2p_comm_buffers[(i + 1) % 2],
                             recv_src,
                             cp_group,
                             batch_p2p_comm,
                         )
 
-                    kv_inputs[i % 2] = p2p_comm_buffers[i]
+                    kv_inputs[i % 2] = p2p_comm_buffers[i % 2]
                     k_part = kv_inputs[i % 2][:k_numel].view(*k_shape)
                     v_part = kv_inputs[i % 2][k_numel:].view(*v_shape)
                     q_part = q
@@ -2327,7 +2326,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         ctx.fp8 = is_bwd_fp8
 
         kv_fp8 = None
-        kv = p2p_comm_buffers[-1]
+        kv = p2p_comm_buffers[(cp_size - 1) % 2]
         if fp8 and not fp8_recipe.mxfp8():
             q_fp8, kv_fp8 = [
                 Float8Tensor.make_like(x, data=y, dtype=fwd_nominal_dtype)

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -223,6 +223,41 @@ def flash_attn_fwd_second_half_softmax_lse_correction(
 
 
 @jit_fuser
+def flash_attn_fwd_incremental_out_correction(
+    out: torch.Tensor,
+    out_per_step: torch.Tensor,
+    old_softmax_lse: torch.Tensor,
+    new_softmax_lse: torch.Tensor,
+    softmax_lse_per_step: torch.Tensor,
+    seq_dim: int,
+):
+    """Online softmax merge: rescale accumulated output and add new step's contribution."""
+    scale_old = torch.exp(old_softmax_lse - new_softmax_lse).movedim(2, seq_dim).unsqueeze(-1)
+    scale_new = torch.exp(softmax_lse_per_step - new_softmax_lse).movedim(2, seq_dim).unsqueeze(-1)
+    out.mul_(scale_old)
+    out.addcmul_(out_per_step, scale_new)
+
+
+@jit_fuser
+def flash_attn_fwd_incremental_second_half_out_correction(
+    out: torch.Tensor,
+    out_per_step: torch.Tensor,
+    old_softmax_lse: torch.Tensor,
+    new_softmax_lse: torch.Tensor,
+    softmax_lse_per_step: torch.Tensor,
+    seq_dim: int,
+):
+    """Online softmax merge for second-half tokens only (causal upper-triangle steps)."""
+    out_ = out.select(seq_dim, 1)
+    old_lse_ = old_softmax_lse.view(*old_softmax_lse.shape[:-1], 2, -1)[..., 1, :]
+    new_lse_ = new_softmax_lse.view(*new_softmax_lse.shape[:-1], 2, -1)[..., 1, :]
+    scale_old = torch.exp(old_lse_ - new_lse_).movedim(2, seq_dim).unsqueeze(-1)
+    scale_new = torch.exp(softmax_lse_per_step - new_lse_).movedim(2, seq_dim).unsqueeze(-1)
+    out_.mul_(scale_old)
+    out_.addcmul_(out_per_step, scale_new)
+
+
+@jit_fuser
 def get_cu_seqlens_on_cp_rank(
     cu_seqlens: torch.Tensor,
     cu_seqlens_padded_on_cp_rank: torch.Tensor,
@@ -1684,7 +1719,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         amax_per_step = None
         S_quantizer_per_step = [None for _ in range(cp_size)]
         O_quantizer_per_step = [None for _ in range(cp_size)]
-        max_logit_per_step = [None for _ in range(cp_size)]
+        max_logit_per_step = [None, None]
         max_logit = None
 
         assert isinstance(k, q.__class__) and isinstance(
@@ -1793,7 +1828,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 fused_attn_backend = FusedAttnBackend["F16_arbitrary_seqlen"]
             if return_max_logit:
                 max_logit_per_step = [
-                    torch.empty(q.shape[-2], dtype=q.dtype, device=q.device) for _ in range(cp_size)
+                    torch.empty(q.shape[-2], dtype=q.dtype, device=q.device) for _ in range(2)
                 ]
 
         # split qkv to two halves and prepare for load balancing
@@ -1911,8 +1946,8 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # set up inputs for forward
         q_inputs = [None, None]
         kv_inputs = [None, None]
-        out_per_step = [None for _ in range(cp_size)]
-        softmax_lse_per_step = [None for _ in range(cp_size)]
+        out_per_step = [None, None]
+        softmax_lse_per_step = [None, None]
         rng_states = [None for _ in range(cp_size)]
         attn_biases = [None for _ in range(cp_size)]
 
@@ -1933,7 +1968,10 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # MXFP8/F16 attention:    q, k, v: torch.Tensor, dtype=fwd_nominal_dtype
         # FP8DS/CS attention:     q, k, v: torch.Tensor, dtype=torch.uint8
         out = None
+        # Current fused/A2A plumbing still consumes this original format; the
+        # online merge only changes the lifetime of per-step outputs.
         o_format = qkv_format
+        second_half_lse_seqlen = None
         for i in range(cp_size + 1):
             if i < cp_size:
                 with torch.cuda.stream(flash_attn_streams[i % 2]):
@@ -1942,9 +1980,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         req.wait()
 
                     if i < (cp_size - 1):
-                        p2p_comm_buffers[(i + 1) % 2] = torch.empty_like(
-                            p2p_comm_buffers[i % 2]
-                        )
+                        p2p_comm_buffers[(i + 1) % 2] = torch.empty_like(p2p_comm_buffers[i % 2])
                         send_recv_reqs[i % 2] = flash_attn_p2p_communicate(
                             rank,
                             p2p_comm_buffers[i % 2],
@@ -2049,16 +2085,16 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             q_inputs[i % 2] = q_part
                             if use_fused_attention:
                                 (
-                                    out_per_step[i],
-                                    softmax_lse_per_step[i],
+                                    out_per_step[i % 2],
+                                    softmax_lse_per_step[i % 2],
                                     rng_states[i],
                                     attn_biases[i],
-                                    max_logit_per_step[i],
+                                    max_logit_per_step[i % 2],
                                 ) = cp_p2p_fwd_fused_attn(
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                                out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                     cp_p2p_fwd_flash_attn(
                                         *flash_attn_inputs,
                                         *prepare_outputs,
@@ -2078,16 +2114,16 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             q_inputs[i % 2] = q_part
                             if use_fused_attention:
                                 (
-                                    out_per_step[i],
-                                    softmax_lse_per_step[i],
+                                    out_per_step[i % 2],
+                                    softmax_lse_per_step[i % 2],
                                     rng_states[i],
                                     attn_biases[i],
-                                    max_logit_per_step[i],
+                                    max_logit_per_step[i % 2],
                                 ) = cp_p2p_fwd_fused_attn(
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                                out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                     cp_p2p_fwd_flash_attn(
                                         *flash_attn_inputs,
                                         *prepare_outputs,
@@ -2107,16 +2143,16 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             q_inputs[i % 2] = q_part
                             if use_fused_attention:
                                 (
-                                    out_per_step[i],
-                                    softmax_lse_per_step[i],
+                                    out_per_step[i % 2],
+                                    softmax_lse_per_step[i % 2],
                                     rng_states[i],
                                     attn_biases[i],
-                                    max_logit_per_step[i],
+                                    max_logit_per_step[i % 2],
                                 ) = cp_p2p_fwd_fused_attn(
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                                out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                     cp_p2p_fwd_flash_attn(
                                         *flash_attn_inputs,
                                         *prepare_outputs,
@@ -2137,14 +2173,14 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         q_inputs[i % 2] = q_part
                         if use_fused_attention:
                             (
-                                out_per_step[i],
-                                softmax_lse_per_step[i],
+                                out_per_step[i % 2],
+                                softmax_lse_per_step[i % 2],
                                 rng_states[i],
                                 attn_biases[i],
-                                max_logit_per_step[i],
+                                max_logit_per_step[i % 2],
                             ) = cp_p2p_fwd_fused_attn(*fused_attn_inputs, *prepare_outputs, section)
                         else:
-                            out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
+                            out_per_step[i % 2], softmax_lse_per_step[i % 2], rng_states[i] = (
                                 cp_p2p_fwd_flash_attn(
                                     *flash_attn_inputs,
                                     *prepare_outputs,
@@ -2152,7 +2188,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                                 )
                             )
 
-            # softmax_lse correction
+            # Incremental softmax_lse + output correction (online softmax merge)
             if i > 0:
                 # wait until fwd results correction of last step is done
                 if i > 1:
@@ -2160,51 +2196,98 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
 
                 with torch.cuda.stream(flash_attn_streams[(i - 1) % 2]):
                     if use_fused_attention:
-                        # [b, h, sq, 1] -> [b, h, sq]
-                        # [t, h, 1] -> [t, h]
-                        softmax_lse_per_step[i - 1].squeeze_(-1)
+                        # [b, h, sq, 1] -> [b, h, sq] or [t, h, 1] -> [t, np]
+                        softmax_lse_per_step[(i - 1) % 2].squeeze_(-1)
                         if softmax_lse_in_packed_format:
-                            softmax_lse_per_step[i - 1] = (
-                                softmax_lse_per_step[i - 1].transpose(0, 1).contiguous()
+                            softmax_lse_per_step[(i - 1) % 2] = (
+                                softmax_lse_per_step[(i - 1) % 2].transpose(0, 1).contiguous()
                             )
                     if fp8:
                         # dequantize out_per_step to torch.float32
                         if fp8_recipe.delayed():
-                            out_per_step[i - 1] = out_per_step[i - 1].dequantize(
+                            out_per_step[(i - 1) % 2] = out_per_step[(i - 1) % 2].dequantize(
                                 dtype=torch.float32
                             )
                         if fp8_recipe.float8_current_scaling() or fp8_recipe.mxfp8():
-                            out_per_step[i - 1] = out_per_step[i - 1].to(dtype=torch.float32)
+                            out_per_step[(i - 1) % 2] = out_per_step[(i - 1) % 2].to(
+                                dtype=torch.float32
+                            )
 
                     if i == 1:
                         softmax_lse = torch.clone(softmax_lse_per_step[0])
                         if qkv_format == "thd":
-                            if fp8:
-                                out = torch.zeros_like(out_per_step[0]).view(o_shape)
-                            else:
-                                out = torch.zeros(o_shape, dtype=q.dtype, device=q.device)
+                            # Keep THD in the kernel's input dtype; thd_out_correction
+                            # performs its own promotion and requires matching dtypes.
+                            out = out_per_step[0].clone().view(o_shape)
+                        elif qkv_format in ["bshd", "sbhd"]:
+                            out = out_per_step[0].to(torch.float32)
+                            out = out.view(o_shape)
                     elif (i - 1) <= rank or not causal:
+                        old_softmax_lse = softmax_lse.clone()
                         flash_attn_fwd_softmax_lse_correction(
-                            softmax_lse, softmax_lse_per_step[i - 1]
+                            softmax_lse, softmax_lse_per_step[(i - 1) % 2]
                         )
+                        if qkv_format in ["bshd", "sbhd"]:
+                            flash_attn_fwd_incremental_out_correction(
+                                out.view(*out_per_step[(i - 1) % 2].shape),
+                                out_per_step[(i - 1) % 2],
+                                old_softmax_lse,
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                seq_dim,
+                            )
+                        elif qkv_format == "thd":
+                            tex.thd_out_correction(
+                                out,
+                                out_per_step[(i - 1) % 2],
+                                old_softmax_lse,
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                cu_seqlens_q_padded,
+                                False,
+                                softmax_lse_in_packed_format,
+                            )
                     else:
+                        old_softmax_lse = softmax_lse.clone()
                         if qkv_format == "thd":
                             tex.thd_second_half_lse_correction(
                                 softmax_lse,
-                                softmax_lse_per_step[i - 1],
+                                softmax_lse_per_step[(i - 1) % 2],
                                 cu_seqlens_q_padded,
+                                softmax_lse_in_packed_format,
+                            )
+                            tex.thd_out_correction(
+                                out,
+                                out_per_step[(i - 1) % 2],
+                                old_softmax_lse,
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                cu_seqlens_q_padded,
+                                True,
                                 softmax_lse_in_packed_format,
                             )
                         else:
                             flash_attn_fwd_second_half_softmax_lse_correction(
                                 softmax_lse.view(*softmax_lse.shape[:-1], 2, -1),
-                                softmax_lse_per_step[i - 1],
+                                softmax_lse_per_step[(i - 1) % 2],
+                            )
+                            flash_attn_fwd_incremental_second_half_out_correction(
+                                out,
+                                out_per_step[(i - 1) % 2],
+                                old_softmax_lse,
+                                softmax_lse,
+                                softmax_lse_per_step[(i - 1) % 2],
+                                seq_dim,
                             )
                     if return_max_logit:
                         if i == 1:
                             max_logit = torch.clone(max_logit_per_step[0])
                         else:
-                            max_logit = torch.maximum(max_logit, max_logit_per_step[i - 1])
+                            max_logit = torch.maximum(max_logit, max_logit_per_step[(i - 1) % 2])
+
+                    # Capture second_half_lse_seqlen from the last step's LSE
+                    if i == cp_size and causal and rank < (cp_size - 1):
+                        second_half_lse_seqlen = softmax_lse_per_step[(cp_size - 1) % 2].shape[-1]
 
                 if i < cp_size:
                     flash_attn_streams[(i - 1) % 2].record_event(fwd_results_correction_done)
@@ -2215,59 +2298,14 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 max_logit, op=torch.distributed.ReduceOp.MAX, group=cp_group
             )
 
-        second_half_lse_seqlen = None
-        if causal and rank < (cp_size - 1):
-            second_half_lse_seqlen = softmax_lse_per_step[-1].shape[-1]
-
-        # fwd output correction: out in torch.float32
-        for i in range(cp_size):
-            if i <= rank or not causal:
-                if o_format in ["bshd", "sbhd"]:
-                    if i == 0:
-                        out = flash_attn_fwd_out_correction_init(
-                            out_per_step[0],
-                            softmax_lse,
-                            softmax_lse_per_step[0],
-                            seq_dim,
-                        )
-                        out = out.view(o_shape)
-                    else:
-                        flash_attn_fwd_out_correction(
-                            out.view(*out_per_step[i].shape),
-                            out_per_step[i],
-                            softmax_lse,
-                            softmax_lse_per_step[i],
-                            seq_dim,
-                        )
-                elif o_format == "thd":
-                    tex.thd_out_correction(
-                        out,
-                        out_per_step[i],
-                        softmax_lse,
-                        softmax_lse_per_step[i],
-                        cu_seqlens_q_padded,
-                        False,
-                        softmax_lse_in_packed_format,
-                    )
-            else:
-                if o_format in ["bshd", "sbhd"]:
-                    flash_attn_fwd_second_half_out_correction(
-                        out,
-                        out_per_step[i],
-                        softmax_lse,
-                        softmax_lse_per_step[i],
-                        seq_dim,
-                    )
-                elif o_format == "thd":
-                    tex.thd_out_correction(
-                        out,
-                        out_per_step[i],
-                        softmax_lse,
-                        softmax_lse_per_step[i],
-                        cu_seqlens_q_padded,
-                        True,
-                        softmax_lse_in_packed_format,
-                    )
+        if qkv_format == "bshd":
+            out = out.view(out.shape[0], -1, *out.shape[-2:])
+            ctx.batch_size = out.shape[0]
+        elif qkv_format == "sbhd":
+            out = out.view(-1, *out.shape[-3:])
+            ctx.batch_size = out.shape[1]
+        # The backward context needs the rank-local output before any A2A
+        # restoration, matching the pre-existing post-loop correction path.
         out = out.view(post_a2a_o_shape)
         out_part = out.to(fwd_nominal_dtype)
 

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -619,9 +619,9 @@ void thd_second_half_lse_correction(at::Tensor lse, const at::Tensor &lse_per_st
 at::Tensor thd_read_second_half_lse(const at::Tensor &lse, const at::Tensor &cu_seqlens,
                                     bool lse_packed, int second_half_lse_seqlen);
 
-void thd_out_correction(at::Tensor out, const at::Tensor &out_per_step, const at::Tensor &lse,
-                        const at::Tensor &lse_per_step, const at::Tensor &cu_seqlens,
-                        bool only_second_half, bool lse_packed);
+void thd_out_correction(at::Tensor out, const at::Tensor &out_per_step, const at::Tensor &old_lse,
+                        const at::Tensor &lse, const at::Tensor &lse_per_step,
+                        const at::Tensor &cu_seqlens, bool only_second_half, bool lse_packed);
 
 void thd_grad_correction(at::Tensor grad, const at::Tensor &grad_per_step,
                          const at::Tensor &cu_seqlens, const std::string &first_half,

--- a/transformer_engine/pytorch/csrc/extensions/attention.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/attention.cpp
@@ -883,17 +883,18 @@ at::Tensor thd_read_second_half_lse(const at::Tensor &lse, const at::Tensor &cu_
  * Support THD format for Context Parallel: Out correction in forward
  **************************************************************************************************/
 
-void thd_out_correction(at::Tensor out, const at::Tensor &out_per_step, const at::Tensor &lse,
-                        const at::Tensor &lse_per_step, const at::Tensor &cu_seqlens,
-                        bool only_second_half, bool lse_packed) {
+void thd_out_correction(at::Tensor out, const at::Tensor &out_per_step, const at::Tensor &old_lse,
+                        const at::Tensor &lse, const at::Tensor &lse_per_step,
+                        const at::Tensor &cu_seqlens, bool only_second_half, bool lse_packed) {
   auto te_out = makeTransformerEngineTensor(out);
   auto te_out_per_step = makeTransformerEngineTensor(out_per_step);
+  auto te_old_lse = makeTransformerEngineTensor(old_lse);
   auto te_lse = makeTransformerEngineTensor(lse);
   auto te_lse_per_step = makeTransformerEngineTensor(lse_per_step);
   auto te_cu_seqlens = makeTransformerEngineTensor(cu_seqlens);
-  nvte_cp_thd_out_correction(te_out.data(), te_out_per_step.data(), te_lse.data(),
-                             te_lse_per_step.data(), te_cu_seqlens.data(), only_second_half,
-                             lse_packed, at::cuda::getCurrentCUDAStream());
+  nvte_cp_thd_out_correction(te_out.data(), te_out_per_step.data(), te_old_lse.data(),
+                             te_lse.data(), te_lse_per_step.data(), te_cu_seqlens.data(),
+                             only_second_half, lse_packed, at::cuda::getCurrentCUDAStream());
 }
 
 /***************************************************************************************************


### PR DESCRIPTION
## Summary

Reduce P2P attention forward temporary storage from O(CP) to O(1) with two independent optimizations:

1. **KV storage:** rotate two communication buffers instead of retaining one per CP step, saving 1.50 GiB per GPU for the profiled CP8 workloads.
2. **Output/LSE storage:** rotate two partial-result slots instead of retaining every step's output and LSE, saving another 1.52-3.05 GiB per GPU depending on causal rank.

The second optimization requires an online merge because each partial result must be consumed before its slot is reused. When a new step changes the combined LSE, the existing accumulator is renormalized and the new partial output is added. The THD correction kernel performs both operations in one traversal.

Together, the two optimizations reduce retained tensor payload by 3.02-4.55 GiB per GPU for these CP8 workloads.

`rng_states` and `attn_biases` remain CP-sized because backward requires them. The existing output format is preserved for downstream fused and all-to-all paths.

## Type of change

- [x] Breaking change (the experimental `nvte_cp_thd_out_correction` C API gains an `old_lse` argument)

## Performance

H100, CP8, BF16 THD, causal P2P FusedAttention, eager execution. End-to-end values are synchronized means from five paired runs on the same node.

| Fixed-token workload | Pre-PR | Final online merge | Change |
|---|---:|---:|---:|
| 16 x 32K | 152.476 ms | 152.360 ms | -0.08% |
| 64 x 8K | 70.593 ms | 70.677 ms | +0.12% |
| 256 x 2K | 57.992 ms | 57.670 ms | -0.55% |

The online merge is effectively performance-neutral end to end. Its direct correction cost returns to the pre-PR level while retaining bounded storage:

| Fixed-token workload | Pre-PR correction | Separate rescale | Fused correction |
|---|---:|---:|---:|
| 16 x 32K | 3.73 ms | 13.73 ms | 3.81 ms |
| 64 x 8K | 3.72 ms | 13.36 ms | 3.72 ms |
| 256 x 2K | 3.75 ms | 13.60 ms | 3.62 ms |
| Launches per iteration | 8 | 28 | 7 |

Correction values are cross-rank means of GPU kernel durations over the final five of seven iterations. The separate-rescale and fused variants were profiled together; the pre-PR values are a prior-profile reference.

## Memory

The fused correction keeps the same two-buffer/two-slot storage model and removes the separate rescale temporary. Rank-max allocator measurements for `B=2`, `S=262144`, `H=16`, `G=16`, and `D=128`:

| CP | Forward peak before | Bounded forward peak | Forward saving | E2E peak before | Bounded E2E peak | E2E saving |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 8752 MiB | 7704 MiB | 1048 MiB (12.0%) | 10268 MiB | 10268 MiB | 0 MiB |
| 8 | 7464 MiB | 3860 MiB | 3604 MiB (48.3%) | 7464 MiB | 5134 MiB | 2330 MiB (31.2%) |

## Numerics

BSHD/SBHD accumulation remains in the partial-output dtype (BF16/FP16 for non-FP8; FP8 partial outputs are dequantized to FP32). THD also retains the partial-output dtype; its fused correction computes each merge in FP32 and writes the result back to that dtype. The online merge changes operation ordering relative to post-loop correction, and the CP4/CP8 forward/backward comparisons remain within the existing test tolerances.

## Validation

- CP4 and CP8 BF16 THD causal P2P FusedAttention forward/backward correctness passed on all ranks, including output, dQ, dK, and dV comparisons.
- Independent allocator runs reproduced the CP4 and CP8 memory results.
- Python syntax validation and `git diff --check` pass.
- [CI checks](https://github.com/NVIDIA/TransformerEngine/pull/2916/checks) will run on the updated branch.