### PR TITLE
ci: declare contents:read on Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ concurrency:
   # Group by workflow name + PR number (for PRs) or ref (for branch/tag pushes)
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   pytorch_cpplint:
     name: 'PyTorch C++'


### PR DESCRIPTION
The Lint workflow currently doesn't declare a `permissions:` block, so its `GITHUB_TOKEN` inherits the repository default. Both jobs (`pytorch_cpplint`, `pytorch_pylint`) only check out the repo and run shell scripts that invoke cpplint and pylint locally. No cache, no GitHub API call, no comment-on-PR step.

This patch sets `permissions: contents: read` at workflow scope, matching the per-job permissions blocks already declared by `deploy_nightly_docs.yml` (`pages: write, id-token: write`) and `upload-ci-logs.yml` (`statuses: write`).

Out of scope for this PR (left for a separate change):

- `build.yml` uses `mozilla-actions/sccache-action`, which writes to the GitHub Actions cache. Declaring explicit permissions there has to account for the `actions: write` need on the cache save path; that's a more involved discussion than a drive-by warrants.
- `attach-wheels-to-release.yml`, `blossom-ci.yml`, `trigger-ci.yml` -- each is a multi-stage workflow (release publishing, hybrid-CI authorization). Their per-job permission story deserves a careful review on its own.
- `license.yml` is small enough (~20 lines) that the noise/value ratio isn't worth a separate PR.

No behavioural change to the Lint workflow.