### PR TITLE
docs: expand comm gemm overlap guidance

### DIFF
--- a/examples/pytorch/comm_gemm_overlap/README.md
+++ b/examples/pytorch/comm_gemm_overlap/README.md
@@ -34,12 +34,18 @@ dist.init_process_group(backend="nccl")
 tp_group = dist.group.WORLD
 tp_size = dist.get_world_size(tp_group)
 
+num_heads = 16
+head_dim = 128
+seq_length = 2048
+micro_batch_size = 4
+
 hidden_size = num_heads * head_dim
-batched_size = seq_length * batch_size
+batched_size = seq_length * micro_batch_size
 
 te.module.base.initialize_ub(
     [batched_size, hidden_size],
     tp_size,
+    quantization_modes=[te.module.base.UserBufferQuantizationMode.NONE],
     dtype=torch.bfloat16,
     bootstrap_backend="nccl",
 )

--- a/examples/pytorch/comm_gemm_overlap/README.md
+++ b/examples/pytorch/comm_gemm_overlap/README.md
@@ -9,6 +9,75 @@
 - Devices older than compute capability 9.0 require `UB_SKIPMC=1` in the environment in order to fall
   back on a less performant implementation based on CUDA Inter-Process Communication (IPC) handles.
 
+## Enabling overlap in your own module
+
+The example follows the same setup sequence that user code should use:
+
+1. Set `CUDA_DEVICE_MAX_CONNECTIONS=1` before creating the layer.
+2. Initialize `torch.distributed` and create the tensor-parallel process group.
+3. Call `te.module.base.initialize_ub(...)` with the local activation shape and tensor-parallel
+   size before constructing TE layers with userbuffer overlap enabled.
+4. Pass the tensor-parallel group, tensor-parallel size, and overlap flags to the TE layer.
+5. Call `te.module.base.destroy_ub()` before shutting down the process group.
+
+Minimal setup sketch:
+
+```python
+import os
+import torch
+import torch.distributed as dist
+import transformer_engine.pytorch as te
+
+os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
+
+dist.init_process_group(backend="nccl")
+tp_group = dist.group.WORLD
+tp_size = dist.get_world_size(tp_group)
+
+hidden_size = num_heads * head_dim
+batched_size = seq_length * batch_size
+
+te.module.base.initialize_ub(
+    [batched_size, hidden_size],
+    tp_size,
+    dtype=torch.bfloat16,
+    bootstrap_backend="nccl",
+)
+
+layer = te.TransformerLayer(
+    hidden_size,
+    4 * hidden_size,
+    num_heads,
+    tp_group=tp_group,
+    tp_size=tp_size,
+    sequence_parallel=True,
+    fuse_qkv_params=True,
+    ub_tp_comm_overlap=True,
+    ub_overlap_ag=True,
+    ub_overlap_rs=True,
+    ub_bulk_wgrad=True,
+    ub_bulk_dgrad=True,
+    seq_length=seq_length,
+)
+
+# ... run forward/backward/optimizer steps ...
+
+te.module.base.destroy_ub()
+```
+
+`ub_tp_comm_overlap` is the top-level gate on `TransformerLayer`: when it is `False`, the
+layer disables the individual userbuffer overlap paths even if the per-path flags are `True`.
+For lower-level layers such as `Linear`, `LayerNormLinear`, `LayerNormMLP`, or
+`MultiheadAttention`, enable the relevant per-path flags directly (for example
+`ub_overlap_ag`, `ub_overlap_rs`, `ub_bulk_wgrad`, and `ub_bulk_dgrad`) and set the `ub_name`
+where the layer requires one.
+
+When replacing modules in a Hugging Face model, run the userbuffer initialization once before
+constructing the replacement TE modules. The replacement modules need the same tensor-parallel
+group, tensor-parallel size, sequence-parallel setting, and overlap flags shown above; the
+activation shape passed to `initialize_ub` should match the sequence length, micro-batch size,
+and hidden size used by the replaced blocks.
+
 ## Examples
 
 ### Single node, tensor-parallel LayerNormMLP:


### PR DESCRIPTION
# Description

Adds source-backed setup guidance to the `comm_gemm_overlap` example README so users can see the userbuffer initialization flow, the relationship between `ub_tp_comm_overlap` and individual overlap flags, and the key Hugging Face replacement considerations.

Fixes #2618

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Documented the setup order: environment, process group, `initialize_ub`, overlap-enabled layer construction, and `destroy_ub`
- Added a minimal `TransformerLayer` setup sketch based on the existing example flow
- Clarified that `ub_tp_comm_overlap` gates the lower-level overlap flags on `TransformerLayer`
- Added cautious Hugging Face replacement guidance without changing example code

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Verification:

```powershell
rg -n "initialize_ub|destroy_ub|ub_tp_comm_overlap|ub_overlap_ag|Hugging Face|CUDA_DEVICE_MAX_CONNECTIONS" examples\pytorch\comm_gemm_overlap\README.md examples\pytorch\comm_gemm_overlap\te_layer_with_overlap.py transformer_engine\pytorch\transformer.py
git diff --check
```

No runtime tests were run because this is a docs-only change for a distributed CUDA example.

This was prepared with Codex assistance, with the final docs reviewed manually against the existing example and `TransformerLayer` source.