### PR TITLE
[PyTorch Debug] Fix scale_inv_min returning 0 for MXFP8/NVFP4

### DIFF
--- a/transformer_engine/debug/features/utils/stats_computation.py
+++ b/transformer_engine/debug/features/utils/stats_computation.py
@@ -348,6 +348,16 @@ def add_scale_inv_stats(recipe_name: str, columnwise: bool = False):
             return getattr(quantized_tensor, "_columnwise_scale_inv")
         return getattr(quantized_tensor, "_rowwise_scale_inv")
 
+    def nonzero_min(scale_inv):
+        # MXFP8/NVFP4 scale_inv is padded to a multiple of [128, 4] (or [4, 128]
+        # for columnwise) with zeros, so a plain .min() always returns 0. Mask
+        # those padding zeros out; if everything is zero (degenerate case) fall
+        # back to 0 so the buffer aggregation stays well-defined.
+        nz = scale_inv[scale_inv != 0]
+        if nz.numel() == 0:
+            return scale_inv.new_zeros(())
+        return nz.min()
+
     columnwise_suffix = "_columnwise" if columnwise else ""
     # Prepare stat names.
     stat_name_min = (
@@ -363,7 +373,7 @@ def add_scale_inv_stats(recipe_name: str, columnwise: bool = False):
 
     # Capture the attribute name inside lambdas via default args to avoid late binding.
     STATS[stat_name_min] = (
-        lambda x, aux_dict, _col=columnwise: get_scale_inv(aux_dict[recipe_name], _col).min(),
+        lambda x, aux_dict, _col=columnwise: nonzero_min(get_scale_inv(aux_dict[recipe_name], _col)),
         lambda buffers, _sn=stat_name_min: min(_get(buffers, _sn)),
     )
     STATS[stat_name_max] = (

--- a/transformer_engine/debug/features/utils/stats_computation.py
+++ b/transformer_engine/debug/features/utils/stats_computation.py
@@ -349,10 +349,15 @@ def add_scale_inv_stats(recipe_name: str, columnwise: bool = False):
         return getattr(quantized_tensor, "_rowwise_scale_inv")
 
     def nonzero_min(scale_inv):
-        # MXFP8/NVFP4 scale_inv is padded to a multiple of [128, 4] (or [4, 128]
-        # for columnwise) with zeros, so a plain .min() always returns 0. Mask
-        # those padding zeros out; if everything is zero (degenerate case) fall
-        # back to 0 so the buffer aggregation stays well-defined.
+        # MXFP8/NVFP4 quantizers round the scale_inv shape up to multiples of
+        # 128 along one axis and 4 along the other and fill the extra slots
+        # with zeros (via torch.nn.functional.pad with the default value=0),
+        # so a plain .min() always returns 0 for shapes that needed padding.
+        # A real scale_inv entry is never 0: compute_scale_from_amax returns
+        # scale=1.0 for all-zero blocks and clamps the inf case to a finite
+        # fallback, so zeros uniquely identify padding and masking them out
+        # gives the true minimum. The empty-after-mask branch is a safety
+        # net for the (in practice unreachable) all-zero tensor.
         nz = scale_inv[scale_inv != 0]
         if nz.numel() == 0:
             return scale_inv.new_zeros(())

--- a/transformer_engine/debug/features/utils/stats_computation.py
+++ b/transformer_engine/debug/features/utils/stats_computation.py
@@ -373,7 +373,9 @@ def add_scale_inv_stats(recipe_name: str, columnwise: bool = False):
 
     # Capture the attribute name inside lambdas via default args to avoid late binding.
     STATS[stat_name_min] = (
-        lambda x, aux_dict, _col=columnwise: nonzero_min(get_scale_inv(aux_dict[recipe_name], _col)),
+        lambda x, aux_dict, _col=columnwise: nonzero_min(
+            get_scale_inv(aux_dict[recipe_name], _col)
+        ),
         lambda buffers, _sn=stat_name_min: min(_get(buffers, _sn)),
     )
     STATS[stat_name_max] = (


### PR DESCRIPTION
 # Description

  The debug API stat `scale_inv_min` was always reporting `0` for MXFP8 and NVFP4 recipes.

  Root cause: `MXFP8Quantizer.get_scale_shape` and `NVFP4Quantizer.get_scale_shape` round the `scale_inv` shape up to multiples of 128 along one axis and 4 along the other:

  - MXFP8 rowwise:    `[round_up(M, 128), round_up(N/32, 4)]`
  - MXFP8 columnwise: `[round_up(M/32, 4), round_up(N, 128)]`
  - NVFP4 rowwise:    `[round_up(M, 128), round_up(⌈K/16⌉, 4)]`
  - NVFP4 columnwise: `[round_up(K, 128), round_up(⌈M/16⌉, 4)]`

  The padded buffer is allocated upfront at the padded shape (`at::empty(padded_shape)` in `quantizer.cpp`), and the cast kernel issues `cudaMemsetAsync(scale_inv, 0, ...)` over the whole buffer before filling the valid region (see `quantize_mxfp8.cuh:780-794`), so padded
   slots end up as literal zeros. `add_scale_inv_stats` in `stats_computation.py` was calling `.min()` over the whole padded tensor, which therefore always returned `0` whenever the unpadded scale shape did not already meet the alignment.

  A real `scale_inv` entry is never zero: `compute_scale_from_amax` (`recipe_common.cuh`) returns `scale = 1.0` for all-zero data blocks and clamps inf to a finite fallback, so zero in `scale_inv` uniquely identifies padding. Masking zeros before `.min()` is therefore
  exact, not heuristic. `.max()` is unaffected (zero cannot be the maximum of a non-negative tensor) and is left as-is.

  Fixes #2628

  ## Type of change

  - [ ] Documentation change (change only to the documentation, either a fix or a new content)
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Infra/Build change
  - [ ] Code refactoring

  ## Changes

  Please list the changes introduced in this PR:

  - Add `nonzero_min` helper in `add_scale_inv_stats` (`transformer_engine/debug/features/utils/stats_computation.py`) that masks out padding zeros before computing the minimum of `scale_inv`.
  - Route the `scale_inv_min` per-step lambda through `nonzero_min`; `scale_inv_max` is unchanged.
  - Degenerate all-zero case returns a `0` scalar of the right dtype/device so the buffer aggregator (`min(_get(...))`) stays well-defined.

  # Checklist:

  - [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
  - [x] The functionality is complete
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes