### PR TITLE
[PyTorch] Remove internal PyTorch testing helper

### DIFF
--- a/tests/pytorch/test_fused_optimizer.py
+++ b/tests/pytorch/test_fused_optimizer.py
@@ -8,7 +8,6 @@ from contextlib import nullcontext
 import pytest
 import torch
 from torch import nn
-from torch.testing._internal.common_device_type import largeTensorTest
 import transformer_engine.pytorch as te
 from transformer_engine.common.recipe import DelayedScaling, MXFP8BlockScaling, Float8BlockScaling
 from transformer_engine.pytorch import MultiheadAttention, quantized_model_init, is_bf16_available
@@ -1053,8 +1052,9 @@ class TestAdamTest:
 
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
 
-    @largeTensorTest("60GB", "cuda")
     def test_large_tensor(self):
+        if torch.cuda.memory.mem_get_info()[0] < 60 * 1024**3:
+            pytest.skip("Insufficient available memory")
         t = torch.zeros(2359332864, dtype=torch.half, device="cuda")
         t2 = torch.zeros(2359332864, dtype=torch.half, device="cuda")
         grad = torch.randn_like(t)

--- a/tests/pytorch/test_fused_optimizer.py
+++ b/tests/pytorch/test_fused_optimizer.py
@@ -1053,6 +1053,9 @@ class TestAdamTest:
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
 
     def test_large_tensor(self):
+        import gc
+        gc.collect()
+        torch.cuda.empty_cache()
         if torch.cuda.memory.mem_get_info()[0] < 60 * 1024**3:
             pytest.skip("Insufficient available memory")
         t = torch.zeros(2359332864, dtype=torch.half, device="cuda")

--- a/tests/pytorch/test_fused_optimizer.py
+++ b/tests/pytorch/test_fused_optimizer.py
@@ -1054,6 +1054,7 @@ class TestAdamTest:
 
     def test_large_tensor(self):
         import gc
+
         gc.collect()
         torch.cuda.empty_cache()
         if torch.cuda.memory.mem_get_info()[0] < 60 * 1024**3:


### PR DESCRIPTION
# Description

We have been experiencing test failures in `test_fused_optimizer.py`. There is some import error when importing `torch.testing._internal.common_device_type`. Fortunately, [`largeTensorTest`](https://github.com/pytorch/pytorch/blob/8f59e83cbf3eef992745eccb6ca052078a5ea607/torch/testing/_internal/common_device_type.py#L1486) is simple to reimplement, so I figure that's better than dealing with unstable internal tools.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Remove internal PyTorch testing helper

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
