### PR TITLE
[JAX] [PyT] [Common] Enable D=256 BWD cuDNN fused attn for Blackwell CC 10.x 

### DIFF
--- a/qa/L1_jax_distributed_unittest/test.sh
+++ b/qa/L1_jax_distributed_unittest/test.sh
@@ -31,11 +31,11 @@ python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/py
 
 python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_dist_mlp.xml $TE_PATH/tests/jax/test_distributed_layernorm_mlp.py || test_fail "test_distributed_layernorm_mlp.py"
 
-# XLA_FLAGS to WAR for test_distributed_softmax issue with NCCL
-# TODO(Kshitij): remove when NCCL issue is fixed
-XLA_FLAGS="$XLA_FLAGS --xla_gpu_enable_nccl_comm_splitting=false" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_dist_softmax.xml $TE_PATH/tests/jax/test_distributed_softmax.py || test_fail "test_distributed_softmax.py"
-
 python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_dist_fused_attn.xml $TE_PATH/tests/jax/test_distributed_fused_attn.py || test_fail "test_distributed_fused_attn.py"
+
+# XLA_FLAGS to WAR for test_distributed_softmax issue with NCCL
+# TODO(KshitijLakhani): remove when NCCL issue is fixed
+XLA_FLAGS="$XLA_FLAGS --xla_gpu_enable_nccl_comm_splitting=false" python3 -m pytest -c $TE_PATH/tests/jax/pytest.ini -v --junitxml=$XML_LOG_DIR/pytest_dist_softmax.xml $TE_PATH/tests/jax/test_distributed_softmax.py || test_fail "test_distributed_softmax.py"
 
 # NCCL EP multi-process suite. Self-skips on <4 GPUs.
 TE_PATH=$TE_PATH bash $TE_PATH/tests/jax/multi_process_launch_ep.sh || test_fail "test_multi_process_ep.py"

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -22,6 +22,7 @@ from test_fused_attn_score_mod import (
     _has_cudnn_frontend_python,
 )
 from utils import pytest_parametrize_wrapper
+from transformer_engine_jax import get_cudnn_version, get_device_compute_capability
 from transformer_engine.jax.attention import (
     is_fused_attn_kernel_available,
     AttnBiasType,
@@ -345,6 +346,60 @@ DISTRIBUTED_CONTEXT_SELF_ATTN_DATA_SHAPES = [
     pytest.param([4, 256, 16, 64], id="4-256xCPx2-16-64"),
 ]
 
+DISTRIBUTED_CONTEXT_SELF_ATTN_D256_DATA_SHAPES = {
+    "L0": [],
+    "L1": [[2, 128, 16, 256]],
+    "L2": [],
+}
+
+# Keep these as explicit tuples instead of independent layout/mask/window as:
+# BSHD CP uses CAUSAL_MASK, THD CP uses PADDING_CAUSAL_MASK, SWA is
+# only valid for THD, and stripe_size behavior is different for
+# BSHD vs THD in these tests. Splitting the axes would mostly add
+# invalid BSHD+SWA and THD+CAUSAL combinations that fail or skip.
+DISTRIBUTED_CONTEXT_SELF_ATTN_D256_LAYOUTS_MASKS_WINDOWS = [
+    # BSHD with different layouts, but same causal mask and no sliding window
+    pytest.param(
+        QKVLayout.BSHD_BS2HD,
+        AttnMaskType.CAUSAL_MASK,
+        (-1, -1),
+        id="BSHD_KVPACKED-CAUSAL-NO_SWA",
+    ),
+    pytest.param(
+        QKVLayout.BSHD_BSHD_BSHD,
+        AttnMaskType.CAUSAL_MASK,
+        (-1, -1),
+        id="BSHD_SEPARATE-CAUSAL-NO_SWA",
+    ),
+    # THD with different sliding window sizes, but same packed layout and padding causal mask
+    pytest.param(
+        QKVLayout.THD_T2HD,
+        AttnMaskType.PADDING_CAUSAL_MASK,
+        (-1, -1),
+        id="THD_KVPACKED-PADDING_CAUSAL-NO_SWA",
+    ),
+    pytest.param(
+        QKVLayout.THD_T2HD,
+        AttnMaskType.PADDING_CAUSAL_MASK,
+        (20, 0),
+        id="THD_KVPACKED-PADDING_CAUSAL-SWA",
+    ),
+    # THD with different sliding window sizes, but same separate layout and padding causal mask
+    pytest.param(
+        QKVLayout.THD_THD_THD,
+        AttnMaskType.PADDING_CAUSAL_MASK,
+        (-1, -1),
+        id="THD_SEPARATE-PADDING_CAUSAL-NO_SWA",
+    ),
+    pytest.param(
+        QKVLayout.THD_THD_THD,
+        AttnMaskType.PADDING_CAUSAL_MASK,
+        (20, 0),
+        id="THD_SEPARATE-PADDING_CAUSAL-SWA",
+    ),
+]
+
+
 
 class TestDistributedContextParallelSelfAttn:
     # TODO(KshitijLakhani): parametrize num_segments_per_seq for all CP tests
@@ -636,6 +691,118 @@ class TestDistributedContextParallelSelfAttn:
             use_scan_ring=use_scan,
             window_size=window_size,
             stripe_size=stripe_size,
+        )
+    # CP ring and all-gather tests for D=256
+    # TODO(KshitijLakhani): Replace this with common-provided fused-attn disable reasons once
+    # they can be surfaced to framework tests.
+    @staticmethod
+    def skip_if_d256_cp_unsupported(qkv_layout):
+        compute_capability = get_device_compute_capability(0)
+        if not 100 <= compute_capability < 110:
+            pytest.skip("D=256 CP fused attention is only enabled on Blackwell server GPUs.")
+
+        required_cudnn_version = 93000 if qkv_layout.is_thd() else 92300
+        required_cudnn_version_label = "9.30" if qkv_layout.is_thd() else "9.23"
+        if get_cudnn_version() < required_cudnn_version:
+            pytest.skip(
+                f"D=256 CP fused attention with {qkv_layout} requires cuDNN"
+                f" {required_cudnn_version_label} or newer."
+            )
+
+    @pytest_parametrize_wrapper(
+        "device_count,mesh_shape,mesh_axes,mesh_resource",
+        generate_context_parallel_configs_for_attn(),
+    )
+    @pytest_parametrize_wrapper(
+        "data_shape",
+        DISTRIBUTED_CONTEXT_SELF_ATTN_D256_DATA_SHAPES,
+    )
+    @pytest.mark.parametrize(
+        "dtype",
+        [pytest.param(jnp.float16, id="FP16"), pytest.param(jnp.bfloat16, id="BF16")],
+    )
+    @pytest.mark.parametrize(
+        "qkv_layout, attn_mask_type, window_size",
+        DISTRIBUTED_CONTEXT_SELF_ATTN_D256_LAYOUTS_MASKS_WINDOWS,
+    )
+    def test_context_parallel_ring_attn_d256(
+        self,
+        device_count,
+        mesh_shape,
+        mesh_axes,
+        mesh_resource,
+        data_shape,
+        dtype,
+        qkv_layout,
+        attn_mask_type,
+        window_size,
+    ):
+        """D=256 CP ring coverage."""
+        self.skip_if_d256_cp_unsupported(qkv_layout)
+
+        self.impl_test_context_parallel_attn(
+            device_count,
+            mesh_shape,
+            mesh_axes,
+            mesh_resource,
+            data_shape,
+            1,
+            attn_mask_type,
+            dtype,
+            qkv_layout,
+            True,
+            CPStrategy.RING,
+            use_scan_ring=False,
+            window_size=window_size,
+            stripe_size=1 if qkv_layout.is_thd() else None,
+        )
+
+    @pytest_parametrize_wrapper(
+        "device_count,mesh_shape,mesh_axes,mesh_resource",
+        generate_context_parallel_configs_for_attn(),
+    )
+    @pytest_parametrize_wrapper(
+        "data_shape",
+        DISTRIBUTED_CONTEXT_SELF_ATTN_D256_DATA_SHAPES,
+    )
+    @pytest.mark.parametrize(
+        "dtype",
+        [pytest.param(jnp.float16, id="FP16"), pytest.param(jnp.bfloat16, id="BF16")],
+    )
+    @pytest.mark.parametrize(
+        "qkv_layout, attn_mask_type, window_size",
+        DISTRIBUTED_CONTEXT_SELF_ATTN_D256_LAYOUTS_MASKS_WINDOWS,
+    )
+    def test_context_parallel_allgather_attn_d256(
+        self,
+        device_count,
+        mesh_shape,
+        mesh_axes,
+        mesh_resource,
+        data_shape,
+        dtype,
+        qkv_layout,
+        attn_mask_type,
+        window_size,
+    ):
+        """D=256 CP all-gather coverage."""
+        self.skip_if_d256_cp_unsupported(qkv_layout)
+
+        self.impl_test_context_parallel_attn(
+            device_count,
+            mesh_shape,
+            mesh_axes,
+            mesh_resource,
+            data_shape,
+            1,
+            attn_mask_type,
+            dtype,
+            qkv_layout,
+            True,
+            CPStrategy.ALL_GATHER,
+            window_size=window_size,
+            stripe_size=128 if qkv_layout.is_thd() else None,
+            num_segments_per_seq=5 if qkv_layout.is_thd() else None,
         )
 
 

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -701,8 +701,8 @@ class TestDistributedContextParallelSelfAttn:
         if not 100 <= compute_capability < 110:
             pytest.skip("D=256 CP fused attention is only enabled on Blackwell server GPUs.")
 
-        required_cudnn_version = 93000 if qkv_layout.is_thd() else 92300
-        required_cudnn_version_label = "9.30" if qkv_layout.is_thd() else "9.23"
+        required_cudnn_version = 92500 if qkv_layout.is_thd() else 92300
+        required_cudnn_version_label = "9.25" if qkv_layout.is_thd() else "9.23"
         if get_cudnn_version() < required_cudnn_version:
             pytest.skip(
                 f"D=256 CP fused attention with {qkv_layout} requires cuDNN"

--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -400,7 +400,6 @@ DISTRIBUTED_CONTEXT_SELF_ATTN_D256_LAYOUTS_MASKS_WINDOWS = [
 ]
 
 
-
 class TestDistributedContextParallelSelfAttn:
     # TODO(KshitijLakhani): parametrize num_segments_per_seq for all CP tests
     def impl_test_context_parallel_attn(
@@ -692,6 +691,7 @@ class TestDistributedContextParallelSelfAttn:
             window_size=window_size,
             stripe_size=stripe_size,
         )
+
     # CP ring and all-gather tests for D=256
     # TODO(KshitijLakhani): Replace this with common-provided fused-attn disable reasons once
     # they can be surfaced to framework tests.

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -511,16 +511,16 @@ class FusedAttnRunner:
                     "D=256 BWD on Blackwell requires cuDNN 9.23 or newer;"
                     f" got cuDNN {cudnn_version}."
                 )
-            # Non-learnable bias is fine (bias is allowed as an input); only dBias is
-            # unsupported. The JAX runner asks for dBias iff the bias shape is [1, h, s, s]
-            # (see test_backward), so gate on that.
+            # TODO(KshitijLakhani): cuDNN FE can model bias input separately from dBias,
+            # but TE does not yet plumb whether dBias is requested into the common backend selector. 
+            # Until that distinction is available, the D=256 SM10x gate requires no bias.
             unsupported = None
             if self.attn_bias_type == AttnBiasType.PRE_SCALE_BIAS:
                 unsupported = "pre-scale bias"
