### PR TITLE
[JAX] Extend tensor inspect utility to dump out tensors in identifiable names

### DIFF
--- a/tests/jax/test_custom_call_compute.py
+++ b/tests/jax/test_custom_call_compute.py
@@ -2033,8 +2033,10 @@ class TestDebugInspectFFI:
         ]
         + ([jnp.float8_e4m3fn, jnp.float8_e5m2] if is_fp8_supported else []),
     )
-    def test_debug_inspect_ffi(self, shape, dtype):
+    def test_debug_inspect_ffi(self, shape, dtype, tmp_path, monkeypatch):
         from transformer_engine.jax.debug.experimental import inspect_array, load_array_dump
+
+        monkeypatch.chdir(tmp_path)
 
         def f(x):
             x = x + 1
@@ -2048,7 +2050,7 @@ class TestDebugInspectFFI:
         _ = jax.jit(f)(x)
 
         expected = x + 1
-        actual = load_array_dump("my_tensor_gpu0.bin", shape, dtype)
+        actual = load_array_dump("my_tensor_gpu0_my_array.bin", shape, dtype)
 
         assert_allclose(actual, expected, dtype=dtype)
 

--- a/transformer_engine/jax/csrc/extensions/inspect.cpp
+++ b/transformer_engine/jax/csrc/extensions/inspect.cpp
@@ -121,14 +121,14 @@ Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type mi
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(InspectHandler, InspectFFI,
                               FFI::Bind()
-                                  .Ctx<FFI_Stream_Type>()           // stream
-                                  .Arg<Buffer_Type>()               // input
-                                  .Arg<Buffer_Type>()               // min
-                                  .Arg<Buffer_Type>()               // max
-                                  .Arg<Buffer_Type>()               // mean
-                                  .Arg<Buffer_Type>()               // std
-                                  .Ret<Buffer_Type>()               // output
-                                  .Attr<std::string_view>("name")   // probe name
+                                  .Ctx<FFI_Stream_Type>()          // stream
+                                  .Arg<Buffer_Type>()              // input
+                                  .Arg<Buffer_Type>()              // min
+                                  .Arg<Buffer_Type>()              // max
+                                  .Arg<Buffer_Type>()              // mean
+                                  .Arg<Buffer_Type>()              // std
+                                  .Ret<Buffer_Type>()              // output
+                                  .Attr<std::string_view>("name")  // probe name
 );
 
 }  // namespace jax

