### PR TITLE
Fix the permissions in the automatic labeler

### DIFF
--- a/.github/workflows/community_label.yml
+++ b/.github/workflows/community_label.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
# Description

Added the permission to write to the pull requests, since that is what is needed to add the existing label to a PR, rather than the issue: write, which is needed to create the new labels.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

