### PR TITLE
Revert "[PyTorch] Add op-level activation offload opt-out API"

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -634,40 +634,6 @@ class TestFuser:
             assert x.grad.dtype == model_dtype
             assert op.weight.grad.dtype == model_dtype
 
-    def test_activation_offloading_policy(self, monkeypatch):
-        """Test opt-out API for activation CPU offloading."""
-        import transformer_engine.pytorch.ops.op as op_module
-
-        calls = []
-        tensor = torch.empty(1)
-        tensor_id = id(tensor)
-        op = te_ops.Identity()
-
-        monkeypatch.setattr(
-            op_module,
-            "mark_activation_offload",
-            lambda *tensors: calls.append(("mark", [id(t) for t in tensors])),
-        )
-        monkeypatch.setattr(
-            op_module,
-            "mark_not_offload",
-            lambda *tensors: calls.append(("skip", [id(t) for t in tensors])),
-        )
-        monkeypatch.setattr(op_module, "is_cpu_offload_enabled", lambda: True)
-
-        op.mark_for_cpu_offload_if_needed(tensor, None)
-        assert calls == [("mark", [tensor_id])]
-
-        calls.clear()
-        op.set_activation_offloading(False)
-        op.mark_for_cpu_offload_if_needed(tensor)
-        assert calls == [("skip", [tensor_id])]
-
-        calls.clear()
-        op.set_activation_offloading(True)
-        op.mark_for_cpu_offload_if_needed(tensor)
-        assert calls == [("mark", [tensor_id])]
-
 
 class TestBasicOps:
     """Tests for individual operations"""

