### PR TITLE
guard fuser grad checks on non-leaf nodes

### DIFF
--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -509,14 +509,14 @@ class OperationFuser:
         # Fuser forward pass
         # When is_grad_enabled is False, we call forward directly.
         # This does not register a PyTorch autograd node, so
-        # no fuser backward will run. We pass set_output_requires_grad=False 
+        # no fuser backward will run. We pass set_output_requires_grad=False
         # to avoid setting requires_grad on outputs in
         # this path since they may be non-leaf tensors from the inner ops.
         args = (
             input,
             self,
             basic_op_kwargs,
-            is_grad_enabled, # set_output_requires_grad
+            is_grad_enabled,  # set_output_requires_grad
             *self._flat_basic_op_params,
             *extra_inputs,
         )

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -65,6 +65,7 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
         input_: torch.Tensor,
         fuser: OperationFuser,
         basic_op_kwargs: list[dict[str, Any]],
+        set_output_requires_grad: bool,
         *params_and_extra_inputs: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
         """Forward pass
@@ -79,6 +80,8 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
             Container for the pipeline of operations to run
         basic_op_kwargs: list of dict
             Keyword arguments to BasicOperation
+        set_output_requires_grad: bool
+            Whether to set ``requires_grad`` flags on returned tensors
         *params_and_extra_inputs: torch.Tensor
             Other tensor inputs to include in autograd graph. Consists
             of parameter tensors, followed by extra operation inputs.
@@ -138,7 +141,7 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
             )
             for idx, ys in zip(basic_op_idxs, fused_op_extra_outputs):
                 for y in ys:
-                    if func_ctx is not None:
+                    if set_output_requires_grad:
                         y.requires_grad_(idx >= fuser.first_op_requiring_backward)
                 extra_outputs[idx] = ys
 
@@ -191,7 +194,7 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
         for tensor in [x] + extra_outputs_flat:
             tensor._do_not_clear = True
 
-        if func_ctx is not None:
+        if set_output_requires_grad:
             x.requires_grad_(fuser.first_op_requiring_backward < fuser._num_basic_ops)
 
         if extra_outputs_flat:
@@ -295,6 +298,7 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
             dx,  # input_
             None,  # fuser
             None,  # basic_op_kwargs
+            None,  # set_output_requires_grad
             *grad_params_flat,
             *grad_extra_inputs_flat,
         )
@@ -503,20 +507,19 @@ class OperationFuser:
             op.pre_fuser_forward(requires_grad=idx >= self.first_op_requiring_backward)
 
         # Fuser forward pass
-        if is_grad_enabled:
-            forward_func = _OperationFuserAutogradFunction.apply
-            args = []
-        else:
-            forward_func = _OperationFuserAutogradFunction.forward
-            args = [None]
-        args += (
+        args = (
             input,
             self,
             basic_op_kwargs,
+            is_grad_enabled,
             *self._flat_basic_op_params,
             *extra_inputs,
         )
-        return forward_func(*args)
+
+        if is_grad_enabled:
+            return _OperationFuserAutogradFunction.apply(*args)
+
+        return _OperationFuserAutogradFunction.forward(None, *args)
 
 
 def register_forward_fusion(

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -509,14 +509,14 @@ class OperationFuser:
         # Fuser forward pass
         # When is_grad_enabled is False, we call forward directly.
         # This does not register a PyTorch autograd node, so
-        # no fuser backward will run. We pass set_output_requires_grad=False
+        # no fuser backward will run. We pass set_output_requires_grad=False 
         # to avoid setting requires_grad on outputs in
         # this path since they may be non-leaf tensors from the inner ops.
         args = (
             input,
             self,
             basic_op_kwargs,
-            is_grad_enabled,
+            is_grad_enabled, # set_output_requires_grad
             *self._flat_basic_op_params,
             *extra_inputs,
         )

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -507,19 +507,24 @@ class OperationFuser:
             op.pre_fuser_forward(requires_grad=idx >= self.first_op_requiring_backward)
 
         # Fuser forward pass
+        # When is_grad_enabled is False, we call forward directly.
+        # This does not register a PyTorch autograd node, so
+        # no fuser backward will run. We pass set_output_requires_grad=False 
+        # to avoid setting requires_grad on outputs in
+        # this path since they may be non-leaf tensors from the inner ops.
         args = (
             input,
             self,
             basic_op_kwargs,
-            is_grad_enabled,
+            is_grad_enabled, # set_output_requires_grad
             *self._flat_basic_op_params,
             *extra_inputs,
         )
 
-        if is_grad_enabled:
-            return _OperationFuserAutogradFunction.apply(*args)
+        if not is_grad_enabled:
+            return _OperationFuserAutogradFunction.forward(None, *args)
 
-        return _OperationFuserAutogradFunction.forward(None, *args)
+        return _OperationFuserAutogradFunction.apply(*args)
 
 
 def register_forward_fusion(

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -516,7 +516,7 @@ class OperationFuser:
             input,
             self,
             basic_op_kwargs,
-            is_grad_enabled,  # set_output_requires_grad
+            is_grad_enabled,
             *self._flat_basic_op_params,
             *extra_inputs,
         )

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -138,7 +138,8 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
             )
             for idx, ys in zip(basic_op_idxs, fused_op_extra_outputs):
                 for y in ys:
-                    y.requires_grad_(idx >= fuser.first_op_requiring_backward)
+                    if func_ctx is not None:
+                        y.requires_grad_(idx >= fuser.first_op_requiring_backward)
                 extra_outputs[idx] = ys
 
         # Flatten list of extra outputs
@@ -190,7 +191,8 @@ class _OperationFuserAutogradFunction(torch.autograd.Function):
         for tensor in [x] + extra_outputs_flat:
             tensor._do_not_clear = True
 
-        x.requires_grad_(fuser.first_op_requiring_backward < fuser._num_basic_ops)
+        if func_ctx is not None:
+            x.requires_grad_(fuser.first_op_requiring_backward < fuser._num_basic_ops)
 
         if extra_outputs_flat:
             return x, *extra_outputs_flat

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -507,11 +507,9 @@ class OperationFuser:
             op.pre_fuser_forward(requires_grad=idx >= self.first_op_requiring_backward)
 
         # Fuser forward pass
-        # When is_grad_enabled is False, we call forward directly.
-        # This does not register a PyTorch autograd node, so
-        # no fuser backward will run. We pass set_output_requires_grad=False
-        # to avoid setting requires_grad on outputs in
-        # this path since they may be non-leaf tensors from the inner ops.
+        # Note: We call forward directly when is_grad_enabled=False,
+        # which can expose non-leaf tensors to the inner ops. Avoid
+        # problems in this case by passing set_output_requires_grad=False.
         args = (
             input,
             self,


### PR DESCRIPTION
# Description

Pass an explicit flag that controls whether the fuser forward pass sets requires_grad on outputs. This is required so that in no_grad mode we dont try to mutate this information on non-leaf nodes (which is not allowed by torch)

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
