### PR TITLE
[JAX] Skip score_mod tests on older cuDNN

### DIFF
--- a/tests/jax/test_fused_attn_score_mod.py
+++ b/tests/jax/test_fused_attn_score_mod.py
@@ -24,6 +24,8 @@ from test_fused_attn import FusedAttnRunner, SeqDescFormat
 
 _CONFIG_TEST_HEAD_DIM = 128
 _CONFIG_TEST_SCALING_FACTOR = 1.0 / sqrt(_CONFIG_TEST_HEAD_DIM)
+_SCORE_MOD_MIN_CUDNN_VERSION = (9, 23)
+_SCORE_MOD_MIN_CUDNN_VERSION_STRING = ".".join(map(str, _SCORE_MOD_MIN_CUDNN_VERSION))
 
 
 def _has_cudnn_frontend_python():
@@ -197,14 +199,17 @@ class ScoreModFusedAttnRunner(FusedAttnRunner):
 
     @staticmethod
     def require_cudnn_frontend():
-        """Skip unless cuDNN Python frontend supports score_mod SDPA."""
+        """Skip unless cuDNN frontend supports score_mod SDPA."""
         try:
             cudnn = tex_attention._import_cudnn_for_score_mod()
         except ImportError:
             pytest.skip("cuDNN Python frontend is required for score_mod")
         version = tuple(int(part) for part in cudnn.backend_version_string().split(".")[:2])
-        if version < (9, 6):
-            pytest.skip("cuDNN score_mod SDPA requires cuDNN frontend 9.6 or newer")
+        if version < _SCORE_MOD_MIN_CUDNN_VERSION:
+            pytest.skip(
+                "cuDNN frontend score_mod SDPA requires "
+                f"cuDNN {_SCORE_MOD_MIN_CUDNN_VERSION_STRING} or newer"
+            )
 
     @staticmethod
     def _compute_input_scale(head_dim):


### PR DESCRIPTION
# Description

Skip score-mod tests if cuDNN backend version is less than 9.23

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Skip score-mod tests if cuDNN backend version is less than 9.23

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
