### PR TITLE
Fix GroupedLinear FP8 calibration loop

### DIFF
--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -599,11 +599,8 @@ class _GroupedLinear(torch.autograd.Function):
 
         if fp8_calibration:
             for i in range(num_gemms):
-                # amax of input
-                for i in range(num_gemms):
-                    input_quantizers[i].calibrate(inputmats[i])
-                for i in range(num_gemms):
-                    weight_quantizers[i].calibrate(weights[i])
+                input_quantizers[i].calibrate(inputmats[i])
+                weight_quantizers[i].calibrate(weights[i])
 
         if cpu_offloading:
             mark_not_offload(*weights_fp8, *weights)


### PR DESCRIPTION
## Summary

- remove the unused outer calibration loop in `GroupedLinear`
- calibrate each input and weight quantizer once per GEMM
- avoid repeating calibration `num_gemms` times for every GEMM

## Validation

- ran `python3 -m py_compile transformer_engine/pytorch/module/grouped_linear.py`
- ran `git diff --check -- transformer_engine/pytorch/module/grouped_linear.py`