### PR TITLE
[JAX] Support new JAX triton_kernel_call_ffi for cuda-graph support

### DIFF
--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -44,14 +44,17 @@ import zlib
 from packaging import version
 
 from jax import core
+from jaxlib.mlir import ir
 import jax
 import jax.numpy as jnp
 
 from ..version_utils import (
     TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION,
+    TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION,
     TRITON_EXTENSION_MIN_JAX_VERSION,
     is_triton_autotuned_alias_safe,
     is_triton_extension_supported,
+    jax_version_meet_requirement,
 )
 
 
@@ -626,12 +629,19 @@ def triton_call_lowering(
     else:
         ffi_operand_output_aliases = None
 
-    # Use JAX FFI lowering with compressed protobuf
-    rule = jax.ffi.ffi_lowering(
-        "triton_kernel_call",  # Custom call target registered in gpu_triton.py
-        api_version=2,
-        backend_config=zlib.compress(call_proto),
-        operand_output_aliases=ffi_operand_output_aliases,
-    )
+    compressed_call_proto = zlib.compress(call_proto)
+    if jax_version_meet_requirement(TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION):
+        rule = jax.ffi.ffi_lowering(
+            "triton_kernel_call_ffi",
+            backend_config={"opaque": ir.StringAttr.get(compressed_call_proto)},
+            operand_output_aliases=ffi_operand_output_aliases,
+        )
+    else:
+        rule = jax.ffi.ffi_lowering(
+            "triton_kernel_call",  # Custom call target registered in gpu_triton.py
+            api_version=2,
+            backend_config=compressed_call_proto,
+            operand_output_aliases=ffi_operand_output_aliases,
+        )
 
     return rule(ctx, *array_args)

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -26,7 +26,7 @@ def jax_version_meet_requirement(version: str):
 TRITON_EXTENSION_MIN_JAX_VERSION = "0.8.0"
 
 # Minimum JAX version for non-legacy Triton kernel FFI (supports CUDA graph capture).
-TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION = "0.10.1.dev0"
+TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION = "0.10.1"
 
 # Nightly and stable floors for safe input_output_aliases in TritonAutotunedKernelCall.
 # jaxlib/gpu/triton_kernels.cc had a bug in the autotuning save/restore loop:

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -25,6 +25,9 @@ def jax_version_meet_requirement(version: str):
 # Minimum JAX version required for Triton kernel dispatch (jaxlib < 0.8.0 segfaults).
 TRITON_EXTENSION_MIN_JAX_VERSION = "0.8.0"
 
+# Minimum JAX version for non-legacy Triton kernel FFI (supports CUDA graph capture).
+TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION = "0.10.1.dev0"
+
 # Nightly and stable floors for safe input_output_aliases in TritonAutotunedKernelCall.
 # jaxlib/gpu/triton_kernels.cc had a bug in the autotuning save/restore loop:
 # it iterated over all declared aliases unconditionally, but input_copies only
@@ -76,5 +79,6 @@ __all__ = [
     "is_triton_autotuned_alias_safe",
     "is_triton_extension_supported",
     "TRITON_EXTENSION_MIN_JAX_VERSION",
+    "TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION",
     "TRITON_AUTOTUNED_INPUT_OUTPUT_ALIAS_MIN_JAX_VERSION",
 ]


### PR DESCRIPTION
# Description

Supports JAX triton_kernel_call_ffi on supported JAX versions. This new custom op differs from the legacy triton_kernel_call in that it can be cuda-graphed. See https://github.com/jax-ml/jax/commit/b5479a17c53ff340ed8c501484ea872198a39bcf for more details

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Update triton wrapper to use new triton_kernel_call_ffi if on a supported JAX version

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
