### PR TITLE
[Common] Fix "0" literal for compilation

### DIFF
--- a/transformer_engine/common/fused_attn/flash_attn.cu
+++ b/transformer_engine/common/fused_attn/flash_attn.cu
@@ -311,7 +311,7 @@ __device__ __forceinline__ void permute_vec_loop(const T *__restrict__ in, T *__
       const size_t s_local = w / pad_elems;
       const size_t s_i = s_begin + s_local;
       const size_t d_off = D + (w % pad_elems);
-      out[out_base + s_i * D_out + d_off] = static_cast<T>(0);
+      out[out_base + s_i * D_out + d_off] = static_cast<T>(0.f);
     }
   }
 }


### PR DESCRIPTION
# Description

This PR fixes a zero-init ambiguity for CUDA 12.1 (used in GitHub CI). By using a floating zero literal, `static_cast<T>(0.f)` goes down the `float` constructor unambiguously.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

See Description.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
