### PR TITLE
[PyTorch] Fix wrong stream capture for cuteDSL delayed wgrad GEMM

### DIFF
--- a/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/backward_grouped_mlp.py
@@ -101,6 +101,9 @@ def _cudnn_compute_wgrad(
     where a = DY^T = (out_features, total_tokens) row-major and
           b = X  = (total_tokens, in_features) column-major.
     """
+    if current_stream is None:
+        current_stream = torch.cuda.current_stream().cuda_stream
+
     out_features, in_features = weight_shape
     total_tokens = grouped_dy.logical_shape[0]
 
@@ -316,7 +319,6 @@ def _compute_grad_params(
                 data_dtype=data_dtype,
                 scale_view_dtype=scale_view_dtype,
                 sf_vec_size=sf_vec_size,
-                current_stream=torch.cuda.current_stream().cuda_stream,
             )
         elif (
             num_groups == 1


### PR DESCRIPTION
## Description

The cuteDSL fused grouped-MLP backward path captured `torch.cuda.current_stream()` when creating the **delayed wgrad GEMM** closure in `_compute_grad_params`. However, the GEMM is later executed on MoE's **separate delayed-wgrad stream** (used for overlapping work across streams), so the kernel ran with the *wrong* stream handle.

As a result, MoE/FSDP synchronization could observe the wgrad as complete before the actual update was safely ordered, corrupting gradients and producing NaNs.

## Fix

Move the stream lookup into `_cudnn_compute_wgrad` so the current stream is resolved at **GEMM execution time**, matching the stream the kernel actually runs on. The `current_stream` argument now defaults to `None` at closure-creation time and is resolved lazily inside the GEMM function.

```python
def _cudnn_compute_wgrad(..., current_stream=None):
    if current_stream is None:
        current_stream = torch.cuda.current_stream().cuda_stream
    ...
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)