### PR TITLE
Add public NVFP4 quantize API

### DIFF
--- a/tests/pytorch/nvfp4/test_nvfp4_public_api.py
+++ b/tests/pytorch/nvfp4/test_nvfp4_public_api.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+import pytest
+import torch
+
+import transformer_engine.pytorch as te
+from transformer_engine.pytorch import NVFP4Quantizer, NVFP4Tensor
+
+
+recipe_available, reason_for_no_recipe = te.is_nvfp4_available(return_reason=True)
+
+
+def _valid_rowwise_scale(scale: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    """Trim rowwise scale padding."""
+    return scale[: shape[0], : (shape[1] + 15) // 16]
+
+
+def _valid_columnwise_scale(scale: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    """Trim columnwise scale padding."""
+    return scale[: shape[1], : (shape[0] + 15) // 16]
+
+
+def _assert_same_nvfp4_tensors(
+    actual: NVFP4Tensor,
+    expected: NVFP4Tensor,
+    shape: torch.Size,
+    columnwise: bool,
+) -> None:
+    """Check public NVFP4 tensor accessors against another NVFP4 tensor."""
+    assert actual.rowwise_data is not None
+    assert actual.rowwise_scale_inv is not None
+    assert actual.amax_rowwise is not None
+    torch.testing.assert_close(actual.rowwise_data, expected.rowwise_data, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        _valid_rowwise_scale(actual.rowwise_scale_inv, shape),
+        _valid_rowwise_scale(expected.rowwise_scale_inv, shape),
+        atol=0.0,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(actual.amax_rowwise, expected.amax_rowwise, atol=0.0, rtol=0.0)
+
+    if columnwise:
+        assert actual.columnwise_data is not None
+        assert actual.columnwise_scale_inv is not None
+        assert actual.amax_columnwise is not None
+        torch.testing.assert_close(
+            actual.columnwise_data, expected.columnwise_data, atol=0.0, rtol=0.0
+        )
+        torch.testing.assert_close(
+            _valid_columnwise_scale(actual.columnwise_scale_inv, shape),
+            _valid_columnwise_scale(expected.columnwise_scale_inv, shape),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            actual.amax_columnwise,
+            expected.amax_columnwise,
+            atol=0.0,
+            rtol=0.0,
+        )
+    else:
+        assert actual.columnwise_data is None
+        assert actual.columnwise_scale_inv is None
+        assert actual.amax_columnwise is None
+
+
+@pytest.mark.skipif(not recipe_available, reason=reason_for_no_recipe)
+@pytest.mark.parametrize("shape", [(64, 64), (128, 64)], ids=["64x64", "128x64"])
+@pytest.mark.parametrize(
+    "quantizer_kwargs",
+    [
+        pytest.param({}, id="default"),
+        pytest.param(
+            {
+                "rowwise": True,
+                "columnwise": True,
+                "with_2d_quantization": True,
+            },
+            id="2d",
+        ),
+        pytest.param(
+            {
+                "rowwise": True,
+                "columnwise": False,
+                "row_scaled_nvfp4": True,
+            },
+            id="row_scaled",
+        ),
+        pytest.param(
+            {
+                "rowwise": True,
+                "columnwise": False,
+                "nvfp4_use_4over6": True,
+                "nvfp4_e4m3_max": 256,
+                "nvfp4_4over6_err_mode": "MSE",
+            },
+            id="4over6",
+        ),
+    ],
+)
+def test_quantize_nvfp4_public_api_matches_quantizer(shape, quantizer_kwargs) -> None:
+    """Public NVFP4 API should match direct NVFP4Quantizer usage."""
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.bfloat16, device="cuda")
+
+    public = te.quantize_nvfp4(x, **quantizer_kwargs)
+    direct_quantizer_kwargs = {
+        "columnwise": False,
+        "with_random_sign_mask": False,
+        **quantizer_kwargs,
+    }
+    direct = NVFP4Quantizer(**direct_quantizer_kwargs)(x)
+
+    assert isinstance(public, NVFP4Tensor)
+    _assert_same_nvfp4_tensors(public, direct, x.shape, direct_quantizer_kwargs["columnwise"])
+
+    assert public.nvfp4_use_4over6 == direct_quantizer_kwargs.get("nvfp4_use_4over6", False)
+    assert public.nvfp4_e4m3_max == direct_quantizer_kwargs.get("nvfp4_e4m3_max", 448)

--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -81,6 +81,7 @@ from transformer_engine.pytorch.tensor import Float8CurrentScalingQuantizer
 from transformer_engine.pytorch.tensor import MXFP8Quantizer
 from transformer_engine.pytorch.tensor import Float8BlockQuantizer
 from transformer_engine.pytorch.tensor import NVFP4Quantizer
+from transformer_engine.pytorch.tensor import quantize_nvfp4
 from transformer_engine.pytorch.tensor import Float8TensorStorage
 from transformer_engine.pytorch.tensor import MXFP8TensorStorage
 from transformer_engine.pytorch.tensor import Float8BlockwiseQTensorStorage

--- a/transformer_engine/pytorch/tensor/__init__.py
+++ b/transformer_engine/pytorch/tensor/__init__.py
@@ -22,7 +22,7 @@ from .storage.grouped_tensor_storage import GroupedTensorStorage
 from .float8_tensor import Float8Tensor, Float8Quantizer, Float8CurrentScalingQuantizer
 from .mxfp8_tensor import MXFP8Tensor, MXFP8Quantizer
 from .float8_blockwise_tensor import Float8BlockwiseQTensor, Float8BlockQuantizer
-from .nvfp4_tensor import NVFP4Tensor, NVFP4Quantizer
+from .nvfp4_tensor import NVFP4Tensor, NVFP4Quantizer, quantize_nvfp4
 from .grouped_tensor import GroupedTensor
 from .utils import cast_master_weights_to_fp8, replace_raw_data
 
@@ -33,6 +33,7 @@ __all__ = [
     "MXFP8Quantizer",
     "Float8BlockQuantizer",
     "NVFP4Quantizer",
+    "quantize_nvfp4",
     "QuantizedTensorStorage",
     "Float8TensorStorage",
     "MXFP8TensorStorage",

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -327,6 +327,64 @@ class NVFP4Quantizer(Quantizer):
         return NVFP4BlockScaling
 
 
+def quantize_nvfp4(
+    tensor: torch.Tensor,
+    *,
+    fp4_dtype: TE_DType = tex.DType.kFloat4E2M1,
+    rowwise: bool = True,
+    columnwise: bool = False,
+    with_amax_reduction: bool = False,
+    amax_reduction_group: Optional[dist_group_type] = None,
+    with_rht: bool = False,
+    with_post_rht_amax: bool = False,
+    with_2d_quantization: bool = False,
+    stochastic_rounding: bool = False,
+    row_scaled_nvfp4: bool = False,
+    nvfp4_use_4over6: bool = False,
+    nvfp4_e4m3_max: int = 448,
+    nvfp4_4over6_err_mode: str = "MAE",
+    with_random_sign_mask: bool = False,
+) -> NVFP4Tensor:
+    """Quantize a PyTorch tensor into an ``NVFP4Tensor``.
+
+    This is a public convenience wrapper around :class:`NVFP4Quantizer`
+    for callers that want TE's production NVFP4 kernels without
+    constructing a quantizer object directly. The tensor amax is computed
+    internally by the quantizer. Unlike :class:`NVFP4Quantizer`, this
+    function defaults to ``columnwise=False``.
+
+    The ``nvfp4_e4m3_max`` argument only applies when
+    ``nvfp4_use_4over6=True``. Non-4over6 tensors use the standard NVFP4
+    E4M3 bound of 448.
+
+    Recipe configuration environment variables, e.g.
+    ``NVTE_NVFP4_4OVER6``, ``NVTE_NVFP4_ROW_SCALED_ACTIVATION``, and
+    ``NVTE_NVFP4_4OVER6_ERR_MODE``, are not read by this direct API.
+    Configure those options with the explicit keyword arguments instead.
+    Kernel-level environment variables still apply: ``NVTE_USE_FAST_MATH``
+    controls the standard NVFP4 fast-math path, while
+    ``NVTE_NVFP4_4OVER6_ERR_USE_FAST_MATH`` controls the 4over6 candidate
+    error-comparison fast-math path.
+    """
+    quantizer = NVFP4Quantizer(
+        fp4_dtype=fp4_dtype,
+        rowwise=rowwise,
+        columnwise=columnwise,
+        with_amax_reduction=with_amax_reduction,
+        amax_reduction_group=amax_reduction_group,
+        with_rht=with_rht,
+        with_post_rht_amax=with_post_rht_amax,
+        with_2d_quantization=with_2d_quantization,
+        stochastic_rounding=stochastic_rounding,
+        row_scaled_nvfp4=row_scaled_nvfp4,
+        nvfp4_use_4over6=nvfp4_use_4over6,
+        nvfp4_e4m3_max=nvfp4_e4m3_max,
+        nvfp4_4over6_err_mode=nvfp4_4over6_err_mode,
+        with_random_sign_mask=with_random_sign_mask,
+    )
+    return quantizer(tensor)
+
+
 class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
     """Quantized tensor class with FP4 data
 

--- a/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
@@ -205,6 +205,88 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
             "fake_dtype": self._dtype,
         }
 
+    @property
+    def rowwise_data(self) -> Optional[torch.Tensor]:
+        """Raw packed FP4 data in rowwise layout.
+
+        This exposes internal tensor storage; callers must not mutate the
+        returned tensor in place.
+        """
+        return self._rowwise_data
+
+    @property
+    def rowwise_scale_inv(self) -> Optional[torch.Tensor]:
+        """Rowwise block scale inverses.
+
+        This exposes internal tensor storage; callers must not mutate the
+        returned tensor in place.
+        """
+        return self._rowwise_scale_inv
+
+    @property
+    def columnwise_data(self) -> Optional[torch.Tensor]:
+        """Raw packed FP4 data in columnwise layout.
+
+        This exposes internal tensor storage; callers must not mutate the
+        returned tensor in place.
+        """
+        return self._columnwise_data
+
+    @property
+    def columnwise_scale_inv(self) -> Optional[torch.Tensor]:
+        """Columnwise block scale inverses.
+
+        This exposes internal tensor storage; callers must not mutate the
+        returned tensor in place.
+        """
+        return self._columnwise_scale_inv
+
+    @property
+    def amax_rowwise(self) -> Optional[torch.Tensor]:
+        """Amax tensor used for rowwise global NVFP4 scaling.
+
+        This exposes internal tensor storage; callers must not mutate the
+        returned tensor in place.
+        """
+        return self._amax_rowwise
+
+    @property
+    def amax_columnwise(self) -> Optional[torch.Tensor]:
+        """Amax tensor used for columnwise global NVFP4 scaling.
+
+        This exposes internal tensor storage; callers must not mutate the
+        returned tensor in place.
+        """
+        return self._amax_columnwise
+
+    @property
+    def fp4_dtype(self) -> TE_DType:
+        """FP4 data type used by this tensor."""
+        return self._fp4_dtype
+
+    @property
+    def with_gemm_swizzled_scales(self) -> bool:
+        """Whether scale tensors are in the GEMM swizzled layout."""
+        return self._with_gemm_swizzled_scales
+
+    @property
+    def row_scaled_nvfp4(self) -> bool:
+        """Whether this tensor uses one NVFP4 global scale per row."""
+        return self._row_scaled_nvfp4
+
+    @property
+    def nvfp4_use_4over6(self) -> bool:
+        """Whether this tensor was quantized with NVFP4 4over6 selection."""
+        return self._nvfp4_use_4over6
+
+    @property
+    def nvfp4_e4m3_max(self) -> int:
+        """Global E4M3 scale bound used by this tensor.
+
+        Non-4over6 tensors report the standard NVFP4 E4M3 bound of 448.
+        """
+        return self._nvfp4_e4m3_max
+
     def prepare_for_saving(self) -> Tuple[list[Optional[torch.Tensor]], NVFP4TensorStorage]:
         """Prepare the tensor base for saving for backward"""
         tensors = [


### PR DESCRIPTION
# Description

Expose a small public PyTorch API for production NVFP4 quantization. The new `transformer_engine.pytorch.quantize_nvfp4` helper wraps `NVFP4Quantizer` so external training and weight-update frameworks can use TE's NVFP4 kernels without reaching into internal reference quantizers or private tensor fields.

This is intended to make low-precision weight update flows less error-prone by providing stable access to the quantized tensor object and its raw NVFP4 payload buffers.

Fixes # (issue): N/A

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `transformer_engine.pytorch.quantize_nvfp4`, a convenience wrapper around `NVFP4Quantizer` with explicit keyword arguments for rowwise/columnwise, 2D, row-scaled, and 4over6 NVFP4 modes.
- Export public accessors for NVFP4 tensor payloads and metadata, including rowwise/columnwise packed data, scale inverses, amax tensors, 4over6 mode, and E4M3 max. Tensor accessors expose internal buffers; callers should not mutate returned tensors in place.
- Add targeted PyTorch tests that compare the public API output against direct `NVFP4Quantizer` usage across rowwise, 2D, row-scaled, and 4over6 modes.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Validation:

- `pre-commit run --all-files`
- `python3 -m pytest --tb=short tests/pytorch/nvfp4/test_nvfp4_public_api.py`
- `python3 -m pytest --tb=short tests/pytorch/test_quantized_tensor.py -k nvfp4`

