### PR TITLE
[JAX] Fallback to old triton ffi for autotuned kernels

### DIFF
--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -632,9 +632,8 @@ def triton_call_lowering(
         ffi_operand_output_aliases = None
 
     compressed_call_proto = zlib.compress(call_proto)
-    if (
-        not used_autotuned_launch
-        and jax_version_meet_requirement(TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION)
+    if not used_autotuned_launch and jax_version_meet_requirement(
+        TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION
     ):
         rule = jax.ffi.ffi_lowering(
             "triton_kernel_call_ffi",

--- a/transformer_engine/jax/triton_extensions/utils.py
+++ b/transformer_engine/jax/triton_extensions/utils.py
@@ -485,6 +485,7 @@ def triton_call_lowering(
     # NVTE_JAX_ENFORCE_TRITON_AUTOTUNING=1 to raise an error instead, prompting the
     # user to upgrade JAX for improved performance.
     is_autotuned = isinstance(kernel_fn, autotuner.Autotuner)
+    used_autotuned_launch = False
     if is_autotuned and not is_triton_autotuned_alias_safe():
         val = os.environ.get("NVTE_JAX_ENFORCE_TRITON_AUTOTUNING", "0")
         try:
@@ -574,6 +575,7 @@ def triton_call_lowering(
             kernel_calls,
             input_output_aliases_with_sizes,
         )
+        used_autotuned_launch = True
 
     else:
         # Regular kernel: compile single config.
@@ -630,7 +632,10 @@ def triton_call_lowering(
         ffi_operand_output_aliases = None
 
     compressed_call_proto = zlib.compress(call_proto)
-    if jax_version_meet_requirement(TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION):
+    if (
+        not used_autotuned_launch
+        and jax_version_meet_requirement(TRITON_EXTENSION_CUDA_GRAPH_MIN_JAX_VERSION)
+    ):
         rule = jax.ffi.ffi_lowering(
             "triton_kernel_call_ffi",
             backend_config={"opaque": ir.StringAttr.get(compressed_call_proto)},


### PR DESCRIPTION
# Description

Disables new "triton_kernel_call_ffi" and falls back to old "triton_kernel_call" ffi due to CUDA IMA issues observed with autotuned kernels on new "triton_kernel_call_ffi"

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Fallback autotuned kernels to "triton_kernel_call"

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
