### PR TITLE
Test failing from .resolve() when TE is installend in a venv

### DIFF
--- a/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
+++ b/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py
@@ -995,7 +995,7 @@ def run_parallel_nvfp4_partial_cast_test() -> None:
 @pytest.mark.parametrize("world_size", [2])
 def test_cast_master_weights_to_fp8(world_size: int) -> None:
     """Launch parallel job that runs parallel tests"""
-    python_exe = pathlib.Path(sys.executable).resolve()
+    python_exe = pathlib.Path(sys.executable)
     current_file = pathlib.Path(__file__).resolve()
     command = [
         python_exe,
@@ -1200,7 +1200,7 @@ def test_nvfp4_partial_cast_matches_full(world_size: int) -> None:
     if not available:
         pytest.skip(reason)
 
-    python_exe = pathlib.Path(sys.executable).resolve()
+    python_exe = pathlib.Path(sys.executable)
     current_file = pathlib.Path(__file__).resolve()
     command = [
         python_exe,

--- a/tests/pytorch/distributed/test_fusible_ops.py
+++ b/tests/pytorch/distributed/test_fusible_ops.py
@@ -1042,7 +1042,7 @@ if torch.cuda.device_count() >= 2 and 2 not in _world_sizes:
 @pytest.mark.parametrize("world_size", _world_sizes)
 def test_distributed_fuser_ops(world_size: int) -> None:
     """Launch parallel job that runs parallel tests"""
-    python_exe = pathlib.Path(sys.executable).resolve()
+    python_exe = pathlib.Path(sys.executable)
     current_file = pathlib.Path(__file__).resolve()
     command = [
         python_exe,

--- a/tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py
+++ b/tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py
@@ -439,7 +439,7 @@ def test_fuser_ops_with_userbuffers(
     # Parallel job launcher
     command = []
     if tex.ubuf_built_with_mpi():
-        python_exe = pathlib.Path(sys.executable).resolve()
+        python_exe = pathlib.Path(sys.executable)
         command.extend(("mpirun", "-np", str(world_size), "--oversubscribe", "--quiet", python_exe))
     else:
         command.extend(("torchrun", f"--nproc_per_node={world_size}"))


### PR DESCRIPTION
# Description

Several distributed test suites relaunch themselves through `torch.distributed.run` (or `mpirun`) using

```python
python_exe = pathlib.Path(sys.executable).resolve()
```

`Path.resolve()` follows symlinks. In a standard Python virtual environment (`python -m venv`, `uv venv`), `.venv/bin/python3` is a *symlink* to the base interpreter, so `.resolve()` escapes the venv and the child process is launched with the bare base Python which has no `torch`/`transformer_engine` installed:

```
.../bin/python3.11: Error while finding module specification for 'torch.distributed.run'
(ModuleNotFoundError: No module named 'torch')
FAILED
```

Affected tests:

- `tests/pytorch/distributed/test_fusible_ops.py`
- `tests/pytorch/distributed/test_cast_master_weights_to_fp8.py` (two launch sites)
- `tests/pytorch/distributed/test_fusible_ops_with_userbuffers.py` (mpirun path)

**Reproduction**

On any machine where TE is installed in a venv whose `python3` is a symlink (the default for `python -m venv` when the base interpreter is outside the venv, e.g. a system/module-provided Python):

```bash
python -m venv .venv && . .venv/bin/activate   # .venv/bin/python3 -> /usr/bin/python3.x
pip install torch transformer_engine ...
python -m pytest tests/pytorch/distributed/test_fusible_ops.py
# -> ModuleNotFoundError: No module named 'torch' in the torchrun child
```

The bug is invisible in NGC containers because PyTorch is installed in the system interpreter there, so escaping the venv (or not using one) is harmless.

**Fix**

Use `sys.executable` as-is:

```diff
-        python_exe = pathlib.Path(sys.executable).resolve()
+        python_exe = pathlib.Path(sys.executable)
```

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Stop resolving symlinks on `sys.executable` when building the `torch.distributed.run`/`mpirun` relaunch command in `test_fusible_ops.py`, `test_cast_master_weights_to_fp8.py`, and `test_fusible_ops_with_userbuffers.py`, so the child process keeps using the parent's (virtual) environment.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
