### PR TITLE
[fix] Respect per-op activation-offload markers in fused grouped MLP

### DIFF
--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -17,7 +17,12 @@ from packaging.version import Version as PkgVersion
 
 import transformer_engine_torch as tex
 from ...constants import MXFP8_BLOCK_SCALING_SIZE, NVFP4_BLOCK_SCALING_SIZE
-from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload, start_offload
+from ...cpu_offload import (
+    is_cpu_offload_enabled,
+    mark_activation_offload,
+    mark_not_offload,
+    start_offload,
+)
 from ...cpp_extensions import general_gemm, general_grouped_gemm_for_grouped_tensor
 from ...module.base import _2X_ACC_WGRAD
 from ...quantization import Recipe
@@ -1450,9 +1455,29 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                         grouped_fc_x.rowwise_data = None
                         grouped_fc_x.scale_inv = None
 
+            # Per-op fine-grained offload markers.
+            offload_fc1_x = bool(getattr(fc1_op, "fine_grained_activation_offloading", False))
+            offload_act = bool(getattr(activation_op, "fine_grained_activation_offloading", False))
+            fine_grained_offload = offload_fc1_x or offload_act
+            saved_activations = (
+                (grouped_fc1_x, offload_fc1_x),
+                (activation_in, offload_act),
+                (saved_grouped_fc2_x, offload_act),
+            )
+
+            # The hook-based offloader is opt-out, so explicitly keep the
+            # non-selected tensors resident (mark_not_offload sets _TE_do_not_offload).
+            if fine_grained_offload:
+                keep = [t for t, sel in saved_activations if t is not None and not sel]
+                if keep:
+                    mark_not_offload(*keep)
+
             if cpu_offloading:
+                # TE-native path; with no markers, offload everything saved (legacy).
                 activation_tensors = [
-                    t for t in (grouped_fc1_x, activation_in, saved_grouped_fc2_x) if t is not None
+                    t
+                    for t, sel in saved_activations
+                    if t is not None and (sel or not fine_grained_offload)
                 ]
                 start_offload(*activation_tensors)
                 mark_activation_offload(*activation_tensors)


### PR DESCRIPTION
# Description

The fused groupedMLP offloaded it's entire saved set (fc1_input, activation_input and fc2_input) whenever CPU offload is globally enabled, **ignored Megatron-LM's per-module offload selection**.
- e.g., MLM set `--offload-modules moe_act` while grouped_mlp will also offload `fc1_input`, unexpected behavior.


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
