### PR TITLE
skip test if TE is not compiled with cusolver

### DIFF
--- a/tests/pytorch/distributed/test_newton_schulz.py
+++ b/tests/pytorch/distributed/test_newton_schulz.py
@@ -4,15 +4,35 @@
 
 """Tests for distributed Newton-Schulz matrix orthogonalization."""
 
+import mmap
 import os
 import subprocess
 from pathlib import Path
 
 import pytest
 import torch
+from transformer_engine.common import _get_shared_object_file
 
 if torch.cuda.device_count() < 2:
     pytest.skip("Newton-Schulz tests require at least 2 GPUs.", allow_module_level=True)
+
+
+def _built_with_cusolvermp() -> bool:
+    """Whether Transformer Engine was compiled with NVTE_WITH_CUSOLVERMP=1.
+
+    There is no Python-level query for this build option, but cuSolverMp is a
+    link-time dependency, so libtransformer_engine.so has a DT_NEEDED entry for
+    libcusolverMp.so if and only if it was built with support.
+    """
+    so_path = _get_shared_object_file("core")
+    with open(so_path, "rb") as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+        return mm.find(b"libcusolverMp") != -1
+
+
+pytestmark = pytest.mark.skipif(
+    not _built_with_cusolvermp(),
+    reason="Transformer Engine not built with cuSolverMp (NVTE_WITH_CUSOLVERMP=0).",
+)
 
 TEST_ROOT = Path(__file__).parent.resolve()
 NUM_PROCS = torch.cuda.device_count()


### PR DESCRIPTION
# Description

`tests/pytorch/distributed/test_newton_schulz.py` has no skip guard for builds without cuSolverMp support. cuSolverMp is an optional build dependency. On a default build every test in the module fails instead of skipping:

```
RuntimeError: transformer_engine/common/newton_schulz/newton_schulz.cpp:254 in function
nvte_cusolvermp_ctx_create: Transformer Engine has not been built with cuSolverMp support.
```

**Fix**

I wrote (with claude's help) a utility to check if transformer engine was compiled with libcusolverMp. If not the newton schulz tests are skipped

```python
def _built_with_cusolvermp() -> bool:
    """Whether Transformer Engine was compiled with NVTE_WITH_CUSOLVERMP=1.

    There is no Python-level query for this build option, but cuSolverMp is a
    link-time dependency, so libtransformer_engine.so has a DT_NEEDED entry for
    libcusolverMp.so if and only if it was built with support.
    """
    so_path = _get_shared_object_file("core")
    with open(so_path, "rb") as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
        return mm.find(b"libcusolverMp") != -1
```

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add a `_built_with_cusolvermp()` helper to `test_newton_schulz.py` that detects cuSolverMp support by checking `libtransformer_engine.so` (located via `transformer_engine.common._get_shared_object_file`) for the `libcusolverMp` dynamic-linker entry.
- Skip all tests in the module via `pytestmark = pytest.mark.skipif(...)` when TE was built without cuSolverMp, so the suite skips cleanly instead of failing at runtime.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
