### PR TITLE
[Common] Reduce shared-memory bank conflicts in the colwise scaling path of the tuned NVFP4 kernel

### DIFF
--- a/transformer_engine/common/cast/nvfp4/specialized/quantize_transpose_nvfp4_tuned_1D.cuh
+++ b/transformer_engine/common/cast/nvfp4/specialized/quantize_transpose_nvfp4_tuned_1D.cuh
@@ -201,7 +201,7 @@ __device__ __forceinline__ void colwise_scaling(const IType *__restrict__ sIn_pt
   const int warp = threadIdx.x / THREADS_PER_WARP;
   const int thread_lane = threadIdx.x % THREADS_PER_WARP;
 
-  const int tid_Y_colwise = (thread_lane % 4 + warp) % 4;
+  const int tid_Y_colwise = (thread_lane / 2 + warp) % 4;
   const int tid_X_colwise = thread_lane;
 
   const int thread_offset_Y_colwise = tid_Y_colwise * SCALE_DIM;


### PR DESCRIPTION
# Description

This PR optimizes shared-memory accesses in the colwise scaling path by reducing bank conflicts, resulting in an average performance improvement of about 1%.

The colwise Y-lane mapping changed from:

`(thread_lane % 4 + warp) % 4`

<img width="421" height="400" alt="image" src="https://github.com/user-attachments/assets/7f9159f3-9182-4fd2-8fa3-bdaeeffc94e4" />


to:


`(thread_lane / 2 + warp) % 4`

<img width="421" height="400" alt="image" src="https://github.com/user-attachments/assets/66ab741b-0116-41d2-ac96-c6eafa719fc4" />


The intent is to change the shared-memory swizzle pattern used by the `sOut_tr` b64 stores. With the previous `%4` mapping, the bank pattern repeats every 4 lanes, which leads to an 8-way conflict pattern for this store layout. Using `/2` makes the mapping repeat every 8 lanes instead, reducing the conflict degree to 4-way for the same access pattern.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Modified the pattern of accessing shared memory

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