--- a/transformer_engine/jax/csrc/extensions/inspect.cpp
+++ b/transformer_engine/jax/csrc/extensions/inspect.cpp
@@ -17,11 +17,8 @@
 namespace transformer_engine {
 namespace jax {
 
-// Sanitize a probe name for use as a filename component: replace any
-// character that's not [A-Za-z0-9._-] with '_'. Probe names like
-// "fwd/sparse_probs_after_fused_topk" therefore become legal POSIX
-// filenames ("fwd_sparse_probs_after_fused_topk") without losing the
-// trailing semantic suffix.
+// Replace characters not in [A-Za-z0-9._-] with '_' so probe names are
+// safe to use as filename components.
 static std::string SanitizeProbeName(std::string_view name) {
   std::string out;
   out.reserve(name.size());
@@ -69,8 +66,7 @@ Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type mi
 
   // Per-probe filenames: my_tensor_gpu{device}_{sanitized_name}.bin /
   // ..._meta.json. With distinct names, the on-disk dumps survive across
-  // probes instead of being overwritten on every call, so a single test
-  // run produces one .bin per probe per rank ready for offline analysis.
+  // probes instead of being overwritten on every call
   std::string safe_name = SanitizeProbeName(name);
   std::string device_str = std::to_string(device);
   std::string filename = "my_tensor_gpu" + device_str + "_" + safe_name + ".bin";
@@ -102,9 +98,6 @@ Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type mi
   meta_file << "}";
   meta_file.close();
 
-  // Surface the probe name in the live log alongside the file path, so
-  // analysing a multi-probe trace doesn't require correlating by
-  // shape/dtype guesswork.
   printf("[gpu%d %.*s]: written to %s (shape: [", device, static_cast<int>(name.size()),
          name.data(), filename.c_str());
   for (size_t i = 0; i < input_buf.dimensions().size(); ++i) {

--- a/transformer_engine/jax/csrc/extensions/inspect.cpp
+++ b/transformer_engine/jax/csrc/extensions/inspect.cpp
@@ -5,8 +5,11 @@
  ************************************************************************/
 #include <cuda_runtime.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <string_view>
 
 #include "../extensions.h"
 #include "xla/ffi/api/c_api.h"
@@ -14,9 +17,31 @@
 namespace transformer_engine {
 namespace jax {
 
+// Sanitize a probe name for use as a filename component: replace any
+// character that's not [A-Za-z0-9._-] with '_'. Probe names like
+// "fwd/sparse_probs_after_fused_topk" therefore become legal POSIX
+// filenames ("fwd_sparse_probs_after_fused_topk") without losing the
+// trailing semantic suffix.
+static std::string SanitizeProbeName(std::string_view name) {
+  std::string out;
+  out.reserve(name.size());
+  for (char c : name) {
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' ||
+        c == '_' || c == '-') {
+      out.push_back(c);
+    } else {
+      out.push_back('_');
+    }
+  }
+  if (out.empty()) {
+    out = "anon";
+  }
+  return out;
+}
+
 Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type min_buf,
                       Buffer_Type max_buf, Buffer_Type mean_buf, Buffer_Type std_buf,
-                      Result_Type output_buf) {
+                      Result_Type output_buf, std::string_view name) {
   NVTE_CHECK(input_buf.untyped_data() != nullptr, "Input must be provided for inspect operation");
   NVTE_CHECK(output_buf->untyped_data() != nullptr,
              "Output must be provided for inspect operation");
@@ -42,18 +67,25 @@ Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type mi
   int device;
   NVTE_CHECK_CUDA(cudaGetDevice(&device));
 
-  // Write the tensor data to a file as a binary blob
-  std::string filename = "my_tensor_gpu" + std::to_string(device) + ".bin";
+  // Per-probe filenames: my_tensor_gpu{device}_{sanitized_name}.bin /
+  // ..._meta.json. With distinct names, the on-disk dumps survive across
+  // probes instead of being overwritten on every call, so a single test
+  // run produces one .bin per probe per rank ready for offline analysis.
+  std::string safe_name = SanitizeProbeName(name);
+  std::string device_str = std::to_string(device);
+  std::string filename = "my_tensor_gpu" + device_str + "_" + safe_name + ".bin";
   std::ofstream file(filename, std::ios::binary);
   NVTE_CHECK(file.is_open(), "Failed to create file: ", filename);
   file.write(reinterpret_cast<const char *>(input_data.data()), input_data.size());
   file.close();
 
-  // Write out a metadata file
-  std::string meta_filename = "my_tensor_gpu" + std::to_string(device) + "_meta.json";
+  std::string meta_filename = "my_tensor_gpu" + device_str + "_" + safe_name + "_meta.json";
   std::ofstream meta_file(meta_filename);
   NVTE_CHECK(meta_file.is_open(), "Failed to create file: ", meta_filename);
   meta_file << "{";
+  // Echo the original (un-sanitized) probe name so analysis tools can
+  // recover the semantic label even when the filename had to mangle it.
+  meta_file << "\"name\": \"" << name << "\", ";
   meta_file << "\"shape\": [";
   for (size_t i = 0; i < input_buf.dimensions().size(); ++i) {
     meta_file << input_buf.dimensions()[i];
@@ -70,8 +102,11 @@ Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type mi
   meta_file << "}";
   meta_file.close();
 
-  // Log the tensor metadata to the console
-  printf("[gpu%d]: Tensor data written to %s (shape: [", device, filename.c_str());
+  // Surface the probe name in the live log alongside the file path, so
+  // analysing a multi-probe trace doesn't require correlating by
+  // shape/dtype guesswork.
+  printf("[gpu%d %.*s]: written to %s (shape: [", device, static_cast<int>(name.size()),
+         name.data(), filename.c_str());
   for (size_t i = 0; i < input_buf.dimensions().size(); ++i) {
     printf("%zu", static_cast<size_t>(input_buf.dimensions()[i]));
     if (i < input_buf.dimensions().size() - 1) {
@@ -86,13 +121,14 @@ Error_Type InspectFFI(cudaStream_t stream, Buffer_Type input_buf, Buffer_Type mi
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(InspectHandler, InspectFFI,
                               FFI::Bind()
-                                  .Ctx<FFI_Stream_Type>()  // stream
-                                  .Arg<Buffer_Type>()      // input
-                                  .Arg<Buffer_Type>()      // min
-                                  .Arg<Buffer_Type>()      // max
-                                  .Arg<Buffer_Type>()      // mean
-                                  .Arg<Buffer_Type>()      // std
-                                  .Ret<Buffer_Type>()      // output
+                                  .Ctx<FFI_Stream_Type>()           // stream
+                                  .Arg<Buffer_Type>()               // input
+                                  .Arg<Buffer_Type>()               // min
+                                  .Arg<Buffer_Type>()               // max
+                                  .Arg<Buffer_Type>()               // mean
+                                  .Arg<Buffer_Type>()               // std
+                                  .Ret<Buffer_Type>()               // output
+                                  .Attr<std::string_view>("name")   // probe name
 );
 
 }  // namespace jax

--- a/transformer_engine/jax/debug/experimental/inspect.py
+++ b/transformer_engine/jax/debug/experimental/inspect.py
@@ -22,12 +22,8 @@ class InspectPrimitive(BasePrimitive):
 
     name = "te_inspect_ffi"
     multiple_results = False
-    # ``name`` is at positional index 5 in ``impl``; declaring it static
-    # here lets ``custom_partitioning`` resolve ``bind(..., name=...)``
-    # kwargs back to that position via ``_resolve_kwargs``. Keyword-only
-    # parameters (``*, name``) would raise
-    #     TypeError: keyword arguments could not be resolved to positions
-    # at trace time, so ``impl`` accepts ``name`` positionally below.
+    # ``name`` is positional (index 5 in ``impl``) so ``custom_partitioning``
+    # can resolve ``bind(..., name=...)`` kwargs back to that position.
     impl_static_args = (5,)
     inner_primitive = None
     outer_primitive = None
@@ -97,11 +93,7 @@ class InspectPrimitive(BasePrimitive):
         x_std,
         name,
     ):
-        """
-        inspect implementation. ``name`` is positional (not keyword-only)
-        so ``custom_partitioning(static_argnums=(5,))`` can resolve
-        ``bind(..., name=...)`` kwargs to position 5.
-        """
+        """inspect implementation"""
         assert InspectPrimitive.inner_primitive is not None
         x = InspectPrimitive.inner_primitive.bind(
             x,
@@ -115,16 +107,7 @@ class InspectPrimitive(BasePrimitive):
 
     @staticmethod
     def partition(name, mesh, arg_infos, result_infos):
-        """
-        Identity in sharding: the output carries the same sharding as ``x``;
-        the four scalar stats (x_min, x_max, x_mean, x_std) are fully
-        replicated. Without this override the primitive falls back to
-        ``BasePrimitive``'s abstract partition and any multi-device JIT
-        rejects the call.
-
-        Static args precede ``mesh`` per the ``custom_partitioning``
-        convention when ``static_argnums`` is set on the wrapped impl.
-        """
+        """Identity sharding: output matches ``x``; scalar stats are replicated."""
         del result_infos
         x_sharding = arg_infos[0].sharding
         scalar_sharding = NamedSharding(mesh, PartitionSpec())
@@ -144,13 +127,7 @@ class InspectPrimitive(BasePrimitive):
 
     @staticmethod
     def shardy_sharding_rule(*args):
-        """
-        Five operands, one output. ``x`` and the output carry the same
-        wildcard rank; the four scalar stats are rank-0 (empty operand
-        entries between commas). ``name`` is a static arg (precedes
-        ``mesh``/``value_types``/``result_types`` in ``args``) and does
-        not participate in the rule.
-        """
+        """``x`` and output share rank; the four scalar stats are rank-0."""
         del args
         return "..., , , , -> ..."
 
@@ -173,10 +150,8 @@ def _inspect_array_inner(x: jnp.ndarray, name: str) -> jnp.ndarray:
     )
 
 
-# ``name`` is a Python string and must not be traced through jax — it is
-# carried as a custom_vjp nondiff argument so it stays static at compile
-# time, threads into the primitive bind as a kwarg, and lands on the
-# FFI as a string attribute.
+# ``name`` is carried as a custom_vjp nondiff argument so it stays static
+# at compile time and lands on the FFI as a string attribute.
 @partial(jax.custom_vjp, nondiff_argnums=(1,))
 def _inspect(x, name):
     """ """
@@ -203,22 +178,18 @@ _inspect.defvjp(_inspect_fwd_rule, _inspect_bwd_rule)
 def inspect_array(x: jnp.ndarray, name: str) -> jnp.ndarray:
     """Inspect a JAX array by dumping its data and stats to disk per-rank.
 
-    On every call the FFI synchronises the input device buffer to host
-    and writes two files per rank, **keyed by ``name``** so multiple
+    Each call writes two files per rank, keyed by ``name`` so multiple
     probes in the same program produce distinct dumps:
 
-    * ``my_tensor_gpu{device}_{sanitized_name}.bin``      – raw bytes.
-    * ``my_tensor_gpu{device}_{sanitized_name}_meta.json`` – ``name``,
+    * ``my_tensor_gpu{device}_{sanitized_name}.bin`` -- raw bytes.
+    * ``my_tensor_gpu{device}_{sanitized_name}_meta.json`` -- ``name``,
       shape, dtype, and min/max/mean/std summary stats.
 
-    A line is also printed to stdout including the probe ``name`` so
-    multi-probe traces are easy to follow in a live log.
+    A summary line is also printed to stdout, including ``name``.
 
-    ``name`` is treated as a static (non-traced) attribute, so the same
-    probe name must be passed in every (re-)trace of an enclosing
-    ``jax.jit``; characters outside ``[A-Za-z0-9._-]`` are mapped to
-    ``_`` when forming the filename, but the unsanitised name is echoed
-    verbatim in the JSON metadata and the printed log line.
+    ``name`` is a static (non-traced) attribute. Characters outside
+    ``[A-Za-z0-9._-]`` are mapped to ``_`` in the filename, but the
+    original name is preserved in the JSON metadata and log line.
 
     Args:
         x (jnp.ndarray): The JAX array to inspect.

--- a/transformer_engine/jax/debug/experimental/inspect.py
+++ b/transformer_engine/jax/debug/experimental/inspect.py
@@ -8,6 +8,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 from jax import ffi
+from jax.sharding import NamedSharding, PartitionSpec
 
 from transformer_engine.jax.cpp_extensions.base import BasePrimitive, register_primitive
 
@@ -95,6 +96,42 @@ class InspectPrimitive(BasePrimitive):
             x_std,
         )
         return x
+
+    @staticmethod
+    def partition(mesh, arg_infos, result_infos):
+        """
+        Identity in sharding: the output carries the same sharding as ``x``;
+        the four scalar stats (x_min, x_max, x_mean, x_std) are fully
+        replicated. Without this override the primitive falls back to
+        ``BasePrimitive``'s abstract partition and any multi-device JIT
+        rejects the call.
+        """
+        del result_infos
+        x_sharding = arg_infos[0].sharding
+        scalar_sharding = NamedSharding(mesh, PartitionSpec())
+        arg_shardings = (
+            x_sharding,
+            scalar_sharding,
+            scalar_sharding,
+            scalar_sharding,
+            scalar_sharding,
+        )
+        out_sharding = x_sharding
+
+        def sharded_impl(x, x_min, x_max, x_mean, x_std):
+            return InspectPrimitive.impl(x, x_min, x_max, x_mean, x_std)
+
+        return mesh, sharded_impl, out_sharding, arg_shardings
+
+    @staticmethod
+    def shardy_sharding_rule(*args):
+        """
+        Five operands, one output. ``x`` and the output carry the same
+        wildcard rank; the four scalar stats are rank-0 (empty operand
+        entries between commas).
+        """
+        del args
+        return "..., , , , -> ..."
 
 
 register_primitive(InspectPrimitive)

--- a/transformer_engine/jax/debug/experimental/inspect.py
+++ b/transformer_engine/jax/debug/experimental/inspect.py
@@ -33,10 +33,13 @@ class InspectPrimitive(BasePrimitive):
         x_max_aval,
         x_mean_aval,
         x_std_aval,
+        *,
+        name,
     ):
         """
         inspect abstract
         """
+        del name
         assert (
             x_min_aval.shape == () and x_min_aval.dtype == jnp.float32
         ), "x_min must be a scalar with dtype float32"
@@ -59,6 +62,8 @@ class InspectPrimitive(BasePrimitive):
         x_max,
         x_mean,
         x_std,
+        *,
+        name,
     ):
         """
         inspect lowering rules
@@ -74,6 +79,7 @@ class InspectPrimitive(BasePrimitive):
             x_max,
             x_mean,
             x_std,
+            name=name,
         )
 
     @staticmethod
@@ -83,6 +89,8 @@ class InspectPrimitive(BasePrimitive):
         x_max,
         x_mean,
         x_std,
+        *,
+        name,
     ):
         """
         inspect implementation
@@ -94,11 +102,12 @@ class InspectPrimitive(BasePrimitive):
             x_max,
             x_mean,
             x_std,
+            name=name,
         )
         return x
 
     @staticmethod
-    def partition(mesh, arg_infos, result_infos):
+    def partition(mesh, arg_infos, result_infos, *, name):
         """
         Identity in sharding: the output carries the same sharding as ``x``;
         the four scalar stats (x_min, x_max, x_mean, x_std) are fully
@@ -119,25 +128,26 @@ class InspectPrimitive(BasePrimitive):
         out_sharding = x_sharding
 
         def sharded_impl(x, x_min, x_max, x_mean, x_std):
-            return InspectPrimitive.impl(x, x_min, x_max, x_mean, x_std)
+            return InspectPrimitive.impl(x, x_min, x_max, x_mean, x_std, name=name)
 
         return mesh, sharded_impl, out_sharding, arg_shardings
 
     @staticmethod
-    def shardy_sharding_rule(*args):
+    def shardy_sharding_rule(*args, **kwargs):
         """
         Five operands, one output. ``x`` and the output carry the same
         wildcard rank; the four scalar stats are rank-0 (empty operand
-        entries between commas).
+        entries between commas). The ``name`` keyword attribute does not
+        participate in the rule.
         """
-        del args
+        del args, kwargs
         return "..., , , , -> ..."
 
 
 register_primitive(InspectPrimitive)
 
 
-def _inspect_array_inner(x: jnp.ndarray) -> jnp.ndarray:
+def _inspect_array_inner(x: jnp.ndarray, name: str) -> jnp.ndarray:
     assert InspectPrimitive.outer_primitive is not None, (
         "InspectPrimitive FFI is not registered. Please ensure the C++ extension is properly built"
         " and registered."
@@ -148,35 +158,31 @@ def _inspect_array_inner(x: jnp.ndarray) -> jnp.ndarray:
         jnp.max(x).astype(jnp.float32),
         jnp.mean(x.astype(jnp.float32)),
         jnp.std(x.astype(jnp.float32)),
+        name=name,
     )
 
 
-@partial(jax.custom_vjp, nondiff_argnums=())
-def _inspect(
-    x,
-):
+# ``name`` is a Python string and must not be traced through jax — it is
+# carried as a custom_vjp nondiff argument so it stays static at compile
+# time, threads into the primitive bind as a kwarg, and lands on the
+# FFI as a string attribute.
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def _inspect(x, name):
     """ """
-    output, _ = _inspect_fwd_rule(
-        x,
-    )
+    output, _ = _inspect_fwd_rule(x, name)
     return output
 
 
-def _inspect_fwd_rule(
-    x,
-):
+def _inspect_fwd_rule(x, name):
     """"""
     ctx = ()
-    x = _inspect_array_inner(x)
+    x = _inspect_array_inner(x, name)
     return x, ctx
 
 
-def _inspect_bwd_rule(
-    ctx,
-    grad,
-):
+def _inspect_bwd_rule(name, ctx, grad):
     """"""
-    del ctx
+    del name, ctx
     return (grad,)
 
 
@@ -184,14 +190,30 @@ _inspect.defvjp(_inspect_fwd_rule, _inspect_bwd_rule)
 
 
 def inspect_array(x: jnp.ndarray, name: str) -> jnp.ndarray:
-    """Utility function to inspect JAX arrays by printing their name, shape, dtype, and statistics.
+    """Inspect a JAX array by dumping its data and stats to disk per-rank.
+
+    On every call the FFI synchronises the input device buffer to host
+    and writes two files per rank, **keyed by ``name``** so multiple
+    probes in the same program produce distinct dumps:
+
+    * ``my_tensor_gpu{device}_{sanitized_name}.bin``      – raw bytes.
+    * ``my_tensor_gpu{device}_{sanitized_name}_meta.json`` – ``name``,
+      shape, dtype, and min/max/mean/std summary stats.
+
+    A line is also printed to stdout including the probe ``name`` so
+    multi-probe traces are easy to follow in a live log.
+
+    ``name`` is treated as a static (non-traced) attribute, so the same
+    probe name must be passed in every (re-)trace of an enclosing
+    ``jax.jit``; characters outside ``[A-Za-z0-9._-]`` are mapped to
+    ``_`` when forming the filename, but the unsanitised name is echoed
+    verbatim in the JSON metadata and the printed log line.
 
     Args:
         x (jnp.ndarray): The JAX array to inspect.
-        name (str): The name of the array for identification in the output.
+        name (str): Identifier for this probe; used in filenames and logs.
     """
-    del name  # Name is currently unused, but can be included in the future for more informative output
-    return _inspect(x)
+    return _inspect(x, name)
 
 
 def load_array_dump(filename: str, shape: tuple, dtype: jnp.dtype) -> jnp.ndarray:

--- a/transformer_engine/jax/debug/experimental/inspect.py
+++ b/transformer_engine/jax/debug/experimental/inspect.py
@@ -22,7 +22,13 @@ class InspectPrimitive(BasePrimitive):
 
     name = "te_inspect_ffi"
     multiple_results = False
-    impl_static_args = ()
+    # ``name`` is at positional index 5 in ``impl``; declaring it static
+    # here lets ``custom_partitioning`` resolve ``bind(..., name=...)``
+    # kwargs back to that position via ``_resolve_kwargs``. Keyword-only
+    # parameters (``*, name``) would raise
+    #     TypeError: keyword arguments could not be resolved to positions
+    # at trace time, so ``impl`` accepts ``name`` positionally below.
+    impl_static_args = (5,)
     inner_primitive = None
     outer_primitive = None
 
@@ -89,14 +95,15 @@ class InspectPrimitive(BasePrimitive):
         x_max,
         x_mean,
         x_std,
-        *,
         name,
     ):
         """
-        inspect implementation
+        inspect implementation. ``name`` is positional (not keyword-only)
+        so ``custom_partitioning(static_argnums=(5,))`` can resolve
+        ``bind(..., name=...)`` kwargs to position 5.
         """
         assert InspectPrimitive.inner_primitive is not None
-        (x) = InspectPrimitive.inner_primitive.bind(
+        x = InspectPrimitive.inner_primitive.bind(
             x,
             x_min,
             x_max,
@@ -107,13 +114,16 @@ class InspectPrimitive(BasePrimitive):
         return x
 
     @staticmethod
-    def partition(mesh, arg_infos, result_infos, *, name):
+    def partition(name, mesh, arg_infos, result_infos):
         """
         Identity in sharding: the output carries the same sharding as ``x``;
         the four scalar stats (x_min, x_max, x_mean, x_std) are fully
         replicated. Without this override the primitive falls back to
         ``BasePrimitive``'s abstract partition and any multi-device JIT
         rejects the call.
+
+        Static args precede ``mesh`` per the ``custom_partitioning``
+        convention when ``static_argnums`` is set on the wrapped impl.
         """
         del result_infos
         x_sharding = arg_infos[0].sharding
@@ -128,19 +138,20 @@ class InspectPrimitive(BasePrimitive):
         out_sharding = x_sharding
 
         def sharded_impl(x, x_min, x_max, x_mean, x_std):
-            return InspectPrimitive.impl(x, x_min, x_max, x_mean, x_std, name=name)
+            return InspectPrimitive.impl(x, x_min, x_max, x_mean, x_std, name)
 
         return mesh, sharded_impl, out_sharding, arg_shardings
 
     @staticmethod
-    def shardy_sharding_rule(*args, **kwargs):
+    def shardy_sharding_rule(*args):
         """
         Five operands, one output. ``x`` and the output carry the same
         wildcard rank; the four scalar stats are rank-0 (empty operand
-        entries between commas). The ``name`` keyword attribute does not
-        participate in the rule.
+        entries between commas). ``name`` is a static arg (precedes
+        ``mesh``/``value_types``/``result_types`` in ``args``) and does
+        not participate in the rule.
         """
-        del args, kwargs
+        del args
         return "..., , , , -> ..."
 
 


### PR DESCRIPTION
# Description
Previously tensors are dumped out with the same my_tensor_gpu*.bin name, and later dumps will overwrite previous dumps making debugging harder as developers have to run multiple times, each capturing a different tensor. 

With this change, we only need to run once with all the tensors dumped out in separate name that is set-able in the API

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
