### PR TITLE
[PyTorch] Use data shape for MXFP8 pointer swizzle

### DIFF
--- a/tests/pytorch/mxfp8/test_mxfp8_quantize_swizzle_fusion.py
+++ b/tests/pytorch/mxfp8/test_mxfp8_quantize_swizzle_fusion.py
@@ -20,6 +20,30 @@ from mxfp8_utils import swizzle_mxfp8_scale, get_mxfp8_scale_shape_no_padding
 recipe_available, reason_for_no_recipe = te.is_mxfp8_available(return_reason=True)
 
 
+def poison_mxfp8_scale_padding_with_nan(
+    scale: torch.Tensor,
+    valid_shape: Tuple[int, int],
+) -> torch.Tensor:
+    """Fill only the padded part of a compact MXFP8 scale tensor with NaNs."""
+    scale = scale.clone()
+    scale_e8m0 = scale.view(dtype=torch.float8_e8m0fnu)
+    scale_e8m0[valid_shape[0] :, :] = float("nan")
+    scale_e8m0[:, valid_shape[1] :] = float("nan")
+    return scale
+
+
+def zero_mxfp8_scale_padding(
+    scale: torch.Tensor,
+    valid_shape: Tuple[int, int],
+) -> torch.Tensor:
+    """Zero only the padded part of a compact MXFP8 scale tensor."""
+    scale = scale.clone()
+    scale_uint8 = scale.view(dtype=torch.uint8)
+    scale_uint8[valid_shape[0] :, :] = 0
+    scale_uint8[:, valid_shape[1] :] = 0
+    return scale
+
+
 def unpack_quantized_tensor(
     quantized_tensor: MXFP8TensorStorage,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -130,3 +154,57 @@ def test_mxfp8_quantize_swizzle_fusion(
         return_rowwise=return_rowwise,
         return_transpose=return_transpose,
     )
+
+
+@pytest.mark.skipif(not recipe_available, reason=reason_for_no_recipe)
+@pytest.mark.parametrize("columnwise", [False, True])
+def test_mxfp8_pointer_swizzle_uses_unpadded_data_shape(columnwise: bool) -> None:
+    # This shape has valid MXFP8 blocks, but its scale tensor needs padding:
+    # rowwise scale is padded from (160, 3) to (256, 4), columnwise from
+    # (5, 96) to (8, 128).
+    M, N = 160, 96
+    x = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+    quantizer = MXFP8Quantizer(
+        fp8_dtype=tex.DType.kFloat8E4M3,
+        rowwise=not columnwise,
+        columnwise=columnwise,
+    )
+    quantized = quantizer(x)
+    valid_scale_shape = get_mxfp8_scale_shape_no_padding(x.shape, columnwise)
+
+    if columnwise:
+        scale = quantized._columnwise_scale_inv
+        transform_type = "uniform_mxfp8_columnwise_swizzle"
+        inferred_padded_shape = (scale.shape[0] * 32, scale.shape[1])
+    else:
+        scale = quantized._rowwise_scale_inv
+        transform_type = "uniform_mxfp8_rowwise_swizzle"
+        inferred_padded_shape = (scale.shape[0], scale.shape[1] * 32)
+
+    # Poison padded scale values with E8M0 NaNs. If swizzle reconstructs the
+    # data shape from the padded scale shape, these values are considered real
+    # and survive.
+    scale = poison_mxfp8_scale_padding_with_nan(scale, valid_scale_shape)
+
+    # With the actual data shape, swizzle should treat the poisoned bytes as
+    # padding. Build the expected output by zeroing that padding before the
+    # Python reference swizzle.
+    expected_compact_scale = zero_mxfp8_scale_padding(scale, valid_scale_shape)
+    padded_M, padded_N = inferred_padded_shape
+    expected = swizzle_mxfp8_scale(
+        padded_M,
+        padded_N,
+        expected_compact_scale,
+        columnwise=columnwise,
+    )
+
+    _, swizzled_buffer = tex.transform_and_copy_data_ptrs_to_device(
+        transform_type,
+        [scale],
+        x.device,
+        x.shape,
+    )
+    torch.cuda.synchronize()
+    actual = swizzled_buffer[: scale.numel()].view(dtype=expected.dtype).view_as(expected)
+
+    torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -492,7 +492,7 @@ at::Tensor copy_data_ptrs_to_device(const std::vector<at::Tensor> &tensors,
 
 std::tuple<at::Tensor, std::optional<at::Tensor>> transform_and_copy_data_ptrs_to_device(
     const std::string &transform_type, const std::vector<at::Tensor> &tensors,
-    const c10::Device &device);
+    const c10::Device &device, const std::vector<int64_t> &actual_data_shape = {});
 
 /***************************************************************************************************
  * Support THD format for Context Parallel

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -497,6 +497,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("transform_and_copy_data_ptrs_to_device",
         &transformer_engine::pytorch::transform_and_copy_data_ptrs_to_device,
         py::arg("transform_type"), py::arg("tensors"), py::arg("device"),
+        py::arg("actual_data_shape") = std::vector<int64_t>{},
         py::call_guard<py::gil_scoped_release>());
   m.def("splits_to_offsets", &transformer_engine::pytorch::splits_to_offsets,
         "Compute grouped tensor offsets from split sizes", py::arg("first_dims"),

--- a/transformer_engine/pytorch/csrc/extensions/utils.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/utils.cpp
@@ -40,7 +40,7 @@ at::Tensor copy_data_ptrs_to_device(const std::vector<at::Tensor> &tensors,
 
 std::tuple<at::Tensor, std::optional<at::Tensor>> transform_and_copy_data_ptrs_to_device(
     const std::string &transform_type, const std::vector<at::Tensor> &tensors,
-    const c10::Device &device) {
+    const c10::Device &device, const std::vector<int64_t> &actual_data_shape) {
   const size_t num_tensors = tensors.size();
 
   // Trivial cases
@@ -93,12 +93,15 @@ std::tuple<at::Tensor, std::optional<at::Tensor>> transform_and_copy_data_ptrs_t
     const size_t scale_dtype_bits = transformer_engine::pytorch::typeToNumBits(scale_dtype);
     const size_t scale_bytes = ceildiv(scale_numel * scale_dtype_bits, 8);
 
-    // Expected data shape
-    // Note: May not match actual data shape since the scales are padded.
-    // This is fine since we're not actually touching the data.
+    // Swizzle uses data shape to mask padded scale blocks.
     NVTEShape data_shape;
     data_shape.ndim = 2;
-    if (uniform_mxfp8_rowwise_swizzle) {
+    if (!actual_data_shape.empty()) {
+      NVTE_CHECK(actual_data_shape.size() == 2, "Expected 2D data shape, but got ",
+                 actual_data_shape.size(), " dimensions.");
+      data_shape.data[0] = static_cast<size_t>(actual_data_shape[0]);
+      data_shape.data[1] = static_cast<size_t>(actual_data_shape[1]);
+    } else if (uniform_mxfp8_rowwise_swizzle) {
       data_shape.data[0] = scale_shape.data[0];
       data_shape.data[1] = scale_shape.data[1] * 32;
     } else if (uniform_mxfp8_colwise_swizzle) {

--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -538,6 +538,7 @@ class _BackwardGroupedMLP_CuTeGEMMDBase_MXFP8(FusedOperation):
                 "uniform_mxfp8_columnwise_swizzle",
                 [w._columnwise_scale_inv for w in grouped_fc2_weight],
                 device,
+                fc2_weight_shape,
             )
             fc2_dactivation_kwargs["b_ptrs"] = fc2_b_ptrs
             fc2_dactivation_kwargs["sfb_ptrs"] = fc2_sfb_ptrs
@@ -729,6 +730,7 @@ class _BackwardGroupedMLP_CuTeGEMMDBase_MXFP8(FusedOperation):
                     "uniform_mxfp8_columnwise_swizzle",
                     [w._columnwise_scale_inv for w in grouped_fc1_weight],
                     device,
+                    fc1_weight_shape,
                 )
                 fc1_dgrad_kwargs["b_ptrs"] = fc1_b_ptrs
                 fc1_dgrad_kwargs["sfb_ptrs"] = fc1_sfb_ptrs

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -389,6 +389,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase_MXFP8(FusedOperation):
                 "uniform_mxfp8_rowwise_swizzle",
                 [w._rowwise_scale_inv for w in grouped_fc1_weight],
                 device,
+                fc1_weight_shape,
             )
             fc1_activation_kwargs["b_ptrs"] = fc1_b_ptrs
             fc1_activation_kwargs["sfb_ptrs"] = fc1_sfb_ptrs
@@ -490,6 +491,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase_MXFP8(FusedOperation):
                 "uniform_mxfp8_rowwise_swizzle",
                 [w._rowwise_scale_inv for w in grouped_fc2_weight],
                 device,
+                fc2_weight_shape,
             )
             fc2_quant_kwargs["b_ptrs"] = fc2_b_ptrs
             fc2_quant_kwargs["sfb_ptrs"] = fc2_sfb_ptrs


### PR DESCRIPTION
# Description
We've started seeing NaN loss in gpt_oss_20b training using MXFP8. gpt_oss_20b uses expert MLP dimensions based on hidden size 2880, producing FC1 weights of (5760, 2880) and FC2 weights of (2880, 2880). I bisected this to NVIDIA/TransformerEngine@9e5a847c90c436c9c9c5f3e756977cf568967ccc. That change is not safe in the presence of MXFP8 scale padding: without the actual unpadded data shape, `transform_and_copy_data_ptrs_to_device` infers the data shape from the padded scale shape, so padded E8M0 scale bytes can be copied into the swizzled GEMM scale buffer and consumed by GEMM, causing NaNs. Fix it by passing the actual data shape to transform_and_copy_data_ptrs_to_device. The patch includes a regression test that poisons padded scale entries and verifies they are masked out.

Fixes #

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix MXFP8 scale padding being read for non-128-aligned dimensions

# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
