### PR TITLE
fix(topk): fix UB and prevent vector load splitting in standalone_topk

### DIFF
--- a/transformer_engine/common/util/standalone_topk.cuh
+++ b/transformer_engine/common/util/standalone_topk.cuh
@@ -252,9 +252,9 @@ __device__ void vectorized_process(const T *in, idxT len, Func f, int sync_width
         const bool valid = i < len_cast;
         // Unconditional 128-bit vector load: invalid threads read in_cast[0] (cached,
         // discarded via valid=false) so NVCC emits LDG.E.128 instead of predicated load.
-        // Safe because len_cast > 0 guarantees at least one valid WideT at in_cast[0].
-        const WideT *load_ptr = valid ? &in_cast[i] : &in_cast[0];
-        const WideT wide_data = *load_ptr;
+        // Index clamping (not pointer ternary) avoids C++ UB from &in_cast[i] when i >= len_cast.
+        const idxT safe_i = valid ? i : static_cast<idxT>(0);
+        const WideT wide_data = in_cast[safe_i];
         T local_array[items_per_scalar];  // NOLINT(runtime/arrays)
         __builtin_memcpy(local_array, &wide_data, sizeof(WideT));
         const idxT real_i = skip_cnt + i * items_per_scalar;

--- a/transformer_engine/common/util/standalone_topk.cuh
+++ b/transformer_engine/common/util/standalone_topk.cuh
@@ -201,7 +201,7 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads, const
       for (int j = 0; j < items_per_scalar; ++j) {
         f(local_array[j], real_i + j);
       }
-   }
+    }
 
     static_assert(WARP_SIZE >= items_per_scalar);
     // and because items_per_scalar > skip_cnt, WARP_SIZE > skip_cnt
@@ -259,11 +259,11 @@ __device__ void vectorized_process(const T *in, idxT len, Func f, int sync_width
         __builtin_memcpy(local_array, &wide_data, sizeof(WideT));
         const idxT real_i = skip_cnt + i * items_per_scalar;
 #pragma unroll
-      for (int j = 0; j < items_per_scalar; ++j) {
-        f(local_array[j], real_i + j, valid);
+        for (int j = 0; j < items_per_scalar; ++j) {
+          f(local_array[j], real_i + j, valid);
+        }
       }
     }
-  }
 
     static_assert(WARP_SIZE >= items_per_scalar);
     // need at most one warp for skipped and remained elements,

--- a/transformer_engine/common/util/standalone_topk.cuh
+++ b/transformer_engine/common/util/standalone_topk.cuh
@@ -181,11 +181,6 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads, const
   } else {
     static_assert(sizeof(WideT) % sizeof(T) == 0);
     constexpr int items_per_scalar = sizeof(WideT) / sizeof(T);
-    // TODO: it's UB
-    union {
-      WideT scalar;
-      T array[items_per_scalar];  // NOLINT(runtime/arrays)
-    } wide;
 
     int skip_cnt =
         (reinterpret_cast<size_t>(in) % sizeof(WideT))
@@ -198,13 +193,15 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads, const
     const idxT len_cast = (len - skip_cnt) / items_per_scalar;
 
     for (idxT i = thread_rank; i < len_cast; i += num_threads) {
-      wide.scalar = in_cast[i];
+      const WideT wide_data = in_cast[i];
+      T local_array[items_per_scalar];  // NOLINT(runtime/arrays)
+      __builtin_memcpy(local_array, &wide_data, sizeof(WideT));
       const idxT real_i = skip_cnt + i * items_per_scalar;
 #pragma unroll
       for (int j = 0; j < items_per_scalar; ++j) {
-        f(wide.array[j], real_i + j);
+        f(local_array[j], real_i + j);
       }
-    }
+   }
 
     static_assert(WARP_SIZE >= items_per_scalar);
     // and because items_per_scalar > skip_cnt, WARP_SIZE > skip_cnt
@@ -236,10 +233,6 @@ __device__ void vectorized_process(const T *in, idxT len, Func f, int sync_width
   } else {
     static_assert(sizeof(WideT) % sizeof(T) == 0);
     constexpr int items_per_scalar = sizeof(WideT) / sizeof(T);
-    union {
-      WideT scalar;
-      T array[items_per_scalar];  // NOLINT(runtime/arrays)
-    } wide;
 
     int skip_cnt =
         (reinterpret_cast<size_t>(in) % sizeof(WideT))
@@ -251,18 +244,26 @@ __device__ void vectorized_process(const T *in, idxT len, Func f, int sync_width
     const WideT *in_cast = reinterpret_cast<decltype(in_cast)>(in + skip_cnt);
     const idxT len_cast = (len - skip_cnt) / items_per_scalar;
 
-    const idxT len_cast_for_sync = ((len_cast - 1) / sync_width + 1) * sync_width;
-    for (idxT i = tid; i < len_cast_for_sync; i += stride) {
-      bool valid = i < len_cast;
-      if (valid) {
-        wide.scalar = in_cast[i];
-      }
-      const idxT real_i = skip_cnt + i * items_per_scalar;
+    // Skip when no full vector chunk exists: avoids len_cast_for_sync underflow and
+    // OOB companion reads (in_cast[0] needs at least one valid WideT).
+    if (len_cast > 0) {
+      const idxT len_cast_for_sync = ((len_cast - 1) / sync_width + 1) * sync_width;
+      for (idxT i = tid; i < len_cast_for_sync; i += stride) {
+        const bool valid = i < len_cast;
+        // Unconditional 128-bit vector load: invalid threads read in_cast[0] (cached,
+        // discarded via valid=false) so NVCC emits LDG.E.128 instead of predicated load.
+        // Safe because len_cast > 0 guarantees at least one valid WideT at in_cast[0].
+        const WideT *load_ptr = valid ? &in_cast[i] : &in_cast[0];
+        const WideT wide_data = *load_ptr;
+        T local_array[items_per_scalar];  // NOLINT(runtime/arrays)
+        __builtin_memcpy(local_array, &wide_data, sizeof(WideT));
+        const idxT real_i = skip_cnt + i * items_per_scalar;
 #pragma unroll
       for (int j = 0; j < items_per_scalar; ++j) {
-        f(wide.array[j], real_i + j, valid);
+        f(local_array[j], real_i + j, valid);
       }
     }
+  }
 
     static_assert(WARP_SIZE >= items_per_scalar);
     // need at most one warp for skipped and remained elements,


### PR DESCRIPTION
# Description

This PR refactors the vectorized processing logic in standalone_topk to eliminate C++ undefined behavior and ensure optimal GPU instruction emission. The changes address a critical issue where conditional vector loads were causing the compiler to split 128-bit memory transactions into scalar operations, degrading performance. Additionally, it fixes potential edge cases related to unsigned integer underflow and out-of-bounds memory access.

Fixes #

Fix C++ UB by replacing union type-punning with __builtin_memcpy.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix C++ UB by replacing union type-punning with `__builtin_memcpy`.
- Prevent NVCC from splitting 128-bit vector loads by using unconditional pointer selection for safe companion reads.
- Fix `len_cast_for_sync` underflow when `len_cast == 0`.
- Guard against OOB reads when input length is smaller than `sizeof(WideT)`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