-            elif self.attn_bias_type != AttnBiasType.NO_BIAS and self.bias_shape == BiasShape._1HSS:
+            elif self.attn_bias_type != AttnBiasType.NO_BIAS:
                 unsupported = (
-                    "bias gradients (dBias); frozen/non-learnable bias inputs"
-                    " (i.e. non-1HSS bias shapes) are supported"
+                    "post-scale bias in TE's D=256 backend gate; bias-input-only"
+                    " support needs TE to distinguish between bias input and dBias"
                 )
             elif self.dropout_prob != 0.0:
                 unsupported = "dropout"

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -497,7 +497,7 @@ class FusedAttnRunner:
         cudnn_version = get_cudnn_version()
         # D=256 bprop on SM10x uses the deterministic algorithm path only. BSHD support
         # starts with cuDNN FE 1.24 / BE 9.23; THD execution-plan support starts with
-        # cuDNN FE 1.26 / BE 9.30. The kernel rejects dBias, dropout, and ALiBi, supports vanilla
+        # cuDNN FE 1.26 / BE 9.25. The kernel rejects dBias, dropout, and ALiBi, supports vanilla
         # softmax only, and allows SWA together with a causal mask only.
         is_sm10x = 100 <= compute_capability < 110
         if self.is_training and is_sm10x and (self.head_dim_qk == 256 or self.head_dim_v == 256):
@@ -506,8 +506,8 @@ class FusedAttnRunner:
                     "D=256 BWD on Blackwell only supports d_qk == d_v == 256;"
                     f" got d_qk={self.head_dim_qk}, d_v={self.head_dim_v}."
                 )
-            required_cudnn_version = 93000 if self.qkv_layout.is_thd() else 92300
-            required_cudnn_version_label = "9.30" if self.qkv_layout.is_thd() else "9.23"
+            required_cudnn_version = 92500 if self.qkv_layout.is_thd() else 92300
+            required_cudnn_version_label = "9.25" if self.qkv_layout.is_thd() else "9.23"
             if cudnn_version < required_cudnn_version:
                 pytest.skip(
                     f"D=256 BWD on Blackwell with {self.qkv_layout} requires cuDNN"
@@ -1694,7 +1694,7 @@ class TestFusedAttn:
             id="2-1024-2048-12-6-128-64-BF16-CROSS-GQA-RAGGED_SEPARATE",
         ),
         # D=256 deterministic backward on the SM100 dedicated SDPA bprop kernel.
-        # BSHD requires cuDNN FE 1.24 / BE 9.23+; THD requires cuDNN FE 1.26 / BE 9.30+.
+        # BSHD requires cuDNN FE 1.24 / BE 9.23+; THD requires cuDNN FE 1.26 / BE 9.25+.
         pytest.param(
             4,
             128,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -469,7 +469,6 @@ class FusedAttnRunner:
             return 1
 
     def _check_configs(self):
-        # TODO(rewang): probably adds this in is_fused_attn_available
         # TODO(KshitijLakhani): probably add/move this to is_fused_attn_available
         if self.qkv_layout.is_thd() and not self.attn_mask_type.is_padding():
             pytest.skip("THD format requires padding masks.")

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1695,6 +1695,21 @@ class TestFusedAttn:
             QKVLayout.THD_THD_THD,
             id="2-1024-2048-12-6-128-64-BF16-CROSS-GQA-RAGGED_SEPARATE",
         ),
