### PR TITLE
[PyTorch] Add op-level activation offload opt-out API

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -83,11 +83,6 @@ def test_basic_operation_activation_offloading_policy(monkeypatch):
 
     monkeypatch.setattr(
         cpu_offload,
-        "start_offload",
-        lambda *tensors: calls.append(("start", [id(t) for t in tensors])),
-    )
-    monkeypatch.setattr(
-        cpu_offload,
         "mark_activation_offload",
         lambda *tensors: calls.append(("mark", [id(t) for t in tensors])),
     )
@@ -97,18 +92,18 @@ def test_basic_operation_activation_offloading_policy(monkeypatch):
         lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
     )
 
-    op.maybe_mark_and_start_activation_offload(tensor, None, start=True)
-    assert calls == [("start", [tensor_id]), ("mark", [tensor_id])]
+    op.maybe_mark_activation_offload(tensor, None)
+    assert calls == [("mark", [tensor_id])]
 
     calls.clear()
     op.set_activation_offloading(False)
-    op.maybe_mark_and_start_activation_offload(tensor, start=True)
+    op.maybe_mark_activation_offload(tensor)
     assert calls == [("skip", [tensor_id])]
 
     calls.clear()
     op.set_activation_offloading(True)
-    op.maybe_mark_and_start_activation_offload(tensor, start=True, mark=False)
-    assert calls == [("start", [tensor_id])]
+    op.maybe_mark_activation_offload(tensor)
+    assert calls == [("mark", [tensor_id])]
 
 
 # Supported quantization recipes

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -107,8 +107,8 @@ def test_basic_operation_activation_offloading_policy(monkeypatch):
 
     calls.clear()
     op.enable_activation_offloading()
-    op.maybe_mark_and_start_activation_offload(tensor, start=True)
-    assert calls == [("start", [tensor_id]), ("mark", [tensor_id])]
+    op.maybe_mark_and_start_activation_offload(tensor, start=True, mark=False)
+    assert calls == [("start", [tensor_id])]
 
 
 # Supported quantization recipes

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -72,8 +72,8 @@ if is_bf16_available():  # bf16 requires sm_80 or higher
 _devices: list[torch.device] = [torch.device("cpu"), torch.device("cuda")]
 
 
-def test_basic_operation_activation_offloading_control(monkeypatch):
-    """BasicOperation should expose a public opt-out for activation CPU offload."""
+def test_basic_operation_activation_offloading_policy(monkeypatch):
+    """BasicOperation should expose a public opt-out for saved activation CPU offload."""
     import transformer_engine.pytorch.cpu_offload as cpu_offload
 
     calls = []
@@ -81,7 +81,6 @@ def test_basic_operation_activation_offloading_control(monkeypatch):
     tensor_id = id(tensor)
     op = te_ops.Identity()
 
-    monkeypatch.setattr(cpu_offload, "is_cpu_offload_enabled", lambda: True)
     monkeypatch.setattr(
         cpu_offload,
         "start_offload",
@@ -108,9 +107,8 @@ def test_basic_operation_activation_offloading_control(monkeypatch):
 
     calls.clear()
     op.enable_activation_offloading()
-    monkeypatch.setattr(cpu_offload, "is_cpu_offload_enabled", lambda: False)
     op.maybe_mark_and_start_activation_offload(tensor, start=True)
-    assert calls == []
+    assert calls == [("start", [tensor_id]), ("mark", [tensor_id])]
 
 
 # Supported quantization recipes

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -101,12 +101,12 @@ def test_basic_operation_activation_offloading_policy(monkeypatch):
     assert calls == [("start", [tensor_id]), ("mark", [tensor_id])]
 
     calls.clear()
-    op.disable_activation_offloading()
+    op.set_activation_offloading(False)
     op.maybe_mark_and_start_activation_offload(tensor, start=True)
     assert calls == [("skip", [tensor_id])]
 
     calls.clear()
-    op.enable_activation_offloading()
+    op.set_activation_offloading(True)
     op.maybe_mark_and_start_activation_offload(tensor, start=True, mark=False)
     assert calls == [("start", [tensor_id])]
 

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -71,42 +71,6 @@ if is_bf16_available():  # bf16 requires sm_80 or higher
 # Supported devices
 _devices: list[torch.device] = [torch.device("cpu"), torch.device("cuda")]
 
-
-def test_basic_operation_activation_offloading_policy(monkeypatch):
-    """BasicOperation should expose a public opt-out for saved activation CPU offload."""
-    import transformer_engine.pytorch.ops.op as op_module
-
-    calls = []
-    tensor = torch.empty(1)
-    tensor_id = id(tensor)
-    op = te_ops.Identity()
-
-    monkeypatch.setattr(
-        op_module,
-        "mark_activation_offload",
-        lambda *tensors: calls.append(("mark", [id(t) for t in tensors])),
-    )
-    monkeypatch.setattr(
-        op_module,
-        "mark_not_offload",
-        lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
-    )
-    monkeypatch.setattr(op_module, "is_cpu_offload_enabled", lambda: True)
-
-    op.mark_for_cpu_offload_if_needed(tensor, None)
-    assert calls == [("mark", [tensor_id])]
-
-    calls.clear()
-    op.set_activation_offloading(False)
-    op.mark_for_cpu_offload_if_needed(tensor)
-    assert calls == [("skip", [tensor_id])]
-
-    calls.clear()
-    op.set_activation_offloading(True)
-    op.mark_for_cpu_offload_if_needed(tensor)
-    assert calls == [("mark", [tensor_id])]
-
-
 # Supported quantization recipes
 _quantization_list: list[Optional[str]] = [None]
 if fp8_available:
@@ -669,6 +633,40 @@ class TestFuser:
             assert y.dtype == autocast_dtype
             assert x.grad.dtype == model_dtype
             assert op.weight.grad.dtype == model_dtype
+
+    def test_activation_offloading_policy(self, monkeypatch):
+        """Test opt-out API for activation CPU offloading."""
+        import transformer_engine.pytorch.ops.op as op_module
+
+        calls = []
+        tensor = torch.empty(1)
+        tensor_id = id(tensor)
+        op = te_ops.Identity()
+
+        monkeypatch.setattr(
+            op_module,
+            "mark_activation_offload",
+            lambda *tensors: calls.append(("mark", [id(t) for t in tensors])),
+        )
+        monkeypatch.setattr(
+            op_module,
+            "mark_not_offload",
+            lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
+        )
+        monkeypatch.setattr(op_module, "is_cpu_offload_enabled", lambda: True)
+
+        op.mark_for_cpu_offload_if_needed(tensor, None)
+        assert calls == [("mark", [tensor_id])]
+
+        calls.clear()
+        op.set_activation_offloading(False)
+        op.mark_for_cpu_offload_if_needed(tensor)
+        assert calls == [("skip", [tensor_id])]
+
+        calls.clear()
+        op.set_activation_offloading(True)
+        op.mark_for_cpu_offload_if_needed(tensor)
+        assert calls == [("mark", [tensor_id])]
 
 
 class TestBasicOps:

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -91,18 +91,19 @@ def test_basic_operation_activation_offloading_policy(monkeypatch):
         "mark_not_offload",
         lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
     )
+    monkeypatch.setattr(op_module, "is_cpu_offload_enabled", lambda: True)
 
-    op.maybe_mark_activation_offload(tensor, None)
+    op.mark_for_cpu_offload_if_needed(tensor, None)
     assert calls == [("mark", [tensor_id])]
 
     calls.clear()
     op.set_activation_offloading(False)
-    op.maybe_mark_activation_offload(tensor)
+    op.mark_for_cpu_offload_if_needed(tensor)
     assert calls == [("skip", [tensor_id])]
 
     calls.clear()
     op.set_activation_offloading(True)
-    op.maybe_mark_activation_offload(tensor)
+    op.mark_for_cpu_offload_if_needed(tensor)
     assert calls == [("mark", [tensor_id])]
 
 

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -72,7 +72,7 @@ if is_bf16_available():  # bf16 requires sm_80 or higher
 _devices: list[torch.device] = [torch.device("cpu"), torch.device("cuda")]
 
 
-def test_basic_operation_cpu_offloading_control(monkeypatch):
+def test_basic_operation_activation_offloading_control(monkeypatch):
     """BasicOperation should expose a public opt-out for activation CPU offload."""
     import transformer_engine.pytorch.cpu_offload as cpu_offload
 
@@ -102,12 +102,12 @@ def test_basic_operation_cpu_offloading_control(monkeypatch):
     assert calls == [("start", [tensor_id]), ("mark", [tensor_id])]
 
     calls.clear()
-    op.disable_cpu_offloading()
+    op.disable_activation_offloading()
     op.maybe_mark_and_start_activation_offload(tensor, start=True)
     assert calls == [("skip", [tensor_id])]
 
     calls.clear()
-    op.enable_cpu_offloading()
+    op.enable_activation_offloading()
     monkeypatch.setattr(cpu_offload, "is_cpu_offload_enabled", lambda: False)
     op.maybe_mark_and_start_activation_offload(tensor, start=True)
     assert calls == []

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -71,6 +71,48 @@ if is_bf16_available():  # bf16 requires sm_80 or higher
 # Supported devices
 _devices: list[torch.device] = [torch.device("cpu"), torch.device("cuda")]
 
+
+def test_basic_operation_cpu_offloading_control(monkeypatch):
+    """BasicOperation should expose a public opt-out for activation CPU offload."""
+    import transformer_engine.pytorch.cpu_offload as cpu_offload
+
+    calls = []
+    tensor = torch.empty(1)
+    tensor_id = id(tensor)
+    op = te_ops.Identity()
+
+    monkeypatch.setattr(cpu_offload, "is_cpu_offload_enabled", lambda: True)
+    monkeypatch.setattr(
+        cpu_offload,
+        "start_offload",
+        lambda *tensors: calls.append(("start", [id(t) for t in tensors])),
+    )
+    monkeypatch.setattr(
+        cpu_offload,
+        "mark_activation_offload",
+        lambda *tensors: calls.append(("mark", [id(t) for t in tensors])),
+    )
+    monkeypatch.setattr(
+        cpu_offload,
+        "mark_not_offload",
+        lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
+    )
+
+    op.maybe_mark_and_start_activation_offload(tensor, None, start=True)
+    assert calls == [("start", [tensor_id]), ("mark", [tensor_id])]
+
+    calls.clear()
+    op.disable_cpu_offloading()
+    op.maybe_mark_and_start_activation_offload(tensor, start=True)
+    assert calls == [("skip", [tensor_id])]
+
+    calls.clear()
+    op.enable_cpu_offloading()
+    monkeypatch.setattr(cpu_offload, "is_cpu_offload_enabled", lambda: False)
+    op.maybe_mark_and_start_activation_offload(tensor, start=True)
+    assert calls == []
+
+
 # Supported quantization recipes
 _quantization_list: list[Optional[str]] = [None]
 if fp8_available:

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -74,7 +74,7 @@ _devices: list[torch.device] = [torch.device("cpu"), torch.device("cuda")]
 
 def test_basic_operation_activation_offloading_policy(monkeypatch):
     """BasicOperation should expose a public opt-out for saved activation CPU offload."""
-    import transformer_engine.pytorch.cpu_offload as cpu_offload
+    import transformer_engine.pytorch.ops.op as op_module
 
     calls = []
     tensor = torch.empty(1)
@@ -82,12 +82,12 @@ def test_basic_operation_activation_offloading_policy(monkeypatch):
     op = te_ops.Identity()
 
     monkeypatch.setattr(
-        cpu_offload,
+        op_module,
         "mark_activation_offload",
         lambda *tensors: calls.append(("mark", [id(t) for t in tensors])),
     )
     monkeypatch.setattr(
-        cpu_offload,
+        op_module,
         "mark_not_offload",
         lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
     )

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -13,6 +13,7 @@ import torch
 
 import transformer_engine_torch as tex
 from ...constants import DType
+from ...cpu_offload import is_cpu_offload_enabled
 from ...tensor.float8_tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
@@ -113,7 +114,8 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(x)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -412,7 +414,8 @@ class ScaledSReLU(BasicOperation):
 
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(x)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(x)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -13,7 +13,6 @@ import torch
 
 import transformer_engine_torch as tex
 from ...constants import DType
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...tensor.float8_tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
@@ -114,8 +113,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x)
+            self.maybe_mark_and_start_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -414,8 +412,7 @@ class ScaledSReLU(BasicOperation):
 
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x)
+            self.maybe_mark_and_start_activation_offload(x)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -115,7 +115,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
         # Save state for backward pass
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(x)
+                self.maybe_mark_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -415,7 +415,7 @@ class ScaledSReLU(BasicOperation):
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(x)
+                self.maybe_mark_activation_offload(x)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -13,7 +13,6 @@ import torch
 
 import transformer_engine_torch as tex
 from ...constants import DType
-from ...cpu_offload import is_cpu_offload_enabled
 from ...tensor.float8_tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
@@ -114,8 +113,7 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(x)
+            self.mark_for_cpu_offload_if_needed(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -414,8 +412,7 @@ class ScaledSReLU(BasicOperation):
 
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(x)
+            self.mark_for_cpu_offload_if_needed(x)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -1053,7 +1053,7 @@ class BasicLinear(BasicOperation):
             # either self.weight (nn.Parameter, auto-excluded from offload) or a
             # workspace freshly created each forward pass.
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(saved_input)
+                self.maybe_mark_activation_offload(saved_input)
             ctx.save_for_backward(saved_input, saved_weight)
             ctx.with_quantized_compute = with_quantized_compute and backward_override is None
             ctx.backward_override = backward_override

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -13,7 +13,6 @@ from typing import Any, Optional
 import torch
 
 from ...cpp_extensions import general_gemm
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...distributed import (
     CudaRNGStatesTracker,
     gather_along_first_dim,
@@ -1049,11 +1048,10 @@ class BasicLinear(BasicOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                # No special CPU offloading logic is needed for weights. saved_weight is
-                # either self.weight (nn.Parameter, auto-excluded from offload) or a
-                # workspace freshly created each forward pass.
-                mark_activation_offload(saved_input)
+            # No special CPU offloading logic is needed for weights. saved_weight is
+            # either self.weight (nn.Parameter, auto-excluded from offload) or a
+            # workspace freshly created each forward pass.
+            self.maybe_mark_and_start_activation_offload(saved_input)
             ctx.save_for_backward(saved_input, saved_weight)
             ctx.with_quantized_compute = with_quantized_compute and backward_override is None
             ctx.backward_override = backward_override

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -13,7 +13,6 @@ from typing import Any, Optional
 import torch
 
 from ...cpp_extensions import general_gemm
-from ...cpu_offload import is_cpu_offload_enabled
 from ...distributed import (
     CudaRNGStatesTracker,
     gather_along_first_dim,
@@ -1049,11 +1048,13 @@ class BasicLinear(BasicOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            # No special CPU offloading logic is needed for weights. saved_weight is
+
+            # Activation CPU offloading
+            # Note: No special CPU offloading logic is needed for weights. saved_weight is
             # either self.weight (nn.Parameter, auto-excluded from offload) or a
             # workspace freshly created each forward pass.
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(saved_input)
+            self.mark_for_cpu_offload_if_needed(saved_input)
+
             ctx.save_for_backward(saved_input, saved_weight)
             ctx.with_quantized_compute = with_quantized_compute and backward_override is None
             ctx.backward_override = backward_override

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 import torch
 
 from ...cpp_extensions import general_gemm
+from ...cpu_offload import is_cpu_offload_enabled
 from ...distributed import (
     CudaRNGStatesTracker,
     gather_along_first_dim,
@@ -1051,7 +1052,8 @@ class BasicLinear(BasicOperation):
             # No special CPU offloading logic is needed for weights. saved_weight is
             # either self.weight (nn.Parameter, auto-excluded from offload) or a
             # workspace freshly created each forward pass.
-            self.maybe_mark_and_start_activation_offload(saved_input)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(saved_input)
             ctx.save_for_backward(saved_input, saved_weight)
             ctx.with_quantized_compute = with_quantized_compute and backward_override is None
             ctx.backward_override = backward_override

--- a/transformer_engine/pytorch/ops/basic/dropout.py
+++ b/transformer_engine/pytorch/ops/basic/dropout.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import torch
 import transformer_engine_torch as tex
+from ...cpu_offload import is_cpu_offload_enabled
 from ...tensor import Quantizer
 from ...tensor.storage.float8_tensor_storage import Float8TensorStorage
 from .._common import maybe_autocast_dtype, maybe_dequantize
@@ -70,7 +71,8 @@ class Dropout(BasicOperation):
 
         # Save context for backward
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(mask)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(mask)
             ctx.save_for_backward(mask)
             ctx.impl = impl
             ctx.dropout_probability = self.dropout_probability

--- a/transformer_engine/pytorch/ops/basic/dropout.py
+++ b/transformer_engine/pytorch/ops/basic/dropout.py
@@ -72,7 +72,7 @@ class Dropout(BasicOperation):
         # Save context for backward
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(mask)
+                self.maybe_mark_activation_offload(mask)
             ctx.save_for_backward(mask)
             ctx.impl = impl
             ctx.dropout_probability = self.dropout_probability

--- a/transformer_engine/pytorch/ops/basic/dropout.py
+++ b/transformer_engine/pytorch/ops/basic/dropout.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import torch
 import transformer_engine_torch as tex
-from ...cpu_offload import is_cpu_offload_enabled
 from ...tensor import Quantizer
 from ...tensor.storage.float8_tensor_storage import Float8TensorStorage
 from .._common import maybe_autocast_dtype, maybe_dequantize
@@ -71,8 +70,7 @@ class Dropout(BasicOperation):
 
         # Save context for backward
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(mask)
+            self.mark_for_cpu_offload_if_needed(mask)
             ctx.save_for_backward(mask)
             ctx.impl = impl
             ctx.dropout_probability = self.dropout_probability

--- a/transformer_engine/pytorch/ops/basic/dropout.py
+++ b/transformer_engine/pytorch/ops/basic/dropout.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import torch
 import transformer_engine_torch as tex
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...tensor import Quantizer
 from ...tensor.storage.float8_tensor_storage import Float8TensorStorage
 from .._common import maybe_autocast_dtype, maybe_dequantize
@@ -71,8 +70,7 @@ class Dropout(BasicOperation):
 
         # Save context for backward
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(mask)
+            self.maybe_mark_and_start_activation_offload(mask)
             ctx.save_for_backward(mask)
             ctx.impl = impl
             ctx.dropout_probability = self.dropout_probability

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -16,7 +16,6 @@ import torch
 import transformer_engine_torch as tex
 from ...constants import DType
 from ...cpp_extensions import general_grouped_gemm, general_grouped_gemm_for_grouped_tensor
-from ...cpu_offload import is_cpu_offload_enabled
 from ...distributed import CudaRNGStatesTracker
 from ...module._common import WeightGradStore
 from ...module.base import (
@@ -24,6 +23,7 @@ from ...module.base import (
     _2X_ACC_DGRAD,
     _2X_ACC_WGRAD,
 )
+from ...cpu_offload import is_cpu_offload_enabled, start_offload
 from ...quantization import FP8GlobalStateManager, QuantizerRole, Recipe
 from ...quantized_tensor import QuantizedTensorStorage
 from ...tensor import MXFP8Quantizer, MXFP8Tensor, Quantizer
@@ -1039,12 +1039,12 @@ class GroupedLinear(BasicOperation):
                 # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
                 grouped_x = saved[offset]
                 if grouped_x is not None:
-                    self.maybe_mark_and_start_activation_offload(grouped_x)
+                    self.maybe_mark_activation_offload(grouped_x)
             else:
                 # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
                 live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
                 if live_xs:
-                    self.maybe_mark_and_start_activation_offload(*live_xs)
+                    self.maybe_mark_activation_offload(*live_xs)
 
         ctx.save_for_backward(*tensors_to_save[0])
 
@@ -1133,7 +1133,7 @@ class GroupedLinear(BasicOperation):
         if is_cpu_offload_enabled():
             live_xs = [t for t in xs if t is not None]
             if live_xs:
-                self.maybe_mark_and_start_activation_offload(*live_xs, start=True, mark=False)
+                start_offload(*live_xs)
 
         # Allocate output tensor
         in_shape = list(input_.size())
@@ -1240,7 +1240,7 @@ class GroupedLinear(BasicOperation):
             )
 
         if is_cpu_offload_enabled() and grouped_x is not None:
-            self.maybe_mark_and_start_activation_offload(grouped_x, start=True, mark=False)
+            start_offload(grouped_x)
 
         # Build the weight GroupedTensor / list.
         if self.single_grouped_weight:

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -1032,19 +1032,14 @@ class GroupedLinear(BasicOperation):
         # Note: No special logic is needed for weights. They are
         # either nn.Parameter (auto-excluded from offload) or are
         # temporary workspaces freshly created in each forward pass.
-        if is_cpu_offload_enabled():
-            saved = tensors_to_save[0]
-            offset = 4 if self._scale_bias else 3
-            if use_grouped_tensor_path:
-                # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
-                grouped_x = saved[offset]
-                if grouped_x is not None:
-                    self.maybe_mark_activation_offload(grouped_x)
-            else:
-                # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
-                live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
-                if live_xs:
-                    self.maybe_mark_activation_offload(*live_xs)
+        saved = tensors_to_save[0]
+        offset = 4 if self._scale_bias else 3
+        if use_grouped_tensor_path:
+            # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
+            self.mark_for_cpu_offload_if_needed(saved[offset])
+        else:
+            # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
+            self.mark_for_cpu_offload_if_needed(saved[offset : offset + self.num_groups])
 
         ctx.save_for_backward(*tensors_to_save[0])
 

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -23,7 +23,6 @@ from ...module.base import (
     _2X_ACC_DGRAD,
     _2X_ACC_WGRAD,
 )
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload, start_offload
 from ...quantization import FP8GlobalStateManager, QuantizerRole, Recipe
 from ...quantized_tensor import QuantizedTensorStorage
 from ...tensor import MXFP8Quantizer, MXFP8Tensor, Quantizer
@@ -1032,19 +1031,16 @@ class GroupedLinear(BasicOperation):
         # Note: No special logic is needed for weights. They are
         # either nn.Parameter (auto-excluded from offload) or are
         # temporary workspaces freshly created in each forward pass.
-        if is_cpu_offload_enabled():
-            saved = tensors_to_save[0]
-            offset = 4 if self._scale_bias else 3
-            if use_grouped_tensor_path:
-                # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
-                grouped_x = saved[offset]
-                if grouped_x is not None:
-                    mark_activation_offload(grouped_x)
-            else:
-                # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
-                live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
-                if live_xs:
-                    mark_activation_offload(*live_xs)
+        saved = tensors_to_save[0]
+        offset = 4 if self._scale_bias else 3
+        if use_grouped_tensor_path:
+            # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
+            grouped_x = saved[offset]
+            self.maybe_mark_and_start_activation_offload(grouped_x)
+        else:
+            # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
+            live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
+            self.maybe_mark_and_start_activation_offload(*live_xs)
 
         ctx.save_for_backward(*tensors_to_save[0])
 
@@ -1130,10 +1126,8 @@ class GroupedLinear(BasicOperation):
             xs = tex.split_quantize(x, split_sizes_int, input_quantizers)
         else:
             xs = torch.split(x, split_sizes_int)
-        if is_cpu_offload_enabled():
-            live_xs = [t for t in xs if t is not None]
-            if live_xs:
-                start_offload(*live_xs)
+        live_xs = [t for t in xs if t is not None]
+        self.maybe_mark_and_start_activation_offload(*live_xs, start=True)
 
         # Allocate output tensor
         in_shape = list(input_.size())
@@ -1239,8 +1233,7 @@ class GroupedLinear(BasicOperation):
                 tensor_offsets=base_split_offsets * self.in_features,
             )
 
-        if is_cpu_offload_enabled() and grouped_x is not None:
-            start_offload(grouped_x)
+        self.maybe_mark_and_start_activation_offload(grouped_x, start=True)
 
         # Build the weight GroupedTensor / list.
         if self.single_grouped_weight:

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -1032,17 +1032,19 @@ class GroupedLinear(BasicOperation):
         # Note: No special logic is needed for weights. They are
         # either nn.Parameter (auto-excluded from offload) or are
         # temporary workspaces freshly created in each forward pass.
-        saved = tensors_to_save[0]
-        offset = 4 if self._scale_bias else 3
         if is_cpu_offload_enabled():
+            saved = tensors_to_save[0]
+            offset = 4 if self._scale_bias else 3
             if use_grouped_tensor_path:
                 # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
                 grouped_x = saved[offset]
-                self.maybe_mark_and_start_activation_offload(grouped_x)
+                if grouped_x is not None:
+                    self.maybe_mark_and_start_activation_offload(grouped_x)
             else:
                 # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
                 live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
-                self.maybe_mark_and_start_activation_offload(*live_xs)
+                if live_xs:
+                    self.maybe_mark_and_start_activation_offload(*live_xs)
 
         ctx.save_for_backward(*tensors_to_save[0])
 
@@ -1128,9 +1130,10 @@ class GroupedLinear(BasicOperation):
             xs = tex.split_quantize(x, split_sizes_int, input_quantizers)
         else:
             xs = torch.split(x, split_sizes_int)
-        live_xs = [t for t in xs if t is not None]
         if is_cpu_offload_enabled():
-            self.maybe_mark_and_start_activation_offload(*live_xs, start=True)
+            live_xs = [t for t in xs if t is not None]
+            if live_xs:
+                self.maybe_mark_and_start_activation_offload(*live_xs, start=True, mark=False)
 
         # Allocate output tensor
         in_shape = list(input_.size())
@@ -1236,8 +1239,8 @@ class GroupedLinear(BasicOperation):
                 tensor_offsets=base_split_offsets * self.in_features,
             )
 
-        if is_cpu_offload_enabled():
-            self.maybe_mark_and_start_activation_offload(grouped_x, start=True)
+        if is_cpu_offload_enabled() and grouped_x is not None:
+            self.maybe_mark_and_start_activation_offload(grouped_x, start=True, mark=False)
 
         # Build the weight GroupedTensor / list.
         if self.single_grouped_weight:

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -16,6 +16,7 @@ import torch
 import transformer_engine_torch as tex
 from ...constants import DType
 from ...cpp_extensions import general_grouped_gemm, general_grouped_gemm_for_grouped_tensor
+from ...cpu_offload import is_cpu_offload_enabled
 from ...distributed import CudaRNGStatesTracker
 from ...module._common import WeightGradStore
 from ...module.base import (
@@ -1033,14 +1034,15 @@ class GroupedLinear(BasicOperation):
         # temporary workspaces freshly created in each forward pass.
         saved = tensors_to_save[0]
         offset = 4 if self._scale_bias else 3
-        if use_grouped_tensor_path:
-            # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
-            grouped_x = saved[offset]
-            self.maybe_mark_and_start_activation_offload(grouped_x)
-        else:
-            # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
-            live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
-            self.maybe_mark_and_start_activation_offload(*live_xs)
+        if is_cpu_offload_enabled():
+            if use_grouped_tensor_path:
+                # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
+                grouped_x = saved[offset]
+                self.maybe_mark_and_start_activation_offload(grouped_x)
+            else:
+                # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
+                live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
+                self.maybe_mark_and_start_activation_offload(*live_xs)
 
         ctx.save_for_backward(*tensors_to_save[0])
 
@@ -1127,7 +1129,8 @@ class GroupedLinear(BasicOperation):
         else:
             xs = torch.split(x, split_sizes_int)
         live_xs = [t for t in xs if t is not None]
-        self.maybe_mark_and_start_activation_offload(*live_xs, start=True)
+        if is_cpu_offload_enabled():
+            self.maybe_mark_and_start_activation_offload(*live_xs, start=True)
 
         # Allocate output tensor
         in_shape = list(input_.size())
@@ -1233,7 +1236,8 @@ class GroupedLinear(BasicOperation):
                 tensor_offsets=base_split_offsets * self.in_features,
             )
 
-        self.maybe_mark_and_start_activation_offload(grouped_x, start=True)
+        if is_cpu_offload_enabled():
+            self.maybe_mark_and_start_activation_offload(grouped_x, start=True)
 
         # Build the weight GroupedTensor / list.
         if self.single_grouped_weight:

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -10,7 +10,6 @@ import os
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled
 from ...torch_version import torch_version
 from ...jit import (
     l2normalization_fused,
@@ -102,8 +101,7 @@ class L2Normalization(BasicOperation):
 
         # Save state for backward pass
         if requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(x, rsqrt_norm)
+            self.mark_for_cpu_offload_if_needed(x, rsqrt_norm)
             ctx.save_for_backward(x, rsqrt_norm)
 
         return y

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -10,6 +10,7 @@ import os
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled
 from ...torch_version import torch_version
 from ...jit import (
     l2normalization_fused,
@@ -101,7 +102,8 @@ class L2Normalization(BasicOperation):
 
         # Save state for backward pass
         if requires_grad:
-            self.maybe_mark_and_start_activation_offload(x, rsqrt_norm)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(x, rsqrt_norm)
             ctx.save_for_backward(x, rsqrt_norm)
 
         return y

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -103,7 +103,7 @@ class L2Normalization(BasicOperation):
         # Save state for backward pass
         if requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(x, rsqrt_norm)
+                self.maybe_mark_activation_offload(x, rsqrt_norm)
             ctx.save_for_backward(x, rsqrt_norm)
 
         return y

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -11,7 +11,6 @@ import os
 import torch
 
 from ...torch_version import torch_version
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...jit import (
     l2normalization_fused,
     l2normalization_fwd_fused,
@@ -102,8 +101,7 @@ class L2Normalization(BasicOperation):
 
         # Save state for backward pass
         if requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x, rsqrt_norm)
+            self.maybe_mark_and_start_activation_offload(x, rsqrt_norm)
             ctx.save_for_backward(x, rsqrt_norm)
 
         return y

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -14,7 +14,6 @@ import torch
 
 from transformer_engine_torch import layernorm_bwd, layernorm_fwd
 from ...constants import TE_DType
-from ...cpu_offload import is_cpu_offload_enabled
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -216,8 +215,7 @@ class LayerNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(x, means, rstdevs)
+            self.mark_for_cpu_offload_if_needed(x, means, rstdevs)
             ctx.save_for_backward(x, means, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -217,7 +217,7 @@ class LayerNorm(BasicOperation):
         # Save state for backward pass
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(x, means, rstdevs)
+                self.maybe_mark_activation_offload(x, means, rstdevs)
             ctx.save_for_backward(x, means, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -14,7 +14,6 @@ import torch
 
 from transformer_engine_torch import layernorm_bwd, layernorm_fwd
 from ...constants import TE_DType
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -216,8 +215,7 @@ class LayerNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x, means, rstdevs)
+            self.maybe_mark_and_start_activation_offload(x, means, rstdevs)
             ctx.save_for_backward(x, means, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -14,6 +14,7 @@ import torch
 
 from transformer_engine_torch import layernorm_bwd, layernorm_fwd
 from ...constants import TE_DType
+from ...cpu_offload import is_cpu_offload_enabled
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -215,7 +216,8 @@ class LayerNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(x, means, rstdevs)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(x, means, rstdevs)
             ctx.save_for_backward(x, means, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -14,6 +14,7 @@ import torch
 
 from transformer_engine_torch import rmsnorm_bwd, rmsnorm_fwd
 from ...constants import TE_DType
+from ...cpu_offload import is_cpu_offload_enabled
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -196,7 +197,8 @@ class RMSNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(x, rstdevs)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(x, rstdevs)
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -14,7 +14,6 @@ import torch
 
 from transformer_engine_torch import rmsnorm_bwd, rmsnorm_fwd
 from ...constants import TE_DType
-from ...cpu_offload import is_cpu_offload_enabled
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -197,8 +196,7 @@ class RMSNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(x, rstdevs)
+            self.mark_for_cpu_offload_if_needed(x, rstdevs)
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -198,7 +198,7 @@ class RMSNorm(BasicOperation):
         # Save state for backward pass
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(x, rstdevs)
+                self.maybe_mark_activation_offload(x, rstdevs)
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -14,7 +14,6 @@ import torch
 
 from transformer_engine_torch import rmsnorm_bwd, rmsnorm_fwd
 from ...constants import TE_DType
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -197,8 +196,7 @@ class RMSNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x, rstdevs)
+            self.maybe_mark_and_start_activation_offload(x, rstdevs)
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -12,7 +12,6 @@ import torch
 
 import transformer_engine_torch as tex
 from ...constants import DType
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
@@ -127,8 +126,7 @@ class SwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(input_)
+            self.maybe_mark_and_start_activation_offload(input_)
             ctx.save_for_backward(input_)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -311,8 +309,7 @@ class ClampedSwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x)
+            self.maybe_mark_and_start_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -462,8 +459,7 @@ class _ScaledGLU(BasicOperation):
         # Save state for backward pass
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(input_)
+            self.maybe_mark_and_start_activation_offload(input_)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 import torch
 
 import transformer_engine_torch as tex
+from ...cpu_offload import is_cpu_offload_enabled
 from ...constants import DType
 from ...tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
@@ -126,7 +127,8 @@ class SwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(input_)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(input_)
             ctx.save_for_backward(input_)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -309,7 +311,8 @@ class ClampedSwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(x)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -459,7 +462,8 @@ class _ScaledGLU(BasicOperation):
         # Save state for backward pass
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            self.maybe_mark_and_start_activation_offload(input_)
+            if is_cpu_offload_enabled():
+                self.maybe_mark_and_start_activation_offload(input_)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -128,7 +128,7 @@ class SwiGLU(BasicOperation):
         # Save state for backward pass
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(input_)
+                self.maybe_mark_activation_offload(input_)
             ctx.save_for_backward(input_)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -312,7 +312,7 @@ class ClampedSwiGLU(BasicOperation):
         # Save state for backward pass
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(x)
+                self.maybe_mark_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -463,7 +463,7 @@ class _ScaledGLU(BasicOperation):
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
             if is_cpu_offload_enabled():
-                self.maybe_mark_and_start_activation_offload(input_)
+                self.maybe_mark_activation_offload(input_)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -11,7 +11,6 @@ from typing import Any, Optional
 import torch
 
 import transformer_engine_torch as tex
-from ...cpu_offload import is_cpu_offload_enabled
 from ...constants import DType
 from ...tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
@@ -127,8 +126,7 @@ class SwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(input_)
+            self.mark_for_cpu_offload_if_needed(input_)
             ctx.save_for_backward(input_)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -311,8 +309,7 @@ class ClampedSwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(x)
+            self.mark_for_cpu_offload_if_needed(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -462,8 +459,7 @@ class _ScaledGLU(BasicOperation):
         # Save state for backward pass
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                self.maybe_mark_activation_offload(input_)
+            self.mark_for_cpu_offload_if_needed(input_)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -13,8 +13,8 @@ from typing import Any, Optional
 import torch
 
 import transformer_engine_torch as tex
+from ...cpu_offload import is_cpu_offload_enabled, start_offload
 from ...cpp_extensions import general_gemm, general_grouped_gemm_for_grouped_tensor
-from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import Recipe
 from ...tensor import NVFP4Quantizer, NVFP4Tensor, Quantizer
 from ...utils import (
@@ -749,9 +749,13 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
                         grouped_fc_x.scale_inv = None
 
             if cpu_offloading:
-                fc1_op.maybe_mark_and_start_activation_offload(grouped_fc1_x, start=True)
-                activation_op.maybe_mark_and_start_activation_offload(activation_in, start=True)
-                fc2_op.maybe_mark_and_start_activation_offload(saved_grouped_fc2_x, start=True)
+                activation_tensors = [
+                    t for t in (grouped_fc1_x, activation_in, saved_grouped_fc2_x) if t is not None
+                ]
+                start_offload(*activation_tensors)
+                fc1_op.maybe_mark_activation_offload(grouped_fc1_x)
+                activation_op.maybe_mark_activation_offload(activation_in)
+                fc2_op.maybe_mark_activation_offload(saved_grouped_fc2_x)
 
             # FC1 saved-tensor layout.
             #   [split_sizes, base_split_offsets, split_points,

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -13,7 +13,6 @@ from typing import Any, Optional
 import torch
 
 import transformer_engine_torch as tex
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload, start_offload
 from ...cpp_extensions import general_gemm, general_grouped_gemm_for_grouped_tensor
 from ...quantization import Recipe
 from ...tensor import NVFP4Quantizer, NVFP4Tensor, Quantizer
@@ -170,7 +169,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         # Get basic operations
-        fc1_op, _, fc2_op = self.basic_ops
+        fc1_op, activation_op, fc2_op = self.basic_ops
         fc1_ctx, activation_ctx, fc2_ctx = basic_op_ctxs
 
         # Tensor properties
@@ -726,8 +725,6 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
         # Save state for backward pass
         if requires_grad:
             mark_grouped_tensor(grouped_fc1_x, activation_in, scales, grouped_fc2_x)
-            activation_op = self.basic_ops[1]
-            cpu_offloading = is_cpu_offload_enabled()
             activation_is_srelu = isinstance(activation_op, ScaledSReLU)
             activation_recompute_in_mlp = bool(
                 getattr(activation_op, "activation_recompute_in_mlp", False)
@@ -749,12 +746,9 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
                         grouped_fc_x.rowwise_data = None
                         grouped_fc_x.scale_inv = None
 
-            if cpu_offloading:
-                activation_tensors = [
-                    t for t in (grouped_fc1_x, activation_in, saved_grouped_fc2_x) if t is not None
-                ]
-                start_offload(*activation_tensors)
-                mark_activation_offload(*activation_tensors)
+            fc1_op.maybe_mark_and_start_activation_offload(grouped_fc1_x, start=True)
+            activation_op.maybe_mark_and_start_activation_offload(activation_in, start=True)
+            fc2_op.maybe_mark_and_start_activation_offload(saved_grouped_fc2_x, start=True)
 
             # FC1 saved-tensor layout.
             #   [split_sizes, base_split_offsets, split_points,

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -14,6 +14,7 @@ import torch
 
 import transformer_engine_torch as tex
 from ...cpp_extensions import general_gemm, general_grouped_gemm_for_grouped_tensor
+from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import Recipe
 from ...tensor import NVFP4Quantizer, NVFP4Tensor, Quantizer
 from ...utils import (
@@ -725,6 +726,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
         # Save state for backward pass
         if requires_grad:
             mark_grouped_tensor(grouped_fc1_x, activation_in, scales, grouped_fc2_x)
+            cpu_offloading = is_cpu_offload_enabled()
             activation_is_srelu = isinstance(activation_op, ScaledSReLU)
             activation_recompute_in_mlp = bool(
                 getattr(activation_op, "activation_recompute_in_mlp", False)
@@ -746,9 +748,10 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
                         grouped_fc_x.rowwise_data = None
                         grouped_fc_x.scale_inv = None
 
-            fc1_op.maybe_mark_and_start_activation_offload(grouped_fc1_x, start=True)
-            activation_op.maybe_mark_and_start_activation_offload(activation_in, start=True)
-            fc2_op.maybe_mark_and_start_activation_offload(saved_grouped_fc2_x, start=True)
+            if cpu_offloading:
+                fc1_op.maybe_mark_and_start_activation_offload(grouped_fc1_x, start=True)
+                activation_op.maybe_mark_and_start_activation_offload(activation_in, start=True)
+                fc2_op.maybe_mark_and_start_activation_offload(saved_grouped_fc2_x, start=True)
 
             # FC1 saved-tensor layout.
             #   [split_sizes, base_split_offsets, split_points,

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -753,9 +753,9 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
                     t for t in (grouped_fc1_x, activation_in, saved_grouped_fc2_x) if t is not None
                 ]
                 start_offload(*activation_tensors)
-                fc1_op.maybe_mark_activation_offload(grouped_fc1_x)
-                activation_op.maybe_mark_activation_offload(activation_in)
-                fc2_op.maybe_mark_activation_offload(saved_grouped_fc2_x)
+                fc1_op.mark_for_cpu_offload_if_needed(grouped_fc1_x)
+                activation_op.mark_for_cpu_offload_if_needed(activation_in)
+                fc2_op.mark_for_cpu_offload_if_needed(saved_grouped_fc2_x)
 
             # FC1 saved-tensor layout.
             #   [split_sizes, base_split_offsets, split_points,

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import BasicLinear, Bias
@@ -129,8 +128,7 @@ class ForwardLinearBiasActivation(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                linear_op.maybe_mark_activation_offload(saved_input)
+            linear_op.mark_for_cpu_offload_if_needed(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -130,7 +130,7 @@ class ForwardLinearBiasActivation(FusedOperation):
                 saved_input = x_local
                 saved_weight = w
             if is_cpu_offload_enabled():
-                linear_op.maybe_mark_and_start_activation_offload(saved_input)
+                linear_op.maybe_mark_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import BasicLinear, Bias
@@ -129,8 +128,7 @@ class ForwardLinearBiasActivation(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                mark_activation_offload(saved_input)
+            linear_op.maybe_mark_and_start_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import BasicLinear, Bias
@@ -128,7 +129,8 @@ class ForwardLinearBiasActivation(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            linear_op.maybe_mark_and_start_activation_offload(saved_input)
+            if is_cpu_offload_enabled():
+                linear_op.maybe_mark_and_start_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -127,7 +127,7 @@ class ForwardLinearBiasAdd(FusedOperation):
                 saved_input = x_local
                 saved_weight = w
             if is_cpu_offload_enabled():
-                linear_op.maybe_mark_and_start_activation_offload(saved_input)
+                linear_op.maybe_mark_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, Bias
@@ -126,8 +125,7 @@ class ForwardLinearBiasAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                mark_activation_offload(saved_input)
+            linear_op.maybe_mark_and_start_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, Bias
@@ -126,8 +125,7 @@ class ForwardLinearBiasAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                linear_op.maybe_mark_activation_offload(saved_input)
+            linear_op.mark_for_cpu_offload_if_needed(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, Bias
@@ -125,7 +126,8 @@ class ForwardLinearBiasAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            linear_op.maybe_mark_and_start_activation_offload(saved_input)
+            if is_cpu_offload_enabled():
+                linear_op.maybe_mark_and_start_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, ConstantScale
@@ -107,8 +106,7 @@ class ForwardLinearScaleAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                mark_activation_offload(saved_input)
+            linear_op.maybe_mark_and_start_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import torch
 
-from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, ConstantScale
@@ -107,8 +106,7 @@ class ForwardLinearScaleAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            if is_cpu_offload_enabled():
-                linear_op.maybe_mark_activation_offload(saved_input)
+            linear_op.mark_for_cpu_offload_if_needed(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
@@ -108,7 +108,7 @@ class ForwardLinearScaleAdd(FusedOperation):
                 saved_input = x_local
                 saved_weight = w
             if is_cpu_offload_enabled():
-                linear_op.maybe_mark_and_start_activation_offload(saved_input)
+                linear_op.maybe_mark_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, ConstantScale
@@ -106,7 +107,8 @@ class ForwardLinearScaleAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            linear_op.maybe_mark_and_start_activation_offload(saved_input)
+            if is_cpu_offload_enabled():
+                linear_op.maybe_mark_and_start_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -12,7 +12,6 @@ import torch
 
 from transformer_engine_torch import CommOverlapType
 from ...cpp_extensions import general_gemm
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...distributed import get_distributed_world_size
 from ...quantization import FP8GlobalStateManager
 from ...module.base import (
@@ -354,8 +353,7 @@ class UserbuffersForwardLinear(FusedOperation):
 
         # Save state for backward pass
         if linear_op_ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                mark_activation_offload(x_local)
+            linear_op.maybe_mark_and_start_activation_offload(x_local)
             linear_op_ctx.save_for_backward(x_local, w)
             linear_op_ctx.with_quantized_compute = with_quantized_compute
             linear_op_ctx.input_quantizer = input_quantizer

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -12,6 +12,7 @@ import torch
 
 from transformer_engine_torch import CommOverlapType
 from ...cpp_extensions import general_gemm
+from ...cpu_offload import is_cpu_offload_enabled
 from ...distributed import get_distributed_world_size
 from ...quantization import FP8GlobalStateManager
 from ...module.base import (
@@ -353,7 +354,8 @@ class UserbuffersForwardLinear(FusedOperation):
 
         # Save state for backward pass
         if linear_op_ctx.requires_grad:
-            linear_op.maybe_mark_and_start_activation_offload(x_local)
+            if is_cpu_offload_enabled():
+                linear_op.maybe_mark_and_start_activation_offload(x_local)
             linear_op_ctx.save_for_backward(x_local, w)
             linear_op_ctx.with_quantized_compute = with_quantized_compute
             linear_op_ctx.input_quantizer = input_quantizer

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -12,7 +12,6 @@ import torch
 
 from transformer_engine_torch import CommOverlapType
 from ...cpp_extensions import general_gemm
-from ...cpu_offload import is_cpu_offload_enabled
 from ...distributed import get_distributed_world_size
 from ...quantization import FP8GlobalStateManager
 from ...module.base import (
@@ -354,8 +353,7 @@ class UserbuffersForwardLinear(FusedOperation):
 
         # Save state for backward pass
         if linear_op_ctx.requires_grad:
-            if is_cpu_offload_enabled():
-                linear_op.maybe_mark_activation_offload(x_local)
+            linear_op.mark_for_cpu_offload_if_needed(x_local)
             linear_op_ctx.save_for_backward(x_local, w)
             linear_op_ctx.with_quantized_compute = with_quantized_compute
             linear_op_ctx.input_quantizer = input_quantizer

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -355,7 +355,7 @@ class UserbuffersForwardLinear(FusedOperation):
         # Save state for backward pass
         if linear_op_ctx.requires_grad:
             if is_cpu_offload_enabled():
-                linear_op.maybe_mark_and_start_activation_offload(x_local)
+                linear_op.maybe_mark_activation_offload(x_local)
             linear_op_ctx.save_for_backward(x_local, w)
             linear_op_ctx.with_quantized_compute = with_quantized_compute
             linear_op_ctx.input_quantizer = input_quantizer

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -454,8 +454,8 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
 
     def mark_for_cpu_offload_if_needed(
         self,
-        *tensors: TensorLike | Iterable[Optional[TensorLike]] | None,
-        exclude_tensors: TensorLike | Iterable[Optional[TensorLike]] | None = None,
+        *tensors: Iterable[Optional[TensorLike]] | TensorLike | None,
+        exclude: Iterable[Optional[TensorLike]] | TensorLike | None = None,
     ) -> None:
         """Mark tensors to include and exclude from activation CPU offloading.
 
@@ -465,7 +465,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         and it excludes all tensors if the op is not participating in
         offloading.
         """
-        if not tensors and not exclude_tensors:
+        if not tensors and not exclude:
             return
         if not is_cpu_offload_enabled():
             return
@@ -474,7 +474,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
 
         def filter_supported_and_extend(
             out: list[TensorLike],
-            ts: TensorLike | Iterable[Optional[TensorLike]] | None,
+            ts: Iterable[Optional[TensorLike]] | TensorLike | None,
         ) -> None:
             """Extend a list with objects that support CPU offloading.
 
@@ -492,20 +492,21 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 out.append(t)
 
         # Choose tensors to include and exclude from CPU offloading
-        include = []
-        exclude = []
-        if self._activation_offloading_enabled:
-            filter_supported_and_extend(include, tensors)
-            filter_supported_and_extend(exclude, exclude_tensors)
-        else:
-            filter_supported_and_extend(exclude, tensors)
-            filter_supported_and_extend(exclude, exclude_tensors)
+        include_tensors = []
+        exclude_tensors = []
+        is_enabled = self._activation_offloading_enabled
+        for t in tensors:
+            filter_supported_and_extend(
+                include_tensors if is_enabled else exclude_tensors,
+                t,
+            )
+        filter_supported_and_extend(exclude_tensors, exclude)
 
         # Mark tensors
-        if include:
-            mark_activation_offload(*include)
-        if exclude:
-            mark_not_offload(*exclude)
+        if include_tensors:
+            mark_activation_offload(*include_tensors)
+        if exclude_tensors:
+            mark_not_offload(*exclude_tensors)
 
     @abc.abstractmethod
     def op_forward(

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -212,20 +212,16 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         *tensors: Any,
         start: bool = False,
     ) -> None:
-        """Mark saved activation tensors for CPU offloading when enabled.
+        """Mark saved activation tensors for CPU offloading in an active offload context.
 
         If activation offloading has been disabled for this op, mark the tensors so the
         active offload context skips them.
         """
         from ..cpu_offload import (  # pylint: disable=import-outside-toplevel
-            is_cpu_offload_enabled,
             mark_activation_offload,
             mark_not_offload,
             start_offload,
         )
-
-        if not is_cpu_offload_enabled():
-            return
 
         tensors = tuple(tensor for tensor in tensors if tensor is not None)
         if not tensors:

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -189,24 +189,23 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         # Objects for quantization
         self._fp8_metas: Optional[dict[str, dict[str, Any]]] = None
         self._quantizers: Optional[dict[str, list[Quantizer]]] = None
-        self._cpu_offloading_disabled: bool = False
+        self.activation_offloading: bool = True
 
     @property
     def is_fused_op(self) -> bool:
         return False
 
-    def disable_cpu_offloading(self, disabled: bool = True) -> None:
-        """Disable CPU offloading for activation tensors saved by this op.
+    def disable_activation_offloading(self, disabled: bool = True) -> None:
+        """Disable activation CPU offloading for tensors saved by this op.
 
-        CPU offloading is controlled by the surrounding offload context. This
-        setting only opts this operation's saved activation tensors out of that
-        context.
+        CPU offloading is controlled by the surrounding offload context. This setting only
+        opts this operation's saved activation tensors out of that context.
         """
-        self._cpu_offloading_disabled = disabled
+        self.activation_offloading = not disabled
 
-    def enable_cpu_offloading(self) -> None:
-        """Re-enable CPU offloading for activation tensors saved by this op."""
-        self.disable_cpu_offloading(False)
+    def enable_activation_offloading(self) -> None:
+        """Re-enable activation CPU offloading for tensors saved by this op."""
+        self.disable_activation_offloading(False)
 
     def maybe_mark_and_start_activation_offload(
         self,
@@ -215,8 +214,8 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
     ) -> None:
         """Mark saved activation tensors for CPU offloading when enabled.
 
-        If CPU offloading has been disabled for this op, mark the tensors so
-        the active offload context skips them.
+        If activation offloading has been disabled for this op, mark the tensors so the
+        active offload context skips them.
         """
         from ..cpu_offload import (  # pylint: disable=import-outside-toplevel
             is_cpu_offload_enabled,
@@ -232,7 +231,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         if not tensors:
             return
 
-        if self._cpu_offloading_disabled:
+        if not self.activation_offloading:
             mark_not_offload(*tensors)
             return
 

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -211,11 +211,13 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         self,
         *tensors: Any,
         start: bool = False,
+        mark: bool = True,
     ) -> None:
         """Mark saved activation tensors for CPU offloading in an active offload context.
 
         If activation offloading has been disabled for this op, mark the tensors so the
-        active offload context skips them.
+        active offload context skips them. If mark is False, only start offload for tensors
+        that were already selected by the active offload context.
         """
         from ..cpu_offload import (  # pylint: disable=import-outside-toplevel
             mark_activation_offload,
@@ -233,7 +235,8 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
 
         if start:
             start_offload(*tensors)
-        mark_activation_offload(*tensors)
+        if mark:
+            mark_activation_offload(*tensors)
 
     def num_quantizers(
         self,

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -189,10 +189,56 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         # Objects for quantization
         self._fp8_metas: Optional[dict[str, dict[str, Any]]] = None
         self._quantizers: Optional[dict[str, list[Quantizer]]] = None
+        self._cpu_offloading_disabled: bool = False
 
     @property
     def is_fused_op(self) -> bool:
         return False
+
+    def disable_cpu_offloading(self, disabled: bool = True) -> None:
+        """Disable CPU offloading for activation tensors saved by this op.
+
+        CPU offloading is controlled by the surrounding offload context. This
+        setting only opts this operation's saved activation tensors out of that
+        context.
+        """
+        self._cpu_offloading_disabled = disabled
+
+    def enable_cpu_offloading(self) -> None:
+        """Re-enable CPU offloading for activation tensors saved by this op."""
+        self.disable_cpu_offloading(False)
+
+    def maybe_mark_and_start_activation_offload(
+        self,
+        *tensors: Any,
+        start: bool = False,
+    ) -> None:
+        """Mark saved activation tensors for CPU offloading when enabled.
+
+        If CPU offloading has been disabled for this op, mark the tensors so
+        the active offload context skips them.
+        """
+        from ..cpu_offload import (  # pylint: disable=import-outside-toplevel
+            is_cpu_offload_enabled,
+            mark_activation_offload,
+            mark_not_offload,
+            start_offload,
+        )
+
+        if not is_cpu_offload_enabled():
+            return
+
+        tensors = tuple(tensor for tensor in tensors if tensor is not None)
+        if not tensors:
+            return
+
+        if self._cpu_offloading_disabled:
+            mark_not_offload(*tensors)
+            return
+
+        if start:
+            start_offload(*tensors)
+        mark_activation_offload(*tensors)
 
     def num_quantizers(
         self,

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -14,14 +14,22 @@ from typing import Any, Optional
 import torch
 
 from transformer_engine.common.recipe import Recipe
-from ..cpu_offload import mark_activation_offload, mark_not_offload
+from ..cpu_offload import is_cpu_offload_enabled, mark_activation_offload, mark_not_offload
 from ..quantization import (
     FP8GlobalStateManager,
     QuantizerRole,
     RecipeState,
     autocast,
 )
-from ..tensor import Quantizer
+from ..tensor import (
+    GroupedTensorStorage,
+    QuantizedTensorStorage,
+    Quantizer,
+)
+
+
+# Tensor class supported by fusible operation
+TensorLike = torch.Tensor | QuantizedTensorStorage | GroupedTensorStorage
 
 
 @dataclasses.dataclass
@@ -190,35 +198,13 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         # Objects for quantization
         self._fp8_metas: Optional[dict[str, dict[str, Any]]] = None
         self._quantizers: Optional[dict[str, list[Quantizer]]] = None
-        self.activation_offloading: bool = True
+
+        # Whether to participate when activation CPU offloading is enabled
+        self._activation_offloading_enabled: bool = True
 
     @property
     def is_fused_op(self) -> bool:
         return False
-
-    def set_activation_offloading(self, enabled: bool) -> None:
-        """Enable or disable activation CPU offloading for tensors saved by this op.
-
-        CPU offloading is controlled by the surrounding offload context. This setting only
-        opts this operation's saved activation tensors in or out of that context.
-        """
-        self.activation_offloading = enabled
-
-    def maybe_mark_activation_offload(self, *tensors: Any) -> None:
-        """Mark saved activation tensors for CPU offloading in an active offload context.
-
-        If activation offloading has been disabled for this op, mark the tensors so the
-        active offload context skips them.
-        """
-        tensors = tuple(tensor for tensor in tensors if tensor is not None)
-        if not tensors:
-            return
-
-        if not self.activation_offloading:
-            mark_not_offload(*tensors)
-            return
-
-        mark_activation_offload(*tensors)
 
     def num_quantizers(
         self,
@@ -454,6 +440,72 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 scale, amax_history = tensors
                 self._fp8_metas[mode][fp8_meta_key].scale.copy_(scale)
                 self._fp8_metas[mode][fp8_meta_key].amax_history.copy_(amax_history)
+
+    def set_activation_offloading(self, enabled: bool) -> None:
+        """Set whether to participate when activation CPU offloading is enabled.
+
+        Offloading is controlled by an offloading context (see
+        ``get_cpu_offload_context``). Disabling this setting allows
+        this operation to opt out when the offloading context is
+        active, but enabling does not activate offloading outside that
+        context.
+        """
+        self._activation_offloading_enabled = enabled
+
+    def mark_for_cpu_offload_if_needed(
+        self,
+        *tensors: TensorLike | Iterable[Optional[TensorLike]] | None,
+        exclude_tensors: TensorLike | Iterable[Optional[TensorLike]] | None = None,
+    ) -> None:
+        """Mark tensors to include and exclude from activation CPU offloading.
+
+        Call in op forward implementation in order to control what
+        tensors participate in CPU offloading. It does nothing if
+        offloading is not enabled (see ``get_cpu_offload_context``),
+        and it excludes all tensors if the op is not participating in
+        offloading.
+        """
+        if not tensors and not exclude_tensors:
+            return
+        if not is_cpu_offload_enabled():
+            return
+
+        supported_classes = (torch.Tensor, QuantizedTensorStorage, GroupedTensorStorage)
+
+        def filter_supported_and_extend(
+            out: list[TensorLike],
+            ts: TensorLike | Iterable[Optional[TensorLike]] | None,
+        ) -> None:
+            """Extend a list with objects that support CPU offloading.
+
+            Filters out ``None`` and checks for unsupported classes.
+            """
+            if ts is None:
+                return
+            if isinstance(ts, supported_classes):
+                ts = (ts,)
+            for t in ts:
+                if t is None:
+                    continue
+                if not isinstance(t, supported_classes):
+                    raise TypeError(f"{t.__class__.__name__} does not support CPU offloading.")
+                out.append(t)
+
+        # Choose tensors to include and exclude from CPU offloading
+        include = []
+        exclude = []
+        if self._activation_offloading_enabled:
+            filter_supported_and_extend(include, tensors)
+            filter_supported_and_extend(exclude, exclude_tensors)
+        else:
+            filter_supported_and_extend(exclude, tensors)
+            filter_supported_and_extend(exclude, exclude_tensors)
+
+        # Mark tensors
+        if include:
+            mark_activation_offload(*include)
+        if exclude:
+            mark_not_offload(*exclude)
 
     @abc.abstractmethod
     def op_forward(
@@ -773,6 +825,18 @@ class FusedOperation(FusibleOperation):
 
     def get_grad_output_quantizer(self) -> Optional[Quantizer]:
         return self.basic_ops[-1].get_grad_output_quantizer()
+
+    def set_activation_offloading(self, enabled: bool) -> None:
+        """Whether to participate when activation CPU offloading is enabled globally.
+
+        Offloading is controlled by an offloading context (see
+        ``get_cpu_offload_context``). Disabling this setting allows
+        this operation to opt out when the offloading context is
+        active, but enabling does not activate offloading outside that
+        context.
+        """
+        for op in self.basic_ops:
+            op.set_activation_offloading(enabled)
 
     def pre_first_fuser_forward(self) -> None:
         for op in self.basic_ops:

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -203,22 +203,15 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         """
         self.activation_offloading = enabled
 
-    def maybe_mark_and_start_activation_offload(
-        self,
-        *tensors: Any,
-        start: bool = False,
-        mark: bool = True,
-    ) -> None:
+    def maybe_mark_activation_offload(self, *tensors: Any) -> None:
         """Mark saved activation tensors for CPU offloading in an active offload context.
 
         If activation offloading has been disabled for this op, mark the tensors so the
-        active offload context skips them. If mark is False, only start offload for tensors
-        that were already selected by the active offload context.
+        active offload context skips them.
         """
         from ..cpu_offload import (  # pylint: disable=import-outside-toplevel
             mark_activation_offload,
             mark_not_offload,
-            start_offload,
         )
 
         tensors = tuple(tensor for tensor in tensors if tensor is not None)
@@ -229,10 +222,7 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
             mark_not_offload(*tensors)
             return
 
-        if start:
-            start_offload(*tensors)
-        if mark:
-            mark_activation_offload(*tensors)
+        mark_activation_offload(*tensors)
 
     def num_quantizers(
         self,

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 import torch
 
 from transformer_engine.common.recipe import Recipe
+from ..cpu_offload import mark_activation_offload, mark_not_offload
 from ..quantization import (
     FP8GlobalStateManager,
     QuantizerRole,
@@ -209,11 +210,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         If activation offloading has been disabled for this op, mark the tensors so the
         active offload context skips them.
         """
-        from ..cpu_offload import (  # pylint: disable=import-outside-toplevel
-            mark_activation_offload,
-            mark_not_offload,
-        )
-
         tensors = tuple(tensor for tensor in tensors if tensor is not None)
         if not tensors:
             return

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -195,17 +195,13 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
     def is_fused_op(self) -> bool:
         return False
 
-    def disable_activation_offloading(self, disabled: bool = True) -> None:
-        """Disable activation CPU offloading for tensors saved by this op.
+    def set_activation_offloading(self, enabled: bool) -> None:
+        """Enable or disable activation CPU offloading for tensors saved by this op.
 
         CPU offloading is controlled by the surrounding offload context. This setting only
-        opts this operation's saved activation tensors out of that context.
+        opts this operation's saved activation tensors in or out of that context.
         """
-        self.activation_offloading = not disabled
-
-    def enable_activation_offloading(self) -> None:
-        """Re-enable activation CPU offloading for tensors saved by this op."""
-        self.disable_activation_offloading(False)
+        self.activation_offloading = enabled
 
     def maybe_mark_and_start_activation_offload(
         self,


### PR DESCRIPTION
## Summary
Follow-up to #3047.

This PR adds an op-level activation offload policy for saved activation tensors so downstream fused grouped MLP users can opt individual TE ops out of activation offloading without changing the surrounding CPU offload context.

- add BasicOperation.set_activation_offloading(enabled)
- route activation offload marking through BasicOperation.maybe_mark_activation_offload
- use mark_not_offload for ops whose saved activations are opted out
- keep global CPU offload context checks and start_offload calls at their original call sites
- add unit coverage for the per-op mark/opt-out behavior

## Testing
- git diff --check
- python3.12 -m py_compile on the changed TE op files and tests/pytorch/test_fusible_ops.py