### PR TITLE
[JAX][Common] Enable cuDNN fused attn backend for NO_MASK + bidirectional SWA

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1059,26 +1059,25 @@ class FusedAttnRunner:
                 target_hlo = jitted_primitive.lower(*customcall_args).compile().as_text()
             assert_equal_collectives(target_hlo, self.coll_count_ref)
 
-
-def _swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tuple[int, int]:
+def _get_swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tuple[int, int]:
     """Pick a sliding-window size for SWA tests, gated on cuDNN version.
 
     cuDNN < 9.2: skip (no SWA support).
     cuDNN >= 9.2: left-only window (s_kv // 10, 0).
-    cuDNN >= 9.6: bidirectional window (s_kv // 10, s_kv // 10) for the mask types whose
+    cuDNN >= 9.6: bidirectional window (s_kv // 10, s_kv // 10 + 5) for the mask types whose
                   bidirectional fused dispatch is meaningful here (NO_MASK, PADDING_MASK).
                   Other mask types keep the left-only window: causal-family masks would
-                  collapse (W, W) -> (W, 0) under the causal AND, so a separate bidirectional
-                  case adds no signal.
+                  collapse (W, W) -> (W, 0), hence not tested here.
     """
-    cudnn_v = get_cudnn_version()
-    if cudnn_v < 90200:
+    cudnn_version = get_cudnn_version()
+    if cudnn_version < 90200:
         pytest.skip("Sliding window attention requires cuDNN >= 9.2")
