### PR TITLE
Add entrypoint for flagos multi-backend plugin system

### DIFF
--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -191,6 +191,16 @@ def load_framework_extension(framework: str) -> None:
     sys.modules[module_name] = solib
     spec.loader.exec_module(solib)
 
+    # Plugin system: if NVTE_ENABLE_PLUGIN=1, let plugin stub take over
+    # transformer_engine_torch and register original pybind as _nv for CUDA backend.
+    if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1":
+        sys.modules[module_name + "_nv"] = solib
+        try:
+            from plugin import load_plugins
+            load_plugins()
+        except ImportError as e:
+            print(f"[TE] NVTE_ENABLE_PLUGIN=1 but plugin import failed: {e}")
+
 
 def sanity_checks_for_pypi_installation() -> None:
     """Ensure that package is installed correctly if using PyPI."""

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -196,13 +196,19 @@ def load_framework_extension(framework: str) -> None:
     # transformer_engine_torch and register original pybind as _nv for CUDA backend.
     # Only applies to the PyTorch extension — JAX has no plugin stub.
     if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1" and framework == "torch":
+        _original_module = sys.modules.get(module_name)
         try:
             from transformer_engine_plugin_fl import load_plugins
+
             sys.modules[module_name + "_nv"] = solib
             load_plugins()
         except Exception as e:
-            # Rollback _nv registration if plugin failed to fully initialize
+            # Rollback to pre-plugin state if plugin failed to fully initialize
             sys.modules.pop(module_name + "_nv", None)
