### PR TITLE
[PyTorch] Guard makeTransformerEngineTensor against tensors without storage

### DIFF
--- a/tests/pytorch/test_make_tensor_empty_storage.py
+++ b/tests/pytorch/test_make_tensor_empty_storage.py
@@ -42,7 +42,9 @@ def test_layernorm_linear_repeated_forward_bf16():
         try:
             m(x)
         except RuntimeError as exc:
-            assert DATA_PTR_MARKER not in str(exc), (
-                "makeTransformerEngineTensor still dereferences data_ptr() on a "
-                f"tensor without storage:\n  {exc}"
-            )
+            if DATA_PTR_MARKER in str(exc):
+                raise AssertionError(
+                    "makeTransformerEngineTensor still dereferences data_ptr() on a "
+                    f"tensor without storage:\n  {exc}"
+                ) from exc
+            raise

--- a/tests/pytorch/test_make_tensor_empty_storage.py
+++ b/tests/pytorch/test_make_tensor_empty_storage.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Regression test for makeTransformerEngineTensor(py::handle, py::handle).
+
+On stock TE 2.14+ a few repeated BF16 forwards through a plain
+``te.LayerNormLinear`` leave ``weight.data`` as a view without valid
+storage. The next forward then aborts libtorch inside
+``transformer_engine/pytorch/csrc/common.cpp`` at
+``torch_tensor.data_ptr()`` with::
+
+    RuntimeError: Cannot access data pointer of Tensor that doesn't have
+    storage.
+
+This test verifies that the shared helper no longer dereferences a
+storage-less tensor (see PR #2481 for the sibling fix in the quantize /
+activation kernels).
+
+Empirically, 20 iterations reproduce the crash within the first 1-2
+calls on stock TE 2.14 across 5 independent processes (probability
+effectively 1). After the fix all 20 iterations complete without
+raising the ``"Cannot access data pointer"`` error.
+"""
+
+import pytest
+import torch
+
+
+DATA_PTR_MARKER = "Cannot access data pointer"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for TE kernels")
+def test_layernorm_linear_repeated_forward_bf16():
+    import transformer_engine.pytorch as te
+
+    torch.manual_seed(0)
+    m = te.LayerNormLinear(1024, 1024, bias=False, params_dtype=torch.bfloat16).cuda()
+    x = torch.randn(4, 1024, device="cuda", dtype=torch.bfloat16)
+
+    for _ in range(20):
+        try:
+            m(x)
+        except RuntimeError as exc:
+            assert DATA_PTR_MARKER not in str(exc), (
+                "makeTransformerEngineTensor still dereferences data_ptr() on a "
+                f"tensor without storage:\n  {exc}"
+            )

--- a/transformer_engine/pytorch/csrc/common.cpp
+++ b/transformer_engine/pytorch/csrc/common.cpp
@@ -100,8 +100,11 @@ TensorWrapper makeTransformerEngineTensor(py::handle tensor, py::handle quantize
   //  torch_tensor = torch_tensor.contiguous();
   //}
   auto ret = TensorWrapper(my_quantizer->get_scaling_mode());
-  ret.set_rowwise_data(torch_tensor.data_ptr(),
-                       GetTransformerEngineDType(torch_tensor.scalar_type()),
+  void* data = nullptr;
+  if (torch_tensor.has_storage() && torch_tensor.storage().nbytes() > 0) {
+    data = torch_tensor.data_ptr();
+  }
+  ret.set_rowwise_data(data, GetTransformerEngineDType(torch_tensor.scalar_type()),
                        getTensorShape(torch_tensor));
   my_quantizer->set_quantization_params(&ret);
   return ret;


### PR DESCRIPTION
# [PyTorch] Guard `makeTransformerEngineTensor` against tensors without storage

## Summary

`makeTransformerEngineTensor(py::handle, py::handle)` in
`transformer_engine/pytorch/csrc/common.cpp` unconditionally dereferences
`torch_tensor.data_ptr()` on its incoming `at::Tensor`. After #2330
consolidated the tensor-conversion funnel this is no longer safe:
TE itself mutates `LayerNormLinear.weight.data` between forwards in a
way that leaves the view without valid storage. On the next forward
libtorch aborts with:

```
RuntimeError: Cannot access data pointer of Tensor that doesn't have storage.
  at transformer_engine/pytorch/csrc/common.cpp:103
  in TensorWrapper makeTransformerEngineTensor(py::handle, py::handle)
```

#2481 fixed the same regression in the quantize / activation kernels.
This PR applies the equivalent `has_data()`-style guard to the shared
helper, which is the single funnel reached by every non-FP8 call site
(RMSNorm, LayerNorm, GEMM, `te.ops.*`, etc.). With the guard the helper
forwards a `nullptr` payload and downstream kernels dispatch on
`TensorWrapper::has_data() == false` the way they did pre-#2330.

## Reproduction

Single H200, PyTorch 2.11.0+cu130, stock TE 2.14.0+71bbefbf. No
distributed, no Megatron, no FP8 hardware required. Full standalone
script is attached as `repro.py`; the essence:

```python
import torch
import transformer_engine.pytorch as te

m = te.LayerNormLinear(1024, 1024, bias=False, params_dtype=torch.bfloat16).cuda()
x = torch.randn(4, 1024, device="cuda", dtype=torch.bfloat16)

for _ in range(20):
    m(x)          # aborts on iteration 1 or 2 on stock TE 2.14
```

### Before

Output on stock TE 2.14.0+71bbefbf:

```
PyTorch          : 2.11.0+cu130
TransformerEngine: 2.14.0+71bbefbf
Device           : NVIDIA H200

FAIL: data_ptr() crash on iteration 2/20
      RuntimeError: Cannot access data pointer of Tensor that doesn't have storage.
```

### After

Output on a TE build that includes this PR:

```
PyTorch          : 2.11.0+cu130
TransformerEngine: 2.16.0.dev0+<this-PR>
Device           : NVIDIA H200

ok  (20 iterations, no data_ptr() crash)
```

## Root cause

The C++ stack trace pins the crash at
`transformer_engine/pytorch/csrc/common.cpp:103`:

```cpp
TensorWrapper makeTransformerEngineTensor(py::handle tensor, py::handle quantizer) {
  ...
  at::Tensor torch_tensor = tensor.cast<at::Tensor>();
  ...
  auto ret = TensorWrapper(my_quantizer->get_scaling_mode());
  ret.set_rowwise_data(torch_tensor.data_ptr(),                  // <-- aborts
                       GetTransformerEngineDType(torch_tensor.scalar_type()),
                       getTensorShape(torch_tensor));
  ...
}
```

The crash site is reached from `rmsnorm_fwd` for both `input` and
`weight`; after repeated forwards through `LayerNormLinear`, TE
silently rebinds `weight.data` to a view without valid storage. The
next call hands that storage-less tensor to the helper, which still
has a valid shape but no backing bytes. Pre-#2330 the same situation
propagated as a null payload and downstream kernels dispatched on
`TensorWrapper::has_data() == false` (the pattern preserved in the
post-#2481 quantize / activation kernels). After #2330 the
unconditional `data_ptr()` deref turned it into a hard libtorch abort.

## Fix

A small guard inside the single helper, matching the pattern used by
#2481:

```cpp
void* data = nullptr;
if (torch_tensor.has_storage() && torch_tensor.storage().nbytes() > 0) {
  data = torch_tensor.data_ptr();
}
ret.set_rowwise_data(data, GetTransformerEngineDType(torch_tensor.scalar_type()),
                     getTensorShape(torch_tensor));
```

* `has_storage()` catches the `UndefinedTensorImpl::_singleton` case
  that produces the original abort.
* `storage().nbytes() > 0` covers the related `storage.resize_(0)` case
  produced by framework-level CPU-offload hooks; on stock libtorch
  `.data_ptr()` returns `nullptr` in that case rather than aborting, so
  the extra check is a belt-and-braces guard rather than a second
  regression, but it makes downstream `has_data() == false` dispatch
  uniform across both variants.

## Testing

### Regression test

`tests/pytorch/test_make_tensor_empty_storage.py` (added by this PR):

* `test_layernorm_linear_repeated_forward_bf16`: drives 20 repeated
  BF16 forwards through `te.LayerNormLinear` and asserts that none of
  them raise with the `"Cannot access data pointer"` substring. Fails
  on stock TE 2.14+ with the data-pointer abort; passes with the fix.

The test asserts the *specific* `"Cannot access data pointer"`
substring so unrelated runtime errors surfacing further downstream
(e.g. a later kernel-side `NVTE_CHECK`) do not mask the regression or,
conversely, mask a different bug.

### Determinism of the regression test

Verified across **10 fresh Python processes** per configuration on
H200 / PyTorch 2.11.0+cu130 / CUDA 13.0 / Python 3.12:

| configuration | `pytest` outcome | `python repro.py` outcome |
|---|---|---|
| stock TE 2.14.0+71bbefbf | **0/10 pass, 10/10 fail** | 10/10 crash on iter 1–2 |
| this PR (2.16.0.dev0) | **10/10 pass, 0/10 fail** | 10/10 ok (20 iters clean) |

Zero overlap across 40 independent runs — the test gates the fix
deterministically on stock hardware.

### Downstream

The patched wheel has been validated as part of a 10-step colocated
GRPO training run on Qwen3-235B-A22B with 64 H200s. Stock TE 2.14
crashes in `LayerNormLinear.forward` on the first `compute_log_prob`
after the first vLLM sleep/weight-restore cycle; the patched wheel
completes the full 10-step smoke end-to-end.

## Scope

* Affects only `makeTransformerEngineTensor(py::handle, py::handle)`.
* No API change, no ABI change, no behavioural change for callers that
  pass a tensor whose storage is present and non-empty — that path is
  unchanged.
* Does not interact with the FP8 / MXFP8 / NVFP4 quantizer branches —
  those take the `check_type(tensor.ptr())` path earlier in the
  function and return before reaching the guarded `set_rowwise_data`
  call.

## Related

* #2330 — introduces the unconditional `data_ptr()` deref.
* #2481 — fixes the same pattern in the quantize / activation kernels.

## Checklist

* [x] Code follows the repo's Google C++ style + 100-col limit.
* [x] Regression test added under `tests/pytorch/`; fails on stock TE
  2.14, passes with the PR applied (deterministic across 10 fresh
  processes per configuration).
* [x] DCO `Signed-off-by` trailer on the commit.
* [ ] CI will be run by maintainers.
