### PR TITLE
TritonKernelCall: CUDA graph compatibility

### DIFF
--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -44,14 +44,17 @@ import zlib
 from packaging import version
 
 from jax import core
+from jaxlib.mlir import ir
 import jax
 import jax.numpy as jnp
 
 from ..version_utils import (
     TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION,
     TRITON_EXTENSION_MIN_JAX_VERSION,
+    TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION,
     is_triton_autotuned_alias_safe,
     is_triton_extension_supported,
+    jax_version_meet_requirement,
 )
 
 
@@ -581,6 +584,7 @@ def triton_call_lowering(
 
     serialized_metadata = b""
     call_proto = kernel_call.to_proto(actual_kernel_fn.__name__, serialized_metadata)
+    compressed_call_proto = zlib.compress(call_proto)
 
     if input_output_aliases:
         ffi_operand_output_aliases = input_output_aliases
@@ -588,11 +592,20 @@ def triton_call_lowering(
         ffi_operand_output_aliases = None
 
     # Use JAX FFI lowering with compressed protobuf
-    rule = jax.ffi.ffi_lowering(
-        "triton_kernel_call",  # Custom call target registered in gpu_triton.py
-        api_version=2,
-        backend_config=zlib.compress(call_proto),
-        operand_output_aliases=ffi_operand_output_aliases,
-    )
+    if jax_version_meet_requirement(TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION):
+        rule = jax.ffi.ffi_lowering(
+            "triton_kernel_call_ffi",  # Custom call target registered in gpu_triton.py
+            backend_config={
+                "kernel_call_proto": ir.StringAttr.get(compressed_call_proto)
+            },
+            operand_output_aliases=ffi_operand_output_aliases,
+        )
+    else:
+        rule = jax.ffi.ffi_lowering(
+            "triton_kernel_call",  # Custom call target registered in gpu_triton.py
+            api_version=2,
+            backend_config=compressed_call_proto,
+            operand_output_aliases=ffi_operand_output_aliases,
+        )
 
     return rule(ctx, *array_args)

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -595,9 +595,7 @@ def triton_call_lowering(
     if jax_version_meet_requirement(TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION):
         rule = jax.ffi.ffi_lowering(
             "triton_kernel_call_ffi",  # Custom call target registered in gpu_triton.py
-            backend_config={
-                "kernel_call_proto": ir.StringAttr.get(compressed_call_proto)
-            },
+            backend_config={"kernel_call_proto": ir.StringAttr.get(compressed_call_proto)},
             operand_output_aliases=ffi_operand_output_aliases,
         )
     else:

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -25,6 +25,9 @@ def jax_version_meet_requirement(version: str):
 # Minimum JAX version required for Triton kernel dispatch (jaxlib < 0.8.0 segfaults).
 TRITON_EXTENSION_MIN_JAX_VERSION = "0.8.0"
 
+# Minimum JAX version for non-legacy Triton kernel FFI (supporting CUDA graph capture)
+TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION = "0.10.1.dev0"
+
 # Nightly and stable floors for safe input_output_aliases in TritonAutotunedKernelCall.
 # jaxlib/gpu/triton_kernels.cc had a bug in the autotuning save/restore loop:
 # it iterated over all declared aliases unconditionally, but input_copies only


### PR DESCRIPTION
# Description

Previously triton kernel calls are not CUDA graphable and will show up as individual ops instead of being able to be coalesced into a command buffer. JAX has recently added their end of the support for this. So this PR will connect that support for JAX triton kernels' CUDA graphability in TE.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
Change API version to newer version for the triton kernel call ffi if JAX version supports CUDA graphability for triton kernel calls.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