-    left = s_kv // 10
-    right = left + 5
-    if cudnn_v >= 90600 and attn_mask_type in (AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK):
-        return (left, right)
-    return (left, 0)
+    left_window_size = s_kv // 10
+    # choose asymmetric window size for testing
+    right_window_size = left_window_size + 5
+    if cudnn_version >= 90600 and attn_mask_type in (AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK):
+        return (left_window_size, right_window_size)
+    return (left_window_size, 0)
 
 
 @pytest.mark.parametrize(
@@ -1351,7 +1350,7 @@ class TestFusedAttn:
         This test is not intended to run automatically during CI as it is time-consuming
         It is kept for development and debugging
         """
-        window_size = _swa_window_size_for_test(s_kv, attn_mask_type) if swa else None
+        window_size = _get_swa_window_size_for_test(s_kv, attn_mask_type) if swa else None
         runner = FusedAttnRunner(
             b,
             s_q,
@@ -1402,7 +1401,7 @@ class TestFusedAttn:
         """
         Test backward with parameterized configs
         """
-        window_size = _swa_window_size_for_test(s_kv, attn_mask_type) if swa else None
+        window_size = _get_swa_window_size_for_test(s_kv, attn_mask_type) if swa else None
         runner = FusedAttnRunner(
             b,
             s_q,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1059,6 +1059,7 @@ class FusedAttnRunner:
                 target_hlo = jitted_primitive.lower(*customcall_args).compile().as_text()
             assert_equal_collectives(target_hlo, self.coll_count_ref)
 
+
 def _get_swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tuple[int, int]:
     """Pick a sliding-window size for SWA tests, gated on cuDNN version.
 
@@ -1075,7 +1076,10 @@ def _get_swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tu
     left_window_size = s_kv // 10
     # choose asymmetric window size for testing
     right_window_size = left_window_size + 5
-    if cudnn_version >= 90600 and attn_mask_type in (AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK):
+    if cudnn_version >= 90600 and attn_mask_type in (
+        AttnMaskType.NO_MASK,
+        AttnMaskType.PADDING_MASK,
+    ):
         return (left_window_size, right_window_size)
     return (left_window_size, 0)
 

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1059,6 +1059,7 @@ class FusedAttnRunner:
                 target_hlo = jitted_primitive.lower(*customcall_args).compile().as_text()
             assert_equal_collectives(target_hlo, self.coll_count_ref)
 
+
 def _swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tuple[int, int]:
     """Pick a sliding-window size for SWA tests, gated on cuDNN version.
 
@@ -1078,6 +1079,7 @@ def _swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tuple[
     if cudnn_v >= 90600 and attn_mask_type in (AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK):
         return (left, right)
     return (left, 0)
+
 
 @pytest.mark.parametrize(
     "attn_mask_type",

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1059,6 +1059,25 @@ class FusedAttnRunner:
                 target_hlo = jitted_primitive.lower(*customcall_args).compile().as_text()
             assert_equal_collectives(target_hlo, self.coll_count_ref)
 
+def _swa_window_size_for_test(s_kv: int, attn_mask_type: AttnMaskType) -> Tuple[int, int]:
+    """Pick a sliding-window size for SWA tests, gated on cuDNN version.
+
+    cuDNN < 9.2: skip (no SWA support).
+    cuDNN >= 9.2: left-only window (s_kv // 10, 0).
+    cuDNN >= 9.6: bidirectional window (s_kv // 10, s_kv // 10) for the mask types whose
+                  bidirectional fused dispatch is meaningful here (NO_MASK, PADDING_MASK).
+                  Other mask types keep the left-only window: causal-family masks would
+                  collapse (W, W) -> (W, 0) under the causal AND, so a separate bidirectional
+                  case adds no signal.
+    """
+    cudnn_v = get_cudnn_version()
+    if cudnn_v < 90200:
+        pytest.skip("Sliding window attention requires cuDNN >= 9.2")
+    left = s_kv // 10
+    right = left + 5
+    if cudnn_v >= 90600 and attn_mask_type in (AttnMaskType.NO_MASK, AttnMaskType.PADDING_MASK):
+        return (left, right)
+    return (left, 0)
 
 @pytest.mark.parametrize(
     "attn_mask_type",
@@ -1330,9 +1349,7 @@ class TestFusedAttn:
         This test is not intended to run automatically during CI as it is time-consuming
         It is kept for development and debugging
         """
-        window_size = None
-        if swa:
-            window_size = (s_kv // 10, 0)
+        window_size = _swa_window_size_for_test(s_kv, attn_mask_type) if swa else None
         runner = FusedAttnRunner(
             b,
             s_q,
@@ -1383,9 +1400,7 @@ class TestFusedAttn:
         """
         Test backward with parameterized configs
         """
-        window_size = None
-        if swa:
-            window_size = (s_kv // 10, 0)
+        window_size = _swa_window_size_for_test(s_kv, attn_mask_type) if swa else None
         runner = FusedAttnRunner(
             b,
             s_q,

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -469,6 +469,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
               (sm_arch_ < 100 || (sm_arch_ >= 100 && ((max_seqlen_q == max_seqlen_kv &&
                                                        cudnn_runtime_version <= 90700) ||
                                                       cudnn_runtime_version > 90700)))) ||
+             attn_mask_type == NVTE_Mask_Type::NVTE_NO_MASK ||
              attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_MASK ||
              attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||
              (attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK &&

--- a/transformer_engine/jax/flax/transformer.py
+++ b/transformer_engine/jax/flax/transformer.py
@@ -788,7 +788,7 @@ class DotProductAttention(nn.Module):  # pylint: disable=too-few-public-methods
                 "Fall back to the unfused attention.\n"
                 "Please try to update the cuDNN and TE to the latest version.\n"
                 f"{qkv_layout=}\n{attn_bias_type=}\n{attn_mask_type=}\n"
-                f"{self.attention_dropout=}\n{self.num_attention_heads=}\n"
+                f"{self.attention_dropout=}\n{self.num_attention_heads=}\n{self.window_size=}\n"
                 f"{self.num_gqa_groups=}\n{seqlen_q=}\n{seqlen_kv=}\n{head_dim_qk=}\n{head_dim_v=}\n"
             )
 


### PR DESCRIPTION
# Description

Enable cuDNN fused attn backend for right sided window for NO_MASK when using cuDNN 9.6+

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Enabled cuDNN fused attn backend for right sided window for NO_MASK when using cuDNN 9.6+ in TE common
- No changes needed in TE PyT as there are tests already exercising this path (currently they would use a non cuDNN fused attn backend for NO_MASK + right side window + cuDNN 9.6+ but this PR ensures they use the cuDNN fused attn backend instead)
- TE JAX fused attn did not have any bidirectional window tests - so added those
- Added a helper in the TE JAX fused attn tests to pick the window size based on the cuDNN version
    - If bidirectional is available, run only those (no unidirectional tests run)
    - If only unidirectional available, run only those 
    - If none availabel, skip
- Added window size to the warning string reported when falling back to unfused attn

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
