### PR TITLE
guarding max_logits fused attention for cudnn < 9.21.0

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -455,6 +455,10 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
         (cudnn_runtime_version >= 91301 ||
          (cudnn_runtime_version < 91301 &&
           softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX)) &&
+        // max_logit
+        // pre-9.21: no (the composite softmax node rejects the Stats + Max output combination)
+        // 9.21+: yes (Stats + Max via the unified softmax node)
+        (!return_max_logit || cudnn_runtime_version >= 92100) &&
         // determinism on Blackwell
         // pre-9.18.1: fwd: deterministic; bwd: non-deterministic
         // 9.18.1+: fwd: deterministic; bwd: non-deterministic/deterministic

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -672,13 +672,6 @@ def get_attention_backend(
         if use_flash_attention:
             use_flash_attention = False
             logger.debug("Disabling FlashAttention for max_logit")
-        # FusedAttention emits max_logit alongside the softmax stats, which cuDNN only
-        # supports through the unified softmax node introduced in cuDNN 9.21.0. On older
-        # cuDNN the composite softmax node rejects the stats+max combination, so fall back
-        # to UnfusedDotProductAttention.
-        if use_fused_attention and cudnn_version < (9, 21, 0):
-            use_fused_attention = False
-            logger.debug("Disabling FusedAttention for max_logit for cuDNN < 9.21.0")
         if fp8 and fp8_meta["recipe"].fp8_dpa:
             use_flash_attention = False
             use_fused_attention = False

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -672,6 +672,13 @@ def get_attention_backend(
         if use_flash_attention:
             use_flash_attention = False
             logger.debug("Disabling FlashAttention for max_logit")
+        # FusedAttention emits max_logit alongside the softmax stats, which cuDNN only
+        # supports through the unified softmax node introduced in cuDNN 9.21.0. On older
+        # cuDNN the composite softmax node rejects the stats+max combination, so fall back
+        # to UnfusedDotProductAttention.
+        if use_fused_attention and cudnn_version < (9, 21, 0):
+            use_fused_attention = False
+            logger.debug("Disabling FusedAttention for max_logit for cuDNN < 9.21.0")
         if fp8 and fp8_meta["recipe"].fp8_dpa:
             use_flash_attention = False
             use_fused_attention = False


### PR DESCRIPTION
# Description

`get_attention_backend` selects FusedAttention for `return_max_logit=True` regardless of the cuDNN version, but cuDNN only supports emitting `Max` alongside the softmax `Stats` from cuDNN 9.21.0. On older cuDNN versions the forward pass fails at graph-build time with:

```
RuntimeError: transformer_engine/common/fused_attn/fused_attn_f16_arbitrary_seqlen.cu:419
in function operator(): cuDNN Error: CompositeSoftmaxNode can only output certain
combinations of stats, max and sum_exp: stats only, max and sum_exp only, or none of the above.
```

**Reproduction** (observed on A100 / sm80 with cuDNN 9.10.2; the failure is cuDNN-version dependent, not architecture dependent):

```bash
pytest -x tests/pytorch/attention/test_attention.py::test_dpa_max_logit
# fails in the first non-skipped case, e.g.
# test_dpa_max_logit[sbhd_sbhd_sbhd-max_logit_1-model_configs0-dtype0]
```

**Root cause**

FusedAttention requests both the `Stats` and `Max` outputs from the SDPA node (`fused_attn_f16_arbitrary_seqlen.cu`, `sdpa_options.set_logit_max(Max)`). In cudnn-frontend, that combination is only representable through the unified softmax descriptor (`CUDNN_ATTR_OPERATION_SDPA_FWD_SOFTMAX_DESC`), which requires a cuDNN backend >= 9.21.0:

- `cudnn-frontend/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h`: the composite SDPA node only wires `Stats`/`Max`/`Sum_exp` into a `UnifiedSoftmaxNode` when `effective_cudnn_ver >= 92100`; on older versions only `Stats` is set (via `CUDNN_ATTR_OPERATION_SDPA_FWD_STATSDESC`).
- `cudnn-frontend/include/cudnn_frontend/node/softmax.h` (`CompositeSoftmaxNode::pre_validate_node`): the legacy composite softmax node only allows the output combinations `{}`, `{stats}`, or `{max, sum_exp}` — the `{stats, max}` combination requested for `return_max_logit=True` is rejected, producing the error above.
- `cudnn-frontend/include/cudnn_frontend/node/sdpa_support_surface.h`: the `Max` output is only added to the allowed outputs for `effective_cudnn_ver >= 92100`.

**Fix**

Add a filter in `get_attention_backend` that disables FusedAttention for `return_max_logit=True` when the cuDNN version is below 9.21.0, falling back to UnfusedDotProductAttention (FlashAttention is already disabled for `max_logit`). This follows the existing pattern of cuDNN-version filters in `transformer_engine/pytorch/attention/dot_product_attention/utils.py`.

```python
# Filter: Return max_logit
if return_max_logit:
    ...
    # FusedAttention emits max_logit alongside the softmax stats, which cuDNN only
    # supports through the unified softmax node introduced in cuDNN 9.21.0. On older
    # cuDNN the composite softmax node rejects the stats+max combination, so fall back
    # to UnfusedDotProductAttention.
    if use_fused_attention and cudnn_version < (9, 21, 0):
        use_fused_attention = False
        logger.debug("Disabling FusedAttention for max_logit for cuDNN < 9.21.0")
```

The same policy is also enforced in `nvte_get_fused_attn_backend` (`transformer_engine/common/fused_attn/fused_attn.cpp`) so that non-PyTorch frontends are covered as well — the FP8 branch already checks `!return_max_logit` unconditionally:

```cpp
        // max_logit
        // pre-9.21: no (the composite softmax node rejects the Stats + Max output combination)
        // 9.21+: yes (Stats + Max via the unified softmax node)
        (!return_max_logit || cudnn_runtime_version >= 92100) &&
```

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Disable FusedAttention in `get_attention_backend` when `return_max_logit=True` and cuDNN < 9.21.0, so backend selection falls back to UnfusedDotProductAttention instead of failing at cuDNN graph-build time.
- Enforce the same requirement in `nvte_get_fused_attn_backend` (`fused_attn.cpp`, F16 arbitrary-seqlen condition) so non-PyTorch frontends are covered as well.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