--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -13,6 +13,7 @@ import torch
 
 import transformer_engine_torch as tex
 from ...constants import DType
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...tensor.float8_tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
@@ -113,7 +114,8 @@ class _ActivationOperation(BasicOperation, metaclass=abc.ABCMeta):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(x)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -412,7 +414,8 @@ class ScaledSReLU(BasicOperation):
 
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(x)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 import torch
 
 from ...cpp_extensions import general_gemm
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...distributed import (
     CudaRNGStatesTracker,
     gather_along_first_dim,
@@ -1048,13 +1049,11 @@ class BasicLinear(BasicOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-
-            # Activation CPU offloading
-            # Note: No special CPU offloading logic is needed for weights. saved_weight is
-            # either self.weight (nn.Parameter, auto-excluded from offload) or a
-            # workspace freshly created each forward pass.
-            self.mark_for_cpu_offload_if_needed(saved_input)
-
+            if is_cpu_offload_enabled():
+                # No special CPU offloading logic is needed for weights. saved_weight is
+                # either self.weight (nn.Parameter, auto-excluded from offload) or a
+                # workspace freshly created each forward pass.
+                mark_activation_offload(saved_input)
             ctx.save_for_backward(saved_input, saved_weight)
             ctx.with_quantized_compute = with_quantized_compute and backward_override is None
             ctx.backward_override = backward_override

--- a/transformer_engine/pytorch/ops/basic/dropout.py
+++ b/transformer_engine/pytorch/ops/basic/dropout.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import torch
 import transformer_engine_torch as tex
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...tensor import Quantizer
 from ...tensor.storage.float8_tensor_storage import Float8TensorStorage
 from .._common import maybe_autocast_dtype, maybe_dequantize
@@ -70,7 +71,8 @@ class Dropout(BasicOperation):
 
         # Save context for backward
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(mask)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(mask)
             ctx.save_for_backward(mask)
             ctx.impl = impl
             ctx.dropout_probability = self.dropout_probability

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -23,7 +23,7 @@ from ...module.base import (
     _2X_ACC_DGRAD,
     _2X_ACC_WGRAD,
 )
-from ...cpu_offload import is_cpu_offload_enabled, start_offload
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload, start_offload
 from ...quantization import FP8GlobalStateManager, QuantizerRole, Recipe
 from ...quantized_tensor import QuantizedTensorStorage
 from ...tensor import MXFP8Quantizer, MXFP8Tensor, Quantizer
@@ -1032,14 +1032,19 @@ class GroupedLinear(BasicOperation):
         # Note: No special logic is needed for weights. They are
         # either nn.Parameter (auto-excluded from offload) or are
         # temporary workspaces freshly created in each forward pass.
-        saved = tensors_to_save[0]
-        offset = 4 if self._scale_bias else 3
-        if use_grouped_tensor_path:
-            # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
-            self.mark_for_cpu_offload_if_needed(saved[offset])
-        else:
-            # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
-            self.mark_for_cpu_offload_if_needed(saved[offset : offset + self.num_groups])
+        if is_cpu_offload_enabled():
+            saved = tensors_to_save[0]
+            offset = 4 if self._scale_bias else 3
+            if use_grouped_tensor_path:
+                # Layout: [split_sizes, base_split_offsets, split_points, (scales?), grouped_x, *weights]
+                grouped_x = saved[offset]
+                if grouped_x is not None:
+                    mark_activation_offload(grouped_x)
+            else:
+                # Layout: [split_sizes, None, None, (scales?), *xs, *ws]
+                live_xs = [t for t in saved[offset : offset + self.num_groups] if t is not None]
+                if live_xs:
+                    mark_activation_offload(*live_xs)
 
         ctx.save_for_backward(*tensors_to_save[0])
 

--- a/transformer_engine/pytorch/ops/basic/l2normalization.py
+++ b/transformer_engine/pytorch/ops/basic/l2normalization.py
@@ -11,6 +11,7 @@ import os
 import torch
 
 from ...torch_version import torch_version
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...jit import (
     l2normalization_fused,
     l2normalization_fwd_fused,
@@ -101,7 +102,8 @@ class L2Normalization(BasicOperation):
 
         # Save state for backward pass
         if requires_grad:
-            self.mark_for_cpu_offload_if_needed(x, rsqrt_norm)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x, rsqrt_norm)
             ctx.save_for_backward(x, rsqrt_norm)
 
         return y

--- a/transformer_engine/pytorch/ops/basic/layer_norm.py
+++ b/transformer_engine/pytorch/ops/basic/layer_norm.py
@@ -14,6 +14,7 @@ import torch
 
 from transformer_engine_torch import layernorm_bwd, layernorm_fwd
 from ...constants import TE_DType
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -215,7 +216,8 @@ class LayerNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(x, means, rstdevs)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x, means, rstdevs)
             ctx.save_for_backward(x, means, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -14,6 +14,7 @@ import torch
 
 from transformer_engine_torch import rmsnorm_bwd, rmsnorm_fwd
 from ...constants import TE_DType
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...export import is_in_onnx_export_mode
 from ...tensor import Quantizer
 from ...utils import (
@@ -196,7 +197,8 @@ class RMSNorm(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(x, rstdevs)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x, rstdevs)
             ctx.save_for_backward(x, rstdevs)
             ctx.dtype = dtype
 

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -12,6 +12,7 @@ import torch
 
 import transformer_engine_torch as tex
 from ...constants import DType
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...tensor import Float8CurrentScalingQuantizer, Quantizer
 from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
@@ -126,7 +127,8 @@ class SwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(input_)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(input_)
             ctx.save_for_backward(input_)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -309,7 +311,8 @@ class ClampedSwiGLU(BasicOperation):
 
         # Save state for backward pass
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(x)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x)
             ctx.save_for_backward(x)
             ctx.dtype = dtype
             ctx.prev_op_grad_output_quantizer = prev_op_grad_output_quantizer
@@ -459,7 +462,8 @@ class _ScaledGLU(BasicOperation):
         # Save state for backward pass
         ctx = basic_op_ctxs[0]
         if ctx.requires_grad:
-            self.mark_for_cpu_offload_if_needed(input_)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(input_)
             ctx.input_requires_grad = True
             ctx.extra_input_requires_grad = extra_input.requires_grad
             ctx.dtype = dtype

--- a/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/forward_grouped_mlp.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 import torch
 
 import transformer_engine_torch as tex
-from ...cpu_offload import is_cpu_offload_enabled, start_offload
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload, start_offload
 from ...cpp_extensions import general_gemm, general_grouped_gemm_for_grouped_tensor
 from ...quantization import Recipe
 from ...tensor import NVFP4Quantizer, NVFP4Tensor, Quantizer
@@ -170,7 +170,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
         basic_op_kwargs: list[dict[str, Any]],
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         # Get basic operations
-        fc1_op, activation_op, fc2_op = self.basic_ops
+        fc1_op, _, fc2_op = self.basic_ops
         fc1_ctx, activation_ctx, fc2_ctx = basic_op_ctxs
 
         # Tensor properties
@@ -726,6 +726,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
         # Save state for backward pass
         if requires_grad:
             mark_grouped_tensor(grouped_fc1_x, activation_in, scales, grouped_fc2_x)
+            activation_op = self.basic_ops[1]
             cpu_offloading = is_cpu_offload_enabled()
             activation_is_srelu = isinstance(activation_op, ScaledSReLU)
             activation_recompute_in_mlp = bool(
@@ -753,9 +754,7 @@ class _ForwardGroupedMLP_CuTeGEMMBase(FusedOperation):
                     t for t in (grouped_fc1_x, activation_in, saved_grouped_fc2_x) if t is not None
                 ]
                 start_offload(*activation_tensors)
-                fc1_op.mark_for_cpu_offload_if_needed(grouped_fc1_x)
-                activation_op.mark_for_cpu_offload_if_needed(activation_in)
-                fc2_op.mark_for_cpu_offload_if_needed(saved_grouped_fc2_x)
+                mark_activation_offload(*activation_tensors)
 
             # FC1 saved-tensor layout.
             #   [split_sizes, base_split_offsets, split_points,

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_activation.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import BasicLinear, Bias
@@ -128,7 +129,8 @@ class ForwardLinearBiasActivation(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            linear_op.mark_for_cpu_offload_if_needed(saved_input)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_bias_add.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, Bias
@@ -125,7 +126,8 @@ class ForwardLinearBiasAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            linear_op.mark_for_cpu_offload_if_needed(saved_input)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
+++ b/transformer_engine/pytorch/ops/fused/forward_linear_scale_add.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 import torch
 
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...quantization import FP8GlobalStateManager
 from ...tensor import Quantizer
 from ..basic import AddExtraInput, BasicLinear, ConstantScale
@@ -106,7 +107,8 @@ class ForwardLinearScaleAdd(FusedOperation):
             else:
                 saved_input = x_local
                 saved_weight = w
-            linear_op.mark_for_cpu_offload_if_needed(saved_input)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(saved_input)
             linear_op_ctx.save_for_backward(saved_input, saved_weight)
             linear_op_ctx.with_quantized_compute = (
                 with_quantized_compute and backward_override is None

--- a/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
+++ b/transformer_engine/pytorch/ops/fused/userbuffers_forward_linear.py
@@ -12,6 +12,7 @@ import torch
 
 from transformer_engine_torch import CommOverlapType
 from ...cpp_extensions import general_gemm
+from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload
 from ...distributed import get_distributed_world_size
 from ...quantization import FP8GlobalStateManager
 from ...module.base import (
@@ -353,7 +354,8 @@ class UserbuffersForwardLinear(FusedOperation):
 
         # Save state for backward pass
         if linear_op_ctx.requires_grad:
-            linear_op.mark_for_cpu_offload_if_needed(x_local)
+            if is_cpu_offload_enabled():
+                mark_activation_offload(x_local)
             linear_op_ctx.save_for_backward(x_local, w)
             linear_op_ctx.with_quantized_compute = with_quantized_compute
             linear_op_ctx.input_quantizer = input_quantizer

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -14,22 +14,13 @@ from typing import Any, Optional
 import torch
 
 from transformer_engine.common.recipe import Recipe
-from ..cpu_offload import is_cpu_offload_enabled, mark_activation_offload, mark_not_offload
 from ..quantization import (
     FP8GlobalStateManager,
     QuantizerRole,
     RecipeState,
     autocast,
 )
-from ..tensor import (
-    GroupedTensorStorage,
-    QuantizedTensorStorage,
-    Quantizer,
-)
-
-
-# Tensor class supported by fusible operation
-TensorLike = torch.Tensor | QuantizedTensorStorage | GroupedTensorStorage
+from ..tensor import Quantizer
 
 
 @dataclasses.dataclass
@@ -198,9 +189,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
         # Objects for quantization
         self._fp8_metas: Optional[dict[str, dict[str, Any]]] = None
         self._quantizers: Optional[dict[str, list[Quantizer]]] = None
-
-        # Whether to participate when activation CPU offloading is enabled
-        self._activation_offloading_enabled: bool = True
 
     @property
     def is_fused_op(self) -> bool:
@@ -440,73 +428,6 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
                 scale, amax_history = tensors
                 self._fp8_metas[mode][fp8_meta_key].scale.copy_(scale)
                 self._fp8_metas[mode][fp8_meta_key].amax_history.copy_(amax_history)
-
-    def set_activation_offloading(self, enabled: bool) -> None:
-        """Set whether to participate when activation CPU offloading is enabled.
-
-        Offloading is controlled by an offloading context (see
-        ``get_cpu_offload_context``). Disabling this setting allows
-        this operation to opt out when the offloading context is
-        active, but enabling does not activate offloading outside that
-        context.
-        """
-        self._activation_offloading_enabled = enabled
-
-    def mark_for_cpu_offload_if_needed(
-        self,
-        *tensors: Iterable[Optional[TensorLike]] | TensorLike | None,
-        exclude: Iterable[Optional[TensorLike]] | TensorLike | None = None,
-    ) -> None:
-        """Mark tensors to include and exclude from activation CPU offloading.
-
-        Call in op forward implementation in order to control what
-        tensors participate in CPU offloading. It does nothing if
-        offloading is not enabled (see ``get_cpu_offload_context``),
-        and it excludes all tensors if the op is not participating in
-        offloading.
-        """
-        if not tensors and not exclude:
-            return
-        if not is_cpu_offload_enabled():
-            return
-
-        supported_classes = (torch.Tensor, QuantizedTensorStorage, GroupedTensorStorage)
-
-        def filter_supported_and_extend(
-            out: list[TensorLike],
-            ts: Iterable[Optional[TensorLike]] | TensorLike | None,
-        ) -> None:
-            """Extend a list with objects that support CPU offloading.
-
-            Filters out ``None`` and checks for unsupported classes.
-            """
-            if ts is None:
-                return
-            if isinstance(ts, supported_classes):
-                ts = (ts,)
-            for t in ts:
-                if t is None:
-                    continue
-                if not isinstance(t, supported_classes):
-                    raise TypeError(f"{t.__class__.__name__} does not support CPU offloading.")
-                out.append(t)
-
-        # Choose tensors to include and exclude from CPU offloading
-        include_tensors = []
-        exclude_tensors = []
-        is_enabled = self._activation_offloading_enabled
-        for t in tensors:
-            filter_supported_and_extend(
-                include_tensors if is_enabled else exclude_tensors,
-                t,
-            )
-        filter_supported_and_extend(exclude_tensors, exclude)
-
-        # Mark tensors
-        if include_tensors:
-            mark_activation_offload(*include_tensors)
-        if exclude_tensors:
-            mark_not_offload(*exclude_tensors)
 
     @abc.abstractmethod
     def op_forward(
@@ -826,18 +747,6 @@ class FusedOperation(FusibleOperation):
 
     def get_grad_output_quantizer(self) -> Optional[Quantizer]:
         return self.basic_ops[-1].get_grad_output_quantizer()
-
-    def set_activation_offloading(self, enabled: bool) -> None:
-        """Whether to participate when activation CPU offloading is enabled globally.
-
-        Offloading is controlled by an offloading context (see
-        ``get_cpu_offload_context``). Disabling this setting allows
-        this operation to opt out when the offloading context is
-        active, but enabling does not activate offloading outside that
-        context.
-        """
-        for op in self.basic_ops:
-            op.set_activation_offloading(enabled)
 
     def pre_first_fuser_forward(self) -> None:
         for op in self.basic_ops:


### PR DESCRIPTION
Reverts NVIDIA/TransformerEngine#3108

Per-op configurability becomes very tricky once you start considering things like activation recompute. Unfused ops might save some tensors while fused ops can skip them, and the factors that allow/prevent fusion can be very very complicated. I think this API has the risk of a user carefully tuning for a specific use-case, and then everything blowing up when the model slightly changes.

Adding an option to set a per-layer MB limit for CPU offloading (https://github.com/NVIDIA/TransformerEngine/pull/3108#issuecomment-4669996125) is a much more elegant solution to this problem.