### PR TITLE
mnnvl guard

### DIFF
--- a/qa/L0_pytorch_unittest/test.sh
+++ b/qa/L0_pytorch_unittest/test.sh
@@ -28,7 +28,7 @@ NVTE_GROUPED_LINEAR_SINGLE_PARAM=1 python3 -m pytest --tb=auto --junitxml=$XML_L
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_recipe.xml $TE_PATH/tests/pytorch/test_recipe.py || test_fail "test_recipe.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_custom_recipe.xml $TE_PATH/tests/pytorch/test_custom_recipe.py || test_fail "test_custom_recipe.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_deferred_init.xml $TE_PATH/tests/pytorch/test_deferred_init.py || test_fail "test_deferred_init.py"
-PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 NVTE_FUSED_ATTN=0 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/test_numerics.py || test_fail "test_numerics.py"
+PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 NVTE_FUSED_ATTN=0 NVIDIA_TF32_OVERRIDE=0 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/test_numerics.py || test_fail "test_numerics.py"
 PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 NVTE_FUSED_ATTN=0 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_cuda_graphs.xml $TE_PATH/tests/pytorch/test_cuda_graphs.py || test_fail "test_cuda_graphs.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_jit.xml $TE_PATH/tests/pytorch/test_jit.py || test_fail "test_jit.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_fused_rope.xml $TE_PATH/tests/pytorch/test_fused_rope.py || test_fail "test_fused_rope.py"

--- a/qa/L0_pytorch_unittest/test.sh
+++ b/qa/L0_pytorch_unittest/test.sh
@@ -28,7 +28,7 @@ NVTE_GROUPED_LINEAR_SINGLE_PARAM=1 python3 -m pytest --tb=auto --junitxml=$XML_L
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_recipe.xml $TE_PATH/tests/pytorch/test_recipe.py || test_fail "test_recipe.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_custom_recipe.xml $TE_PATH/tests/pytorch/test_custom_recipe.py || test_fail "test_custom_recipe.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_deferred_init.xml $TE_PATH/tests/pytorch/test_deferred_init.py || test_fail "test_deferred_init.py"
-PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 NVTE_FUSED_ATTN=0 NVIDIA_TF32_OVERRIDE=0 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/test_numerics.py || test_fail "test_numerics.py"
+PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 NVTE_FUSED_ATTN=0 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/test_numerics.py || test_fail "test_numerics.py"
 PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 NVTE_FUSED_ATTN=0 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_cuda_graphs.xml $TE_PATH/tests/pytorch/test_cuda_graphs.py || test_fail "test_cuda_graphs.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_jit.xml $TE_PATH/tests/pytorch/test_jit.py || test_fail "test_jit.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_fused_rope.xml $TE_PATH/tests/pytorch/test_fused_rope.py || test_fail "test_fused_rope.py"

--- a/transformer_engine/common/comm_gemm_overlap/userbuffers/userbuffers-host.cpp
+++ b/transformer_engine/common/comm_gemm_overlap/userbuffers/userbuffers-host.cpp
@@ -92,7 +92,7 @@ int stringCmp(const void *a, const void *b) { return strcmp((const char *)a, (co
   } while (0);
 
 bool has_mnnvl_fabric(int device_id) {
-#if CUDA_VERSION < 12040
+#if !defined(nvmlGpuFabricInfo_v2)
   if (getenv("NVTE_UBDEBUG")) {
     printf(
         "TransformerEngine does not support multi-node NVLINK "


### PR DESCRIPTION
I am trying to compile TE on the CINECA Leonardo cluster and encountered a compilation issue that required a small fix to work around. Since this may also affect other environments with mixed CUDA header/toolkit versions, I am submitting this PR in case it is useful more broadly.

I should also mention that some TE tests are currently failing in my environment. From what I can tell so far, these failures appear unrelated to this change and are more likely tied to the system configuration. I still need to investigate them further, but any feedback or insight on that side would be appreciated.

Thank you for your work on TE and your time with this PR!

--- 

## Description

This fixes a build failure when compiling TE in environments where the CUDA headers provided by pip-installed nvidia-cuda-runtime-cu12 are newer than the system CUDA toolkit.

I encountered this on the CINECA Leonardo cluster (RHEL 8, A100 SXM4, driver 535, system CUDA 12.2, pip nvidia-cuda-runtime-cu12 12.6), but the issue is not cluster-specific and can occur on any system with mixed CUDA header versions.

The failure looks like:
```cpp
transformer_engine/common/comm_gemm_overlap/userbuffers/userbuffers-host.cpp:123:5:
error: 'nvmlGpuFabricInfoV_t' was not declared in this scope
    nvmlGpuFabricInfoV_t fabricInfo = {};
 ```
 
 ## Root cause

The build currently relies on CUDA_VERSION to determine whether the newer NVML fabric APIs are available:
```cpp
#if CUDA_VERSION < 12040
```
However, in mixed environments there are effectively two independent version sources:
----
Source | Controlled by | Example version
-- | -- | --
CUDA_VERSION | pip nvidia-cuda-runtime-cu12 headers | ≥ 12.4
nvml.h | system CUDA toolkit | 12.2
----

If the pip CUDA headers are newer than the system toolkit:

- CUDA_VERSION reports ≥ 12.4
- the #else branch is enabled
- but the system nvml.h does not define:
  - nvmlGpuFabricInfoV_t
  - nvmlGpuFabricInfo_v2

which causes compilation to fail.

This can happen on HPC clusters, shared cloud nodes, or developer systems where Python CUDA packages are updated independently from the system CUDA installation.

## Fix

Replace the version-based guard with a capability-based guard:

```diff
- #if CUDA_VERSION < 12040
+ #if !defined(nvmlGpuFabricInfo_v2)
```

nvmlGpuFabricInfo_v2 is introduced in CUDA 12.4 and is the actual API feature required by the code below. Checking for the symbol directly avoids assuming that all CUDA-related headers come from the same toolkit version.

This makes the logic resilient to mismatched header installations while preserving existing behavior.

Behaviour after this change
- CUDA ≥ 12.4 toolkit:
  - nvmlGpuFabricInfo_v2 is defined
  - existing MNNVL detection path is compiled
- CUDA < 12.4 toolkit:
  - nvmlGpuFabricInfo_v2 is not defined
  - function returns false as before
- Mixed-header environments:
  - CUDA_VERSION may report ≥ 12.4
  - but nvmlGpuFabricInfo_v2 is absent
  - code correctly falls back to return false
build succeeds

This fallback is also semantically correct, since MNNVL support is only relevant on newer H100/GH200-class systems and should return false on A100-era systems regardless.

## Testing

Verified on CINECA Leonardo:
- A100 SXM4
- driver 535
- system CUDA 12.2
- pip nvidia-cuda-runtime-cu12 12.6

--- 

Unrelated but I had to add `NVIDIA_TF32_OVERRIDE=0` to `test_numerics.py` otherwise I would get test failing for small numerical mismatch with layer norms. This has also been done for `test_mhc.py`. 
