### PR TITLE
Add GitHub actions to automatically mark community contributions

### DIFF
--- a/.github/workflows/community_label.yml
+++ b/.github/workflows/community_label.yml
@@ -1,4 +1,9 @@
- name: Label community contributions
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+# A workflow to automatically label the contributions as community/org
+  name: Label community contributions
 
   on:
     pull_request_target:

--- a/.github/workflows/community_label.yml
+++ b/.github/workflows/community_label.yml
@@ -17,7 +17,7 @@
     label:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/github-script@v9
+        - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
           with:
             script: |
               const pr = context.payload.pull_request;

--- a/.github/workflows/community_label.yml
+++ b/.github/workflows/community_label.yml
@@ -1,0 +1,60 @@
+ name: Label community contributions
+
+  on:
+    pull_request_target:
+      types: [opened, reopened, ready_for_review, synchronize]
+
+  permissions:
+    contents: read
+    issues: write
+
+  jobs:
+    label:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/github-script@v9
+          with:
+            script: |
+              const pr = context.payload.pull_request;
+              const user = pr.user.login;
+              const association = pr.author_association;
+
+              const communityLabel = "community-contribution";
+              const orgLabel = "org-contribution";
+
+              let targetLabel = null;
+
+              const isOrgMember =
+                association === "MEMBER" || association === "OWNER";
+
+              if (!isOrgMember) {
+                targetLabel = communityLabel;
+              } else {
+                let permission = "none";
+
+                try {
+                  const res = await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    username: user,
+                  });
+                  permission = res.data.permission;
+                } catch (e) {
+                  if (e.status !== 404) throw e;
+                }
+
+                const isCore = permission === "write" || permission === "admin";
+
+                if (!isCore) {
+                  targetLabel = orgLabel;
+                }
+              }
+
+              if (targetLabel) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [targetLabel],
+                });
+              }

--- a/.github/workflows/community_label.yml
+++ b/.github/workflows/community_label.yml
@@ -3,63 +3,63 @@
 # See LICENSE for license information.
 
 # A workflow to automatically label the contributions as community/org
-  name: Label community contributions
+name: Label community contributions
 
-  on:
-    pull_request_target:
-      types: [opened, reopened, ready_for_review, synchronize]
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
 
-  permissions:
-    contents: read
-    issues: write
+permissions:
+  contents: read
+  issues: write
 
-  jobs:
-    label:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-          with:
-            script: |
-              const pr = context.payload.pull_request;
-              const user = pr.user.login;
-              const association = pr.author_association;
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const user = pr.user.login;
+            const association = pr.author_association;
 
-              const communityLabel = "community-contribution";
-              const orgLabel = "org-contribution";
+            const communityLabel = "community-contribution";
+            const orgLabel = "org-contribution";
 
-              let targetLabel = null;
+            let targetLabel = null;
 
-              const isOrgMember =
-                association === "MEMBER" || association === "OWNER";
+            const isOrgMember =
+              association === "MEMBER" || association === "OWNER";
 
-              if (!isOrgMember) {
-                targetLabel = communityLabel;
-              } else {
-                let permission = "none";
+            if (!isOrgMember) {
+              targetLabel = communityLabel;
+            } else {
+              let permission = "none";
 
-                try {
-                  const res = await github.rest.repos.getCollaboratorPermissionLevel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    username: user,
-                  });
-                  permission = res.data.permission;
-                } catch (e) {
-                  if (e.status !== 404) throw e;
-                }
-
-                const isCore = permission === "write" || permission === "admin";
-
-                if (!isCore) {
-                  targetLabel = orgLabel;
-                }
-              }
-
-              if (targetLabel) {
-                await github.rest.issues.addLabels({
+              try {
+                const res = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: pr.number,
-                  labels: [targetLabel],
+                  username: user,
                 });
+                permission = res.data.permission;
+              } catch (e) {
+                if (e.status !== 404) throw e;
               }
+
+              const isCore = permission === "write" || permission === "admin";
+
+              if (!isCore) {
+                targetLabel = orgLabel;
+              }
+            }
+
+            if (targetLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [targetLabel],
+              });
+            }


### PR DESCRIPTION
# Description

GitHub action to automatically mark the external contributions as community-contribution and the NVIDIA contributions from outside the core team as org-contributions. 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

