### PR TITLE
[JAX] Use TE with_sharding_constraint wrapper even if flax returns successful logical sharding rules

### DIFF
--- a/transformer_engine/jax/sharding.py
+++ b/transformer_engine/jax/sharding.py
@@ -195,9 +195,8 @@ def with_sharding_constraint_by_logical_axes(
 
         flax_rules = flax.linen.get_logical_axis_rules()
         if len(flax_rules) > 0:
-            return flax.linen.with_logical_constraint(
-                x, logical_axis_names, fallback=flax.linen.spmd.RulesFallback.AXIS_IS_UNSHARDED
-            )
+            pspec = flax.linen.logical_to_mesh_axes(logical_axis_names)
+            return with_sharding_constraint(x, pspec)
     except ImportError:
         pass
 


### PR DESCRIPTION
# Description

Fix JAX logical-axis sharding constraints under `shard_map`. When Flax logical axis rules were present, `with_sharding_constraint_by_logical_axes` called `flax.linen.with_logical_constraint` directly. That bypassed TE’s `with_sharding_constraint` wrapper, which strips mesh axes already owned by `shard_map`. As a result, fused attention paths such as `softmax_offset` could apply constraints on manual axes and fail inside `shard_map`.
This change resolves Flax logical axes to a `PartitionSpec` with `flax.linen.logical_to_mesh_axes`, then routes the constraint through TE’s shard-map-aware wrapper.

Fixes #2500

# Reproducer

Minimal reproducer for the softmax_offset path. This mirrors fused attention’s (1, heads, 1, 1) tensor and applies the same logical-axis constraint under shard_map. Expected after fix: (1, 8, 1, 1)

```
  from functools import partial
  import flax.linen as nn
  import jax
  import jax.numpy as jnp
  import numpy as np
  from jax.sharding import Mesh
  from jax.sharding import PartitionSpec as P
  from transformer_engine.jax.sharding import (
      HEAD_AXES,
      with_sharding_constraint_by_logical_axes,
  )
  mesh = Mesh(np.array(jax.devices()[:2]), ("x",))
  @partial(
      jax.shard_map,
      mesh=mesh,
      in_specs=P(None, "x", None, None),
      out_specs=P(None, "x", None, None),
  )
  def constrain_softmax_offset(softmax_offset):
      return with_sharding_constraint_by_logical_axes(
          softmax_offset, (None, HEAD_AXES, None, None)
      )
  with nn.logical_axis_rules(((HEAD_AXES, "x"),)):
      out = constrain_softmax_offset(jnp.ones((1, 8, 1, 1), dtype=jnp.float32))
  print(out.shape)
```
  
## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring


# Checklist:

- [X] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [X] The functionality is complete
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