+            if _original_module is not None:
+                sys.modules[module_name] = _original_module
+            else:
+                sys.modules.pop(module_name, None)
             warnings.warn(
                 f"NVTE_ENABLE_PLUGIN=1 but plugin loading failed: {e}",
                 RuntimeWarning,

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -192,16 +192,17 @@ def load_framework_extension(framework: str) -> None:
     sys.modules[module_name] = solib
     spec.loader.exec_module(solib)
 
-    # Plugin system: if NVTE_ENABLE_PLUGIN=1, let plugin stub take over
+    # Plugin system: set NVTE_PLUGIN=<module_name> to let plugin stub take over
     # transformer_engine_torch and register original pybind as _nv for CUDA backend.
     # Only applies to the PyTorch extension — JAX has no plugin stub.
-    if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1" and framework == "torch":
+    _nvte_plugin = os.environ.get("NVTE_PLUGIN")
+    if _nvte_plugin and framework == "torch":
         _original_module = sys.modules.get(module_name)
         try:
-            from transformer_engine_plugin_fl import load_plugins
+            _plugin = importlib.import_module(_nvte_plugin)
 
             sys.modules[module_name + "_nv"] = solib
-            load_plugins()
+            _plugin.load_plugins()
         except Exception as e:
             # Rollback to pre-plugin state if plugin failed to fully initialize
             sys.modules.pop(module_name + "_nv", None)
@@ -210,7 +211,7 @@ def load_framework_extension(framework: str) -> None:
             else:
                 sys.modules.pop(module_name, None)
             warnings.warn(
-                f"NVTE_ENABLE_PLUGIN=1 but plugin loading failed: {e}",
+                f"NVTE_PLUGIN={_nvte_plugin} but plugin loading failed: {e}",
                 RuntimeWarning,
                 stacklevel=2,
             )

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -199,9 +199,10 @@ def load_framework_extension(framework: str) -> None:
     if _nvte_plugin and framework == "torch":
         _original_module = sys.modules.get(module_name)
         try:
-            _plugin = importlib.import_module(_nvte_plugin)
-
+            # Register _nv alias BEFORE importing the plugin, because the
+            # plugin module may import transformer_engine_torch_nv at top level.
             sys.modules[module_name + "_nv"] = solib
+            _plugin = importlib.import_module(_nvte_plugin)
             _plugin.load_plugins()
         except Exception as e:
             # Rollback to pre-plugin state if plugin failed to fully initialize

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -196,14 +196,16 @@ def load_framework_extension(framework: str) -> None:
     # transformer_engine_torch and register original pybind as _nv for CUDA backend.
     # Only applies to the PyTorch extension — JAX has no plugin stub.
     if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1" and framework == "torch":
-        sys.modules[module_name + "_nv"] = solib
         try:
             from transformer_engine_plugin_fl import load_plugins
+            sys.modules[module_name + "_nv"] = solib
             load_plugins()
-        except ImportError as e:
+        except Exception as e:
+            # Rollback _nv registration if plugin failed to fully initialize
+            sys.modules.pop(module_name + "_nv", None)
             warnings.warn(
-                f"NVTE_ENABLE_PLUGIN=1 but plugin import failed: {e}",
-                ImportWarning,
+                f"NVTE_ENABLE_PLUGIN=1 but plugin loading failed: {e}",
+                RuntimeWarning,
                 stacklevel=2,
             )
 

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import sysconfig
 from typing import Optional, Tuple
+import warnings
 
 
 @functools.lru_cache(maxsize=None)
@@ -193,13 +194,18 @@ def load_framework_extension(framework: str) -> None:
 
     # Plugin system: if NVTE_ENABLE_PLUGIN=1, let plugin stub take over
     # transformer_engine_torch and register original pybind as _nv for CUDA backend.
-    if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1":
+    # Only applies to the PyTorch extension — JAX has no plugin stub.
+    if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1" and framework == "torch":
         sys.modules[module_name + "_nv"] = solib
         try:
-            from plugin import load_plugins
+            from transformer_engine_plugin_fl import load_plugins
             load_plugins()
         except ImportError as e:
-            print(f"[TE] NVTE_ENABLE_PLUGIN=1 but plugin import failed: {e}")
+            warnings.warn(
+                f"NVTE_ENABLE_PLUGIN=1 but plugin import failed: {e}",
+                ImportWarning,
+                stacklevel=2,
+            )
 
 
 def sanity_checks_for_pypi_installation() -> None:

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -148,6 +148,14 @@ _dpa_fp8ds_amax_histlen = int(os.getenv("NVTE_DPA_FP8DS_AMAX_HISTLEN", "1"))
 _dpa_fp8ds_reduce_amax = os.getenv("NVTE_DPA_FP8DS_REDUCE_AMAX", "1") == "1"
 
 
+# Plugin system: override FlashAttention and get_attention_backend if enabled
+if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1":
+    _FlashAttentionNative = FlashAttention
+    FlashAttention = getattr(tex, "flash_attention", _FlashAttentionNative)
+    dpa_utils._original_get_attention_backend = dpa_utils.get_attention_backend
+    dpa_utils.get_attention_backend = tex.get_attention_backend
+
+
 __all__ = ["DotProductAttention"]
 
 

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -152,8 +152,10 @@ _dpa_fp8ds_reduce_amax = os.getenv("NVTE_DPA_FP8DS_REDUCE_AMAX", "1") == "1"
 if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1":
     _FlashAttentionNative = FlashAttention
     FlashAttention = getattr(tex, "flash_attention", _FlashAttentionNative)
-    dpa_utils._original_get_attention_backend = dpa_utils.get_attention_backend
-    dpa_utils.get_attention_backend = tex.get_attention_backend
+    _plugin_get_attention_backend = getattr(tex, "get_attention_backend", None)
+    if _plugin_get_attention_backend is not None:
+        dpa_utils._original_get_attention_backend = dpa_utils.get_attention_backend
+        dpa_utils.get_attention_backend = _plugin_get_attention_backend
 
 
 __all__ = ["DotProductAttention"]

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -149,7 +149,7 @@ _dpa_fp8ds_reduce_amax = os.getenv("NVTE_DPA_FP8DS_REDUCE_AMAX", "1") == "1"
 
 
 # Plugin system: override FlashAttention and get_attention_backend if enabled
-if os.environ.get("NVTE_ENABLE_PLUGIN", "0") == "1":
+if os.environ.get("NVTE_PLUGIN"):
     _FlashAttentionNative = FlashAttention
     FlashAttention = getattr(tex, "flash_attention", _FlashAttentionNative)
     _plugin_get_attention_backend = getattr(tex, "get_attention_backend", None)


### PR DESCRIPTION
# FlagOS Proposal: Plugin Architecture & Device-Agnostic Abstraction for TransformerEngine

##  Plugin System: Initialization-time Backend Loading

We propose a plugin architecture where TransformerEngine (TE) loads backend implementations at initialization time via an explicit plugin interface, while the actual multi-backend plugins reside in a separate repository (`TransformerEngine-Plugin-FL`).

TransformerEngine-Plugin-FL: https://github.com/lxd-cumt/TransformerEngine-Plugin-FL
### Current State

TE already has a prototype (`NVTE_ENABLE_PLUGIN=1` in `common/__init__.py`) that registers the original CUDA pybind module as `transformer_engine_torch_nv` and delegates to an external `load_plugins()` entry point.

### Proposed Design

- TE defines a stable plugin API contract (operator signatures, quantization interfaces, communication primitives).
- At `load_framework_extension()` time, if a plugin is present, TE dispatches backend calls through the plugin registry; otherwise it falls back to the native te implementation.
- The `TransformerEngine-Plugin-FL` repository is independently installable and contains multiple backend implementations for  diverse accelerators, and support more training scenarios.
