### PR TITLE
[JAX] Fix bf16 precision loss in TestGroupedDense reference dbias

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -1923,17 +1923,16 @@ class TestGroupedDense:
         # If bias is added inside _ref_grouped_dense in bf16, JAX lowers the bias
         # backward as a bf16 sum-over-m and loses precision on the largest group,
         # producing a >bf16-rtol mismatch against the primitive's grouped_dbias
-        # (which casts the cotangent to fp32 before segment_sum).
+        # (which casts the cotangent to fp32 before segment_sum). Bias is required
+        # for this helper since it is only used by the grad tests below, which all
+        # set with_bias=True.
+        assert bias is not None, "_ref_sum_grouped_dense requires a non-None bias"
         out_list = self._ref_grouped_dense(x, kernel, None, group_sizes, contracting_dims)
         out_sum_list = []
-        if bias is None:
-            for out_i in out_list:
-                out_sum_list.append(jnp.sum(out_i.astype(jnp.float32)))
-        else:
-            for out_i, bias_i in zip(out_list, bias):
-                out_with_bias_fp32 = out_i.astype(jnp.float32) + bias_i.astype(jnp.float32)
-                out_sum_list.append(jnp.sum(out_with_bias_fp32))
-        return jnp.sum(jnp.asarray(out_sum_list)) / jnp.sqrt(x.size).astype(jnp.float32)
+        for out_i, bias_i in zip(out_list, bias):
+            out_with_bias_fp32 = out_i.astype(jnp.float32) + bias_i.astype(jnp.float32)
+            out_sum_list.append(jnp.sum(out_with_bias_fp32))
+        return jnp.sum(jnp.asarray(out_sum_list)) / jnp.sqrt(x.size)
 
     def _primitive_sum_grouped_dense(
         self, x, kernel, bias, group_sizes, contracting_dims, quantizer_set=noop_quantizer_set
@@ -1943,7 +1942,7 @@ class TestGroupedDense:
         )
         # Match the fp32 accumulation in _ref_sum_grouped_dense so loss values are
         # comparable and the cotangent dtype on `out` is unambiguous.
-        return jnp.sum(out.astype(jnp.float32)) / jnp.sqrt(x.size).astype(jnp.float32)
+        return jnp.sum(out.astype(jnp.float32)) / jnp.sqrt(x.size)
 
     @pytest_parametrize_wrapper("dtype", [jnp.bfloat16, jnp.float16])
     def test_grouped_dense_grad_fp16(self, dtype, input_shape):

--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -1914,12 +1914,26 @@ class TestGroupedDense:
         self._assert_grouped_gemm_output(prim_out, group_sizes, ref_out, allclose_dtype)
 
     def _ref_sum_grouped_dense(self, x, kernel, bias, group_sizes, contracting_dims):
-        out_list = self._ref_grouped_dense(x, kernel, bias, group_sizes, contracting_dims)
         # Note: we use jnp.sum instead of jnp.mean to make the gradient larger
         # and prevent them from being clamp to zero in FP8. / sqrt(x.size) is used to
         # normalize the output and prevent the gradient from being too large for FP8.
-        out_sum_list = [jnp.sum(out) for out in out_list]
-        return jnp.sum(jnp.asarray(out_sum_list)) / jnp.sqrt(x.size)
+        #
+        # We pass bias=None here and add bias externally in fp32 so the autodiff
+        # bias-grad (sum over the m axis of the cotangent) accumulates in fp32.
+        # If bias is added inside _ref_grouped_dense in bf16, JAX lowers the bias
+        # backward as a bf16 sum-over-m and loses precision on the largest group,
+        # producing a >bf16-rtol mismatch against the primitive's grouped_dbias
+        # (which casts the cotangent to fp32 before segment_sum).
+        out_list = self._ref_grouped_dense(x, kernel, None, group_sizes, contracting_dims)
+        out_sum_list = []
+        if bias is None:
+            for out_i in out_list:
+                out_sum_list.append(jnp.sum(out_i.astype(jnp.float32)))
+        else:
+            for out_i, bias_i in zip(out_list, bias):
+                out_with_bias_fp32 = out_i.astype(jnp.float32) + bias_i.astype(jnp.float32)
+                out_sum_list.append(jnp.sum(out_with_bias_fp32))
+        return jnp.sum(jnp.asarray(out_sum_list)) / jnp.sqrt(x.size).astype(jnp.float32)
 
     def _primitive_sum_grouped_dense(
         self, x, kernel, bias, group_sizes, contracting_dims, quantizer_set=noop_quantizer_set
@@ -1927,7 +1941,9 @@ class TestGroupedDense:
         out = grouped_dense(
             x, kernel, group_sizes, contracting_dims, bias=bias, quantizer_set=quantizer_set
         )
-        return jnp.sum(jnp.asarray(out)) / jnp.sqrt(x.size)
+        # Match the fp32 accumulation in _ref_sum_grouped_dense so loss values are
+        # comparable and the cotangent dtype on `out` is unambiguous.
+        return jnp.sum(out.astype(jnp.float32)) / jnp.sqrt(x.size).astype(jnp.float32)
 
     @pytest_parametrize_wrapper("dtype", [jnp.bfloat16, jnp.float16])
     def test_grouped_dense_grad_fp16(self, dtype, input_shape):


### PR DESCRIPTION
# Description

`TestGroupedDense::test_grouped_dense_grad_fp8` fails on `MXFP8_1D_SCALING` with `input_shape=(8, 64, 128, 256)`: `prim_dbias` vs `ref_dbias` differs by ~6% on the largest group, exceeding the bf16 rtol (other rows pass; fwd, dgrad, wgrad pass).

Reference path adds bias in bf16 inside `_ref_grouped_dense`, so JAX autodiff
lowers the bias-grad sum-over-m *in bf16* and saturates on the largest group. The primitive's `grouped_dbias` casts to fp32 before `segment_sum`, so it's accurate. The two computed dbias values therefore disagree even though the kernel is correct. Test-construction issue, not a kernel regression.

To fix this, in the reference impl, add NO bias to the grouped dense call, then add bias externally in fp32, so the autodiff bias-grad accumulates in fp32 --> This matches what `grouped_dbias` does for the primitive. 

Reason why this bug just surface now was because of commit 70af7305 ("[JAX] MXFP8 Grouped Quant+GEMM (#2763)") introduced `group_size_multiplier=128` for MXFP8, which quadrupled M for this shape and pushed the largest group's bf16 bias-grad sum past the bf16 rtol.

Fixes # (issue) 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `_ref_sum_grouped_dense`: pass `bias=None` to `_ref_grouped_dense`, add bias externally in fp32, sum and divisor in fp32
- `_primitive_sum_grouped_dense`: cast `out` and divisor to fp32 to mirror the reference

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes