### PR TITLE
build: fix PyTorch wheel CUDA index calculation

### DIFF
--- a/.github/actions/build-pytorch-wheel/Dockerfile
+++ b/.github/actions/build-pytorch-wheel/Dockerfile
@@ -41,9 +41,5 @@ RUN CUDA_MAJOR_VERSION=$(echo $CUDA_VERSION | awk -F \. {'print $1'}) && \
 # Install PyTorch
 RUN export MATRIX_CUDA_VERSION=$(echo $CUDA_VERSION | awk -F \. {'print $1 $2'}) && \
     export MATRIX_TORCH_VERSION=$(echo $TORCH_VERSION | awk -F \. {'print $1 "." $2'}) && \
-    export TORCH_CUDA_VERSION=$(python -c "from os import environ as env; \ 
-    minv = {'2.5': 118, '2.6': 118, '2.7': 118, '2.8': 126, '2.9': 126}[env['MATRIX_TORCH_VERSION']]; \
-    maxv = {'2.5': 124, '2.6': 126, '2.7': 128, '2.8': 129, '2.9': 130}[env['MATRIX_TORCH_VERSION']]; \
-    print(minv if int(env['MATRIX_CUDA_VERSION']) < 120 else maxv)" \
-    ) && \
+    export TORCH_CUDA_VERSION=$(python -c "from os import environ as env; versions = {'2.5': (118, 124), '2.6': (118, 126), '2.7': (118, 128), '2.8': (126, 129), '2.9': (126, 130)}; minv, maxv = versions[env['MATRIX_TORCH_VERSION']]; print(minv if int(env['MATRIX_CUDA_VERSION']) < 120 else maxv)") && \
     pip install --no-cache-dir torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/cu${TORCH_CUDA_VERSION}


### PR DESCRIPTION
# Description

Fix the PyTorch wheel build Dockerfile so the CUDA wheel index calculation runs as a single valid Python command. The previous multi-line shell string could break the `python -c` invocation while computing `TORCH_CUDA_VERSION`.

Fixes #

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

- Rewrites the Dockerfile `TORCH_CUDA_VERSION` calculation into one shell-safe Python expression.
- Keeps the existing Torch-to-CUDA min/max version table unchanged.

# Checklist:

- [ ] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Validation:
- Ran the embedded Python expression across Torch 2.5-2.9 and CUDA 11.8/12.x matrix values.
- `git diff --check origin/main...HEAD`