### PR TITLE
Remove uncessary ctype being passed to GroupedGEMMQuant kernel

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -4658,7 +4658,6 @@ def test_grouped_gemm_quant_cute_matches_mxfp8_quantized() -> None:
         norm_const_tensor=None,
         prob_tensor=inputs["prob_tensor"],
         acc_dtype=torch.float32,
-        c_dtype=torch.bfloat16,
         d_dtype=torch.bfloat16,
         cd_major="n",
         sf_vec_size=32,

--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -687,7 +687,6 @@ class BackwardGroupedMLP_CuTeGEMMDSwiGLU_MXFP8(FusedOperation):
                 "norm_const_tensor": None,
                 "prob_tensor": torch.ones((out_shape[0], 1, 1), dtype=torch.float32, device=device),
                 "acc_dtype": torch.float32,
-                "c_dtype": dtype,
                 "d_dtype": dtype,
                 "cd_major": "n",
                 "sf_vec_size": MXFP8_BLOCK_SCALING_SIZE,

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -436,7 +436,6 @@ class ForwardGroupedMLP_CuTeGEMMSwiGLU_MXFP8(FusedOperation):
             "norm_const_tensor": None,
             "prob_tensor": fc2_scales_tensor,
             "acc_dtype": torch.float32,
-            "c_dtype": dtype,
             "d_dtype": dtype,
             "cd_major": "n",
             "sf_vec_size": MXFP8_BLOCK_SCALING_SIZE,


### PR DESCRIPTION
# Description
We dont depend on the intermediate C that can be potentially outputted by the grouped_gemm_quant kernel for Fused MOE blocks. 

For future:
Removing this c_type would eliminate unecessary intermediate high precision C tensor being outputted from the cudnn kernel. Although to see any real memory benefit we would need to move to newer cudnn release.

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
