### PR TITLE
[PyTorch] Allocate grouped linear wgrads as tensor views

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/allocate.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/allocate.cpp
@@ -12,6 +12,16 @@
 namespace transformer_engine {
 namespace pytorch {
 
+/* Allocate multiple PyTorch tensors backed by the same buffer.
+ *
+ * Use with caution and avoid exposing externally.
+ *
+ * In order to reduce CPU overhead, we compute pointer offsets
+ * manually and construct PyTorch tensors with raw pointers. The
+ * backing buffer is deallocated once the final tensor is destroyed.
+ * Stream usage is not recorded, so there may be race conditions if
+ * compute is performed on multiple streams.
+ */
 std::vector<at::Tensor> bulk_allocate(const std::vector<std::vector<size_t>> &shapes,
                                       const std::vector<at::ScalarType> &dtypes,
                                       std::optional<c10::Device> device,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -496,13 +496,12 @@ class _GroupedLinear(torch.autograd.Function):
                 if ctx.fuse_wgrad_accumulation:
                     wgrad_list = main_grads
                 else:
-                    weight_shape = list(weights[0].size())
-                    wgrad_list = tex.bulk_allocate(
-                        [weight_shape] * ctx.num_gemms,
-                        [ctx.activation_dtype] * ctx.num_gemms,
-                        ctx.device,
-                        [256] * ctx.num_gemms,  # alignment
+                    wgrad_packed = torch.empty(
+                        ctx.num_gemms, *weights[0].size(),
+                        dtype=ctx.activation_dtype,
+                        device=ctx.device,
                     )
+                    wgrad_list = [wgrad_packed[i] for i in range(ctx.num_gemms)]
 
                 if ctx.save_original_input:
                     inp = inputmats[0]

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -497,7 +497,8 @@ class _GroupedLinear(torch.autograd.Function):
                     wgrad_list = main_grads
                 else:
                     wgrad_packed = torch.empty(
-                        ctx.num_gemms, *weights[0].size(),
+                        ctx.num_gemms,
+                        *weights[0].size(),
                         dtype=ctx.activation_dtype,
                         device=ctx.device,
                     )

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -1393,12 +1393,12 @@ class GroupedLinear(BasicOperation):
                     ]
                     accumulate_into_main_grad = get_accumulate_flag_in_param(weights[0])
                 else:
-                    grad_weights = tex.bulk_allocate(
-                        [weight_shape] * num_groups,
-                        [ctx.dtype] * num_groups,
-                        device,
-                        [256] * num_groups,  # alignment
+                    grad_weights_packed = torch.empty(
+                        grouped_shape,
+                        dtype=ctx.dtype,
+                        device=device,
                     )
+                    grad_weights = [grad_weights_packed[i] for i in range(num_groups)]
                 final_weight_grads = list(grad_weights)
 
         # Perform dgrad GEMMs

--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -197,12 +197,12 @@ def _compute_grad_params(
                 w_list = [get_main_grad_from_param(w, op_label=op_label) for w in weights]
                 accumulate_into_main_grad = get_accumulate_flag_in_param(weights[0])
             else:
-                w_list = tex.bulk_allocate(
-                    [weight_shape] * num_groups,
-                    [dtype] * num_groups,
-                    device,
-                    [256] * num_groups,  # alignment
+                wgrad_packed = torch.empty(
+                    num_groups, *weight_shape,
+                    dtype=dtype,
+                    device=device,
                 )
+                w_list = [wgrad_packed[i] for i in range(num_groups)]
             wgrad_output = w_list
 
     if ctx.weight_requires_grad:

--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -198,7 +198,8 @@ def _compute_grad_params(
                 accumulate_into_main_grad = get_accumulate_flag_in_param(weights[0])
             else:
                 wgrad_packed = torch.empty(
-                    num_groups, *weight_shape,
+                    num_groups,
+                    *weight_shape,
                     dtype=dtype,
                     device=device,
                 )


### PR DESCRIPTION
# Description

Under certain configurations, https://github.com/NVIDIA/TransformerEngine/pull/2900 has introduced race conditions with the grouped linear weight grads. This is because [`tex.bulk_allocate`](https://github.com/NVIDIA/TransformerEngine/blob/5f1eaffde87336ef3f1bd877044a7159e02e569d/transformer_engine/pytorch/csrc/extensions/allocate.cpp#L15) constructs tensor views out of raw pointers, bypassing the stream synchronization logic in standard tensor views. This PR fixes this issue by constructing weight grad tensors as plain tensor views.

A simple benchmark on a GB200 node finds that allocating 64 tensor views takes 50 us while `tex.bulk_allocate` takes 58 us. Weight grads are uniform, so they don't need all of the reshaping and dtype conversion logic in `tex.bulk_allocate`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Allocate grouped linear wgrads as tensor views

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