+        # D=256 deterministic backward on the SM100 dedicated SDPA bprop kernel
+        # (cuDNN FE 1.24 / BE 9.23+). Unsupported configs (e.g. dBias, non-256 head dims)
+        # are skipped by FusedAttnRunner._check_configs.
+        pytest.param(
+            4,
+            128,
+            128,
+            16,
+            16,
+            256,
+            256,
+            jnp.float16,
+            QKVLayout.BSHD_BS2HD,
+            id="4-128-128-16-16-256-256-FP16-SELF-KV_PACKED",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -1807,113 +1822,6 @@ class TestFusedAttnWithDeterminism:
     ):
         """
         Test backward with parameterized configs
-        """
-        TestFusedAttn.test_backward(
-            b,
-            s_q,
-            s_kv,
-            h_q,
-            h_kv,
-            d_qk,
-            d_v,
-            attn_bias_type,
-            attn_mask_type,
-            softmax_type,
-            dropout_prob,
-            dtype,
-            qkv_layout,
-            bias_shape,
-            swa,
-            seq_desc_format,
-        )
-
-
-@pytest.mark.parametrize(
-    "attn_mask_type",
-    [
-        pytest.param(AttnMaskType.NO_MASK, id="NO_MASK"),
-        pytest.param(AttnMaskType.PADDING_MASK, id="PADDING"),
-        pytest.param(AttnMaskType.CAUSAL_MASK, id="CAUSAL"),
-        pytest.param(AttnMaskType.PADDING_CAUSAL_MASK, id="PADDING_CAUSAL"),
-        pytest.param(
-            AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK, id="PADDING_CAUSAL_BOTTOM_RIGHT"
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "softmax_type",
-    [
-        pytest.param(AttnSoftmaxType.VANILLA_SOFTMAX, id="VANILLA_SOFTMAX"),
-    ],
-)
-@pytest.mark.parametrize(
-    "dropout_prob",
-    [
-        pytest.param(0.0, id="DROP_0.0"),
-    ],
-)
-@pytest.mark.parametrize(
-    "swa",
-    [
-        pytest.param(False, id="NO_SWA"),
-    ],
-)
-@pytest.mark.parametrize(
-    "seq_desc_format",
-    [
-        pytest.param(SeqDescFormat.Seqlens, id="Seqlens"),
-    ],
-)
-@pytest.mark.skipif(not _deterministic, reason="Test determinism only")
-class TestFusedAttnD256WithDeterminism:
-    """
-    Fused attention D=256 deterministic backward tester.
-    """
-
-    @staticmethod
-    @pytest.mark.parametrize(
-        "b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout",
-        [
-            pytest.param(
-                4,
-                128,
-                128,
-                16,
-                16,
-                256,
-                256,
-                jnp.float16,
-                QKVLayout.BSHD_BS2HD,
-                id="4-128-128-16-16-256-256-FP16-SELF-KV_PACKED",
-            ),
-        ],
-    )
-    @pytest.mark.parametrize(
-        "attn_bias_type, bias_shape",
-        [
-            pytest.param(AttnBiasType.NO_BIAS, None, id="NO_BIAS"),
-        ],
-    )
-    def test_backward(
-        b,
-        s_q,
-        s_kv,
-        h_q,
-        h_kv,
-        d_qk,
-        d_v,
-        attn_bias_type,
-        attn_mask_type,
-        softmax_type,
-        dropout_prob,
-        dtype,
-        qkv_layout,
-        bias_shape,
-        swa,
-        seq_desc_format,
-    ):
-        """
-        Test D=256 backward with the supported deterministic SM100 bprop configuration.
         """
         TestFusedAttn.test_backward(
             b,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -512,7 +512,7 @@ class FusedAttnRunner:
                     f" got cuDNN {cudnn_version}."
                 )
             # TODO(KshitijLakhani): cuDNN FE can model bias input separately from dBias,
-            # but TE does not yet plumb whether dBias is requested into the common backend selector. 
+            # but TE does not yet plumb whether dBias is requested into the common backend selector.
             # Until that distinction is available, the D=256 SM10x gate requires no bias.
             unsupported = None
             if self.attn_bias_type == AttnBiasType.PRE_SCALE_BIAS:

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1705,6 +1705,22 @@ class TestFusedAttn:
             QKVLayout.BSHD_BS2HD,
             id="4-128-128-16-16-256-256-FP16-SELF-KV_PACKED",
         ),
+        pytest.param(
+            4,
+            128,
+            128,
+            16,
+            16,
+            256,
+            256,
+            jnp.float16,
+            QKVLayout.THD_T2HD,
+            id="4-128-128-16-16-256-256-FP16-SELF-RAGGED_KV_PACKED",
+            marks=pytest.mark.xfail(
+                reason="cuDNN 9.23 D=256 BWD currently does not build a THD execution plan.",
+                strict=True,
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -520,6 +520,59 @@ class FusedAttnRunner:
                 "is either BSHD_BSHD_BSHD or THD_THD_THD"
             )
 
+        # D=256 bprop on SM10.x uses cuDNN's dedicated SDPA bprop kernel
+        # (cuDNN FE 1.24 / BE 9.23+). FE forces this path onto the deterministic algorithm path,
+        # which rejects dBias, dropout, and ALiBi. It supports vanilla softmax only and allows SWA
+        # together with a causal mask only.
+        compute_capability = get_device_compute_capability(0)
+        is_sm10x = 100 <= compute_capability < 110
+        if self.is_training and is_sm10x and (self.head_dim_qk == 256 or self.head_dim_v == 256):
+            if self.head_dim_qk != 256 or self.head_dim_v != 256:
+                pytest.skip(
+                    "D=256 BWD on Blackwell only supports d_qk == d_v == 256;"
+                    f" got d_qk={self.head_dim_qk}, d_v={self.head_dim_v}."
+                )
+            cudnn_version = get_cudnn_version()
+            if cudnn_version < 92300:
+                pytest.skip(
+                    "D=256 BWD on Blackwell requires cuDNN 9.23 or newer;"
+                    f" got cuDNN {cudnn_version}."
+                )
+            # Non-learnable bias is fine (bias is allowed as an input); only dBias is
+            # unsupported. The JAX runner asks for dBias iff the bias shape is [1, h, s, s]
+            # (see test_backward), so gate on that.
+            unsupported = None
+            if self.attn_bias_type == AttnBiasType.PRE_SCALE_BIAS:
+                unsupported = "pre-scale bias"
+            elif (
+                self.attn_bias_type != AttnBiasType.NO_BIAS
+                and self.bias_shape == BiasShape._1HSS
+            ):
+                unsupported = (
+                    "bias gradients (dBias); frozen/non-learnable bias inputs"
+                    " (i.e. non-1HSS bias shapes) are supported"
+                )
+            elif self.dropout_prob != 0.0:
+                unsupported = "dropout"
+            elif self.softmax_type != AttnSoftmaxType.VANILLA_SOFTMAX:
+                unsupported = "non-vanilla softmax"
+            if unsupported is not None:
+                pytest.skip(
+                    "D=256 BWD on Blackwell uses the deterministic SM100 D=256 SDPA BWD"
+                    f" kernel which does not support {unsupported}."
+                )
+            if self.window_size is not None and self.window_size != (-1, -1):
+                if not self.attn_mask_type.is_causal():
+                    pytest.skip(
+                        "D=256 BWD on Blackwell uses the SM100 D=256 SDPA BWD kernel"
+                        " which requires window_size=(-1, -1) for non-causal masks."
+                    )
+                if self.window_size[1] not in (-1, 0):
+                    pytest.skip(
+                        "D=256 BWD on Blackwell only supports right window -1 or 0"
+                        " for causal masks."
+                    )
+
         self.backend = FusedAttnHelper(
             self.is_training,
             self.dtype,
@@ -1754,6 +1807,113 @@ class TestFusedAttnWithDeterminism:
     ):
         """
         Test backward with parameterized configs
+        """
+        TestFusedAttn.test_backward(
+            b,
+            s_q,
+            s_kv,
+            h_q,
+            h_kv,
+            d_qk,
+            d_v,
+            attn_bias_type,
+            attn_mask_type,
+            softmax_type,
+            dropout_prob,
+            dtype,
+            qkv_layout,
+            bias_shape,
+            swa,
+            seq_desc_format,
+        )
+
+
+@pytest.mark.parametrize(
+    "attn_mask_type",
+    [
+        pytest.param(AttnMaskType.NO_MASK, id="NO_MASK"),
+        pytest.param(AttnMaskType.PADDING_MASK, id="PADDING"),
+        pytest.param(AttnMaskType.CAUSAL_MASK, id="CAUSAL"),
+        pytest.param(AttnMaskType.PADDING_CAUSAL_MASK, id="PADDING_CAUSAL"),
+        pytest.param(
+            AttnMaskType.PADDING_CAUSAL_BOTTOM_RIGHT_MASK, id="PADDING_CAUSAL_BOTTOM_RIGHT"
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "softmax_type",
+    [
+        pytest.param(AttnSoftmaxType.VANILLA_SOFTMAX, id="VANILLA_SOFTMAX"),
+    ],
+)
+@pytest.mark.parametrize(
+    "dropout_prob",
+    [
+        pytest.param(0.0, id="DROP_0.0"),
+    ],
+)
+@pytest.mark.parametrize(
+    "swa",
+    [
+        pytest.param(False, id="NO_SWA"),
+    ],
+)
+@pytest.mark.parametrize(
+    "seq_desc_format",
+    [
+        pytest.param(SeqDescFormat.Seqlens, id="Seqlens"),
+    ],
+)
+@pytest.mark.skipif(not _deterministic, reason="Test determinism only")
+class TestFusedAttnD256WithDeterminism:
+    """
+    Fused attention D=256 deterministic backward tester.
+    """
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "b, s_q, s_kv, h_q, h_kv, d_qk, d_v, dtype, qkv_layout",
+        [
+            pytest.param(
+                4,
+                128,
+                128,
+                16,
+                16,
+                256,
+                256,
+                jnp.float16,
+                QKVLayout.BSHD_BS2HD,
+                id="4-128-128-16-16-256-256-FP16-SELF-KV_PACKED",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "attn_bias_type, bias_shape",
+        [
+            pytest.param(AttnBiasType.NO_BIAS, None, id="NO_BIAS"),
+        ],
+    )
+    def test_backward(
+        b,
+        s_q,
+        s_kv,
+        h_q,
+        h_kv,
+        d_qk,
+        d_v,
+        attn_bias_type,
+        attn_mask_type,
+        softmax_type,
+        dropout_prob,
+        dtype,
+        qkv_layout,
+        bias_shape,
+        swa,
+        seq_desc_format,
+    ):
+        """
+        Test D=256 backward with the supported deterministic SM100 bprop configuration.
         """
         TestFusedAttn.test_backward(
             b,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -470,6 +470,7 @@ class FusedAttnRunner:
 
     def _check_configs(self):
         # TODO(rewang): probably adds this in is_fused_attn_available
+        # TDOD(KshitijLakhani): probably add/move this to is_fused_attn_available
         if self.qkv_layout.is_thd() and not self.attn_mask_type.is_padding():
             pytest.skip("THD format requires padding masks.")
 
@@ -493,38 +494,11 @@ class FusedAttnRunner:
             pytest.skip(
                 "seqlen_q > seqlen_kv is not supported with sliding window attention in cuDNN"
             )
-
-        if get_device_compute_capability(0) >= 100 and self.is_training:
-            if FusedAttnHelper.is_non_deterministic_allowed() and (
-                (self.dropout_prob != 0.0 and self.attn_bias_type != AttnBiasType.NO_BIAS)
-                or get_cudnn_version() < 90700
-            ):
-                pytest.skip(
-                    "For sm100+, non-deterministic bprop (cuDNN 9.7+) does not support bias with"
-                    " dropout"
-                )
-            if not FusedAttnHelper.is_non_deterministic_allowed() and (
-                self.dropout_prob != 0.0
-                or self.attn_bias_type != AttnBiasType.NO_BIAS
-                or get_cudnn_version() < 91801
-            ):
-                pytest.skip(
-                    "For sm100+, deterministic bprop (cuDNN 9.18.1+) does not support bias or"
-                    " dropout"
-                )
-        # Test the MLA case where head dims for qk differ from head dims for v, only if the tensors
-        # are provided in BSHD_BSHD_BSHD or THD_THD_THD formats
-        if self.head_dim_qk != self.head_dim_v and not self.qkv_layout.is_separate():
-            pytest.skip(
-                "For head_dim_qk != head_dim_v, it is necessary that the QKV layout "
-                "is either BSHD_BSHD_BSHD or THD_THD_THD"
-            )
-
-        # D=256 bprop on SM10.x uses cuDNN's dedicated SDPA bprop kernel
-        # (cuDNN FE 1.24 / BE 9.23+). FE forces this path onto the deterministic algorithm path,
-        # which rejects dBias, dropout, and ALiBi. It supports vanilla softmax only and allows SWA
-        # together with a causal mask only.
         compute_capability = get_device_compute_capability(0)
+        cudnn_version = get_cudnn_version()
+        # D=256 bprop on SM10x (cuDNN FE 1.24 / BE 9.23+) uses the deterministic algorithm path only,
+        # which rejects dBias, dropout, and ALiBi. It supports vanilla type of softmax only and allows SWA
+        # together with a causal mask only.
         is_sm10x = 100 <= compute_capability < 110
         if self.is_training and is_sm10x and (self.head_dim_qk == 256 or self.head_dim_v == 256):
             if self.head_dim_qk != 256 or self.head_dim_v != 256:
@@ -532,7 +506,6 @@ class FusedAttnRunner:
                     "D=256 BWD on Blackwell only supports d_qk == d_v == 256;"
                     f" got d_qk={self.head_dim_qk}, d_v={self.head_dim_v}."
                 )
-            cudnn_version = get_cudnn_version()
             if cudnn_version < 92300:
                 pytest.skip(
                     "D=256 BWD on Blackwell requires cuDNN 9.23 or newer;"
@@ -569,6 +542,32 @@ class FusedAttnRunner:
                         "D=256 BWD on Blackwell only supports right window -1 or 0"
                         " for causal masks."
                     )
+
+        if compute_capability >= 100 and self.is_training:
+            if FusedAttnHelper.is_non_deterministic_allowed() and (
+                (self.dropout_prob != 0.0 and self.attn_bias_type != AttnBiasType.NO_BIAS)
+                or cudnn_version < 90700
+            ):
+                pytest.skip(
+                    "For sm100+, non-deterministic bprop (cuDNN 9.7+) does not support bias with"
+                    " dropout"
+                )
+            if not FusedAttnHelper.is_non_deterministic_allowed() and (
+                self.dropout_prob != 0.0
+                or self.attn_bias_type != AttnBiasType.NO_BIAS
+                or cudnn_version < 91801
+            ):
+                pytest.skip(
+                    "For sm100+, deterministic bprop (cuDNN 9.18.1+) does not support bias or"
+                    " dropout"
+                )
+        # Test the MLA case where head dims for qk differ from head dims for v, only if the tensors
+        # are provided in BSHD_BSHD_BSHD or THD_THD_THD formats
+        if self.head_dim_qk != self.head_dim_v and not self.qkv_layout.is_separate():
+            pytest.skip(
+                "For head_dim_qk != head_dim_v, it is necessary that the QKV layout "
+                "is either BSHD_BSHD_BSHD or THD_THD_THD"
+            )
 
         self.backend = FusedAttnHelper(
             self.is_training,
@@ -1693,8 +1692,7 @@ class TestFusedAttn:
             id="2-1024-2048-12-6-128-64-BF16-CROSS-GQA-RAGGED_SEPARATE",
         ),
         # D=256 deterministic backward on the SM100 dedicated SDPA bprop kernel
-        # (cuDNN FE 1.24 / BE 9.23+). Unsupported configs (e.g. dBias, non-256 head dims)
-        # are skipped by FusedAttnRunner._check_configs.
+        # (cuDNN FE 1.24 / BE 9.23+).
         pytest.param(
             4,
             128,

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -544,10 +544,7 @@ class FusedAttnRunner:
             unsupported = None
             if self.attn_bias_type == AttnBiasType.PRE_SCALE_BIAS:
                 unsupported = "pre-scale bias"
-            elif (
-                self.attn_bias_type != AttnBiasType.NO_BIAS
-                and self.bias_shape == BiasShape._1HSS
-            ):
+            elif self.attn_bias_type != AttnBiasType.NO_BIAS and self.bias_shape == BiasShape._1HSS:
                 unsupported = (
                     "bias gradients (dBias); frozen/non-learnable bias inputs"
                     " (i.e. non-1HSS bias shapes) are supported"

--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -470,7 +470,7 @@ class FusedAttnRunner:
 
     def _check_configs(self):
         # TODO(rewang): probably adds this in is_fused_attn_available
-        # TDOD(KshitijLakhani): probably add/move this to is_fused_attn_available
+        # TODO(KshitijLakhani): probably add/move this to is_fused_attn_available
         if self.qkv_layout.is_thd() and not self.attn_mask_type.is_padding():
             pytest.skip("THD format requires padding masks.")
 
@@ -496,9 +496,10 @@ class FusedAttnRunner:
             )
         compute_capability = get_device_compute_capability(0)
         cudnn_version = get_cudnn_version()
-        # D=256 bprop on SM10x (cuDNN FE 1.24 / BE 9.23+) uses the deterministic algorithm path only,
-        # which rejects dBias, dropout, and ALiBi. It supports vanilla type of softmax only and allows SWA
-        # together with a causal mask only.
+        # D=256 bprop on SM10x uses the deterministic algorithm path only. BSHD support
+        # starts with cuDNN FE 1.24 / BE 9.23; THD execution-plan support starts with
+        # cuDNN FE 1.26 / BE 9.30. The kernel rejects dBias, dropout, and ALiBi, supports vanilla
+        # softmax only, and allows SWA together with a causal mask only.
         is_sm10x = 100 <= compute_capability < 110
         if self.is_training and is_sm10x and (self.head_dim_qk == 256 or self.head_dim_v == 256):
             if self.head_dim_qk != 256 or self.head_dim_v != 256:
@@ -506,10 +507,12 @@ class FusedAttnRunner:
                     "D=256 BWD on Blackwell only supports d_qk == d_v == 256;"
                     f" got d_qk={self.head_dim_qk}, d_v={self.head_dim_v}."
                 )
-            if cudnn_version < 92300:
+            required_cudnn_version = 93000 if self.qkv_layout.is_thd() else 92300
+            required_cudnn_version_label = "9.30" if self.qkv_layout.is_thd() else "9.23"
+            if cudnn_version < required_cudnn_version:
                 pytest.skip(
-                    "D=256 BWD on Blackwell requires cuDNN 9.23 or newer;"
-                    f" got cuDNN {cudnn_version}."
+                    f"D=256 BWD on Blackwell with {self.qkv_layout} requires cuDNN"
+                    f" {required_cudnn_version_label} or newer; got cuDNN {cudnn_version}."
                 )
             # TODO(KshitijLakhani): cuDNN FE can model bias input separately from dBias,
             # but TE does not yet plumb whether dBias is requested into the common backend selector.
@@ -1691,8 +1694,8 @@ class TestFusedAttn:
             QKVLayout.THD_THD_THD,
             id="2-1024-2048-12-6-128-64-BF16-CROSS-GQA-RAGGED_SEPARATE",
         ),
-        # D=256 deterministic backward on the SM100 dedicated SDPA bprop kernel
-        # (cuDNN FE 1.24 / BE 9.23+).
+        # D=256 deterministic backward on the SM100 dedicated SDPA bprop kernel.
+        # BSHD requires cuDNN FE 1.24 / BE 9.23+; THD requires cuDNN FE 1.26 / BE 9.30+.
         pytest.param(
             4,
             128,
@@ -1716,10 +1719,6 @@ class TestFusedAttn:
             jnp.float16,
             QKVLayout.THD_T2HD,
             id="4-128-128-16-16-256-256-FP16-SELF-RAGGED_KV_PACKED",
-            marks=pytest.mark.xfail(
-                reason="cuDNN 9.23 D=256 BWD currently does not build a THD execution plan.",
-                strict=True,
-            ),
         ),
     ],
 )

--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -18,7 +18,7 @@ from transformer_engine.pytorch import DType
 from test_attention_with_cp import (
     model_configs_flash_attn,
     model_configs_fused_attn,
-    model_configs_fused_attn_hdim256,
+    model_configs_fused_attn_d256,
 )
 from transformer_engine.pytorch import (
     autocast,
@@ -242,8 +242,8 @@ def run_dpa_with_cp(
         os.environ["NVTE_FUSED_ATTN"] = "1"
         if model in model_configs_fused_attn:
             config = copy.deepcopy(model_configs_fused_attn[model])
-        elif model in model_configs_fused_attn_hdim256:
-            config = copy.deepcopy(model_configs_fused_attn_hdim256[model])
+        elif model in model_configs_fused_attn_d256:
+            config = copy.deepcopy(model_configs_fused_attn_d256[model])
         else:
             assert False, f"{model=} is not a known FusedAttention CP config!"
     assert config.attn_mask_type in [

--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -18,7 +18,6 @@ from transformer_engine.pytorch import DType
 from test_attention_with_cp import (
     model_configs_flash_attn,
     model_configs_fused_attn,
-    model_configs_fused_attn_d256,
 )
 from transformer_engine.pytorch import (
     autocast,
@@ -242,8 +241,6 @@ def run_dpa_with_cp(
         os.environ["NVTE_FUSED_ATTN"] = "1"
         if model in model_configs_fused_attn:
             config = copy.deepcopy(model_configs_fused_attn[model])
-        elif model in model_configs_fused_attn_d256:
-            config = copy.deepcopy(model_configs_fused_attn_d256[model])
         else:
             assert False, f"{model=} is not a known FusedAttention CP config!"
     assert config.attn_mask_type in [

--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -15,7 +15,11 @@ from transformer_engine.pytorch.attention.dot_product_attention.context_parallel
 from transformer_engine.pytorch.attention.dot_product_attention.utils import combine_and_quantize
 import transformer_engine_torch as tex
 from transformer_engine.pytorch import DType
-from test_attention_with_cp import model_configs_flash_attn, model_configs_fused_attn
+from test_attention_with_cp import (
+    model_configs_flash_attn,
+    model_configs_fused_attn,
+    model_configs_fused_attn_hdim256,
+)
 from transformer_engine.pytorch import (
     autocast,
     DotProductAttention,
@@ -236,7 +240,12 @@ def run_dpa_with_cp(
         config = copy.deepcopy(model_configs_flash_attn[model])
     if kernel_backend == "FusedAttention":
         os.environ["NVTE_FUSED_ATTN"] = "1"
-        config = copy.deepcopy(model_configs_fused_attn[model])
+        if model in model_configs_fused_attn:
+            config = copy.deepcopy(model_configs_fused_attn[model])
+        elif model in model_configs_fused_attn_hdim256:
+            config = copy.deepcopy(model_configs_fused_attn_hdim256[model])
+        else:
+            assert False, f"{model=} is not a known FusedAttention CP config!"
     assert config.attn_mask_type in [
         "causal",
         "no_mask",

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -134,6 +134,7 @@ def test_dot_product_attention(
     swa,
     pad_between_seqs,
     declarative_packed=False,
+    run_backward=True,
 ):
     """Test DotProductAttention module"""
 
@@ -168,10 +169,10 @@ def test_dot_product_attention(
 
     # Get backends
     # For 111s, dbias calculation is not supported as of cuDNN 9.18, hence, test fwd only for 111s.
-    # For all other shapes test fwd+bwd
-    is_training = True
+    # For all other shapes test fwd+bwd unless the caller requests fwd-only coverage.
+    is_training = run_backward
     # TODO(KshitijLakhani): Set is_training to True for all cases once cuDNN supports dbias for 111s.
-    if config.bias_shape == "111s":
+    if is_training and config.bias_shape == "111s":
         is_training = False
         logging.info(
             "Setting is_training to False as cuDNN does not support dbias for"
@@ -374,7 +375,11 @@ model_configs_fa4_hdim256 = {
 @pytest.mark.parametrize("model", model_configs_fa4_hdim256.keys())
 def test_dpa_fa4_hdim256(dtype, model_configs, model):
     """Test DotProductAttention with FA4: head_dim=256 dedicated kernel on SM100"""
-    test_dot_product_attention(dtype, model_configs, model, False, None, False, False)
+    # Keep this FA4 D=256 test forward-only. Before cuDNN D=256 backward support,
+    # the generic helper took this path implicitly because fused-attn training was unavailable.
+    test_dot_product_attention(
+        dtype, model_configs, model, False, None, False, False, run_backward=False
+    )
 
 
 # cuDNN FusedAttention D=256 bprop is supported on sm10x by the dedicated deterministic

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -381,16 +381,16 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
 # SDPA bprop kernel. BSHD support starts with cuDNN FE 1.24 / BE 9.23; THD support starts
 # with cuDNN FE 1.26 / BE 9.25. The kernel supports d_qk == d_v == 256 only, vanilla softmax only,
 # no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
-model_configs_fused_d256 = {
+model_configs_d256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
-    "fused_d256_no_mask": ModelConfig(2, 512, 16, 256),
-    "fused_d256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
+    "d256_no_mask": ModelConfig(2, 512, 16, 256),
+    "d256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
     # SWA is allowed only together with a causal mask on the D=256 bprop kernel.
-    "fused_d256_causal_swa": ModelConfig(
+    "d256_causal_swa": ModelConfig(
         2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
     ),
     # GQA variant (num_gqa_groups < num_heads).
-    "fused_d256_padding_causal_gqa": ModelConfig(
+    "d256_padding_causal_gqa": ModelConfig(
         2, 1024, 16, 256, num_gqa_groups=4, attn_mask_type="padding_causal"
     ),
 }
@@ -401,8 +401,8 @@ model_configs_fused_d256 = {
     reason="cuDNN FusedAttention head_dim=256 backward is Blackwell server (SM100/SM103) only.",
 )
 @pytest.mark.parametrize("dtype", param_types)
-@pytest.mark.parametrize("model_configs", [model_configs_fused_d256])
-@pytest.mark.parametrize("model", model_configs_fused_d256.keys())
+@pytest.mark.parametrize("model_configs", [model_configs_d256])
+@pytest.mark.parametrize("model", model_configs_d256.keys())
 @pytest.mark.parametrize(
     "qkv_layout",
     [
@@ -424,8 +424,8 @@ model_configs_fused_d256 = {
         ),
     ],
 )
-def test_dpa_fused_attn_d256(dtype, model_configs, model, qkv_layout):
-    """Test DotProductAttention with cuDNN FusedAttention: head_dim=256 backward on Blackwell"""
+def test_dpa_d256(dtype, model_configs, model, qkv_layout):
+    """Test DotProductAttention with head_dim=256 backward on Blackwell"""
     test_dot_product_attention(dtype, model_configs, model, False, qkv_layout, False, False)
 
 

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -376,13 +376,10 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
     test_dot_product_attention(dtype, model_configs, model, False, None, False, False)
 
 
-# cuDNN FusedAttention head_dim=256 backward is supported on Blackwell server GPUs
-# (SM100/SM103) from cuDNN 9.23 (FE 1.24), via the dedicated deterministic SDPA bprop
-# kernel. It requires d_qk == d_v == 256, vanilla softmax, no dropout, no ALiBi, and
-# (for non-causal masks) full-window attention. See nvte_get_fused_attn_backend in
-# transformer_engine/common/fused_attn/fused_attn.cpp. These configs use d_qk == d_v == 256
-# with s_q == s_kv > 1 so the training (forward + backward) FusedAttention route is exercised
-# and compared against the reference backends.
+# cuDNN FusedAttention D=256 bprop is supported on sm10x from cuDNN 9.23 (FE 1.24),
+# via the dedicated deterministic SDPA bprop kernel, which supports d_qk == d_v == 256 only, 
+# vanilla type of softmax only, no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
+# (for non-causal masks) full-window attention.
 model_configs_fused_hdim256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
     "fused_hd256_no_mask": ModelConfig(2, 512, 16, 256),

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -386,18 +386,13 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
 model_configs_fused_hdim256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
     "fused_hd256_no_mask": ModelConfig(2, 512, 16, 256),
-    "fused_hd256_causal": ModelConfig(2, 512, 16, 256, attn_mask_type="causal"),
     "fused_hd256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
-    "fused_hd256_padding_causal": ModelConfig(2, 512, 16, 256, attn_mask_type="padding_causal"),
-    "fused_hd256_padding_causal_br": ModelConfig(
-        2, 512, 16, 256, attn_mask_type="padding_causal_bottom_right"
-    ),
     # SWA is allowed only together with a causal mask on the D=256 bprop kernel.
     "fused_hd256_causal_swa": ModelConfig(
-        2, 512, 16, 256, attn_mask_type="causal", window_size=(128, 0)
+        2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
     ),
     # GQA variant (num_gqa_groups < num_heads).
-    "fused_hd256_gqa": ModelConfig(2, 512, 16, 256, num_gqa_groups=4, attn_mask_type="causal"),
+    "fused_hd256_padding_causal_gqa": ModelConfig(2, 1024, 16, 256, num_gqa_groups=4, attn_mask_type="padding_causal"),
 }
 
 

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -392,7 +392,9 @@ model_configs_fused_hdim256 = {
         2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
     ),
     # GQA variant (num_gqa_groups < num_heads).
-    "fused_hd256_padding_causal_gqa": ModelConfig(2, 1024, 16, 256, num_gqa_groups=4, attn_mask_type="padding_causal"),
+    "fused_hd256_padding_causal_gqa": ModelConfig(
+        2, 1024, 16, 256, num_gqa_groups=4, attn_mask_type="padding_causal"
+    ),
 }
 
 

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -381,16 +381,16 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
 # SDPA bprop kernel. BSHD support starts with cuDNN FE 1.24 / BE 9.23; THD support starts
 # with cuDNN FE 1.26 / BE 9.30. The kernel supports d_qk == d_v == 256 only, vanilla softmax only,
 # no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
-model_configs_fused_hdim256 = {
+model_configs_fused_d256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
-    "fused_hd256_no_mask": ModelConfig(2, 512, 16, 256),
-    "fused_hd256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
+    "fused_d256_no_mask": ModelConfig(2, 512, 16, 256),
+    "fused_d256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
     # SWA is allowed only together with a causal mask on the D=256 bprop kernel.
-    "fused_hd256_causal_swa": ModelConfig(
+    "fused_d256_causal_swa": ModelConfig(
         2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
     ),
     # GQA variant (num_gqa_groups < num_heads).
-    "fused_hd256_padding_causal_gqa": ModelConfig(
+    "fused_d256_padding_causal_gqa": ModelConfig(
         2, 1024, 16, 256, num_gqa_groups=4, attn_mask_type="padding_causal"
     ),
 }
@@ -401,8 +401,8 @@ model_configs_fused_hdim256 = {
     reason="cuDNN FusedAttention head_dim=256 backward is Blackwell server (SM100/SM103) only.",
 )
 @pytest.mark.parametrize("dtype", param_types)
-@pytest.mark.parametrize("model_configs", [model_configs_fused_hdim256])
-@pytest.mark.parametrize("model", model_configs_fused_hdim256.keys())
+@pytest.mark.parametrize("model_configs", [model_configs_fused_d256])
+@pytest.mark.parametrize("model", model_configs_fused_d256.keys())
 @pytest.mark.parametrize(
     "qkv_layout",
     [
@@ -424,7 +424,7 @@ model_configs_fused_hdim256 = {
         ),
     ],
 )
-def test_dpa_fused_attn_hdim256(dtype, model_configs, model, qkv_layout):
+def test_dpa_fused_attn_d256(dtype, model_configs, model, qkv_layout):
     """Test DotProductAttention with cuDNN FusedAttention: head_dim=256 backward on Blackwell"""
     test_dot_product_attention(dtype, model_configs, model, False, qkv_layout, False, False)
 

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -379,7 +379,7 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
 
 # cuDNN FusedAttention D=256 bprop is supported on sm10x by the dedicated deterministic
 # SDPA bprop kernel. BSHD support starts with cuDNN FE 1.24 / BE 9.23; THD support starts
-# with cuDNN FE 1.26 / BE 9.30. The kernel supports d_qk == d_v == 256 only, vanilla softmax only,
+# with cuDNN FE 1.26 / BE 9.25. The kernel supports d_qk == d_v == 256 only, vanilla softmax only,
 # no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
 model_configs_fused_d256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
@@ -418,8 +418,8 @@ model_configs_fused_d256 = {
             "thd_t2hd",
             id="THD_KV_PACKED",
             marks=pytest.mark.skipif(
-                get_cudnn_version() < (9, 30, 0),
-                reason="cuDNN 9.30+ is required for THD D=256 fused-attn backward.",
+                get_cudnn_version() < (9, 25, 0),
+                reason="cuDNN 9.25+ is required for THD D=256 fused-attn backward.",
             ),
         ),
     ],

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -376,6 +376,44 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
     test_dot_product_attention(dtype, model_configs, model, False, None, False, False)
 
 
+# cuDNN FusedAttention head_dim=256 backward is supported on Blackwell server GPUs
+# (SM100/SM103) from cuDNN 9.23 (FE 1.24), via the dedicated deterministic SDPA bprop
+# kernel. It requires d_qk == d_v == 256, vanilla softmax, no dropout, no ALiBi, and
+# (for non-causal masks) full-window attention. See nvte_get_fused_attn_backend in
+# transformer_engine/common/fused_attn/fused_attn.cpp. These configs use d_qk == d_v == 256
+# with s_q == s_kv > 1 so the training (forward + backward) FusedAttention route is exercised
+# and compared against the reference backends.
+model_configs_fused_hdim256 = {
+    # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
+    "fused_hd256_no_mask": ModelConfig(2, 512, 16, 256),
+    "fused_hd256_causal": ModelConfig(2, 512, 16, 256, attn_mask_type="causal"),
+    "fused_hd256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
+    "fused_hd256_padding_causal": ModelConfig(2, 512, 16, 256, attn_mask_type="padding_causal"),
+    "fused_hd256_padding_causal_br": ModelConfig(
+        2, 512, 16, 256, attn_mask_type="padding_causal_bottom_right"
+    ),
+    # SWA is allowed only together with a causal mask on the D=256 bprop kernel.
+    "fused_hd256_causal_swa": ModelConfig(
+        2, 512, 16, 256, attn_mask_type="causal", window_size=(128, 0)
+    ),
+    # GQA variant (num_gqa_groups < num_heads).
+    "fused_hd256_gqa": ModelConfig(2, 512, 16, 256, num_gqa_groups=4, attn_mask_type="causal"),
+}
+
+
+@pytest.mark.skipif(get_cudnn_version() < (9, 23, 0), reason="cuDNN 9.23+ is required.")
+@pytest.mark.skipif(
+    device_compute_capability not in ((10, 0), (10, 3)),
+    reason="cuDNN FusedAttention head_dim=256 backward is Blackwell server (SM100/SM103) only.",
+)
+@pytest.mark.parametrize("dtype", param_types)
+@pytest.mark.parametrize("model_configs", [model_configs_fused_hdim256])
+@pytest.mark.parametrize("model", model_configs_fused_hdim256.keys())
+def test_dpa_fused_attn_hdim256(dtype, model_configs, model):
+    """Test DotProductAttention with cuDNN FusedAttention: head_dim=256 backward on Blackwell"""
+    test_dot_product_attention(dtype, model_configs, model, False, True, None, False, False)
+
+
 model_configs_fa4_mla = {
     # test: ModelConfig(b, sq, hq, dqk, head_dim_v=dv)
     "fa4_mla_1": ModelConfig(4, 128, 16, 128, head_dim_v=64),

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import pathlib
+import copy
 from typing import Any, Dict, Tuple, Union
 
 import pytest
@@ -140,7 +141,7 @@ def test_dot_product_attention(
     tols = dict(atol=1e-3, rtol=1e-3)
     if dtype == torch.bfloat16:
         tols = dict(atol=1.5e-2, rtol=1.5e-2)
-    config = model_configs[model]
+    config = copy.deepcopy(model_configs[model])
     is_mla = config.head_dim_qk != config.head_dim_v
     is_mqa_gqa = config.num_heads != config.num_gqa_groups
     if qkv_layout is None:
@@ -376,9 +377,10 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
     test_dot_product_attention(dtype, model_configs, model, False, None, False, False)
 
 
-# cuDNN FusedAttention D=256 bprop is supported on sm10x from cuDNN 9.23 (FE 1.24),
-# via the dedicated deterministic SDPA bprop kernel, which supports d_qk == d_v == 256 only,
-# vanilla type of softmax only, no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
+# cuDNN FusedAttention D=256 bprop is supported on sm10x by the dedicated deterministic
+# SDPA bprop kernel. BSHD support starts with cuDNN FE 1.24 / BE 9.23; THD support starts
+# with cuDNN FE 1.26 / BE 9.30. The kernel supports d_qk == d_v == 256 only, vanilla softmax only,
+# no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
 model_configs_fused_hdim256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
     "fused_hd256_no_mask": ModelConfig(2, 512, 16, 256),
@@ -394,7 +396,6 @@ model_configs_fused_hdim256 = {
 }
 
 
-@pytest.mark.skipif(get_cudnn_version() < (9, 23, 0), reason="cuDNN 9.23+ is required.")
 @pytest.mark.skipif(
     device_compute_capability not in ((10, 0), (10, 3)),
     reason="cuDNN FusedAttention head_dim=256 backward is Blackwell server (SM100/SM103) only.",
@@ -402,9 +403,30 @@ model_configs_fused_hdim256 = {
 @pytest.mark.parametrize("dtype", param_types)
 @pytest.mark.parametrize("model_configs", [model_configs_fused_hdim256])
 @pytest.mark.parametrize("model", model_configs_fused_hdim256.keys())
-def test_dpa_fused_attn_hdim256(dtype, model_configs, model):
+@pytest.mark.parametrize(
+    "qkv_layout",
+    [
+        pytest.param(
+            "bshd_bs2hd",
+            id="BSHD_KV_PACKED",
+            marks=pytest.mark.skipif(
+                get_cudnn_version() < (9, 23, 0),
+                reason="cuDNN 9.23+ is required for BSHD D=256 fused-attn backward.",
+            ),
+        ),
+        pytest.param(
+            "thd_t2hd",
+            id="THD_KV_PACKED",
+            marks=pytest.mark.skipif(
+                get_cudnn_version() < (9, 30, 0),
+                reason="cuDNN 9.30+ is required for THD D=256 fused-attn backward.",
+            ),
+        ),
+    ],
+)
+def test_dpa_fused_attn_hdim256(dtype, model_configs, model, qkv_layout):
     """Test DotProductAttention with cuDNN FusedAttention: head_dim=256 backward on Blackwell"""
-    test_dot_product_attention(dtype, model_configs, model, False, True, None, False, False)
+    test_dot_product_attention(dtype, model_configs, model, False, True, qkv_layout, False, False)
 
 
 model_configs_fa4_mla = {

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -391,9 +391,7 @@ model_configs_d256 = {
     "d256_no_mask": ModelConfig(2, 512, 16, 256),
     "d256_padding": ModelConfig(2, 512, 16, 256, attn_mask_type="padding"),
     # SWA is allowed only together with a causal mask on the D=256 bprop kernel.
-    "d256_causal_swa": ModelConfig(
-        2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
-    ),
+    "d256_causal_swa": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)),
     # GQA variant (num_gqa_groups < num_heads).
     "d256_padding_causal_gqa": ModelConfig(
         2, 1024, 16, 256, num_gqa_groups=4, attn_mask_type="padding_causal"

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -377,7 +377,7 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
 
 
 # cuDNN FusedAttention D=256 bprop is supported on sm10x from cuDNN 9.23 (FE 1.24),
-# via the dedicated deterministic SDPA bprop kernel, which supports d_qk == d_v == 256 only, 
+# via the dedicated deterministic SDPA bprop kernel, which supports d_qk == d_v == 256 only,
 # vanilla type of softmax only, no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
 # (for non-causal masks) full-window attention.
 model_configs_fused_hdim256 = {

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -408,7 +408,6 @@ model_configs_d256 = {
     [
         pytest.param(
             "bshd_bs2hd",
-            id="BSHD_KV_PACKED",
             marks=pytest.mark.skipif(
                 get_cudnn_version() < (9, 23, 0),
                 reason="cuDNN 9.23+ is required for BSHD D=256 fused-attn backward.",
@@ -416,7 +415,6 @@ model_configs_d256 = {
         ),
         pytest.param(
             "thd_t2hd",
-            id="THD_KV_PACKED",
             marks=pytest.mark.skipif(
                 get_cudnn_version() < (9, 25, 0),
                 reason="cuDNN 9.25+ is required for THD D=256 fused-attn backward.",

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -379,7 +379,6 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
 # cuDNN FusedAttention D=256 bprop is supported on sm10x from cuDNN 9.23 (FE 1.24),
 # via the dedicated deterministic SDPA bprop kernel, which supports d_qk == d_v == 256 only,
 # vanilla type of softmax only, no dropout, no ALiBi, and (for non-causal masks) full-window attention only.
-# (for non-causal masks) full-window attention.
 model_configs_fused_hdim256 = {
     # test: ModelConfig(b, sq, hq, dqk)  -> head_dim_v defaults to head_dim_qk (256)
     "fused_hd256_no_mask": ModelConfig(2, 512, 16, 256),

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -426,7 +426,7 @@ model_configs_fused_hdim256 = {
 )
 def test_dpa_fused_attn_hdim256(dtype, model_configs, model, qkv_layout):
     """Test DotProductAttention with cuDNN FusedAttention: head_dim=256 backward on Blackwell"""
-    test_dot_product_attention(dtype, model_configs, model, False, True, qkv_layout, False, False)
+    test_dot_product_attention(dtype, model_configs, model, False, qkv_layout, False, False)
 
 
 model_configs_fa4_mla = {

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -134,7 +134,7 @@ def test_dot_product_attention(
     swa,
     pad_between_seqs,
     declarative_packed=False,
-    run_backward=True,
+    is_training=True,
 ):
     """Test DotProductAttention module"""
 
@@ -170,7 +170,6 @@ def test_dot_product_attention(
     # Get backends
     # For 111s, dbias calculation is not supported as of cuDNN 9.18, hence, test fwd only for 111s.
     # For all other shapes test fwd+bwd unless the caller requests fwd-only coverage.
-    is_training = run_backward
     # TODO(KshitijLakhani): Set is_training to True for all cases once cuDNN supports dbias for 111s.
     if is_training and config.bias_shape == "111s":
         is_training = False
@@ -378,7 +377,7 @@ def test_dpa_fa4_hdim256(dtype, model_configs, model):
     # Keep this FA4 D=256 test forward-only. Before cuDNN D=256 backward support,
     # the generic helper took this path implicitly because fused-attn training was unavailable.
     test_dot_product_attention(
-        dtype, model_configs, model, False, None, False, False, run_backward=False
+        dtype, model_configs, model, False, None, False, False, is_training=False
     )
 
 

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -718,8 +718,8 @@ BSHD_FUSED_D256_CP_CUDNN_MARK = pytest.mark.skipif(
     reason="cuDNN 9.23+ is required for BSHD D=256 fused-attn CP backward.",
 )
 THD_FUSED_D256_CP_CUDNN_MARK = pytest.mark.skipif(
-    get_cudnn_version() < (9, 30, 0),
-    reason="cuDNN 9.30+ is required for THD D=256 fused-attn CP backward.",
+    get_cudnn_version() < (9, 25, 0),
+    reason="cuDNN 9.25+ is required for THD D=256 fused-attn CP backward.",
 )
 
 DPA_CP_FUSED_D256_CASES = [

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -483,6 +483,16 @@ model_configs_fused_attn = {
 }
 
 
+model_configs_fused_attn_hdim256 = {
+    # cuDNN FusedAttention D=256 bprop is Blackwell server only. Keep these
+    # outside the generic CP sweep so the D=256 signal is focused and inexpensive.
+    "cp_hd256_causal": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal"),
+    "cp_hd256_causal_swa": ModelConfig(
+        2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
+    ),
+}
+
+
 dtypes = ["bf16", "fp16", "fp8"]
 qkv_formats = ["bshd", "sbhd", "thd"]
 cp_comm_types = ["p2p", "all_gather", "a2a", "a2a+p2p"]
@@ -693,6 +703,128 @@ def test_cp_with_fused_attention(
         scaling_mode=scaling_mode,
         f16_O=f16_O,
         is_training=is_training,
+        deterministic=_deterministic,
+        log_level=pytest_logging_level,
+    )
+
+
+# Keep these as explicit cases because the CP axes are not independent:
+# - This runner covers separate-layout CP (bshd_bshd_bshd/thd_thd_thd); KV-packed
+#   D=256 is covered by test_dpa_fused_attn_hdim256 in test_attention.py.
+# - THD starts from a causal config and is rewritten to padding_causal by the runner.
+# - SWA is sampled only through all_gather; p2p does not support SWA.
+BSHD_FUSED_HD256_CP_CUDNN_MARK = pytest.mark.skipif(
+    get_cudnn_version() < (9, 23, 0),
+    reason="cuDNN 9.23+ is required for BSHD D=256 fused-attn CP backward.",
+)
+THD_FUSED_HD256_CP_CUDNN_MARK = pytest.mark.skipif(
+    get_cudnn_version() < (9, 30, 0),
+    reason="cuDNN 9.30+ is required for THD D=256 fused-attn CP backward.",
+)
+
+DPA_CP_FUSED_HD256_CASES = [
+    pytest.param(
+        "cp_hd256_causal",
+        "bshd",
+        "p2p",
+        id="BSHD-P2P-CAUSAL-NO_SWA",
+        marks=BSHD_FUSED_HD256_CP_CUDNN_MARK,
+    ),
+    pytest.param(
+        "cp_hd256_causal",
+        "bshd",
+        "all_gather",
+        id="BSHD-ALL_GATHER-CAUSAL-NO_SWA",
+        marks=BSHD_FUSED_HD256_CP_CUDNN_MARK,
+    ),
+    pytest.param(
+        "cp_hd256_causal_swa",
+        "bshd",
+        "all_gather",
+        id="BSHD-ALL_GATHER-CAUSAL-SWA",
+        marks=BSHD_FUSED_HD256_CP_CUDNN_MARK,
+    ),
+    pytest.param(
+        "cp_hd256_causal",
+        "thd",
+        "p2p",
+        id="THD-P2P-PADDING_CAUSAL-NO_SWA",
+        marks=THD_FUSED_HD256_CP_CUDNN_MARK,
+    ),
+    pytest.param(
+        "cp_hd256_causal",
+        "thd",
+        "all_gather",
+        id="THD-ALL_GATHER-PADDING_CAUSAL-NO_SWA",
+        marks=THD_FUSED_HD256_CP_CUDNN_MARK,
+    ),
+    pytest.param(
+        "cp_hd256_causal_swa",
+        "thd",
+        "all_gather",
+        id="THD-ALL_GATHER-PADDING_CAUSAL-SWA",
+        marks=THD_FUSED_HD256_CP_CUDNN_MARK,
+    ),
+]
+
+
+@pytest.mark.skipif(
+    get_device_compute_capability() not in ((10, 0), (10, 3)),
+    reason="cuDNN FusedAttention head_dim=256 backward is SM100/SM103-only.",
+)
+@pytest.mark.parametrize("dtype", ["bf16", "fp16"])
+@pytest.mark.parametrize("model,qkv_format,cp_comm_type", DPA_CP_FUSED_HD256_CASES)
+def test_cp_with_fused_attention_hdim256(cp_pool, dtype, model, qkv_format, cp_comm_type):
+    """Test cuDNN FusedAttention CP with head_dim=256 backward on Blackwell."""
+    pool = cp_pool(2)
+    config = copy.deepcopy(model_configs_fused_attn_hdim256[model])
+    config.context_parallel = True
+    config.cp_comm_type = cp_comm_type
+
+    if qkv_format == "thd":
+        config.attn_mask_type = "padding_causal"
+
+    dtype_map = {"fp16": torch.float16, "bf16": torch.bfloat16}
+    available_backends, _, _ = get_available_attention_backends(
+        config,
+        qkv_dtype=dtype_map[dtype],
+        qkv_layout="_".join([qkv_format] * 3),
+        is_training=True,
+        deterministic=_deterministic,
+    )
+
+    _, fused_attn_supported, _ = available_backends
+    if fused_attn_supported and config.attn_mask_type in ["causal", "padding_causal"]:
+        # CP can internally invoke bottom-right aligned fused-attn subcalls for
+        # causal masks. Check that inner fused-attn backend directly; the CP wrapper
+        # itself rejects user-facing bottom-right masks.
+        config_copy = copy.deepcopy(config)
+        config_copy.context_parallel = False
+        config_copy.attn_mask_type = config.attn_mask_type + "_bottom_right"
+        available_backends, _, _ = get_available_attention_backends(
+            config_copy,
+            qkv_dtype=dtype_map[dtype],
+            qkv_layout="_".join([qkv_format] * 3),
+            is_training=True,
+            deterministic=_deterministic,
+        )
+        _, fused_attn_supported, _ = available_backends
+    if not fused_attn_supported:
+        pytest.skip("No attention backend available.")
+
+    _submit(
+        pool,
+        dtype=dtype,
+        model=model,
+        qkv_format=qkv_format,
+        kernel_backend="FusedAttention",
+        cp_comm_type=cp_comm_type,
+        fp8_bwd=False,
+        fp8_dpa=False,
+        fp8_mha=False,
+        scaling_mode=None,
+        f16_O=True,
+        is_training=True,
         deterministic=_deterministic,
         log_level=pytest_logging_level,
     )

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -483,11 +483,11 @@ model_configs_fused_attn = {
 }
 
 
-model_configs_fused_attn_hdim256 = {
+model_configs_fused_attn_d256 = {
     # cuDNN FusedAttention D=256 bprop is Blackwell server only. Keep these
     # outside the generic CP sweep so the D=256 signal is focused and inexpensive.
-    "cp_hd256_causal": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal"),
-    "cp_hd256_causal_swa": ModelConfig(
+    "cp_d256_causal": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal"),
+    "cp_d256_causal_swa": ModelConfig(
         2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
     ),
 }
@@ -710,60 +710,60 @@ def test_cp_with_fused_attention(
 
 # Keep these as explicit cases because the CP axes are not independent:
 # - This runner covers separate-layout CP (bshd_bshd_bshd/thd_thd_thd); KV-packed
-#   D=256 is covered by test_dpa_fused_attn_hdim256 in test_attention.py.
+#   D=256 is covered by test_dpa_fused_attn_d256 in test_attention.py.
 # - THD starts from a causal config and is rewritten to padding_causal by the runner.
 # - SWA is sampled only through all_gather; p2p does not support SWA.
-BSHD_FUSED_HD256_CP_CUDNN_MARK = pytest.mark.skipif(
+BSHD_FUSED_D256_CP_CUDNN_MARK = pytest.mark.skipif(
     get_cudnn_version() < (9, 23, 0),
     reason="cuDNN 9.23+ is required for BSHD D=256 fused-attn CP backward.",
 )
-THD_FUSED_HD256_CP_CUDNN_MARK = pytest.mark.skipif(
+THD_FUSED_D256_CP_CUDNN_MARK = pytest.mark.skipif(
     get_cudnn_version() < (9, 30, 0),
     reason="cuDNN 9.30+ is required for THD D=256 fused-attn CP backward.",
 )
 
-DPA_CP_FUSED_HD256_CASES = [
+DPA_CP_FUSED_D256_CASES = [
     pytest.param(
-        "cp_hd256_causal",
+        "cp_d256_causal",
         "bshd",
         "p2p",
         id="BSHD-P2P-CAUSAL-NO_SWA",
-        marks=BSHD_FUSED_HD256_CP_CUDNN_MARK,
+        marks=BSHD_FUSED_D256_CP_CUDNN_MARK,
     ),
     pytest.param(
-        "cp_hd256_causal",
+        "cp_d256_causal",
         "bshd",
         "all_gather",
         id="BSHD-ALL_GATHER-CAUSAL-NO_SWA",
-        marks=BSHD_FUSED_HD256_CP_CUDNN_MARK,
+        marks=BSHD_FUSED_D256_CP_CUDNN_MARK,
     ),
     pytest.param(
-        "cp_hd256_causal_swa",
+        "cp_d256_causal_swa",
         "bshd",
         "all_gather",
         id="BSHD-ALL_GATHER-CAUSAL-SWA",
-        marks=BSHD_FUSED_HD256_CP_CUDNN_MARK,
+        marks=BSHD_FUSED_D256_CP_CUDNN_MARK,
     ),
     pytest.param(
-        "cp_hd256_causal",
+        "cp_d256_causal",
         "thd",
         "p2p",
         id="THD-P2P-PADDING_CAUSAL-NO_SWA",
-        marks=THD_FUSED_HD256_CP_CUDNN_MARK,
+        marks=THD_FUSED_D256_CP_CUDNN_MARK,
     ),
     pytest.param(
-        "cp_hd256_causal",
+        "cp_d256_causal",
         "thd",
         "all_gather",
         id="THD-ALL_GATHER-PADDING_CAUSAL-NO_SWA",
-        marks=THD_FUSED_HD256_CP_CUDNN_MARK,
+        marks=THD_FUSED_D256_CP_CUDNN_MARK,
     ),
     pytest.param(
-        "cp_hd256_causal_swa",
+        "cp_d256_causal_swa",
         "thd",
         "all_gather",
         id="THD-ALL_GATHER-PADDING_CAUSAL-SWA",
-        marks=THD_FUSED_HD256_CP_CUDNN_MARK,
+        marks=THD_FUSED_D256_CP_CUDNN_MARK,
     ),
 ]
 
@@ -773,11 +773,11 @@ DPA_CP_FUSED_HD256_CASES = [
     reason="cuDNN FusedAttention head_dim=256 backward is SM100/SM103-only.",
 )
 @pytest.mark.parametrize("dtype", ["bf16", "fp16"])
-@pytest.mark.parametrize("model,qkv_format,cp_comm_type", DPA_CP_FUSED_HD256_CASES)
-def test_cp_with_fused_attention_hdim256(cp_pool, dtype, model, qkv_format, cp_comm_type):
+@pytest.mark.parametrize("model,qkv_format,cp_comm_type", DPA_CP_FUSED_D256_CASES)
+def test_cp_with_fused_attention_d256(cp_pool, dtype, model, qkv_format, cp_comm_type):
     """Test cuDNN FusedAttention CP with head_dim=256 backward on Blackwell."""
     pool = cp_pool(2)
-    config = copy.deepcopy(model_configs_fused_attn_hdim256[model])
+    config = copy.deepcopy(model_configs_fused_attn_d256[model])
     config.context_parallel = True
     config.cp_comm_type = cp_comm_type
 

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -480,14 +480,8 @@ model_configs_fused_attn = {
     "cp_4_3": ModelConfig(
         2, 4096, 64, 64, attn_mask_type="causal", window_size=(128, 0), softmax_type="learnable"
     ),  # GQA
-}
-
-
-model_configs_fused_attn_d256 = {
-    # cuDNN FusedAttention D=256 bprop is Blackwell server only. Keep these
-    # outside the generic CP sweep so the D=256 signal is focused and inexpensive.
-    "cp_d256_causal": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal"),
-    "cp_d256_causal_swa": ModelConfig(
+    "cp_5_0": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal"),
+    "cp_5_1": ModelConfig(
         2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
     ),
 }
@@ -508,6 +502,8 @@ if test_essential:
         "cp_3_4",
         "cp_4_2",
         "cp_4_3",
+        "cp_5_0",
+        "cp_5_1",
     ]
     model_configs_fused_attn = {k: model_configs_fused_attn[k] for k in configs}
     dtypes = ["bf16", "fp8"]
@@ -540,6 +536,23 @@ def test_cp_with_fused_attention(
     config = model_configs_fused_attn[model]
     config.context_parallel = True
     config.cp_comm_type = cp_comm_type
+
+    if config.head_dim_qk == 256 and config.head_dim_v == 256:
+        # D=256 uses this generic CP runner, but only a subset of its axes is supported.
+        if get_device_compute_capability() not in ((10, 0), (10, 3)):
+            pytest.skip("D=256 CP fused attention is only enabled on Blackwell server GPUs.")
+        if dtype == "fp8":
+            pytest.skip("D=256 CP fused attention is covered for BF16/FP16 only.")
+        if cp_comm_type not in ["p2p", "all_gather"]:
+            pytest.skip("D=256 CP fused attention is covered for p2p and all_gather only.")
+
+        required_cudnn_version = (9, 25, 0) if qkv_format == "thd" else (9, 23, 0)
+        required_cudnn_version_label = "9.25" if qkv_format == "thd" else "9.23"
+        if get_cudnn_version() < required_cudnn_version:
+            pytest.skip(
+                f"D=256 CP fused attention with {qkv_format.upper()} requires cuDNN"
+                f" {required_cudnn_version_label} or newer."
+            )
 
     num_gpus = 4 if cp_comm_type == "a2a+p2p" else 2
     pool = cp_pool(num_gpus)
@@ -707,124 +720,3 @@ def test_cp_with_fused_attention(
         log_level=pytest_logging_level,
     )
 
-
-# Keep these as explicit cases because the CP axes are not independent:
-# - This runner covers separate-layout CP (bshd_bshd_bshd/thd_thd_thd); KV-packed
-#   D=256 is covered by test_dpa_fused_attn_d256 in test_attention.py.
-# - THD starts from a causal config and is rewritten to padding_causal by the runner.
-# - SWA is sampled only through all_gather; p2p does not support SWA.
-BSHD_FUSED_D256_CP_CUDNN_MARK = pytest.mark.skipif(
-    get_cudnn_version() < (9, 23, 0),
-    reason="cuDNN 9.23+ is required for BSHD D=256 fused-attn CP backward.",
-)
-THD_FUSED_D256_CP_CUDNN_MARK = pytest.mark.skipif(
-    get_cudnn_version() < (9, 25, 0),
-    reason="cuDNN 9.25+ is required for THD D=256 fused-attn CP backward.",
-)
-
-DPA_CP_FUSED_D256_CASES = [
-    pytest.param(
-        "cp_d256_causal",
-        "bshd",
-        "p2p",
-        id="BSHD-P2P-CAUSAL-NO_SWA",
-        marks=BSHD_FUSED_D256_CP_CUDNN_MARK,
-    ),
-    pytest.param(
-        "cp_d256_causal",
-        "bshd",
-        "all_gather",
-        id="BSHD-ALL_GATHER-CAUSAL-NO_SWA",
-        marks=BSHD_FUSED_D256_CP_CUDNN_MARK,
-    ),
-    pytest.param(
-        "cp_d256_causal_swa",
-        "bshd",
-        "all_gather",
-        id="BSHD-ALL_GATHER-CAUSAL-SWA",
-        marks=BSHD_FUSED_D256_CP_CUDNN_MARK,
-    ),
-    pytest.param(
-        "cp_d256_causal",
-        "thd",
-        "p2p",
-        id="THD-P2P-PADDING_CAUSAL-NO_SWA",
-        marks=THD_FUSED_D256_CP_CUDNN_MARK,
-    ),
-    pytest.param(
-        "cp_d256_causal",
-        "thd",
-        "all_gather",
-        id="THD-ALL_GATHER-PADDING_CAUSAL-NO_SWA",
-        marks=THD_FUSED_D256_CP_CUDNN_MARK,
-    ),
-    pytest.param(
-        "cp_d256_causal_swa",
-        "thd",
-        "all_gather",
-        id="THD-ALL_GATHER-PADDING_CAUSAL-SWA",
-        marks=THD_FUSED_D256_CP_CUDNN_MARK,
-    ),
-]
-
-
-@pytest.mark.skipif(
-    get_device_compute_capability() not in ((10, 0), (10, 3)),
-    reason="cuDNN FusedAttention head_dim=256 backward is SM100/SM103-only.",
-)
-@pytest.mark.parametrize("dtype", ["bf16", "fp16"])
-@pytest.mark.parametrize("model,qkv_format,cp_comm_type", DPA_CP_FUSED_D256_CASES)
-def test_cp_with_fused_attention_d256(cp_pool, dtype, model, qkv_format, cp_comm_type):
-    """Test cuDNN FusedAttention CP with head_dim=256 backward on Blackwell."""
-    pool = cp_pool(2)
-    config = copy.deepcopy(model_configs_fused_attn_d256[model])
-    config.context_parallel = True
-    config.cp_comm_type = cp_comm_type
-
-    if qkv_format == "thd":
-        config.attn_mask_type = "padding_causal"
-
-    dtype_map = {"fp16": torch.float16, "bf16": torch.bfloat16}
-    available_backends, _, _ = get_available_attention_backends(
-        config,
-        qkv_dtype=dtype_map[dtype],
-        qkv_layout="_".join([qkv_format] * 3),
-        is_training=True,
-        deterministic=_deterministic,
-    )
-
-    _, fused_attn_supported, _ = available_backends
-    if fused_attn_supported and config.attn_mask_type in ["causal", "padding_causal"]:
-        # CP can internally invoke bottom-right aligned fused-attn subcalls for
-        # causal masks. Check that inner fused-attn backend directly; the CP wrapper
-        # itself rejects user-facing bottom-right masks.
-        config_copy = copy.deepcopy(config)
-        config_copy.context_parallel = False
-        config_copy.attn_mask_type = config.attn_mask_type + "_bottom_right"
-        available_backends, _, _ = get_available_attention_backends(
-            config_copy,
-            qkv_dtype=dtype_map[dtype],
-            qkv_layout="_".join([qkv_format] * 3),
-            is_training=True,
-            deterministic=_deterministic,
-        )
-        _, fused_attn_supported, _ = available_backends
-    if not fused_attn_supported:
-        pytest.skip("No attention backend available.")
-
-    _submit(
-        pool,
-        dtype=dtype,
-        model=model,
-        qkv_format=qkv_format,
-        kernel_backend="FusedAttention",
-        cp_comm_type=cp_comm_type,
-        fp8_bwd=False,
-        fp8_dpa=False,
-        fp8_mha=False,
-        scaling_mode=None,
-        f16_O=True,
-        is_training=True,
-        deterministic=_deterministic,
-        log_level=pytest_logging_level,
-    )

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -481,9 +481,7 @@ model_configs_fused_attn = {
         2, 4096, 64, 64, attn_mask_type="causal", window_size=(128, 0), softmax_type="learnable"
     ),  # GQA
     "cp_5_0": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal"),
-    "cp_5_1": ModelConfig(
-        2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)
-    ),
+    "cp_5_1": ModelConfig(2, 1024, 16, 256, attn_mask_type="causal", window_size=(128, 0)),
 }
 
 
@@ -719,4 +717,3 @@ def test_cp_with_fused_attention(
         deterministic=_deterministic,
         log_level=pytest_logging_level,
     )
-

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -315,6 +315,19 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           (head_dim_qk <= 256 && head_dim_v <= 256 &&
            ((!is_training && sm_arch_ == 90 && cudnn_runtime_version >= 90100) ||
             (is_training && sm_arch_ == 90 && cudnn_runtime_version >= 90500))) ||
+          // 9.9: any head_dim + Blackwell + fprop + non_paged + sq > 1
+          (!is_training && sm_arch_ >= 100 && cudnn_runtime_version >= 90900 && max_seqlen_q > 1 &&
+           layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD) ||
+          // 9.10.2: any head_dim + any arch + fprop + paged
+          // 9.10.2: any head_dim + any arch + fprop + non_paged + sq > 1
+          // 9.10.2: any head_dim + any arch + fprop + non_paged + sq = 1 + {no_mask, padding, BRCM, padding_BRCM}
+          (!is_training && cudnn_runtime_version >= 91002 &&
+           (layout_group == NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD || max_seqlen_q > 1 ||
+            (max_seqlen_q == 1 && attn_mask_type != NVTE_Mask_Type::NVTE_CAUSAL_MASK &&
+             attn_mask_type != NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK))) ||
+          // 9.11: d_qk = 192, d_v = 128 + Blackwell + bprop + non-paged
+          (head_dim_qk == 192 && head_dim_v == 128 && is_training && sm_arch_ >= 100 &&
+           cudnn_runtime_version >= 91100) ||
           // 9.23: d_qk = d_v = 256 + SM10x (cuDNN FE 1.24 / BE 9.23+) + bprop + non-paged
           (head_dim_qk == 256 && head_dim_v == 256 && is_training && sm_arch_ >= 100 &&
            sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
@@ -329,20 +342,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
               attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||
               attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK ||
               attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK) &&
-             (window_size_right == -1 || window_size_right == 0)))) ||
-          // 9.9: any head_dim + Blackwell + fprop + non_paged + sq > 1
-          (!is_training && sm_arch_ >= 100 && cudnn_runtime_version >= 90900 && max_seqlen_q > 1 &&
-           layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD) ||
-          // 9.10.2: any head_dim + any arch + fprop + paged
-          // 9.10.2: any head_dim + any arch + fprop + non_paged + sq > 1
-          // 9.10.2: any head_dim + any arch + fprop + non_paged + sq = 1 + {no_mask, padding, BRCM, padding_BRCM}
-          (!is_training && cudnn_runtime_version >= 91002 &&
-           (layout_group == NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD || max_seqlen_q > 1 ||
-            (max_seqlen_q == 1 && attn_mask_type != NVTE_Mask_Type::NVTE_CAUSAL_MASK &&
-             attn_mask_type != NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK))) ||
-          // 9.11: d_qk = 192, d_v = 128 + Blackwell + bprop + non-paged
-          (head_dim_qk == 192 && head_dim_v == 128 && is_training && sm_arch_ >= 100 &&
-           cudnn_runtime_version >= 91100)) &&
+             (window_size_right == -1 || window_size_right == 0))))) &&
          // 9.11+ bug: 128 < d_qk <= 256, 128 < d_v <= 256 + Hopper + bprop + MLA
          // Conditional to temporarily use blanket cudnn_runtime_version >= 9.11 until fixed
          (!((cudnn_runtime_version >= 91100) && is_training && sm_arch_ == 90 &&

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -318,16 +318,16 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           // 9.23: d_qk = d_v = 256 + SM10.x + bprop + non-paged
           // cuDNN's dedicated SM10.x D=256 SDPA backward kernel (cuDNN FE 1.24 /
           // BE 9.23+) only supports d_qk == d_v == 256.
-          (head_dim_qk == 256 && head_dim_v == 256 && is_training &&
-           sm_arch_ >= 100 && sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
+          (head_dim_qk == 256 && head_dim_v == 256 && is_training && sm_arch_ >= 100 &&
+           sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
            layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD &&
            // The FE forces this path onto deterministic bprop, which then rejects alibi and
            // dropout, and only supports vanilla softmax.
            bias_type != NVTE_Bias_Type::NVTE_ALIBI && dropout == 0.0 &&
            softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX &&
            // Non-causal D=256 supports only full-window attention; SWA is allowed only for causal masks.
-           // NOTE: SWA support for non causal would be available when cuDNN decides to redirect 
-           // D=256 support to a CUDA backend instead of a Python OSS kernel 
+           // NOTE: SWA support for non causal would be available when cuDNN decides to redirect
+           // D=256 support to a CUDA backend instead of a Python OSS kernel
            ((window_size_left == -1 && window_size_right == -1) ||
             ((attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK ||
               attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -321,9 +321,12 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           (head_dim_qk == 256 && head_dim_v == 256 && is_training && sm_arch_ >= 100 &&
            sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
            layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD &&
-           // The FE forces this path onto deterministic bprop, which then rejects alibi and
-           // dropout, and only supports vanilla softmax.
-           bias_type != NVTE_Bias_Type::NVTE_ALIBI && dropout == 0.0 &&
+           // The FE forces this path onto the deterministic bprop algorithm, which on
+           // Blackwell rejects dBias, dropout, and ALiBi (and supports vanilla softmax only).
+           // Require NO_BIAS: a learnable pre/post-scale bias would request dBias in the bprop
+           // graph and fail validation. The selector has no visibility into the bias shape, so
+           // gate on the bias type to avoid over-selecting this backend.
+           bias_type == NVTE_Bias_Type::NVTE_NO_BIAS && dropout == 0.0 &&
            softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX &&
            // Non-causal D=256 supports only full-window attention; SWA is allowed only for causal masks.
            // NOTE: SWA support for non causal would be available when cuDNN decides to redirect

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -240,6 +240,9 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
   NVTE_QKV_Format qkv_format = nvte_get_qkv_format(qkv_layout);
   NVTE_QKV_Format q_format = nvte_get_q_format(qkv_layout);
   NVTE_QKV_Format kv_format = nvte_get_kv_format(qkv_layout);
+  const bool is_thd_layout = q_format == NVTE_QKV_Format::NVTE_THD ||
+                             kv_format == NVTE_QKV_Format::NVTE_THD ||
+                             qkv_format == NVTE_QKV_Format::NVTE_THD;
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
   auto cudnn_runtime_version = cudnnGetVersion();
 
@@ -328,9 +331,10 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           // 9.11: d_qk = 192, d_v = 128 + Blackwell + bprop + non-paged
           (head_dim_qk == 192 && head_dim_v == 128 && is_training && sm_arch_ >= 100 &&
            cudnn_runtime_version >= 91100) ||
-          // 9.23: d_qk = d_v = 256 + SM10x (cuDNN FE 1.24 / BE 9.23+) + bprop + non-paged
+          // 9.23: d_qk = d_v = 256 + SM10x (cuDNN FE 1.24 / BE 9.23+) + bprop + non-paged.
+          // THD layouts require cuDNN FE 1.26 / BE 9.30+ for execution-plan support.
           (head_dim_qk == 256 && head_dim_v == 256 && is_training && sm_arch_ >= 100 &&
-           sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
+           sm_arch_ < 110 && cudnn_runtime_version >= (is_thd_layout ? 93000 : 92300) &&
            layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD &&
            // The FE forces this path onto the deterministic bprop algorithm, which on
            // Blackwell rejects dBias, dropout, and ALiBi (and supports vanilla softmax only).

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -315,22 +315,15 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           (head_dim_qk <= 256 && head_dim_v <= 256 &&
            ((!is_training && sm_arch_ == 90 && cudnn_runtime_version >= 90100) ||
             (is_training && sm_arch_ == 90 && cudnn_runtime_version >= 90500))) ||
-          // 9.23: d_qk = d_v = 256 + SM10.x + bprop + non-paged
-          // cuDNN's dedicated SM10.x D=256 SDPA backward kernel (cuDNN FE 1.24 /
-          // BE 9.23+) only supports d_qk == d_v == 256.
+          // 9.23: d_qk = d_v = 256 + SM10x (cuDNN FE 1.24 / BE 9.23+) + bprop + non-paged
           (head_dim_qk == 256 && head_dim_v == 256 && is_training && sm_arch_ >= 100 &&
            sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
            layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD &&
            // The FE forces this path onto the deterministic bprop algorithm, which on
            // Blackwell rejects dBias, dropout, and ALiBi (and supports vanilla softmax only).
-           // Require NO_BIAS: a learnable pre/post-scale bias would request dBias in the bprop
-           // graph and fail validation. The selector has no visibility into the bias shape, so
-           // gate on the bias type to avoid over-selecting this backend.
            bias_type == NVTE_Bias_Type::NVTE_NO_BIAS && dropout == 0.0 &&
            softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX &&
            // Non-causal D=256 supports only full-window attention; SWA is allowed only for causal masks.
-           // NOTE: SWA support for non causal would be available when cuDNN decides to redirect
-           // D=256 support to a CUDA backend instead of a Python OSS kernel
            ((window_size_left == -1 && window_size_right == -1) ||
             ((attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK ||
               attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -240,8 +240,8 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
   NVTE_QKV_Format qkv_format = nvte_get_qkv_format(qkv_layout);
   NVTE_QKV_Format q_format = nvte_get_q_format(qkv_layout);
   NVTE_QKV_Format kv_format = nvte_get_kv_format(qkv_layout);
-  const bool is_thd_layout = q_format == NVTE_QKV_Format::NVTE_THD ||
-                             kv_format == NVTE_QKV_Format::NVTE_THD;
+  const bool is_thd_layout =
+      q_format == NVTE_QKV_Format::NVTE_THD || kv_format == NVTE_QKV_Format::NVTE_THD;
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
   auto cudnn_runtime_version = cudnnGetVersion();
 

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -331,9 +331,9 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           (head_dim_qk == 192 && head_dim_v == 128 && is_training && sm_arch_ >= 100 &&
            cudnn_runtime_version >= 91100) ||
           // 9.23: d_qk = d_v = 256 + SM10x (cuDNN FE 1.24 / BE 9.23+) + bprop + non-paged.
-          // THD layouts require cuDNN FE 1.26 / BE 9.30+ for execution-plan support.
+          // THD layouts require cuDNN FE 1.26 / BE 9.25+ for execution-plan support.
           (head_dim_qk == 256 && head_dim_v == 256 && is_training && sm_arch_ >= 100 &&
-           sm_arch_ < 110 && cudnn_runtime_version >= (is_thd_layout ? 93000 : 92300) &&
+           sm_arch_ < 110 && cudnn_runtime_version >= (is_thd_layout ? 92500 : 92300) &&
            layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD &&
            // The FE forces this path onto the deterministic bprop algorithm, which on
            // Blackwell rejects dBias, dropout, and ALiBi (and supports vanilla softmax only).

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -315,6 +315,25 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
           (head_dim_qk <= 256 && head_dim_v <= 256 &&
            ((!is_training && sm_arch_ == 90 && cudnn_runtime_version >= 90100) ||
             (is_training && sm_arch_ == 90 && cudnn_runtime_version >= 90500))) ||
+          // 9.23: d_qk = d_v = 256 + SM10.x + bprop + non-paged
+          // cuDNN's dedicated SM10.x D=256 SDPA backward kernel (cuDNN FE 1.24 /
+          // BE 9.23+) only supports d_qk == d_v == 256.
+          (head_dim_qk == 256 && head_dim_v == 256 && is_training &&
+           sm_arch_ >= 100 && sm_arch_ < 110 && cudnn_runtime_version >= 92300 &&
+           layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD &&
+           // The FE forces this path onto deterministic bprop, which then rejects alibi and
+           // dropout, and only supports vanilla softmax.
+           bias_type != NVTE_Bias_Type::NVTE_ALIBI && dropout == 0.0 &&
+           softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX &&
+           // Non-causal D=256 supports only full-window attention; SWA is allowed only for causal masks.
+           // NOTE: SWA support for non causal would be available when cuDNN decides to redirect 
+           // D=256 support to a CUDA backend instead of a Python OSS kernel 
+           ((window_size_left == -1 && window_size_right == -1) ||
+            ((attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_MASK ||
+              attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||
+              attn_mask_type == NVTE_Mask_Type::NVTE_CAUSAL_BOTTOM_RIGHT_MASK ||
+              attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK) &&
+             (window_size_right == -1 || window_size_right == 0)))) ||
           // 9.9: any head_dim + Blackwell + fprop + non_paged + sq > 1
           (!is_training && sm_arch_ >= 100 && cudnn_runtime_version >= 90900 && max_seqlen_q > 1 &&
            layout_group != NVTE_QKV_Layout_Group::NVTE_Paged_KV_HD_HD_HD) ||

--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -241,8 +241,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
   NVTE_QKV_Format q_format = nvte_get_q_format(qkv_layout);
   NVTE_QKV_Format kv_format = nvte_get_kv_format(qkv_layout);
   const bool is_thd_layout = q_format == NVTE_QKV_Format::NVTE_THD ||
-                             kv_format == NVTE_QKV_Format::NVTE_THD ||
-                             qkv_format == NVTE_QKV_Format::NVTE_THD;
+                             kv_format == NVTE_QKV_Format::NVTE_THD;
   NVTE_QKV_Layout_Group layout_group = nvte_get_qkv_layout_group(qkv_layout);
   auto cudnn_runtime_version = cudnnGetVersion();
 

--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -1040,6 +1040,21 @@ class FlashAttention(torch.nn.Module):
         use_flash_attn_3 = (
             flash_attention_backend is not None and flash_attention_backend.major == 3
         )
+        if (
+            use_flash_attn_4
+            and (10, 0) <= get_device_compute_capability() < (12, 0)
+            and query_layer.shape[-1] == key_layer.shape[-1] == value_layer.shape[-1] == 256
+            and all(
+                not isinstance(x, Float8Tensor)
+                for x in [query_layer, key_layer, value_layer]
+            )
+            and any(not x.is_contiguous() for x in [query_layer, key_layer, value_layer])
+        ):
+            # FA4 D=256 SM10x kernels need packed K/V views materialized, even
+            # when the last dimension is contiguous.
+            query_layer, key_layer, value_layer = [
+                x.contiguous() for x in (query_layer, key_layer, value_layer)
+            ]
         if context_parallel and all(
             not isinstance(x, Float8Tensor) for x in [query_layer, key_layer, value_layer]
         ):

--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -1044,10 +1044,7 @@ class FlashAttention(torch.nn.Module):
             use_flash_attn_4
             and (10, 0) <= get_device_compute_capability() < (12, 0)
             and query_layer.shape[-1] == key_layer.shape[-1] == value_layer.shape[-1] == 256
-            and all(
-                not isinstance(x, Float8Tensor)
-                for x in [query_layer, key_layer, value_layer]
-            )
+            and all(not isinstance(x, Float8Tensor) for x in [query_layer, key_layer, value_layer])
             and any(not x.is_contiguous() for x in [query_layer, key_layer, value_layer])
         ):
             # FA4 D=256 SM10x kernels need packed K/V views materialized, even

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -1309,6 +1309,18 @@ def get_attention_backend(
     #                            |                        | converts window_size to an 'arbitrary' mask
     if window_size is None:
         window_size = check_set_window_size(attn_mask_type, window_size)
+    if (
+        use_flash_attention_4
+        and (10, 0) <= device_compute_capability < (12, 0)
+        and head_dim_qk == head_dim_v == 256
+        and (window_size[0] != -1 or window_size[1] not in [-1, 0])
+    ):
+        logger.debug(
+            "Disabling FlashAttention 4 as SM100 head_dim=256 does not support "
+            "sliding-window/local attention yet. Found: window_size = %s.",
+            window_size,
+        )
+        use_flash_attention_4 = False
     if use_fused_attention and (window_size[0] != -1 or window_size[1] not in [-1, 0]):
         if (
             fp8


### PR DESCRIPTION
# Description

Support for D=256 BWD for Blackwell CC 10x via the C++ API (which TE uses) was added in cuDNN 9.23 + cuDNN FE 1.24 (BSHD) and cuDNN 9.25 + cuDNN FE 1.26 (THD)
Enabling this support in TE attention and adding conditional tests for the same

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
 
 Add guard when picking the backend (sub backend) in TE common.
 Add tests for D=256 case in TE PyT and TE JAX

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
