### PR TITLE
[Common/PyTorch] Grouped-quantize kernels for 1D and 2D FP8 block-scaling

### DIFF
--- a/tests/cpp/operator/CMakeLists.txt
+++ b/tests/cpp/operator/CMakeLists.txt
@@ -15,8 +15,10 @@ add_executable(test_operator
                test_cast_mxfp8_grouped.cu
                test_cast_nvfp4_transpose.cu
                test_cast_float8blockwise.cu
+               test_cast_float8blockwise_grouped.cu
                test_dequantize_mxfp8.cu
                test_dequantize_mxfp8_grouped.cu
+               test_dequantize_float8blockwise_grouped.cu
                test_dequantize_nvfp4.cu
                test_transpose.cu
                test_cast_transpose.cu

--- a/tests/cpp/operator/test_cast_float8blockwise_grouped.cu
+++ b/tests/cpp/operator/test_cast_float8blockwise_grouped.cu
@@ -1,0 +1,416 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <transformer_engine/cast.h>
+#include <transformer_engine/transformer_engine.h>
+
+#include <random>
+#include <vector>
+
+#include "../test_common.h"
+
+using namespace transformer_engine;
+using namespace test;
+
+namespace {
+
+enum class ShapeRep { SAME_BOTH_DIMS = 0, VARYING_FIRST_DIM = 1 };
+enum class ScalingDir { ROWWISE = 0, COLWISE = 1, BOTH = 2 };
+enum class BlockDim { ONE_D = 1, TWO_D = 2 };
+
+constexpr size_t kBlock = 128;
+
+inline size_t align4(size_t x) { return ((x + 3) / 4) * 4; }
+
+// Configure split-quantize reference: call non-grouped nvte_quantize_v2 on each tensor slice.
+// Returns flat host buffers for per-tensor outputs and scales (in their per-tensor natural
+// layout) so the test can index them and compare element-wise against the grouped layout.
+struct PerTensorRef {
+  std::vector<std::vector<uint8_t>> output;          // per tensor, FP8 raw bytes (R_t * K)
+  std::vector<std::vector<uint8_t>> output_t;        // per tensor, FP8 raw bytes (K * R_t)
+  std::vector<std::vector<float>> scale_inv;         // per tensor, layout per non-grouped impl
+  std::vector<std::vector<float>> scale_inv_t;       // per tensor, layout per non-grouped impl
+};
+
+// Per-expert scale layout helpers mirroring the kernel + cuBLAS grouped GEMM
+// expectation. Each expert's scales occupy a contiguous sub-block of the global
+// scale buffer; these compute per-expert padded sizes (in floats) so the test
+// can both size the buffer and compute per-expert base offsets.
+//   1D rowwise   : blocks_X * roundup(M_t, 4)
+//   1D colwise   : blocks_y_t * roundup(K, 4)
+//   2D rowwise   : blocks_y_t * roundup(blocks_X, 4)
+//   2D colwise   : blocks_X * roundup(blocks_y_t, 4)
+inline size_t per_expert_scale_floats(BlockDim block_dim, bool columnwise, size_t M_t, size_t K) {
+  constexpr size_t kBlk = 128;
+  const size_t blocks_X = (K + kBlk - 1) / kBlk;
+  const size_t blocks_y = (M_t + kBlk - 1) / kBlk;
+  if (block_dim == BlockDim::ONE_D) {
+    if (!columnwise) return blocks_X * align4(M_t);
+    return blocks_y * align4(K);
+  }
+  // 2D
+  if (!columnwise) return blocks_y * align4(blocks_X);
+  return blocks_X * align4(blocks_y);
+}
+
+// Cumulative per-expert offset (in floats) for tensor `t`.
+inline size_t per_expert_scale_offset(const std::vector<size_t>& first_dims, size_t t,
+                                      BlockDim block_dim, bool columnwise, size_t K) {
+  size_t offset = 0;
+  for (size_t i = 0; i < t; ++i) {
+    offset += per_expert_scale_floats(block_dim, columnwise, first_dims[i], K);
+  }
+  return offset;
+}
+
+template <typename InputType, typename OutputType>
+void perform_test(ShapeRep shape_rep, BlockDim block_dim, ScalingDir dir,
+                  const std::vector<size_t>& first_dims_h, size_t K,
+                  bool force_pow_2_scales, float epsilon) {
+  if (getDeviceComputeCapability() < hopperComputeCapability) {
+    GTEST_SKIP();
+  }
+
+  DType itype = TypeInfo<InputType>::dtype;
+  DType otype = TypeInfo<OutputType>::dtype;
+
+  const size_t num_tensors = first_dims_h.size();
+  size_t R_total = 0;
+  for (size_t m : first_dims_h) {
+    ASSERT_EQ(m % kBlock, 0u) << "Per-tensor first dim must be multiple of 128";
+    R_total += m;
+  }
+  ASSERT_EQ(K % 16u, 0u);
+
+  // Host data
+  std::mt19937 gen(0xC0FFEEu);
+  std::uniform_real_distribution<float> dist(-2.0f, 1.0f);
+  std::vector<InputType> input_h(R_total * K);
+  for (auto& v : input_h) v = static_cast<InputType>(dist(gen));
+
+  // Tensor offsets (element offsets)
+  std::vector<int64_t> offsets_h(num_tensors + 1, 0);
+  for (size_t t = 0; t < num_tensors; ++t) {
+    offsets_h[t + 1] = offsets_h[t] + static_cast<int64_t>(first_dims_h[t] * K);
+  }
+  std::vector<int64_t> first_dims_i64(num_tensors);
+  for (size_t t = 0; t < num_tensors; ++t) first_dims_i64[t] = static_cast<int64_t>(first_dims_h[t]);
+
+  const bool use_rowwise = (dir == ScalingDir::ROWWISE || dir == ScalingDir::BOTH);
+  const bool use_colwise = (dir == ScalingDir::COLWISE || dir == ScalingDir::BOTH);
+
+  const NVTEScalingMode mode =
+      (block_dim == BlockDim::ONE_D) ? NVTE_BLOCK_SCALING_1D : NVTE_BLOCK_SCALING_2D;
+
+  // Allocate grouped device buffers.
+  InputType* input_d = nullptr;
+  OutputType* output_d = nullptr;
+  OutputType* output_t_d = nullptr;
+  float* scale_inv_d = nullptr;
+  float* scale_inv_t_d = nullptr;
+  int64_t* offsets_d = nullptr;
+  int64_t* first_dims_d = nullptr;
+
+  const size_t blocks_X = (K + kBlock - 1) / kBlock;
+
+  // Grouped scale buffers are sized as the sum of per-expert padded sub-blocks,
+  // matching cuBLAS grouped FP8 block-scaling GEMM's per-expert layout.
+  size_t scale_inv_elems = 0;
+  size_t scale_inv_t_elems = 0;
+  for (size_t t = 0; t < num_tensors; ++t) {
+    scale_inv_elems += per_expert_scale_floats(block_dim, /*columnwise=*/false, first_dims_h[t], K);
+    scale_inv_t_elems +=
+        per_expert_scale_floats(block_dim, /*columnwise=*/true, first_dims_h[t], K);
+  }
+  std::vector<size_t> scale_inv_shape = {scale_inv_elems};
+  std::vector<size_t> scale_inv_t_shape = {scale_inv_t_elems};
+
+  const size_t input_bytes = R_total * K * sizeof(InputType);
+  const size_t output_bytes = R_total * K * sizeof(OutputType);
+
+  cudaMalloc(&input_d, input_bytes);
+  cudaMemcpy(input_d, input_h.data(), input_bytes, cudaMemcpyHostToDevice);
+  cudaMalloc(&offsets_d, (num_tensors + 1) * sizeof(int64_t));
+  cudaMemcpy(offsets_d, offsets_h.data(), (num_tensors + 1) * sizeof(int64_t),
+             cudaMemcpyHostToDevice);
+  if (shape_rep == ShapeRep::VARYING_FIRST_DIM) {
+    cudaMalloc(&first_dims_d, num_tensors * sizeof(int64_t));
+    cudaMemcpy(first_dims_d, first_dims_i64.data(), num_tensors * sizeof(int64_t),
+               cudaMemcpyHostToDevice);
+  }
+  if (use_rowwise) {
+    cudaMalloc(&output_d, output_bytes);
+    cudaMemset(output_d, 0, output_bytes);
+    cudaMalloc(&scale_inv_d, scale_inv_elems * sizeof(float));
+    cudaMemset(scale_inv_d, 0, scale_inv_elems * sizeof(float));
+  }
+  if (use_colwise) {
+    cudaMalloc(&output_t_d, output_bytes);
+    cudaMemset(output_t_d, 0, output_bytes);
+    cudaMalloc(&scale_inv_t_d, scale_inv_t_elems * sizeof(float));
+    cudaMemset(scale_inv_t_d, 0, scale_inv_t_elems * sizeof(float));
+  }
+
+  // Build grouped tensors.
+  std::vector<size_t> logical_shape_vec = {R_total, K};
+  NVTEShape logical_shape = nvte_make_shape(logical_shape_vec.data(), logical_shape_vec.size());
+
+  NVTEGroupedTensor in_gt = nvte_create_grouped_tensor(NVTE_DELAYED_TENSOR_SCALING, num_tensors,
+                                                       logical_shape);
+  NVTEGroupedTensor out_gt = nvte_create_grouped_tensor(mode, num_tensors, logical_shape);
+
+  NVTEBasicTensor in_data = {input_d, static_cast<NVTEDType>(itype), logical_shape};
+  nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedRowwiseData, &in_data, sizeof(in_data));
+
+  NVTEShape offsets_shape;
+  offsets_shape.ndim = 1;
+  offsets_shape.data[0] = num_tensors + 1;
+  NVTEBasicTensor offsets_bt = {offsets_d, kNVTEInt64, offsets_shape};
+  if (shape_rep == ShapeRep::VARYING_FIRST_DIM) {
+    NVTEShape first_dims_shape;
+    first_dims_shape.ndim = 1;
+    first_dims_shape.data[0] = num_tensors;
+    NVTEBasicTensor first_dims_bt = {first_dims_d, kNVTEInt64, first_dims_shape};
+    nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedFirstDims, &first_dims_bt,
+                                  sizeof(first_dims_bt));
+    nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedFirstDims, &first_dims_bt,
+                                  sizeof(first_dims_bt));
+    nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedTensorOffsets, &offsets_bt,
+                                  sizeof(offsets_bt));
+    nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedTensorOffsets, &offsets_bt,
+                                  sizeof(offsets_bt));
+  }
+
+  if (use_rowwise) {
+    NVTEBasicTensor out_data = {output_d, static_cast<NVTEDType>(otype), logical_shape};
+    NVTEShape scale_inv_shape_nv = nvte_make_shape(scale_inv_shape.data(), scale_inv_shape.size());
+    NVTEBasicTensor scale_bt = {scale_inv_d, kNVTEFloat32, scale_inv_shape_nv};
+    nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedRowwiseData, &out_data, sizeof(out_data));
+    nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedRowwiseScaleInv, &scale_bt, sizeof(scale_bt));
+  }
+  if (use_colwise) {
+    NVTEBasicTensor out_t_data = {output_t_d, static_cast<NVTEDType>(otype), logical_shape};
+    NVTEShape scale_inv_t_shape_nv = nvte_make_shape(scale_inv_t_shape.data(),
+                                                     scale_inv_t_shape.size());
+    NVTEBasicTensor scale_t_bt = {scale_inv_t_d, kNVTEFloat32, scale_inv_t_shape_nv};
+    nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedColumnwiseData, &out_t_data,
+                                  sizeof(out_t_data));
+    nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedColumnwiseScaleInv, &scale_t_bt,
+                                  sizeof(scale_t_bt));
+  }
+
+  // Run grouped quantize.
+  QuantizationConfigWrapper quant_config;
+  quant_config.set_force_pow_2_scales(force_pow_2_scales);
+  quant_config.set_amax_epsilon(epsilon);
+  nvte_group_quantize(in_gt, out_gt, quant_config, 0);
+  cudaDeviceSynchronize();
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+
+  // Pull grouped outputs back to host.
+  std::vector<uint8_t> output_h(use_rowwise ? R_total * K : 0);
+  std::vector<uint8_t> output_t_h(use_colwise ? R_total * K : 0);
+  std::vector<float> scale_inv_h(use_rowwise ? scale_inv_elems : 0);
+  std::vector<float> scale_inv_t_h(use_colwise ? scale_inv_t_elems : 0);
+  if (use_rowwise) {
+    cudaMemcpy(output_h.data(), output_d, R_total * K, cudaMemcpyDeviceToHost);
+    cudaMemcpy(scale_inv_h.data(), scale_inv_d, scale_inv_elems * sizeof(float),
+               cudaMemcpyDeviceToHost);
+  }
+  if (use_colwise) {
+    cudaMemcpy(output_t_h.data(), output_t_d, R_total * K, cudaMemcpyDeviceToHost);
+    cudaMemcpy(scale_inv_t_h.data(), scale_inv_t_d, scale_inv_t_elems * sizeof(float),
+               cudaMemcpyDeviceToHost);
+  }
+
+  // Run split-quantize reference per tensor and compare element-wise.
+  for (size_t t = 0; t < num_tensors; ++t) {
+    const size_t M = first_dims_h[t];
+    const size_t row_offset = static_cast<size_t>(offsets_h[t]) / K;
+
+    std::vector<size_t> tshape = {M, K};
+    Tensor ref_in("ref_in_" + std::to_string(t), tshape, itype);
+    // The non-grouped 2D kernel requires rowwise output to be allocated even when only colwise
+    // data is consumed. We always allocate both and compare only what the grouped kernel produced.
+    const bool ref_rowwise = (block_dim == BlockDim::TWO_D) ? true : use_rowwise;
+    const bool ref_colwise = use_colwise;
+    Tensor ref_out("ref_out_" + std::to_string(t), tshape, otype, ref_rowwise, ref_colwise, mode);
+
+    // Copy this tensor's input slice into ref_in.
+    {
+      auto* dst = ref_in.rowwise_dptr();
+      const InputType* src = reinterpret_cast<const InputType*>(input_d) + row_offset * K;
+      cudaMemcpy(dst, src, M * K * sizeof(InputType), cudaMemcpyDeviceToDevice);
+    }
+
+    QuantizationConfigWrapper qc;
+    qc.set_force_pow_2_scales(force_pow_2_scales);
+    qc.set_amax_epsilon(epsilon);
+    nvte_quantize_v2(ref_in.data(), ref_out.data(), qc, 0);
+    cudaDeviceSynchronize();
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+    ref_out.to_cpu();  // sync output and scale_inv buffers from GPU to CPU
+
+    // Compare data.
+    if (use_rowwise) {
+      const OutputType* ref_data = ref_out.rowwise_cpu_dptr<OutputType>();
+      for (size_t r = 0; r < M; ++r) {
+        for (size_t c = 0; c < K; ++c) {
+          const uint8_t got = output_h[(row_offset + r) * K + c];
+          const uint8_t exp = reinterpret_cast<const uint8_t*>(ref_data)[r * K + c];
+          ASSERT_EQ(got, exp) << "rowwise data mismatch t=" << t << " r=" << r << " c=" << c;
+        }
+      }
+    }
+    if (use_colwise) {
+      const OutputType* ref_data_t = ref_out.columnwise_cpu_dptr<OutputType>();
+      // Per-expert columnwise data: contiguous (K, M_t) block at element offset
+      // K * row_offset, matching cuBLAS grouped GEMM's per-expert data pointer.
+      const size_t expert_data_off = static_cast<size_t>(row_offset) * K;
+      for (size_t c = 0; c < K; ++c) {
+        for (size_t r = 0; r < M; ++r) {
+          const uint8_t got = output_t_h[expert_data_off + c * M + r];
+          const uint8_t exp = reinterpret_cast<const uint8_t*>(ref_data_t)[c * M + r];
+          ASSERT_EQ(got, exp) << "colwise data mismatch t=" << t << " c=" << c << " r=" << r;
+        }
+      }
+    }
+
+    // Compare scales. Per-expert layout: each expert's scales live in a
+    // contiguous sub-block at per_expert_scale_offset(...).
+    if (block_dim == BlockDim::ONE_D) {
+      const size_t M_pad = align4(M);
+      const size_t K_pad = align4(K);
+      const size_t blocks_y_per_tensor = M / kBlock;
+      if (use_rowwise) {
+        const float* ref_sc = ref_out.rowwise_cpu_scale_inv_ptr<float>();
+        // Per-expert RW: (blocks_X, roundup(M_t, 4)).
+        const size_t expert_off =
+            per_expert_scale_offset(first_dims_h, t, block_dim, false, K);
+        for (size_t bx = 0; bx < blocks_X; ++bx) {
+          for (size_t r = 0; r < M; ++r) {
+            const float got = scale_inv_h[expert_off + bx * M_pad + r];
+            const float exp = ref_sc[bx * M_pad + r];
+            ASSERT_EQ(got, exp) << "1D rowwise scale mismatch t=" << t << " bx=" << bx
+                                << " r=" << r;
+          }
+        }
+      }
+      if (use_colwise) {
+        const float* ref_sct = ref_out.columnwise_cpu_scale_inv_ptr<float>();
+        // Per-expert CW: (blocks_y_t, roundup(K, 4)) compact.
+        const size_t expert_off = per_expert_scale_offset(first_dims_h, t, block_dim, true, K);
+        for (size_t by = 0; by < blocks_y_per_tensor; ++by) {
+          for (size_t c = 0; c < K; ++c) {
+            const float got = scale_inv_t_h[expert_off + by * K_pad + c];
+            const float exp = ref_sct[by * K_pad + c];
+            ASSERT_EQ(got, exp) << "1D colwise scale mismatch t=" << t << " by=" << by
+                                << " c=" << c;
+          }
+        }
+      }
+    } else {
+      // 2D per-expert: rowwise (blocks_y_t, roundup(blocks_X, 4)); colwise
+      // (blocks_X, roundup(blocks_y_t, 4)) compact.
+      const size_t blocks_y_per_tensor = M / kBlock;
+      const size_t bx_pad = align4(blocks_X);
+      const size_t by_pad_t = align4(blocks_y_per_tensor);
+      if (use_rowwise) {
+        const float* ref_sc = ref_out.rowwise_cpu_scale_inv_ptr<float>();
+        const size_t expert_off =
+            per_expert_scale_offset(first_dims_h, t, block_dim, false, K);
+        for (size_t by = 0; by < blocks_y_per_tensor; ++by) {
+          for (size_t bx = 0; bx < blocks_X; ++bx) {
+            const float got = scale_inv_h[expert_off + by * bx_pad + bx];
+            const float exp = ref_sc[by * bx_pad + bx];
+            ASSERT_EQ(got, exp) << "2D rowwise scale mismatch t=" << t << " by=" << by
+                                << " bx=" << bx;
+          }
+        }
+      }
+      if (use_colwise) {
+        const float* ref_sct = ref_out.columnwise_cpu_scale_inv_ptr<float>();
+        const size_t expert_off = per_expert_scale_offset(first_dims_h, t, block_dim, true, K);
+        for (size_t bx = 0; bx < blocks_X; ++bx) {
+          for (size_t by = 0; by < blocks_y_per_tensor; ++by) {
+            const float got = scale_inv_t_h[expert_off + bx * by_pad_t + by];
+            const float exp = ref_sct[bx * by_pad_t + by];
+            ASSERT_EQ(got, exp) << "2D colwise scale mismatch t=" << t << " bx=" << bx
+                                << " by=" << by;
+          }
+        }
+      }
+    }
+  }
+
+  nvte_destroy_grouped_tensor(in_gt);
+  nvte_destroy_grouped_tensor(out_gt);
+  cudaFree(input_d);
+  if (output_d) cudaFree(output_d);
+  if (output_t_d) cudaFree(output_t_d);
+  if (scale_inv_d) cudaFree(scale_inv_d);
+  if (scale_inv_t_d) cudaFree(scale_inv_t_d);
+  cudaFree(offsets_d);
+  if (first_dims_d) cudaFree(first_dims_d);
+}
+
+struct TestConfig {
+  ShapeRep shape_rep;
+  BlockDim block_dim;
+  ScalingDir dir;
+  std::vector<size_t> first_dims;
+  size_t K;
+};
+
+class GroupedFP8BlockwiseTestSuite : public ::testing::TestWithParam<TestConfig> {};
+
+TEST_P(GroupedFP8BlockwiseTestSuite, Test) {
+  const TestConfig& cfg = GetParam();
+  perform_test<bf16, fp8e4m3>(cfg.shape_rep, cfg.block_dim, cfg.dir, cfg.first_dims, cfg.K,
+                              /*force_pow_2_scales=*/false, /*epsilon=*/0.0f);
+}
+
+std::vector<TestConfig> make_configs() {
+  std::vector<TestConfig> configs;
+  std::vector<std::vector<size_t>> uniform = {{128, 128}, {256, 256, 256, 256}};
+  std::vector<std::vector<size_t>> jagged = {
+      {128, 256, 384, 512}, {256, 128, 512, 384, 1024}};
+  std::vector<size_t> Ks = {128, 256, 512};
+  for (auto bd : {BlockDim::ONE_D, BlockDim::TWO_D}) {
+    for (auto dir : {ScalingDir::ROWWISE, ScalingDir::COLWISE, ScalingDir::BOTH}) {
+      for (size_t K : Ks) {
+        for (const auto& v : uniform) {
+          configs.push_back({ShapeRep::SAME_BOTH_DIMS, bd, dir, v, K});
+        }
+        for (const auto& v : jagged) {
+          configs.push_back({ShapeRep::VARYING_FIRST_DIM, bd, dir, v, K});
+        }
+      }
+    }
+  }
+  return configs;
+}
+
+std::string make_name(const ::testing::TestParamInfo<TestConfig>& info) {
+  const auto& c = info.param;
+  std::string s = (c.shape_rep == ShapeRep::SAME_BOTH_DIMS ? "SAME" : "VARYFIRST");
+  s += "_BD" + std::to_string(static_cast<int>(c.block_dim));
+  s += (c.dir == ScalingDir::ROWWISE ? "_RW"
+                                     : c.dir == ScalingDir::COLWISE ? "_CW" : "_BOTH");
+  s += "_K" + std::to_string(c.K) + "_N" + std::to_string(c.first_dims.size());
+  s += "_M";
+  for (size_t m : c.first_dims) s += "_" + std::to_string(m);
+  return s;
+}
+
+INSTANTIATE_TEST_SUITE_P(GroupedFP8Blockwise, GroupedFP8BlockwiseTestSuite,
+                         ::testing::ValuesIn(make_configs()), make_name);
+
+}  // namespace

--- a/tests/cpp/operator/test_dequantize_float8blockwise_grouped.cu
+++ b/tests/cpp/operator/test_dequantize_float8blockwise_grouped.cu
@@ -1,0 +1,317 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <transformer_engine/cast.h>
+#include <transformer_engine/transformer_engine.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "../test_common.h"
+
+using namespace transformer_engine;
+using namespace test;
+
+namespace {
+
+enum class ShapeRep { SAME_BOTH_DIMS = 0, VARYING_FIRST_DIM = 1 };
+enum class ScalingDir { ROWWISE = 0, COLWISE = 1 };
+enum class BlockDim { ONE_D = 1, TWO_D = 2 };
+
+constexpr size_t kBlock = 128;
+
+inline size_t align4(size_t x) { return ((x + 3) / 4) * 4; }
+
+// Per-expert padded scale size (in floats), matching the grouped FP8 block-scaling layout that
+// the grouped quantize kernel writes and cuBLAS grouped GEMM consumes:
+//   1D rowwise : blocks_X   * roundup(M_t, 4)     (scale shape {blocks_X,   roundup(M_t, 4)})
+//   1D colwise : blocks_y_t * roundup(K, 4)       (scale shape {blocks_y_t, roundup(K, 4)})
+//   2D rowwise : blocks_y_t * roundup(blocks_X,4) (scale shape {blocks_y_t, roundup(blocks_X, 4)})
+//   2D colwise : blocks_X   * roundup(blocks_y_t,4)(scale shape {blocks_X,  roundup(blocks_y_t,4)})
+inline void per_expert_scale_shape(BlockDim block_dim, bool columnwise, size_t M_t, size_t K,
+                                   size_t& scale_y, size_t& scale_x) {
+  const size_t blocks_X = (K + kBlock - 1) / kBlock;
+  const size_t blocks_y = (M_t + kBlock - 1) / kBlock;
+  if (block_dim == BlockDim::ONE_D) {
+    if (!columnwise) {
+      scale_y = blocks_X;
+      scale_x = align4(M_t);
+    } else {
+      scale_y = blocks_y;
+      scale_x = align4(K);
+    }
+  } else {
+    if (!columnwise) {
+      scale_y = blocks_y;
+      scale_x = align4(blocks_X);
+    } else {
+      scale_y = blocks_X;
+      scale_x = align4(blocks_y);
+    }
+  }
+}
+
+inline size_t per_expert_scale_floats(BlockDim block_dim, bool columnwise, size_t M_t, size_t K) {
+  size_t y, x;
+  per_expert_scale_shape(block_dim, columnwise, M_t, K, y, x);
+  return y * x;
+}
+
+// Grouped FP8 block-scaling dequantize test.
+//
+// Methodology mirrors test_dequantize_mxfp8_grouped.cu: the grouped dequantize kernel is
+// validated against single-tensor nvte_dequantize called in a loop for each tensor; results must
+// be bitwise identical. We generate random FP8 data and random FP32 scales laid out in the
+// grouped per-expert format, run nvte_group_dequantize, and for each expert slice out its data +
+// scale sub-block, feed it to a per-tensor (direction-only) dequantize, and compare.
+template <typename InputType, typename OutputType>
+void performTest(ShapeRep shape_rep, BlockDim block_dim, bool rowwise,
+                 const std::vector<size_t>& first_dims_h, size_t K) {
+  // FP8 block-scaling grouped kernels are Hopper-only (SM90-SM99).
+  if (getDeviceComputeCapability() < hopperComputeCapability ||
+      getDeviceComputeCapability() >= blackwellComputeCapability) {
+    GTEST_SKIP();
+  }
+
+  const DType itype = TypeInfo<InputType>::dtype;
+  const DType otype = TypeInfo<OutputType>::dtype;
+  const bool columnwise = !rowwise;
+
+  const size_t num_tensors = first_dims_h.size();
+  size_t R_total = 0;
+  for (size_t m : first_dims_h) {
+    ASSERT_EQ(m % kBlock, 0u) << "Per-tensor first dim must be a multiple of 128";
+    R_total += m;
+  }
+  ASSERT_EQ(K % 16u, 0u);
+
+  const NVTEScalingMode mode =
+      (block_dim == BlockDim::ONE_D) ? NVTE_BLOCK_SCALING_1D : NVTE_BLOCK_SCALING_2D;
+
+  // Element offsets (both data and, for columnwise, the transposed (K, M_t) block are contiguous
+  // per expert at element offset row_offset * K).
+  std::vector<int64_t> offsets_h(num_tensors + 1, 0);
+  for (size_t t = 0; t < num_tensors; ++t)
+    offsets_h[t + 1] = offsets_h[t] + static_cast<int64_t>(first_dims_h[t] * K);
+  std::vector<int64_t> first_dims_i64(num_tensors);
+  for (size_t t = 0; t < num_tensors; ++t)
+    first_dims_i64[t] = static_cast<int64_t>(first_dims_h[t]);
+
+  // Per-expert scale sub-block offsets (in floats).
+  std::vector<size_t> scale_off(num_tensors + 1, 0);
+  for (size_t t = 0; t < num_tensors; ++t)
+    scale_off[t + 1] =
+        scale_off[t] + per_expert_scale_floats(block_dim, columnwise, first_dims_h[t], K);
+  const size_t total_scales = scale_off[num_tensors];
+
+  // ---- Random FP8 data (valid normals) + random FP32 scales ----
+  std::mt19937 gen(0xD3C0DEu);
+  const double minAbs = Numeric_Traits<InputType>::minNorm;
+  const double maxAbs = Numeric_Traits<InputType>::maxNorm;
+  std::uniform_real_distribution<> dis(minAbs, maxAbs);
+  std::uniform_real_distribution<> dis_sign(-1.0, 1.0);
+  std::uniform_real_distribution<float> scale_dis(0.25f, 4.0f);
+
+  std::vector<InputType> data_h(R_total * K);
+  for (auto& v : data_h) {
+    double val = dis(gen);
+    if (dis_sign(gen) < 0.0) val = -val;
+    v = static_cast<InputType>(val);
+  }
+  std::vector<float> scales_h(total_scales);
+  for (auto& s : scales_h) s = scale_dis(gen);
+
+  // ---- Device buffers ----
+  InputType* data_d = nullptr;
+  float* scales_d = nullptr;
+  OutputType* out_grouped_d = nullptr;
+  int64_t* offsets_d = nullptr;
+  int64_t* first_dims_d = nullptr;
+
+  cudaMalloc(&data_d, R_total * K * sizeof(InputType));
+  cudaMemcpy(data_d, data_h.data(), R_total * K * sizeof(InputType), cudaMemcpyHostToDevice);
+  cudaMalloc(&scales_d, total_scales * sizeof(float));
+  cudaMemcpy(scales_d, scales_h.data(), total_scales * sizeof(float), cudaMemcpyHostToDevice);
+  cudaMalloc(&out_grouped_d, R_total * K * sizeof(OutputType));
+  cudaMemset(out_grouped_d, 0, R_total * K * sizeof(OutputType));
+  cudaMalloc(&offsets_d, (num_tensors + 1) * sizeof(int64_t));
+  cudaMemcpy(offsets_d, offsets_h.data(), (num_tensors + 1) * sizeof(int64_t),
+             cudaMemcpyHostToDevice);
+  if (shape_rep == ShapeRep::VARYING_FIRST_DIM) {
+    cudaMalloc(&first_dims_d, num_tensors * sizeof(int64_t));
+    cudaMemcpy(first_dims_d, first_dims_i64.data(), num_tensors * sizeof(int64_t),
+               cudaMemcpyHostToDevice);
+  }
+
+  // ---- Build grouped input (quantized) + output (high precision) tensors ----
+  std::vector<size_t> logical_shape_vec = {R_total, K};
+  NVTEShape logical_shape = nvte_make_shape(logical_shape_vec.data(), logical_shape_vec.size());
+  std::vector<size_t> data_1d = {R_total * K};
+  NVTEShape data_shape = nvte_make_shape(data_1d.data(), data_1d.size());
+  std::vector<size_t> scale_1d = {total_scales};
+  NVTEShape scale_shape = nvte_make_shape(scale_1d.data(), scale_1d.size());
+
+  NVTEShape offsets_shape;
+  offsets_shape.ndim = 1;
+  offsets_shape.data[0] = num_tensors + 1;
+  NVTEShape first_dims_shape;
+  first_dims_shape.ndim = 1;
+  first_dims_shape.data[0] = num_tensors;
+  NVTEBasicTensor offsets_bt = {offsets_d, kNVTEInt64, offsets_shape};
+  NVTEBasicTensor first_dims_bt = {first_dims_d, kNVTEInt64, first_dims_shape};
+  auto set_shape_meta = [&](NVTEGroupedTensor gt) {
+    if (shape_rep == ShapeRep::VARYING_FIRST_DIM) {
+      nvte_set_grouped_tensor_param(gt, kNVTEGroupedFirstDims, &first_dims_bt,
+                                    sizeof(first_dims_bt));
+      nvte_set_grouped_tensor_param(gt, kNVTEGroupedTensorOffsets, &offsets_bt, sizeof(offsets_bt));
+    }
+  };
+
+  NVTEGroupedTensor in_gt = nvte_create_grouped_tensor(mode, num_tensors, logical_shape);
+  NVTEBasicTensor in_data_bt = {data_d, static_cast<NVTEDType>(itype), data_shape};
+  NVTEBasicTensor in_scale_bt = {scales_d, kNVTEFloat32, scale_shape};
+  if (rowwise) {
+    nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedRowwiseData, &in_data_bt, sizeof(in_data_bt));
+    nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedRowwiseScaleInv, &in_scale_bt,
+                                  sizeof(in_scale_bt));
+  } else {
+    nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedColumnwiseData, &in_data_bt,
+                                  sizeof(in_data_bt));
+    nvte_set_grouped_tensor_param(in_gt, kNVTEGroupedColumnwiseScaleInv, &in_scale_bt,
+                                  sizeof(in_scale_bt));
+  }
+  set_shape_meta(in_gt);
+
+  NVTEGroupedTensor out_gt =
+      nvte_create_grouped_tensor(NVTE_DELAYED_TENSOR_SCALING, num_tensors, logical_shape);
+  NVTEBasicTensor out_data_bt = {out_grouped_d, static_cast<NVTEDType>(otype), data_shape};
+  nvte_set_grouped_tensor_param(out_gt, kNVTEGroupedRowwiseData, &out_data_bt, sizeof(out_data_bt));
+  set_shape_meta(out_gt);
+
+  // ---- Grouped dequantize ----
+  nvte_group_dequantize(in_gt, out_gt, 0);
+  cudaDeviceSynchronize();
+  {
+    auto err = cudaGetLastError();
+    ASSERT_EQ(err, cudaSuccess) << cudaGetErrorString(err);
+  }
+  std::vector<OutputType> out_grouped_h(R_total * K);
+  cudaMemcpy(out_grouped_h.data(), out_grouped_d, R_total * K * sizeof(OutputType),
+             cudaMemcpyDeviceToHost);
+
+  // ---- Reference: host dequantize (out = float(fp8) * scale_inv) ----
+  //
+  // There is no non-grouped FP8 block-scaling dequantize to loop over (only the grouped path
+  // implements it), so the reference is computed on the host. The per-expert scale sub-block
+  // indexing mirrors what test_cast_float8blockwise_grouped.cu validates the grouped quantize
+  // kernel writes; this makes the host reference an independent check of the grouped dequant.
+  //   1D rowwise : scale[bx * roundup(M,4) + r]       (bx = c/128)
+  //   1D colwise : scale[by * roundup(K,4) + c]       (by = r/128)
+  //   2D rowwise : scale[by * roundup(blocks_X,4) + bx]
+  //   2D colwise : scale[bx * roundup(blocks_y,4) + by]
+  // Data is contiguous (M,K) for rowwise and transposed (K,M) for columnwise.
+  auto scale_index = [&](size_t r, size_t c, size_t M) -> size_t {
+    const size_t blocks_X = (K + kBlock - 1) / kBlock;
+    const size_t blocks_y = (M + kBlock - 1) / kBlock;
+    const size_t bx = c / kBlock;
+    const size_t by = r / kBlock;
+    if (block_dim == BlockDim::ONE_D) {
+      return columnwise ? (by * align4(K) + c) : (bx * align4(M) + r);
+    }
+    return columnwise ? (bx * align4(blocks_y) + by) : (by * align4(blocks_X) + bx);
+  };
+
+  for (size_t t = 0; t < num_tensors; ++t) {
+    const size_t M = first_dims_h[t];
+    const size_t row_offset = static_cast<size_t>(offsets_h[t]) / K;
+    const size_t data_off = row_offset * K;  // rowwise (M,K) or colwise transposed (K,M)
+    const size_t s_off = scale_off[t];
+    for (size_t r = 0; r < M; ++r) {
+      for (size_t c = 0; c < K; ++c) {
+        const size_t d_idx = columnwise ? (c * M + r) : (r * K + c);
+        const float fp8v = static_cast<float>(data_h[data_off + d_idx]);
+        const float sc = scales_h[s_off + scale_index(r, c, M)];
+        const float ref = fp8v * sc;
+        const float got = static_cast<float>(out_grouped_h[(row_offset + r) * K + c]);
+        const float rel = std::fabs(got - ref) / std::max(std::fabs(ref), 1e-3f);
+        ASSERT_LT(rel, 1e-2f) << "dequant mismatch t=" << t << " r=" << r << " c=" << c
+                              << " got=" << got << " ref=" << ref << " (fp8=" << fp8v
+                              << " scale=" << sc << ")";
+      }
+    }
+  }
+
+  nvte_destroy_grouped_tensor(in_gt);
+  nvte_destroy_grouped_tensor(out_gt);
+  cudaFree(data_d);
+  cudaFree(scales_d);
+  cudaFree(out_grouped_d);
+  cudaFree(offsets_d);
+  if (first_dims_d) cudaFree(first_dims_d);
+}
+
+struct TestConfig {
+  ShapeRep shape_rep;
+  BlockDim block_dim;
+  bool rowwise;
+  std::vector<size_t> first_dims;
+  size_t K;
+};
+
+std::vector<TestConfig> make_configs() {
+  std::vector<TestConfig> configs;
+  std::vector<std::vector<size_t>> uniform = {{128, 128}, {256, 256, 256, 256}};
+  std::vector<std::vector<size_t>> jagged = {{128, 256, 384, 512}, {256, 128, 512, 384, 1024}};
+  std::vector<size_t> Ks = {128, 256, 512};
+  for (auto bd : {BlockDim::ONE_D, BlockDim::TWO_D}) {
+    for (bool rowwise : {true, false}) {
+      for (size_t K : Ks) {
+        for (const auto& v : uniform)
+          configs.push_back({ShapeRep::SAME_BOTH_DIMS, bd, rowwise, v, K});
+        for (const auto& v : jagged)
+          configs.push_back({ShapeRep::VARYING_FIRST_DIM, bd, rowwise, v, K});
+      }
+    }
+  }
+  return configs;
+}
+
+}  // namespace
+
+class GroupedDequantizeFP8BlockwiseTestSuite
+    : public ::testing::TestWithParam<std::tuple<TestConfig, transformer_engine::DType>> {};
+
+TEST_P(GroupedDequantizeFP8BlockwiseTestSuite, Test) {
+  const TestConfig cfg = std::get<0>(GetParam());
+  const DType output_type = std::get<1>(GetParam());
+  // FP8 block scaling is E4M3-centric (matches the grouped quantize test scope).
+  TRANSFORMER_ENGINE_TYPE_SWITCH_FP16_FP32_ONLY(
+      output_type, OutputType,
+      performTest<fp8e4m3, OutputType>(cfg.shape_rep, cfg.block_dim, cfg.rowwise, cfg.first_dims,
+                                       cfg.K););
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    GroupedFP8Blockwise, GroupedDequantizeFP8BlockwiseTestSuite,
+    ::testing::Combine(::testing::ValuesIn(make_configs()),
+                       ::testing::Values(DType::kFloat32, DType::kBFloat16, DType::kFloat16)),
+    [](const testing::TestParamInfo<GroupedDequantizeFP8BlockwiseTestSuite::ParamType>& info) {
+      const TestConfig& c = std::get<0>(info.param);
+      std::string s = (c.shape_rep == ShapeRep::SAME_BOTH_DIMS ? "SAME" : "VARYFIRST");
+      s += "_BD" + std::to_string(static_cast<int>(c.block_dim));
+      s += (c.rowwise ? "_RW" : "_CW");
+      s += "_K" + std::to_string(c.K) + "_N" + std::to_string(c.first_dims.size());
+      s += "_" + test::typeName(std::get<1>(info.param));
+      return s;
+    });

--- a/tests/cpp/operator/test_grouped_gemm.cu
+++ b/tests/cpp/operator/test_grouped_gemm.cu
@@ -385,6 +385,36 @@ inline AlphaBetaTensors make_alpha_beta(size_t num_gemms) {
 
 // Compare each tensor inside a grouped D buffer (with per-tensor offsets) against the
 // reference D_multi[i] tensors.
+// Capture `body(stream)` into a CUDA graph and replay it `n_replays` times, calling
+// `verify(iter)` after each launch+sync. Used to assert that the grouped GEMM kernels
+// are graph-safe (capture succeeds, replay is correct, and replays are deterministic).
+template <typename Body, typename Verify>
+inline void capture_and_replay_grouped_gemm(cudaStream_t stream, int n_replays,
+                                            Body&& body, Verify&& verify) {
+  // Warmup off-graph so cuBLASLt can initialize its internal heuristic / handle state
+  // outside capture (the very first matmul on a handle may do host-side setup that
+  // isn't capturable in some cuBLAS versions).
+  body(stream);
+  NVTE_CHECK_CUDA(cudaStreamSynchronize(stream));
+
+  NVTE_CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  body(stream);
+  cudaGraph_t graph;
+  NVTE_CHECK_CUDA(cudaStreamEndCapture(stream, &graph));
+
+  cudaGraphExec_t exec;
+  NVTE_CHECK_CUDA(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  for (int i = 0; i < n_replays; ++i) {
+    NVTE_CHECK_CUDA(cudaGraphLaunch(exec, stream));
+    NVTE_CHECK_CUDA(cudaStreamSynchronize(stream));
+    verify(i);
+  }
+
+  NVTE_CHECK_CUDA(cudaGraphExecDestroy(exec));
+  NVTE_CHECK_CUDA(cudaGraphDestroy(graph));
+}
+
 inline void compare_grouped_d_to_multi(
     const GroupedBuffers& grouped_D,
     const std::vector<std::tuple<size_t, size_t, size_t>>& shapes,
@@ -649,6 +679,255 @@ void run_grouped_gemm_discrete_in_case(const TestParams& params) {
   compare_grouped_d_to_multi(grouped_D, shapes, ref.D_multi, "grouped_discrete_in_vs_multi");
 }
 
+// Graph-capture variant of run_grouped_gemm_case. Captures nvte_grouped_gemm on a
+// non-default stream and replays it twice, verifying outputs against the multi-tensor
+// reference after each replay. Asserts capture succeeds, replay is correct, and the
+// operation is deterministic across replays.
+void run_grouped_gemm_graph_case(const TestParams& params) {
+  if (auto reason = grouped_gemm_skip_reason(params); !reason.empty()) {
+    GTEST_SKIP() << reason;
+  }
+  auto ref = make_grouped_gemm_ref(params);
+  const auto& shapes = ref.shapes;
+  const size_t num_gemms = ref.num_gemms;
+
+  std::vector<Tensor*> A_views, B_views;
+  A_views.reserve(num_gemms);
+  B_views.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) {
+    A_views.push_back(&ref.A_tensors[i]);
+    B_views.push_back(&ref.B_tensors[i]);
+  }
+  GroupedBuffers grouped_A = build_grouped_tensor(A_views, ref.A_tensors[0].scaling_mode());
+  GroupedBuffers grouped_B = build_grouped_tensor(B_views, ref.B_tensors[0].scaling_mode());
+
+  std::vector<Tensor> C_tensors, D_group_tensors;
+  C_tensors.reserve(num_gemms);
+  D_group_tensors.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) {
+    const auto [M, N, K] = shapes[i];
+    (void)K;
+    if (!params.use_null_c) {
+      C_tensors.emplace_back(
+          Tensor("C" + std::to_string(i), std::vector<size_t>{M, N}, params.output_dtype));
+    }
+    D_group_tensors.emplace_back(
+        Tensor("D_group" + std::to_string(i), std::vector<size_t>{M, N}, params.output_dtype));
+  }
+
+  std::vector<Tensor*> C_views, D_views;
+  for (size_t i = 0; i < num_gemms; ++i) {
+    if (!params.use_null_c) C_views.push_back(&C_tensors[i]);
+    D_views.push_back(&D_group_tensors[i]);
+  }
+
+  std::optional<GroupedBuffers> grouped_C;
+  if (!params.use_null_c) {
+    grouped_C = build_grouped_tensor(C_views, NVTE_DELAYED_TENSOR_SCALING);
+  }
+  GroupedBuffers grouped_D = build_grouped_tensor(D_views, NVTE_DELAYED_TENSOR_SCALING);
+
+  AlphaBetaTensors ab = make_alpha_beta(num_gemms);
+  const size_t setup_ws_bytes = nvte_get_grouped_gemm_setup_workspace_size(num_gemms);
+  Tensor setup_ws("setup_ws", std::vector<size_t>{setup_ws_bytes}, DType::kByte);
+  Tensor cublas_ws("cublas_ws", std::vector<size_t>{kCublasWorkspaceBytes}, DType::kByte);
+  GroupedMatmulConfigWrapper grouped_config;
+  if (ref.use_split_accum) grouped_config.set_use_split_accumulator(true);
+
+  cudaStream_t stream;
+  NVTE_CHECK_CUDA(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  auto body = [&](cudaStream_t s) {
+    for (auto& d : D_group_tensors) {
+      NVTE_CHECK_CUDA(cudaMemsetAsync(d.rowwise_dptr(), 0,
+                                      bytes(d.rowwise_shape(), d.dtype()), s));
+    }
+    nvte_grouped_gemm(grouped_A.get_handle(), params.transa, grouped_B.get_handle(),
+                      params.transb,
+                      params.use_null_c ? nullptr : grouped_C->get_handle(),
+                      grouped_D.get_handle(), ab.alpha.data(), ab.beta.data(),
+                      setup_ws.data(), cublas_ws.data(), grouped_config, s);
+  };
+
+  capture_and_replay_grouped_gemm(
+      stream, /*n_replays=*/2, body,
+      [&](int iter) {
+        const std::string tag = "grouped_graph_replay_" + std::to_string(iter);
+        compare_grouped_d_to_multi(grouped_D, shapes, ref.D_multi, tag.c_str());
+      });
+
+  NVTE_CHECK_CUDA(cudaStreamDestroy(stream));
+}
+
+// Graph-capture variant of run_grouped_gemm_discrete_out_case.
+void run_grouped_gemm_discrete_out_graph_case(const TestParams& params) {
+  if (auto reason = grouped_gemm_skip_reason(params); !reason.empty()) {
+    GTEST_SKIP() << reason;
+  }
+  auto ref = make_grouped_gemm_ref(params);
+  const auto& shapes = ref.shapes;
+  const size_t num_gemms = ref.num_gemms;
+
+  std::vector<Tensor*> A_views, B_views;
+  A_views.reserve(num_gemms);
+  B_views.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) {
+    A_views.push_back(&ref.A_tensors[i]);
+    B_views.push_back(&ref.B_tensors[i]);
+  }
+  GroupedBuffers grouped_A = build_grouped_tensor(A_views, ref.A_tensors[0].scaling_mode());
+  GroupedBuffers grouped_B = build_grouped_tensor(B_views, ref.B_tensors[0].scaling_mode());
+
+  std::vector<Tensor> C_tensors, D_list_tensors;
+  C_tensors.reserve(num_gemms);
+  D_list_tensors.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) {
+    const auto [M, N, K] = shapes[i];
+    (void)K;
+    if (!params.use_null_c) {
+      C_tensors.emplace_back(
+          Tensor("C" + std::to_string(i), std::vector<size_t>{M, N}, params.output_dtype));
+    }
+    D_list_tensors.emplace_back(
+        Tensor("D_list" + std::to_string(i), std::vector<size_t>{M, N}, params.output_dtype));
+  }
+
+  std::vector<NVTETensor> C_list_ptrs, D_list_ptrs;
+  if (!params.use_null_c) C_list_ptrs.reserve(num_gemms);
+  D_list_ptrs.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) {
+    if (!params.use_null_c) C_list_ptrs.push_back(C_tensors[i].data());
+    D_list_ptrs.push_back(D_list_tensors[i].data());
+  }
+
+  AlphaBetaTensors ab = make_alpha_beta(num_gemms);
+  const size_t setup_ws_bytes = nvte_get_grouped_gemm_setup_workspace_size(num_gemms);
+  Tensor setup_ws("setup_ws", std::vector<size_t>{setup_ws_bytes}, DType::kByte);
+  Tensor cublas_ws("cublas_ws", std::vector<size_t>{kCublasWorkspaceBytes}, DType::kByte);
+  GroupedMatmulConfigWrapper grouped_config;
+  if (ref.use_split_accum) grouped_config.set_use_split_accumulator(true);
+
+  cudaStream_t stream;
+  NVTE_CHECK_CUDA(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  auto body = [&](cudaStream_t s) {
+    for (auto& d : D_list_tensors) {
+      NVTE_CHECK_CUDA(cudaMemsetAsync(d.rowwise_dptr(), 0,
+                                      bytes(d.rowwise_shape(), d.dtype()), s));
+    }
+    nvte_grouped_gemm_with_discrete_out(
+        grouped_A.get_handle(), params.transa, grouped_B.get_handle(), params.transb,
+        params.use_null_c ? nullptr : C_list_ptrs.data(),
+        params.use_null_c ? 0 : num_gemms, D_list_ptrs.data(), num_gemms, ab.alpha.data(),
+        ab.beta.data(), setup_ws.data(), cublas_ws.data(), grouped_config, s);
+  };
+
+  auto verify = [&](int iter) {
+    const std::string tag = "discrete_out_graph_replay_" + std::to_string(iter);
+    for (size_t i = 0; i < num_gemms; ++i) {
+      D_list_tensors[i].to_cpu();
+      ref.D_multi[i].to_cpu();
+      auto [atol, rtol] = getTolerances(ref.D_multi[i].dtype());
+      switch (ref.D_multi[i].dtype()) {
+        case DType::kBFloat16:
+          compareResults(tag.c_str(), D_list_tensors[i],
+                         ref.D_multi[i].rowwise_cpu_dptr<bf16>(), true, atol, rtol);
+          break;
+        case DType::kFloat16:
+          compareResults(tag.c_str(), D_list_tensors[i],
+                         ref.D_multi[i].rowwise_cpu_dptr<fp16>(), true, atol, rtol);
+          break;
+        case DType::kFloat32:
+          compareResults(tag.c_str(), D_list_tensors[i],
+                         ref.D_multi[i].rowwise_cpu_dptr<float>(), true, atol, rtol);
+          break;
+        default:
+          NVTE_ERROR("Unsupported D dtype in test: " +
+                     std::to_string(static_cast<int>(ref.D_multi[i].dtype())));
+      }
+    }
+  };
+
+  capture_and_replay_grouped_gemm(stream, /*n_replays=*/2, body, verify);
+  NVTE_CHECK_CUDA(cudaStreamDestroy(stream));
+}
+
+// Graph-capture variant of run_grouped_gemm_discrete_in_case.
+void run_grouped_gemm_discrete_in_graph_case(const TestParams& params) {
+  if (auto reason = grouped_gemm_skip_reason(params); !reason.empty()) {
+    GTEST_SKIP() << reason;
+  }
+  auto ref = make_grouped_gemm_ref(params);
+  const auto& shapes = ref.shapes;
+  const size_t num_gemms = ref.num_gemms;
+
+  std::vector<Tensor*> B_views;
+  B_views.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) B_views.push_back(&ref.B_tensors[i]);
+  GroupedBuffers grouped_B = build_grouped_tensor(B_views, ref.B_tensors[0].scaling_mode());
+
+  std::vector<Tensor> C_tensors, D_group_tensors;
+  C_tensors.reserve(num_gemms);
+  D_group_tensors.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) {
+    const auto [M, N, K] = shapes[i];
+    (void)K;
+    if (!params.use_null_c) {
+      C_tensors.emplace_back(Tensor("C" + std::to_string(i),
+                                    std::vector<size_t>{M, N}, params.output_dtype));
+    }
+    D_group_tensors.emplace_back(Tensor("D_group" + std::to_string(i),
+                                        std::vector<size_t>{M, N}, params.output_dtype));
+  }
+
+  std::vector<Tensor*> C_views, D_views;
+  for (size_t i = 0; i < num_gemms; ++i) {
+    if (!params.use_null_c) C_views.push_back(&C_tensors[i]);
+    D_views.push_back(&D_group_tensors[i]);
+  }
+
+  std::optional<GroupedBuffers> grouped_C;
+  if (!params.use_null_c) {
+    grouped_C = build_grouped_tensor(C_views, NVTE_DELAYED_TENSOR_SCALING);
+  }
+  GroupedBuffers grouped_D = build_grouped_tensor(D_views, NVTE_DELAYED_TENSOR_SCALING);
+
+  AlphaBetaTensors ab = make_alpha_beta(num_gemms);
+  const size_t setup_ws_bytes = nvte_get_grouped_gemm_setup_workspace_size(num_gemms);
+  Tensor setup_ws("setup_ws", std::vector<size_t>{setup_ws_bytes}, DType::kByte);
+  Tensor cublas_ws("cublas_ws", std::vector<size_t>{kCublasWorkspaceBytes}, DType::kByte);
+
+  std::vector<NVTETensor> A_list_ptrs;
+  A_list_ptrs.reserve(num_gemms);
+  for (size_t i = 0; i < num_gemms; ++i) A_list_ptrs.push_back(ref.A_tensors[i].data());
+
+  GroupedMatmulConfigWrapper grouped_config;
+  if (ref.use_split_accum) grouped_config.set_use_split_accumulator(true);
+
+  cudaStream_t stream;
+  NVTE_CHECK_CUDA(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  auto body = [&](cudaStream_t s) {
+    for (auto& d : D_group_tensors) {
+      NVTE_CHECK_CUDA(cudaMemsetAsync(d.rowwise_dptr(), 0,
+                                      bytes(d.rowwise_shape(), d.dtype()), s));
+    }
+    nvte_grouped_gemm_with_discrete_inputA(
+        A_list_ptrs.data(), num_gemms, params.transa, grouped_B.get_handle(), params.transb,
+        params.use_null_c ? nullptr : grouped_C->get_handle(), grouped_D.get_handle(),
+        ab.alpha.data(), ab.beta.data(), setup_ws.data(), cublas_ws.data(), grouped_config, s);
+  };
+
+  capture_and_replay_grouped_gemm(
+      stream, /*n_replays=*/2, body,
+      [&](int iter) {
+        const std::string tag = "discrete_in_graph_replay_" + std::to_string(iter);
+        compare_grouped_d_to_multi(grouped_D, shapes, ref.D_multi, tag.c_str());
+      });
+
+  NVTE_CHECK_CUDA(cudaStreamDestroy(stream));
+}
+
 class GroupedGemmTest : public ::testing::TestWithParam<TestParams> {};
 
 TEST_P(GroupedGemmTest, CompareWithMultiTensorGemm) {
@@ -661,6 +940,18 @@ TEST_P(GroupedGemmTest, CompareWithMultiTensorGemmDiscreteOut) {
 
 TEST_P(GroupedGemmTest, CompareWithMultiTensorGemmDiscreteIn) {
   run_grouped_gemm_discrete_in_case(GetParam());
+}
+
+TEST_P(GroupedGemmTest, CudaGraphCapture) {
+  run_grouped_gemm_graph_case(GetParam());
+}
+
+TEST_P(GroupedGemmTest, CudaGraphCaptureDiscreteOut) {
+  run_grouped_gemm_discrete_out_graph_case(GetParam());
+}
+
+TEST_P(GroupedGemmTest, CudaGraphCaptureDiscreteIn) {
+  run_grouped_gemm_discrete_in_graph_case(GetParam());
 }
 
 std::string MakeGroupedGemmTestName(const testing::TestParamInfo<GroupedGemmTest::ParamType>& info) {

--- a/tests/pytorch/test_grouped_tensor.py
+++ b/tests/pytorch/test_grouped_tensor.py
@@ -33,6 +33,21 @@ fp8_block_scaling_available, reason_for_no_fp8_block_scaling = te.is_fp8_block_s
 mxfp8_available, reason_for_no_mxfp8 = te.is_mxfp8_available(return_reason=True)
 nvfp4_available, reason_for_no_nvfp4 = te.is_nvfp4_available(return_reason=True)
 
+# The fused grouped FP8 block-scaling quantize/dequantize kernels are Hopper-only: they gate on
+# SM90-SM99 (NVTE_CHECK(sm >= 90 && sm < 100)). FP8 block scaling is still reported "available" on
+# Blackwell (SM100+) for the emulated/non-grouped paths, so ``fp8_block_scaling_available`` alone
+# does not exclude SM100 — add the Hopper arch bound for the grouped tests.
+_device_cc = torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0)
+fp8_block_scaling_grouped_available = fp8_block_scaling_available and (9, 0) <= _device_cc < (10, 0)
+reason_for_no_fp8_block_scaling_grouped = (
+    reason_for_no_fp8_block_scaling
+    if not fp8_block_scaling_available
+    else (
+        "Fused grouped FP8 block-scaling quantize/dequantize is only supported on Hopper"
+        " (SM90-SM99)."
+    )
+)
+
 _quantization_params = [
     pytest.param(
         "fp8_delayed_scaling",
@@ -113,6 +128,33 @@ def _rowwise_offset_bytes(numel: int, quantization: str) -> int:
     if quantization == "nvfp4":
         return numel // 2
     return numel
+
+
+def _fp8bs_per_expert_scale_floats(
+    block_scaling_dim: int, columnwise: bool, m_t: int, k: int
+) -> int:
+    """Per-expert padded scale size (in floats) for grouped FP8 block-scaling.
+
+    Mirrors the per-expert sub-block layout that cuBLAS grouped GEMM consumes (and that the C++
+    test ``test_cast_float8blockwise_grouped.cu`` verifies against)::
+
+        1D rowwise : blocks_X   * roundup(M_t, 4)
+        1D colwise : blocks_y_t * roundup(K, 4)
+        2D rowwise : blocks_y_t * roundup(blocks_X, 4)
+        2D colwise : blocks_X   * roundup(blocks_y_t, 4)
+
+    The 2D columnwise roundup of each expert's block-rows to a multiple of 4 is the source of the
+    per-expert slack reserved in ``Float8BlockQuantizer.create_grouped_tensor``.
+    """
+
+    def align4(x: int) -> int:
+        return ((x + 3) // 4) * 4
+
+    blocks_x = (k + 127) // 128
+    blocks_y = (m_t + 127) // 128
+    if block_scaling_dim == 1:
+        return blocks_y * align4(k) if columnwise else blocks_x * align4(m_t)
+    return blocks_x * align4(blocks_y) if columnwise else blocks_y * align4(blocks_x)
 
 
 class TestGroupedTensor:
@@ -715,6 +757,54 @@ class TestGroupedTensor:
         if output_dbias:
             assert torch.allclose(static_dbias, expected_dbias)
 
+    @pytest.mark.parametrize("block_scaling_dim", [1, 2], ids=["1D", "2D"])
+    @pytest.mark.skipif(
+        not fp8_block_scaling_grouped_available, reason=reason_for_no_fp8_block_scaling_grouped
+    )
+    def test_group_quantize_fp8_blockwise_cudagraph_capturable(
+        self, block_scaling_dim: int
+    ) -> None:
+        """Ensure grouped FP8 block-scaling quantize is CUDA graph capturable (parity with MXFP8)."""
+        first_dims_host = [256, 128, 384]
+        num_tensors = len(first_dims_host)
+        hidden = 512
+        shape = [(r, hidden) for r in first_dims_host]
+        input_tensors = [torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in shape]
+        grouped_input = torch.cat(input_tensors, dim=0)
+        first_dims = torch.tensor(first_dims_host, dtype=torch.int64, device="cuda")
+
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            rowwise=True,
+            columnwise=False,
+            force_pow_2_scales=False,
+            amax_epsilon=0.0,
+            block_scaling_dim=block_scaling_dim,
+        )
+
+        torch.cuda.synchronize()
+        static_input = grouped_input.clone()
+        static_first_dims = first_dims.clone()
+
+        def _run(inp):
+            return tex.group_quantize(inp, quantizer, num_tensors, static_first_dims)
+
+        _ = _run(static_input)  # warmup allocator/kernels
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            static_output = _run(static_input)
+
+        # Replay with fresh input copied into the captured buffer.
+        static_input.copy_(torch.randn_like(grouped_input))
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected = _run(static_input)
+        assert torch.equal(static_output.rowwise_data, expected.rowwise_data)
+        assert torch.equal(static_output.scale_inv, expected.scale_inv)
+
     @pytest.mark.parametrize("mode", ["rowwise", "columnwise", "both"])
     @pytest.mark.parametrize(
         "shape_case",
@@ -914,6 +1004,117 @@ class TestGroupedTensor:
             expected = torch.cat(expected_columnwise)
             assert torch.equal(grouped_output.columnwise_data[: expected.numel()], expected)
 
+    @pytest.mark.parametrize("block_scaling_dim", [1, 2], ids=["1D", "2D"])
+    @pytest.mark.parametrize("shape_case", ["uniform", "varying_first"])
+    @pytest.mark.parametrize("direction", ["rowwise", "columnwise", "both"])
+    @pytest.mark.parametrize("output_dbias", [False, True])
+    @pytest.mark.skipif(
+        not fp8_block_scaling_grouped_available, reason=reason_for_no_fp8_block_scaling_grouped
+    )
+    def test_quantize_grouped_fp8_blockwise(
+        self, block_scaling_dim: int, shape_case: str, direction: str, output_dbias: bool
+    ) -> None:
+        """Test grouped FP8 block-scaling quantization against per-tensor quantization.
+
+        Covers rowwise, columnwise and both directions. Each expert's data sub-block (and, for
+        rowwise, its scale sub-block placed at the cumulative padded offset from
+        ``_fp8bs_per_expert_scale_floats``) is compared against an independent per-tensor reference
+        quantizer. The columnwise scale layout carries 2D padding plus the per-expert slack
+        reserved in ``Float8BlockQuantizer.create_grouped_tensor``; it is validated end to end by
+        ``test_group_dequantize_fp8_blockwise`` rather than by a fragile byte-compare here.
+
+        FP8 block-scaling supports only SAME_BOTH_DIMS (``uniform``) and VARYING_FIRST_DIM
+        (``varying_first``); ``varying_last``/``varying_both`` are rejected at the kernel level.
+        Per-tensor first dim must be a multiple of 128 (kernel tile size).
+        """
+        rowwise = direction in ("rowwise", "both")
+        columnwise = direction in ("columnwise", "both")
+
+        # dbias is the bias gradient (per-column input sum) emitted by the bgrad path, which
+        # requires rowwise output; the columnwise-only + dbias combination is not applicable.
+        if output_dbias and not rowwise:
+            pytest.skip("bgrad (dbias) requires rowwise output; columnwise-only does not apply.")
+
+        if shape_case == "uniform":
+            per_tensor_shapes = [(128, 512)] * 3
+            first_dims_host = None
+        else:  # varying_first
+            per_tensor_shapes = [(128, 512), (256, 512), (384, 512)]
+            first_dims_host = [s[0] for s in per_tensor_shapes]
+
+        num_tensors = len(per_tensor_shapes)
+
+        input_tensors = [
+            torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in per_tensor_shapes
+        ]
+        flat_buffer = torch.cat([t.reshape(-1) for t in input_tensors])
+        common_last = per_tensor_shapes[0][1]
+        grouped_input = flat_buffer.view(-1, common_last)
+
+        first_dims = (
+            torch.tensor(first_dims_host, dtype=torch.int64, device="cuda")
+            if first_dims_host is not None
+            else None
+        )
+
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            rowwise=rowwise,
+            columnwise=columnwise,
+            force_pow_2_scales=False,
+            amax_epsilon=0.0,
+            block_scaling_dim=block_scaling_dim,
+        )
+
+        if output_dbias:
+            grouped_output, dbias = tex.bgrad_group_quantize(
+                grouped_input, quantizer, num_tensors, first_dims
+            )
+        else:
+            grouped_output = tex.group_quantize(grouped_input, quantizer, num_tensors, first_dims)
+
+        # Compare each expert's sub-block against an independent per-tensor reference. The
+        # reference enables both directions: the non-grouped 2D kernel requires rowwise output to
+        # be allocated even when only columnwise is consumed, and the columnwise data/scale it
+        # emits are independent of whether rowwise is also computed.
+        ref_quantizer = Float8BlockQuantizer(
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            rowwise=True,
+            columnwise=True,
+            force_pow_2_scales=False,
+            amax_epsilon=0.0,
+            block_scaling_dim=block_scaling_dim,
+        )
+        # Data sub-blocks are contiguous (rowwise (M_t, K) / columnwise transposed (K, M_t)) with
+        # no inter-expert padding. The rowwise scale sub-block is placed at the cumulative
+        # per-expert padded offset, so a wrong stride fails byte-equality here. The columnwise
+        # scale carries 2D ``roundup(blocks_y_t, 4)`` padding columns (and the per-expert slack),
+        # so its layout is validated end to end by ``test_group_dequantize_fp8_blockwise`` instead.
+        data_off = 0
+        rw_scale_off = 0
+        for tensor in input_tensors:
+            m_t, k = tensor.shape
+            numel = m_t * k
+            ref = ref_quantizer(tensor)
+            if rowwise:
+                ref_rw = ref._rowwise_data.reshape(-1)
+                assert torch.equal(grouped_output.rowwise_data[data_off : data_off + numel], ref_rw)
+                ref_rs = ref._rowwise_scale_inv.reshape(-1)
+                assert torch.equal(
+                    grouped_output.scale_inv[rw_scale_off : rw_scale_off + ref_rs.numel()], ref_rs
+                )
+                rw_scale_off += _fp8bs_per_expert_scale_floats(block_scaling_dim, False, m_t, k)
+            if columnwise:
+                ref_cw = ref._columnwise_data.reshape(-1)
+                assert torch.equal(
+                    grouped_output.columnwise_data[data_off : data_off + numel], ref_cw
+                )
+            data_off += numel
+
+        if output_dbias:
+            expected_dbias = torch.stack([t.sum(dim=0) for t in input_tensors])
+            assert torch.allclose(dbias, expected_dbias)
+
     @pytest.mark.parametrize(
         "shape",
         [[(512, 1024), (512, 1024)], [(256, 512), (512, 512), (768, 512)]],
@@ -994,6 +1195,115 @@ class TestGroupedTensor:
         static_tensors = static_output.split_into_quantized_tensors()
         for exp, got in zip(expected_tensors, static_tensors):
             assert torch.equal(got, exp)
+
+    @pytest.mark.parametrize("block_scaling_dim", [1, 2], ids=["1D", "2D"])
+    @pytest.mark.parametrize("direction", ["rowwise", "columnwise"])
+    @pytest.mark.skipif(
+        not fp8_block_scaling_grouped_available, reason=reason_for_no_fp8_block_scaling_grouped
+    )
+    def test_group_dequantize_fp8_blockwise_cudagraph_capturable(
+        self, block_scaling_dim: int, direction: str
+    ) -> None:
+        """Ensure grouped FP8 block-scaling dequantize is CUDA graph capturable (parity with MXFP8)."""
+        rowwise = direction == "rowwise"
+        columnwise = direction == "columnwise"
+        num_tensors = 2
+        shape = [(512, 1024) for _ in range(num_tensors)]
+        input_tensors = [torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in shape]
+        grouped_input = torch.cat(input_tensors, dim=0)
+
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            rowwise=rowwise,
+            columnwise=columnwise,
+            force_pow_2_scales=False,
+            amax_epsilon=0.0,
+            block_scaling_dim=block_scaling_dim,
+        )
+        first_dims = torch.tensor(
+            [shape[0][0] for _ in range(num_tensors)], dtype=torch.int64, device="cuda"
+        )
+
+        quantized = tex.group_quantize(grouped_input, quantizer, num_tensors, first_dims)
+
+        # Warmup dequantize.
+        torch.cuda.synchronize()
+        _ = tex.group_dequantize(quantized, te.DType.kBFloat16)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            static_output = tex.group_dequantize(quantized, te.DType.kBFloat16)
+
+        # Replay with fresh quantized data copied into the captured input buffers.
+        fresh_input = torch.cat(
+            [torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in shape], dim=0
+        )
+        fresh_quantized = tex.group_quantize(fresh_input, quantizer, num_tensors, first_dims)
+        if rowwise:
+            quantized.rowwise_data.copy_(fresh_quantized.rowwise_data)
+            quantized.scale_inv.copy_(fresh_quantized.scale_inv)
+        else:
+            quantized.columnwise_data.copy_(fresh_quantized.columnwise_data)
+            quantized.columnwise_scale_inv.copy_(fresh_quantized.columnwise_scale_inv)
+
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected = tex.group_dequantize(quantized, te.DType.kBFloat16)
+        expected_tensors = expected.split_into_quantized_tensors()
+        static_tensors = static_output.split_into_quantized_tensors()
+        for exp, got in zip(expected_tensors, static_tensors):
+            assert torch.equal(got, exp)
+
+    @pytest.mark.parametrize("block_scaling_dim", [1, 2], ids=["1D", "2D"])
+    @pytest.mark.parametrize("direction", ["rowwise", "columnwise"])
+    @pytest.mark.parametrize(
+        "shape",
+        [[(512, 1024), (512, 1024)], [(128, 512), (256, 512), (384, 512)]],
+    )
+    @pytest.mark.skipif(
+        not fp8_block_scaling_grouped_available, reason=reason_for_no_fp8_block_scaling_grouped
+    )
+    def test_group_dequantize_fp8_blockwise(
+        self, block_scaling_dim: int, direction: str, shape: List[Tuple[int, int]]
+    ) -> None:
+        """Test grouped FP8 block-scaling dequantize round-trip for rowwise and columnwise.
+
+        The columnwise + ``varying_first`` + 2D case exercises the per-expert columnwise
+        scale-buffer slack end to end: a wrong slack/stride would place scales at the wrong
+        offsets and corrupt the dequantized values. ``group_dequantize`` consumes exactly one of
+        rowwise / columnwise data, so ``both`` is not a valid round-trip and is not tested here.
+        """
+        rowwise = direction == "rowwise"
+        columnwise = direction == "columnwise"
+        num_tensors = len(shape)
+
+        input_tensors = [torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in shape]
+        grouped_input = torch.cat(input_tensors, dim=0)
+
+        quantizer = Float8BlockQuantizer(
+            fp8_dtype=tex.DType.kFloat8E4M3,
+            rowwise=rowwise,
+            columnwise=columnwise,
+            force_pow_2_scales=False,
+            amax_epsilon=0.0,
+            block_scaling_dim=block_scaling_dim,
+        )
+        first_dims = torch.tensor([s[0] for s in shape], dtype=torch.int64, device="cuda")
+
+        quantized = tex.group_quantize(grouped_input, quantizer, num_tensors, first_dims)
+        dequantized = tex.group_dequantize(quantized, te.DType.kBFloat16)
+
+        assert dequantized.num_tensors == num_tensors
+        assert dequantized.logical_shape == quantized.logical_shape
+        assert torch.equal(dequantized.first_dims, quantized.first_dims)
+        assert torch.equal(dequantized.tensor_offsets, quantized.tensor_offsets)
+
+        dequantized_tensors = dequantized.split_into_quantized_tensors()
+        assert len(dequantized_tensors) == num_tensors
+        for orig, deq in zip(input_tensors, dequantized_tensors):
+            torch.testing.assert_close(deq, orig, atol=0.125, rtol=0.1)
 
     def test_clear(self) -> None:
         """Test clear method"""

--- a/transformer_engine/common/cast/dispatch/dequantize.cuh
+++ b/transformer_engine/common/cast/dispatch/dequantize.cuh
@@ -15,6 +15,7 @@
 
 #include "../../common.h"
 #include "../fp8/dequantize_fp8.cuh"
+#include "../fp8_blockwise/group_dequantize_fp8_blockwise.cuh"
 #include "../mxfp8/dequantize_mxfp8.cuh"
 #include "../mxfp8/group_dequantize_mxfp8.cuh"
 #include "../nvfp4/dequantize_nvfp4.cuh"
@@ -67,6 +68,11 @@ inline void group_dequantize_helper(const GroupedTensor &input, GroupedTensor *o
       } else {
         NVTE_ERROR("MXFP8 Grouped Dequantization is NOT supported by architectures < 10.0");
       }
+      break;
+    }
+    case NVTE_BLOCK_SCALING_1D:
+    case NVTE_BLOCK_SCALING_2D: {
+      fp8_blockwise::group_dequantize(&input, output, stream);
       break;
     }
     default:

--- a/transformer_engine/common/cast/dispatch/quantize.cuh
+++ b/transformer_engine/common/cast/dispatch/quantize.cuh
@@ -19,6 +19,7 @@
 #include "../core/common.cuh"
 #include "../fp8/group_quantize_fp8.cuh"
 #include "../fp8/quantize_fp8.cuh"
+#include "../fp8_blockwise/group_quantize_fp8_blockwise.cuh"
 #include "../mxfp8/group_quantize_mxfp8.cuh"
 #include "../mxfp8/quantize_mxfp8.cuh"
 #include "../nvfp4/group_quantize_transpose_nvfp4.cuh"
@@ -472,6 +473,26 @@ void group_quantize_fwd_helper(const NVTEGroupedTensor input, NVTEGroupedTensor 
           workspace_tensor, &quant_config_cpp, stream);
       break;
     }
+    case NVTE_BLOCK_SCALING_1D: {
+      NVTE_CHECK(!IS_ACT, "IS_ACT is not implemented for grouped NVTE_BLOCK_SCALING_1D.");
+      NVTE_CHECK(!quant_config_cpp.force_pow_2_scales,
+                 "Fused grouped FP8 block-scaling quantize does not support "
+                 "force_pow_2_scales=True. Set force_pow_2_scales=False, or use the unfused "
+                 "split-quantize path (NVTE_GROUPED_LINEAR_USE_FUSED_GROUPED_GEMM=0).");
+      fp8_blockwise::group_quantize_blockwise_1d(input_tensor, output_tensor, noop_tensor,
+                                                 quant_config_cpp.amax_epsilon, stream);
+      break;
+    }
+    case NVTE_BLOCK_SCALING_2D: {
+      NVTE_CHECK(!IS_ACT, "IS_ACT is not implemented for grouped NVTE_BLOCK_SCALING_2D.");
+      NVTE_CHECK(!quant_config_cpp.force_pow_2_scales,
+                 "Fused grouped FP8 block-scaling quantize does not support "
+                 "force_pow_2_scales=True. Set force_pow_2_scales=False, or use the unfused "
+                 "split-quantize path (NVTE_GROUPED_LINEAR_USE_FUSED_GROUPED_GEMM=0).");
+      fp8_blockwise::group_quantize_blockwise_2d(input_tensor, output_tensor, noop_tensor,
+                                                 quant_config_cpp.amax_epsilon, stream);
+      break;
+    }
     default:
       NVTE_ERROR("Not implemented scaling mode: " + to_string(scaling_mode) + ".");
   }
@@ -511,6 +532,28 @@ void group_quantize_bwd_helper(const NVTEGroupedTensor grad, const NVTEGroupedTe
       mxfp8::group_quantize<IS_DBIAS, IS_DACT, /*IS_ACT=*/false, ParamOP, OP>(
           grad_tensor, input_tensor, noop_tensor, output_tensor, dbias_tensor, workspace_tensor,
           &quant_config_cpp, stream);
+      break;
+    }
+    case NVTE_BLOCK_SCALING_1D:
+    case NVTE_BLOCK_SCALING_2D: {
+      NVTE_CHECK(!IS_DACT, "IS_DACT is not implemented for grouped FP8 block scaling.");
+      NVTE_CHECK(!quant_config_cpp.force_pow_2_scales,
+                 "Fused grouped FP8 block-scaling quantize does not support "
+                 "force_pow_2_scales=True. Set force_pow_2_scales=False, or use the unfused "
+                 "split-quantize path (NVTE_GROUPED_LINEAR_USE_FUSED_GROUPED_GEMM=0).");
+      // dbias is computed in-kernel and reduced per-expert inside group_quantize_blockwise_{1d,2d}
+      // (mirrors MXFP8); those also handle the two-call workspace sizing protocol.
+      GroupedTensor *dbias_arg = IS_DBIAS ? dbias_tensor : nullptr;
+      Tensor *workspace_arg = IS_DBIAS ? workspace_tensor : nullptr;
+      if (scaling_mode == NVTE_BLOCK_SCALING_1D) {
+        fp8_blockwise::group_quantize_blockwise_1d(grad_tensor, output_tensor, noop_tensor,
+                                                   quant_config_cpp.amax_epsilon, stream, dbias_arg,
+                                                   workspace_arg);
+      } else {
+        fp8_blockwise::group_quantize_blockwise_2d(grad_tensor, output_tensor, noop_tensor,
+                                                   quant_config_cpp.amax_epsilon, stream, dbias_arg,
+                                                   workspace_arg);
+      }
       break;
     }
     default:

--- a/transformer_engine/common/cast/fp8_blockwise/group_dequantize_fp8_blockwise.cuh
+++ b/transformer_engine/common/cast/fp8_blockwise/group_dequantize_fp8_blockwise.cuh
@@ -1,0 +1,519 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+/*! \file group_dequantize_fp8_blockwise.cuh
+ *  \brief CUDA kernels to dequantize grouped tensors from FP8 with 1D/2D
+ *  block scaling (rowwise or columnwise) back to BF16 / FP16 / FP32. Mirrors
+ *  the per-expert layouts written by ``group_quantize_fp8_blockwise``.
+ */
+
+#ifndef TRANSFORMER_ENGINE_GROUP_DEQUANTIZE_FP8_BLOCKWISE_CUH_
+#define TRANSFORMER_ENGINE_GROUP_DEQUANTIZE_FP8_BLOCKWISE_CUH_
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <transformer_engine/transformer_engine.h>
+
+#include "../../common.h"
+#include "../../utils.cuh"
+#include "../core/common.cuh"
+#include "group_quantize_fp8_blockwise.cuh"
+
+namespace transformer_engine {
+namespace dispatch {
+namespace fp8_blockwise {
+
+namespace group_dequantize_kernel {
+
+// Resolve which expert a tile (blocks_X x total_row_blocks grid) belongs to and its row range.
+// tensor_M (the expert's first-dim length) addresses the per-expert (K, M_t) transposed block
+// in the columnwise modes.
+struct TileExpertInfo {
+  size_t tensor_id;
+  size_t tensor_block_y_base;
+  size_t tensor_row_blocks;
+  size_t tensor_row_base;
+  size_t tensor_M;
+  bool in_bounds;
+};
+
+template <bool kSameBothDims>
+__device__ __forceinline__ TileExpertInfo resolve_tile_expert(
+    size_t tile_y_global, size_t num_tensors, size_t common_first_dim_blocks, size_t K,
+    size_t total_row_blocks, const int64_t* __restrict__ tensor_offsets_ptr) {
+  TileExpertInfo info{};
+  info.in_bounds = false;
+  if (tile_y_global >= total_row_blocks) return info;
+  const size_t tile_row_stride = static_cast<size_t>(kTileDim) * K;
+  info.tensor_id = find_tensor_id_by_block_y<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+  info.tensor_block_y_base =
+      kSameBothDims
+          ? (info.tensor_id * common_first_dim_blocks)
+          : tensor_block_y_base_from_offsets(info.tensor_id, tensor_offsets_ptr, tile_row_stride);
+  info.tensor_row_blocks = kSameBothDims
+                               ? common_first_dim_blocks
+                               : (tensor_block_y_base_from_offsets(
+                                      info.tensor_id + 1, tensor_offsets_ptr, tile_row_stride) -
+                                  info.tensor_block_y_base);
+  if (tile_y_global >= info.tensor_block_y_base + info.tensor_row_blocks) return info;
+  info.tensor_row_base = info.tensor_block_y_base * kTileDim;
+  info.tensor_M = info.tensor_row_blocks * kTileDim;
+  info.in_bounds = true;
+  return info;
+}
+
+// ===== 1D rowwise =====
+// Per-expert scale layout: (blocks_X, roundup(M_t, 4)) floats.
+// scale[expert_off + tile_x * roundup(M_t, 4) + r_local]
+template <bool kSameBothDims, typename IType, typename OType, typename CType>
+__global__ void __launch_bounds__(kThreadsPerBlock)
+    group_dequantize_blockwise_1d_rw_kernel(const IType* __restrict__ input_base,
+                                            OType* __restrict__ output_base,
+                                            const CType* __restrict__ scale_inv_base,
+                                            const int64_t* __restrict__ tensor_offsets_ptr,
+                                            const size_t num_tensors,
+                                            const size_t common_first_dim_blocks, const size_t K,
+                                            const size_t total_row_blocks, const size_t R_total) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  const auto info = resolve_tile_expert<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, K, total_row_blocks, tensor_offsets_ptr);
+  if (!info.in_bounds) return;
+
+  const size_t blocks_X = DIVUP(K, static_cast<size_t>(kTileDim));
+  const size_t tile_row_stride = static_cast<size_t>(kTileDim) * K;
+  const size_t expert_offset = expert_scale_offset_1d_rowwise<kSameBothDims>(
+      info.tensor_id, blocks_X, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+  const size_t per_expert_stride = DIVUP_TO_MULTIPLE(info.tensor_M, kScaleColAlign);
+  const CType* const tile_scale_inv_base =
+      scale_inv_base + expert_offset + tile_x * per_expert_stride;
+
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  constexpr int kThreadsPerRow = 8;
+  constexpr int kVec = 16;
+  constexpr int kRowsPerIter = kThreadsPerBlock / kThreadsPerRow;  // 32
+  constexpr int kIters = kTileDim / kRowsPerIter;                  // 4
+
+  const int tid = threadIdx.x;
+  const int thr_col = tid % kThreadsPerRow;
+  const int thr_row = tid / kThreadsPerRow;
+  const size_t c = global_col_base + static_cast<size_t>(thr_col) * kVec;
+
+#pragma unroll
+  for (int it = 0; it < kIters; ++it) {
+    const int row_local = thr_row + it * kRowsPerIter;
+    const size_t r_global = global_row_base + row_local;
+    if (r_global >= R_total) continue;
+
+    const size_t r_local = r_global - info.tensor_row_base;
+    const CType s_inv = tile_scale_inv_base[r_local];
+
+    Vec<IType, kVec> in_vec;
+    if (c + kVec <= K) {
+      in_vec.load_from(input_base + r_global * K + c);
+    } else if (c < K) {
+      in_vec.load_from_elts(input_base + r_global * K + c, 0, K - c);
+    } else {
+      continue;
+    }
+
+    Vec<OType, kVec> out_vec;
+#pragma unroll
+    for (int e = 0; e < kVec; ++e) {
+      out_vec.data.elt[e] = static_cast<OType>(static_cast<float>(in_vec.data.elt[e]) * s_inv);
+    }
+
+    if (c + kVec <= K) {
+      out_vec.store_to(output_base + r_global * K + c);
+    } else if (c < K) {
+      out_vec.store_to_elts(output_base + r_global * K + c, 0, K - c);
+    }
+  }
+#endif
+}
+
+// ===== 1D columnwise =====
+// Data layout per-expert: (K, M_t) transposed -- element (r, c) is at
+//   input[tensor_row_base * K + c * tensor_M + r_local].
+// Scale layout GLOBAL: (total_row_blocks, roundup(K, 4)) floats.
+//   scale_inv[tile_y_global * scale_t_stride_aligned_K + c]
+template <bool kSameBothDims, typename IType, typename OType, typename CType>
+__global__ void __launch_bounds__(kThreadsPerBlock)
+    group_dequantize_blockwise_1d_cw_kernel(const IType* __restrict__ input_base,
+                                            OType* __restrict__ output_base,
+                                            const CType* __restrict__ scale_inv_base,
+                                            const size_t scale_t_stride_aligned_K,
+                                            const int64_t* __restrict__ tensor_offsets_ptr,
+                                            const size_t num_tensors,
+                                            const size_t common_first_dim_blocks, const size_t K,
+                                            const size_t total_row_blocks, const size_t R_total) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  const auto info = resolve_tile_expert<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, K, total_row_blocks, tensor_offsets_ptr);
+  if (!info.in_bounds) return;
+
+  const size_t expert_data_off = info.tensor_row_base * K;
+  const CType* const tile_scale_base = scale_inv_base + tile_y_global * scale_t_stride_aligned_K;
+
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  constexpr int kThreadsPerRow = 8;
+  constexpr int kVec = 16;
+  constexpr int kRowsPerIter = kThreadsPerBlock / kThreadsPerRow;
+  constexpr int kIters = kTileDim / kRowsPerIter;
+
+  const int tid = threadIdx.x;
+  const int thr_col = tid % kThreadsPerRow;
+  const int thr_row = tid / kThreadsPerRow;
+  const size_t c = global_col_base + static_cast<size_t>(thr_col) * kVec;
+
+  // 1D columnwise has one scale per column. Pre-load this thread's 16 columns.
+  CType s_inv[kVec];
+#pragma unroll
+  for (int e = 0; e < kVec; ++e) {
+    s_inv[e] = (c + e < K) ? tile_scale_base[c + e] : static_cast<CType>(0.f);
+  }
+
+#pragma unroll
+  for (int it = 0; it < kIters; ++it) {
+    const int row_local = thr_row + it * kRowsPerIter;
+    const size_t r_global = global_row_base + row_local;
+    if (r_global >= R_total) continue;
+
+    const size_t r_local = r_global - info.tensor_row_base;
+
+    // Per-expert (K, M_t) transposed input: strided by M_t per column (no vector load).
+    // K % 128 == 0 so c+e < K always holds; the explicit else just keeps correctness
+    // independent of that invariant.
+    Vec<IType, kVec> in_vec;
+#pragma unroll
+    for (int e = 0; e < kVec; ++e) {
+      in_vec.data.elt[e] = (c + e < K)
+                               ? input_base[expert_data_off + (c + e) * info.tensor_M + r_local]
+                               : static_cast<IType>(0);
+    }
+
+    Vec<OType, kVec> out_vec;
+#pragma unroll
+    for (int e = 0; e < kVec; ++e) {
+      out_vec.data.elt[e] = static_cast<OType>(static_cast<float>(in_vec.data.elt[e]) * s_inv[e]);
+    }
+
+    if (c + kVec <= K) {
+      out_vec.store_to(output_base + r_global * K + c);
+    } else if (c < K) {
+      out_vec.store_to_elts(output_base + r_global * K + c, 0, K - c);
+    }
+  }
+#endif
+}
+
+// ===== 2D rowwise =====
+// Data layout: (M, K) flat. One scale per 128x128 tile.
+// Scale layout GLOBAL: (total_row_blocks, roundup(blocks_X, 4)) floats.
+//   scale[tile_y_global * scale_stride_y + tile_x]
+template <bool kSameBothDims, typename IType, typename OType, typename CType>
+__global__ void __launch_bounds__(kThreadsPerBlock)
+    group_dequantize_blockwise_2d_rw_kernel(const IType* __restrict__ input_base,
+                                            OType* __restrict__ output_base,
+                                            const CType* __restrict__ scale_inv_base,
+                                            const size_t scale_stride_y,
+                                            const int64_t* __restrict__ tensor_offsets_ptr,
+                                            const size_t num_tensors,
+                                            const size_t common_first_dim_blocks, const size_t K,
+                                            const size_t total_row_blocks, const size_t R_total) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  const auto info = resolve_tile_expert<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, K, total_row_blocks, tensor_offsets_ptr);
+  if (!info.in_bounds) return;
+
+  // 2D: one scale per tile.
+  const CType s_inv = scale_inv_base[tile_y_global * scale_stride_y + tile_x];
+
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  constexpr int kThreadsPerRow = 8;
+  constexpr int kVec = 16;
+  constexpr int kRowsPerIter = kThreadsPerBlock / kThreadsPerRow;
+  constexpr int kIters = kTileDim / kRowsPerIter;
+
+  const int tid = threadIdx.x;
+  const int thr_col = tid % kThreadsPerRow;
+  const int thr_row = tid / kThreadsPerRow;
+  const size_t c = global_col_base + static_cast<size_t>(thr_col) * kVec;
+
+#pragma unroll
+  for (int it = 0; it < kIters; ++it) {
+    const int row_local = thr_row + it * kRowsPerIter;
+    const size_t r_global = global_row_base + row_local;
+    if (r_global >= R_total) continue;
+
+    Vec<IType, kVec> in_vec;
+    if (c + kVec <= K) {
+      in_vec.load_from(input_base + r_global * K + c);
+    } else if (c < K) {
+      in_vec.load_from_elts(input_base + r_global * K + c, 0, K - c);
+    } else {
+      continue;
+    }
+
+    Vec<OType, kVec> out_vec;
+#pragma unroll
+    for (int e = 0; e < kVec; ++e) {
+      out_vec.data.elt[e] = static_cast<OType>(static_cast<float>(in_vec.data.elt[e]) * s_inv);
+    }
+
+    if (c + kVec <= K) {
+      out_vec.store_to(output_base + r_global * K + c);
+    } else if (c < K) {
+      out_vec.store_to_elts(output_base + r_global * K + c, 0, K - c);
+    }
+  }
+#endif
+}
+
+// ===== 2D columnwise =====
+// Data layout per-expert: (K, M_t) transposed.
+// Scale layout per-expert: (blocks_X, roundup(blocks_y_t, 4)) floats.
+//   scale[expert_off + tile_x * roundup(blocks_y_t, 4) + local_tile_y]
+template <bool kSameBothDims, typename IType, typename OType, typename CType>
+__global__ void __launch_bounds__(kThreadsPerBlock)
+    group_dequantize_blockwise_2d_cw_kernel(const IType* __restrict__ input_base,
+                                            OType* __restrict__ output_base,
+                                            const CType* __restrict__ scale_inv_base,
+                                            const int64_t* __restrict__ tensor_offsets_ptr,
+                                            const size_t num_tensors,
+                                            const size_t common_first_dim_blocks, const size_t K,
+                                            const size_t total_row_blocks, const size_t R_total) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  const auto info = resolve_tile_expert<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, K, total_row_blocks, tensor_offsets_ptr);
+  if (!info.in_bounds) return;
+
+  // `info.in_bounds` is derived from blockIdx.y and is uniform across the CTA,
+  // so the early return above never strands a sibling thread inside
+  // compute_2d_cw_expert_offset's __syncthreads().
+  __shared__ size_t warp_offset_partials[kNumWarps];
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kThreadsPerWarp;
+  const int lane = tid % kThreadsPerWarp;
+
+  const size_t blocks_X = DIVUP(K, static_cast<size_t>(kTileDim));
+  const size_t tile_row_stride = static_cast<size_t>(kTileDim) * K;
+  const size_t expert_offset = compute_2d_cw_expert_offset<kSameBothDims>(
+      info.tensor_id, blocks_X, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr,
+      warp_offset_partials, tid, warp_id, lane);
+  const size_t per_expert_stride_t = DIVUP_TO_MULTIPLE(info.tensor_row_blocks, kScaleColAlign);
+  const size_t local_tile_y = tile_y_global - info.tensor_block_y_base;
+  const CType s_inv = scale_inv_base[expert_offset + tile_x * per_expert_stride_t + local_tile_y];
+
+  const size_t expert_data_off = info.tensor_row_base * K;
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  constexpr int kThreadsPerRow = 8;
+  constexpr int kVec = 16;
+  constexpr int kRowsPerIter = kThreadsPerBlock / kThreadsPerRow;
+  constexpr int kIters = kTileDim / kRowsPerIter;
+
+  const int thr_col = tid % kThreadsPerRow;
+  const int thr_row = tid / kThreadsPerRow;
+  const size_t c = global_col_base + static_cast<size_t>(thr_col) * kVec;
+
+#pragma unroll
+  for (int it = 0; it < kIters; ++it) {
+    const int row_local = thr_row + it * kRowsPerIter;
+    const size_t r_global = global_row_base + row_local;
+    if (r_global >= R_total) continue;
+
+    const size_t r_local = r_global - info.tensor_row_base;
+
+    // Explicit else zeroes out-of-range lanes (c+e < K always holds since K % 128 == 0;
+    // this keeps correctness independent of that invariant).
+    Vec<IType, kVec> in_vec;
+#pragma unroll
+    for (int e = 0; e < kVec; ++e) {
+      in_vec.data.elt[e] = (c + e < K)
+                               ? input_base[expert_data_off + (c + e) * info.tensor_M + r_local]
+                               : static_cast<IType>(0);
+    }
+
+    Vec<OType, kVec> out_vec;
+#pragma unroll
+    for (int e = 0; e < kVec; ++e) {
+      out_vec.data.elt[e] = static_cast<OType>(static_cast<float>(in_vec.data.elt[e]) * s_inv);
+    }
+
+    if (c + kVec <= K) {
+      out_vec.store_to(output_base + r_global * K + c);
+    } else if (c < K) {
+      out_vec.store_to_elts(output_base + r_global * K + c, 0, K - c);
+    }
+  }
+#endif
+}
+
+}  // namespace group_dequantize_kernel
+
+// Host-side dispatcher. Supports all four combinations of {1D, 2D} block
+// scaling x {rowwise, columnwise} data, matching the layouts written by
+// ``group_quantize_fp8_blockwise``. The input GroupedTensor must have exactly
+// one of rowwise / columnwise data populated (the dequantize API rejects
+// both).
+inline void group_dequantize(const GroupedTensor* input, GroupedTensor* output,
+                             cudaStream_t stream) {
+  using namespace group_dequantize_kernel;
+
+  const int sm = transformer_engine::cuda::sm_arch();
+  NVTE_CHECK(sm >= 90 && sm < 100,
+             "Grouped FP8 block-scaling dequantize is only supported on Hopper (SM90-SM99); "
+             "got SM",
+             sm, ".");
+  NVTE_CHECK(
+      input->scaling_mode == NVTE_BLOCK_SCALING_1D || input->scaling_mode == NVTE_BLOCK_SCALING_2D,
+      "Grouped FP8 block-scaling dequantize requires 1D or 2D block scaling "
+      "(got scaling_mode=",
+      to_string(input->scaling_mode), ").");
+  NVTE_CHECK(is_fp8_dtype(input->dtype()), "Input must have FP8 type.");
+  NVTE_CHECK(!is_fp8_dtype(output->dtype()), "Output must be in higher precision.");
+  NVTE_CHECK(!is_fp4_dtype(output->dtype()), "Output must not be FP4.");
+  NVTE_CHECK(input->num_tensors == output->num_tensors,
+             "Number of input and output tensors must match.");
+
+  const bool use_rowwise = input->has_data();
+  const bool use_colwise = input->has_columnwise_data();
+  NVTE_CHECK(use_rowwise || use_colwise, "Input must have rowwise or columnwise data populated.");
+  NVTE_CHECK(!(use_rowwise && use_colwise),
+             "Grouped FP8 block-scaling dequantize accepts exactly one direction at a "
+             "time (not both rowwise and columnwise simultaneously).");
+  NVTE_CHECK(!input->with_gemm_swizzled_scales,
+             "Grouped FP8 block-scaling dequantize requires compact (un-swizzled) scales.");
+
+  const size_t first_logical_dim = input->logical_shape.data[0];
+  const size_t last_logical_dim = input->logical_shape.data[1];
+  if (first_logical_dim == 0 || last_logical_dim == 0) return;
+
+  const bool same_both_dims = input->all_same_shape();
+  const bool varying_first_dim = (!input->all_same_first_dim()) && input->all_same_last_dim();
+  NVTE_CHECK(same_both_dims || varying_first_dim,
+             "Grouped FP8 block-scaling dequantize supports only SAME_BOTH_DIMS and "
+             "VARYING_FIRST_DIM shape representations.");
+
+  const size_t num_tensors = input->num_tensors;
+  const size_t K = last_logical_dim;
+  NVTE_CHECK(K % kTileDim == 0,
+             "Last dim must be a multiple of 128 for FP8 block-scaling dequantize (got ", K, ").");
+
+  size_t common_first_dim_blocks = 0;
+  if (same_both_dims) {
+    const size_t common_first_dim = input->get_common_first_dim();
+    NVTE_CHECK(common_first_dim % kTileDim == 0,
+               "SAME_BOTH_DIMS first dim must be multiple of 128 (got ", common_first_dim, ").");
+    common_first_dim_blocks = common_first_dim / kTileDim;
+  }
+  const size_t total_row_blocks = DIVUP(first_logical_dim, static_cast<size_t>(kTileDim));
+  const size_t blocks_X = K / kTileDim;
+
+  const int64_t* tensor_offsets_ptr =
+      same_both_dims ? nullptr : reinterpret_cast<const int64_t*>(input->tensor_offsets.dptr);
+  if (!same_both_dims) {
+    NVTE_CHECK(tensor_offsets_ptr != nullptr,
+               "VARYING_FIRST_DIM requires tensor_offsets to be set on the input.");
+  }
+
+  const dim3 grid(blocks_X, total_row_blocks);
+  const dim3 block(kThreadsPerBlock);
+  const bool is_1d = (input->scaling_mode == NVTE_BLOCK_SCALING_1D);
+
+  // Pick the populated direction's data + scale buffer. The global-layout strides (1D cw, 2D rw)
+  // are derived from K / blocks_X exactly as the quantize launcher does.
+  const SimpleTensor& input_data = use_rowwise ? input->data : input->columnwise_data;
+  const SimpleTensor& input_scale_inv =
+      use_rowwise ? input->scale_inv : input->columnwise_scale_inv;
+  const size_t scale_t_stride_aligned_K = DIVUP_TO_MULTIPLE(K, kScaleColAlign);
+  const size_t scale_stride_y = DIVUP_TO_MULTIPLE(blocks_X, kScaleColAlign);
+
+  TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(
+      input->dtype(), IType,
+      TRANSFORMER_ENGINE_TYPE_SWITCH_NON_FP8ONLY(
+          output->dtype(), OType, using CType = float;
+          const IType* const input_dptr = reinterpret_cast<const IType*>(input_data.dptr);
+          OType* const output_dptr = reinterpret_cast<OType*>(output->data.dptr);
+          const CType* const scale_inv_dptr = reinterpret_cast<const CType*>(input_scale_inv.dptr);
+
+          if (is_1d && use_rowwise) {
+            if (same_both_dims) {
+              group_dequantize_blockwise_1d_rw_kernel<true, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(
+                      input_dptr, output_dptr, scale_inv_dptr, tensor_offsets_ptr, num_tensors,
+                      common_first_dim_blocks, K, total_row_blocks, first_logical_dim);
+            } else {
+              group_dequantize_blockwise_1d_rw_kernel<false, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(
+                      input_dptr, output_dptr, scale_inv_dptr, tensor_offsets_ptr, num_tensors,
+                      common_first_dim_blocks, K, total_row_blocks, first_logical_dim);
+            }
+          } else if (is_1d && use_colwise) {
+            if (same_both_dims) {
+              group_dequantize_blockwise_1d_cw_kernel<true, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(input_dptr, output_dptr, scale_inv_dptr,
+                                               scale_t_stride_aligned_K, tensor_offsets_ptr,
+                                               num_tensors, common_first_dim_blocks, K,
+                                               total_row_blocks, first_logical_dim);
+            } else {
+              group_dequantize_blockwise_1d_cw_kernel<false, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(input_dptr, output_dptr, scale_inv_dptr,
+                                               scale_t_stride_aligned_K, tensor_offsets_ptr,
+                                               num_tensors, common_first_dim_blocks, K,
+                                               total_row_blocks, first_logical_dim);
+            }
+          } else if (!is_1d && use_rowwise) {
+            if (same_both_dims) {
+              group_dequantize_blockwise_2d_rw_kernel<true, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(
+                      input_dptr, output_dptr, scale_inv_dptr, scale_stride_y, tensor_offsets_ptr,
+                      num_tensors, common_first_dim_blocks, K, total_row_blocks, first_logical_dim);
+            } else {
+              group_dequantize_blockwise_2d_rw_kernel<false, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(
+                      input_dptr, output_dptr, scale_inv_dptr, scale_stride_y, tensor_offsets_ptr,
+                      num_tensors, common_first_dim_blocks, K, total_row_blocks, first_logical_dim);
+            }
+          } else {  // 2D columnwise
+            if (same_both_dims) {
+              group_dequantize_blockwise_2d_cw_kernel<true, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(
+                      input_dptr, output_dptr, scale_inv_dptr, tensor_offsets_ptr, num_tensors,
+                      common_first_dim_blocks, K, total_row_blocks, first_logical_dim);
+            } else {
+              group_dequantize_blockwise_2d_cw_kernel<false, IType, OType, CType>
+                  <<<grid, block, 0, stream>>>(
+                      input_dptr, output_dptr, scale_inv_dptr, tensor_offsets_ptr, num_tensors,
+                      common_first_dim_blocks, K, total_row_blocks, first_logical_dim);
+            }
+          });  // NOLINT(*)
+  );           // NOLINT(*)
+  NVTE_CHECK_CUDA(cudaGetLastError());
+}
+
+}  // namespace fp8_blockwise
+}  // namespace dispatch
+}  // namespace transformer_engine
+
+#endif  // TRANSFORMER_ENGINE_GROUP_DEQUANTIZE_FP8_BLOCKWISE_CUH_

--- a/transformer_engine/common/cast/fp8_blockwise/group_quantize_fp8_blockwise.cuh
+++ b/transformer_engine/common/cast/fp8_blockwise/group_quantize_fp8_blockwise.cuh
@@ -1,0 +1,1022 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+/*! \file group_quantize_fp8_blockwise.cuh
+ *  \brief CUDA kernels to quantize grouped tensors with FP8 1D and 2D
+ *  block scaling. A single launch walks 128x128 tiles across every tensor
+ *  in the group, with each CTA decoding its owning tensor from the device-side
+ *  GroupedTensor metadata. Supports SAME_BOTH_DIMS and VARYING_FIRST_DIM.
+ */
+
+#ifndef TRANSFORMER_ENGINE_GROUP_QUANTIZE_FP8_BLOCKWISE_CUH_
+#define TRANSFORMER_ENGINE_GROUP_QUANTIZE_FP8_BLOCKWISE_CUH_
+
+#include <cuda.h>
+#include <cudaTypedefs.h>
+#include <cuda_runtime.h>
+#include <transformer_engine/transformer_engine.h>
+
+#include <vector>
+
+#include "../../common.h"
+#include "../../recipe/recipe_common.cuh"
+#include "../../transpose/cast_transpose.h"
+#include "../../util/cuda_runtime.h"
+#include "../../util/ptx.cuh"
+#include "../../utils.cuh"
+#include "../core/common.cuh"
+
+namespace transformer_engine {
+namespace dispatch {
+namespace fp8_blockwise {
+
+using transformer_engine::detail::FP8BlockwiseColumnwiseOption;
+using transformer_engine::detail::FP8BlockwiseRowwiseOption;
+
+constexpr int kTileDim = 128;
+constexpr int kThreadsPerWarp = 32;
+constexpr int kThreadsPerBlock = 256;
+constexpr int kNumWarps = kThreadsPerBlock / kThreadsPerWarp;
+
+// ---- Per-expert scale layout helpers --------------------------------------------
+//
+// cuBLAS grouped FP8 block-scaling GEMM expects each expert's scales to live
+// in a contiguous per-expert sub-block of the global scale buffer:
+//
+//   1D rowwise CW (op_rowwise=true)   per expert: (blocks_X, roundup(M_t, 4))    floats
+//   1D columnwise (op_rowwise=false)  per expert: (blocks_y_t, roundup(K, 4))    floats
+//   2D rowwise (op_rowwise=true)      per expert: (blocks_y_t, roundup(blocks_X, 4))
+//   2D columnwise (op_rowwise=false)  per expert: (blocks_X, roundup(blocks_y_t, 4))
+//
+// The grouped kernel writes the GLOBAL buffer in tile-stride order, but the
+// position assigned to each tile must map into the per-expert contiguous
+// sub-block. These helpers compute the per-expert cumulative byte/float
+// offset and the per-expert local stride. SAME_BOTH_DIMS lets us derive
+// without walking offsets; VARYING_FIRST_DIM walks `tensor_offsets_ptr` once
+// per block (only the writing thread).
+
+__device__ __host__ constexpr size_t kScaleColAlign = 4;
+
+// 2D columnwise per-expert scale offset. Per-expert layout is
+// (blocks_X, roundup(blocks_y_t, 4)). Two paths, picked at call sites:
+//   - SAME_BOTH_DIMS: direct formula (no walk, no reduction).
+//   - VARYING_FIRST_DIM: CTA-cooperative prefix sum. Each thread accumulates a
+//     partial over a strided subset of the tensors-before-this-one, a
+//     warp-shuffle reduces inside each warp, then all threads sum the per-warp
+//     partials read from a kNumWarps-element smem buffer to obtain the same
+//     total. The non-linear DIVUP_TO_MULTIPLE on each per-tensor blocks_y_t
+//     prevents a closed form.
+// ALL threads of the CTA must call this in lock-step (the cooperative path
+// contains __syncthreads()).
+template <bool kSameBothDims>
+__device__ __forceinline__ size_t compute_2d_cw_expert_offset(
+    const size_t tensor_id, const size_t blocks_X, const size_t common_first_dim_blocks,
+    const size_t tile_row_stride, const int64_t* __restrict__ tensor_offsets_ptr,
+    size_t* warp_partials_smem, const int tid, const int warp_id, const int lane) {
+  if constexpr (kSameBothDims) {
+    return tensor_id * blocks_X * DIVUP_TO_MULTIPLE(common_first_dim_blocks, kScaleColAlign);
+  }
+  size_t my_partial = 0;
+  for (size_t i = static_cast<size_t>(tid); i < tensor_id;
+       i += static_cast<size_t>(kThreadsPerBlock)) {
+    const size_t blocks_y_i =
+        static_cast<size_t>(tensor_offsets_ptr[i + 1] - tensor_offsets_ptr[i]) / tile_row_stride;
+    my_partial += DIVUP_TO_MULTIPLE(blocks_y_i, kScaleColAlign);
+  }
+  my_partial = warp_allreduce_sum(my_partial);
+  if (lane == 0) warp_partials_smem[warp_id] = my_partial;
+  __syncthreads();
+  size_t total = 0;
+#pragma unroll
+  for (int w = 0; w < kNumWarps; ++w) {
+    total += warp_partials_smem[w];
+  }
+  return total * blocks_X;
+}
+
+// 1D rowwise: per-expert layout (blocks_X, roundup(M_t, 4)).
+template <bool kSameBothDims>
+__device__ __forceinline__ size_t expert_scale_offset_1d_rowwise(
+    size_t tensor_id, size_t blocks_X, size_t common_first_dim_blocks, size_t tile_row_stride,
+    const int64_t* __restrict__ tensor_offsets_ptr) {
+  if constexpr (kSameBothDims) {
+    const size_t M = common_first_dim_blocks * kTileDim;
+    return tensor_id * blocks_X * DIVUP_TO_MULTIPLE(M, kScaleColAlign);
+  } else {
+    // Each M_i is enforced to be a multiple of kTileDim (=128), hence a
+    // multiple of kScaleColAlign (=4), so DIVUP_TO_MULTIPLE(M_i, 4) == M_i and
+    // sum_{i<tensor_id} M_i = tensor_offsets_ptr[tensor_id] / K. Computing the
+    // offset in O(1) avoids a per-CTA O(num_tensors) walk that otherwise
+    // dominates wall-clock for jagged routings at high expert counts.
+    const size_t K = tile_row_stride / kTileDim;
+    const size_t total_M_before = static_cast<size_t>(tensor_offsets_ptr[tensor_id]) / K;
+    return blocks_X * total_M_before;
+  }
+}
+
+// ---- Tensor-lookup helpers ----------------------------------------------------
+
+// Map a global tile-row index to its owning tensor. Delegates to the shared
+// `common::get_current_tensor_id` helper from `cast/core/common.cuh`. The
+// helper is parameterized by total `first_logical_dim` rather than per-tensor
+// block count, so we reconstruct it here for the SAME_BOTH_DIMS specialization
+// (VARYING_FIRST_DIM ignores it and uses `current_offset` + `offsets_ptr`).
+template <bool kSameBothDims>
+__device__ __forceinline__ size_t find_tensor_id_by_block_y(
+    const size_t block_y_global, const size_t num_tensors, const size_t common_first_dim_blocks,
+    const size_t tile_row_stride, const int64_t* __restrict__ tensor_offsets_ptr) {
+  constexpr auto shape_rep =
+      kSameBothDims ? ShapeRepresentation::SAME_BOTH_DIMS : ShapeRepresentation::VARYING_FIRST_DIM;
+  const size_t first_logical_dim = num_tensors * common_first_dim_blocks * kTileDim;
+  const size_t tensor_id = common::get_current_tensor_id<shape_rep, kTileDim>(
+      num_tensors, block_y_global * tile_row_stride, block_y_global, first_logical_dim,
+      /*last_logical_dim=*/0, tensor_offsets_ptr);
+  if constexpr (!kSameBothDims) {
+    // tensor_offsets_ptr carries cumulative element counts; tile_row_stride =
+    // kTileDim * K, so the per-tensor element span is divisible by
+    // tile_row_stride iff first_dim is a multiple of kTileDim.
+    if (tensor_id < num_tensors) {
+      const size_t span =
+          static_cast<size_t>(tensor_offsets_ptr[tensor_id + 1] - tensor_offsets_ptr[tensor_id]);
+      if (span % tile_row_stride != 0) {
+        NVTE_DEVICE_ERROR(
+            "Grouped FP8 block-scaling quantize: each tensor's first dimension must be a "
+            "multiple of 128 (VARYING_FIRST_DIM).");
+      }
+    }
+  }
+  return tensor_id;
+}
+
+// Per-tensor block-y base for VARYING_FIRST_DIM (in 128-row block units).
+__device__ __forceinline__ size_t tensor_block_y_base_from_offsets(
+    const size_t tensor_id, const int64_t* __restrict__ tensor_offsets_ptr,
+    const size_t tile_row_stride) {
+  return static_cast<size_t>(tensor_offsets_ptr[tensor_id]) / tile_row_stride;
+}
+
+// Per-vector amax. Uses bf16x2 `max.xorsign.abs` on sm_89+; FP32 fallback otherwise.
+template <typename IType, typename CType, int kVec>
+__device__ __forceinline__ CType compute_row_amax(const Vec<IType, kVec>& v) {
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 890)
+  if constexpr (std::is_same_v<IType, bf16>) {
+    static_assert(kVec % 2 == 0, "kVec must be even for packed bf16x2 amax");
+    const ptx::bf16x2* pairs = reinterpret_cast<const ptx::bf16x2*>(&v.data.elt[0]);
+    ptx::bf16x2 amax_x2{static_cast<bf16>(0.f), static_cast<bf16>(0.f)};
+#pragma unroll
+    for (int p = 0; p < kVec / 2; ++p) {
+      ptx::abs_max_2x(amax_x2, amax_x2, pairs[p]);
+    }
+    return static_cast<CType>(__hmax(__habs(amax_x2.x), __habs(amax_x2.y)));
+  }
+#endif
+  CType amax = 0.f;
+#pragma unroll
+  for (int e = 0; e < kVec; ++e) {
+    amax = fmaxf(amax, fabsf(static_cast<CType>(v.data.elt[e])));
+  }
+  return amax;
+}
+
+// Per-tile column sum of the high-precision input -> one fp32 row at
+// dbias_workspace[tile_y_global * K + col]. 2 threads/column sum 64 rows each (combined via
+// shfl_xor); grouped_reduce_dbias later sums each expert's row-blocks. Tiles are always full
+// (experts are 128-row aligned), so all 128 rows are summed.
+template <typename IType>
+__device__ __forceinline__ void write_tile_dbias_partial(const IType smem_tile[][kTileDim],
+                                                         const int tid,
+                                                         const size_t global_col_base,
+                                                         const size_t K, const size_t tile_y_global,
+                                                         float* __restrict__ dbias_workspace) {
+  constexpr int kThreadsPerColDB = 2;
+  constexpr int kRowsPerThreadDB = kTileDim / kThreadsPerColDB;  // 64
+  const int col_local = tid / kThreadsPerColDB;                  // 0..127
+  const int sub = tid % kThreadsPerColDB;
+  const int row_start = sub * kRowsPerThreadDB;
+  float partial = 0.f;
+#pragma unroll
+  for (int e = 0; e < kRowsPerThreadDB; ++e) {
+    partial += static_cast<float>(smem_tile[row_start + e][col_local]);
+  }
+  partial += __shfl_xor_sync(0xffffffff, partial, 1);
+  const size_t c_global = global_col_base + col_local;
+  if (sub == 0 && c_global < K) {
+    dbias_workspace[tile_y_global * K + c_global] = partial;
+  }
+}
+
+// Per-vector multiply-and-quantize via fp32 intermediates.
+template <typename IType, typename OType, typename CType, int kVec>
+__device__ __forceinline__ void quantize_row_vec(Vec<OType, kVec>& out, const Vec<IType, kVec>& in,
+                                                 CType scale) {
+#pragma unroll
+  for (int e = 0; e < kVec; ++e) {
+    out.data.elt[e] = static_cast<OType>(static_cast<CType>(in.data.elt[e]) * scale);
+  }
+}
+
+// Bank-conflict swizzle delta for the 2D smem_T staging buffer. delta carries
+// bits 2..5 only so each 4-byte sub-chunk is preserved.
+__device__ __forceinline__ int smem_t_swz_delta(int smem_t_row) {
+  return ((smem_t_row >> 3) & 0xf) << 2;
+}
+
+// Drain smem_T to gmem for the CW path: 4 cols/warp, 8 lanes/col, each lane
+// stores a 16-row chunk so the 8 lanes of a col emit one 128 B gmem line.
+//
+// Columnwise data is stored per-expert contiguously as a (K, M_t) transposed
+// block at element offset K * tensor_row_base, matching cuBLAS grouped GEMM's
+// per-expert data pointer (compute_grouped_tensor_offset = sum_i M_i * K).
+// `tensor_row_base` is expert t's first global row; `tensor_M` is M_t.
+//
+// When `kSwizzledStaging` is true, the writer applied smem_t_swz_delta to the
+// inner index, so the read must XOR back to recover the logical (row, col).
+// Per-byte unswizzled reads are required because the smem_T row stride is not
+// 16 B aligned for arbitrary column offsets.
+template <bool kSwizzledStaging, typename OType, int kSMemTRowStride>
+__device__ __forceinline__ void drain_smem_t_to_gmem(
+    OType (&smem_T)[kTileDim][kSMemTRowStride], OType* __restrict__ output_t_base,
+    const size_t global_col_base, const size_t global_row_base, const size_t tensor_row_base,
+    const size_t tensor_M, const size_t K, const int tid) {
+  constexpr int kStorePerChunk = 16;
+  constexpr int kRowChunksPerCol = kTileDim / kStorePerChunk;        // 8
+  constexpr int kColsPerIter = kThreadsPerBlock / kRowChunksPerCol;  // 32
+  constexpr int kColIters = kTileDim / kColsPerIter;                 // 4
+  const int warp_id = tid / kThreadsPerWarp;
+  const int lane = tid % kThreadsPerWarp;
+  const int col_in_warp = lane / kRowChunksPerCol;
+  const int row_chunk = lane % kRowChunksPerCol;
+  const int out_row_off = row_chunk * kStorePerChunk;
+  const size_t expert_data_off = tensor_row_base * K;
+  const size_t m_local_base = global_row_base - tensor_row_base;
+#pragma unroll
+  for (int it = 0; it < kColIters; ++it) {
+    const int out_col_local = it * kColsPerIter + warp_id * 4 + col_in_warp;
+    const size_t out_col_global = global_col_base + out_col_local;
+    if (out_col_global < K) {
+      // Per-expert (K, M_t): index = expert_off + k * M_t + m_local.
+      OType* out_ptr =
+          output_t_base + expert_data_off + out_col_global * tensor_M + m_local_base + out_row_off;
+      const int swz_delta_r = kSwizzledStaging ? smem_t_swz_delta(out_col_local) : 0;
+      Vec<OType, kStorePerChunk> v;
+#pragma unroll
+      for (int e = 0; e < kStorePerChunk; ++e) {
+        v.data.elt[e] = smem_T[out_col_local][(out_row_off + e) ^ swz_delta_r];
+      }
+      v.store_to(out_ptr);
+    }
+  }
+}
+
+// ----- 2D block scaling kernel with TMA input ------------------------------------------------
+// Pass 1: amax over a 128x128 TMA-loaded tile, with input vectors staged in
+// registers. Pass 2: quantize from registers, emit rowwise output and the
+// transposed smem_T tile, then drain smem_T to gmem.
+
+template <bool kSameBothDims, bool kReturnRowwise, bool kReturnColwise, typename CType,
+          typename IType, typename OType>
+__global__ void __launch_bounds__(kThreadsPerBlock, 4) group_block_scaled_2d_tma_kernel(
+    const __grid_constant__ CUtensorMap tensor_map_input, OType* __restrict__ output_base,
+    OType* __restrict__ output_t_base, CType* __restrict__ scale_inv_base,
+    CType* __restrict__ scale_inv_t_base, const int64_t* __restrict__ tensor_offsets_ptr,
+    const size_t num_tensors, const size_t common_first_dim_blocks, const size_t K,
+    const size_t total_row_blocks, const size_t blocks_X, const size_t scale_stride_y,
+    const float epsilon, const float* __restrict__ noop_ptr, float* __restrict__ dbias_workspace) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  if (noop_ptr != nullptr && noop_ptr[0] == 1.0f) return;
+
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  if (tile_y_global >= total_row_blocks) return;
+
+  const size_t tile_row_stride = static_cast<size_t>(kTileDim) * K;
+  const size_t tensor_id = find_tensor_id_by_block_y<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+  const size_t tensor_block_y_base =
+      kSameBothDims
+          ? (tensor_id * common_first_dim_blocks)
+          : tensor_block_y_base_from_offsets(tensor_id, tensor_offsets_ptr, tile_row_stride);
+  const size_t tensor_row_blocks =
+      kSameBothDims
+          ? common_first_dim_blocks
+          : (tensor_block_y_base_from_offsets(tensor_id + 1, tensor_offsets_ptr, tile_row_stride) -
+             tensor_block_y_base);
+  if (tile_y_global >= tensor_block_y_base + tensor_row_blocks) return;
+
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  // Dynamic smem holds the IType input tile (TMA dest, must be 128 B aligned).
+  // warp_amaxes and tma_mbar are static smem.
+  extern __shared__ unsigned char smem_raw_2d_tma[];
+  IType(*smem_in)[kTileDim] = reinterpret_cast<IType(*)[kTileDim]>(
+      common::align_smem_ptr_per_TMA_requirements(smem_raw_2d_tma));
+
+  __shared__ CType warp_amaxes[kNumWarps];
+  __shared__ size_t warp_offset_partials[kNumWarps];
+  __shared__ uint64_t tma_mbar;
+
+  const int tid = threadIdx.x;
+  const bool leading_thread = (tid == 0);
+
+  // ---- TMA async load of the input tile ----
+  if (leading_thread) {
+    ptx::mbarrier_init(&tma_mbar, 1);
+    // Fence so the TMA engine (async proxy) and the threads (generic proxy)
+    // both observe the just-initialized mbarrier consistently.
+    ptx::fence_proxy_async_shared_cta();
+  }
+  __syncthreads();
+  if (leading_thread) {
+    constexpr uint32_t tx_bytes = kTileDim * kTileDim * sizeof(IType);
+    ptx::mbarrier_arrive_expect_tx(&tma_mbar, tx_bytes);
+    ptx::cp_async_bulk_tensor_2d_global_to_shared_cta(
+        reinterpret_cast<uint64_t*>(smem_in), reinterpret_cast<const uint64_t*>(&tensor_map_input),
+        static_cast<uint32_t>(global_col_base), static_cast<uint32_t>(global_row_base), &tma_mbar);
+  }
+  ptx::mbarrier_wait_parity(&tma_mbar, 0);
+  if (leading_thread) ptx::mbarrier_invalid(&tma_mbar);
+  __syncthreads();
+
+  // ---- Optional dbias: per-tile column sum of the high-precision input (smem-resident) ----
+  if (dbias_workspace != nullptr) {
+    write_tile_dbias_partial<IType>(smem_in, tid, global_col_base, K, tile_y_global,
+                                    dbias_workspace);
+  }
+
+  // ---- Pass 1: tile amax, staging input vectors in registers for reuse in pass 2 ----
+  constexpr int kEltsPerThread = 8;
+  constexpr int kThreadsPerRow = kTileDim / kEltsPerThread;        // 16
+  constexpr int kRowsPerIter = kThreadsPerBlock / kThreadsPerRow;  // 16
+  constexpr int kIters = kTileDim / kRowsPerIter;                  // 8
+
+  const int thr_col = tid % kThreadsPerRow;
+  const int thr_row = tid / kThreadsPerRow;
+
+  using IVec = Vec<IType, kEltsPerThread>;
+  using OVec = Vec<OType, kEltsPerThread>;
+
+  IVec staged[kIters];
+  CType thr_amax = 0.f;
+#pragma unroll
+  for (int it = 0; it < kIters; ++it) {
+    const int r_local = thr_row + it * kRowsPerIter;
+    staged[it].load_from(&smem_in[r_local][thr_col * kEltsPerThread]);
+    thr_amax = fmaxf(thr_amax, compute_row_amax<IType, CType, kEltsPerThread>(staged[it]));
+  }
+  CType warp_amax = warp_reduce_max<kThreadsPerWarp>(thr_amax);
+  const int warp_id = tid / kThreadsPerWarp;
+  const int lane = tid % kThreadsPerWarp;
+  if (lane == 0) warp_amaxes[warp_id] = warp_amax;
+  __syncthreads();
+
+  CType block_amax = warp_amaxes[0];
+#pragma unroll
+  for (int w = 1; w < kNumWarps; ++w) {
+    block_amax = fmaxf(block_amax, warp_amaxes[w]);
+  }
+  const CType scale =
+      compute_scale_from_types<IType, OType>(block_amax, epsilon, /*pow_2_scaling=*/false);
+
+  // The 2D colwise per-expert scale offset requires a CTA-cooperative prefix
+  // sum in the VARYING_FIRST_DIM case, so compute it across all threads before
+  // the leading-thread-only store. All threads end up with the same value;
+  // only thread 0 reads it below.
+  size_t expert_offset_t = 0;
+  if constexpr (kReturnColwise) {
+    expert_offset_t = compute_2d_cw_expert_offset<kSameBothDims>(
+        tensor_id, blocks_X, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr,
+        warp_offset_partials, tid, warp_id, lane);
+  }
+
+  if (leading_thread) {
+    const CType scale_inv = 1.f / scale;
+    if constexpr (kReturnRowwise) {
+      // 2D rowwise: kernel-global stride matches per-expert layout naturally.
+      // Expert t's rows occupy [tensor_block_y_base, +blocks_y_t) of the buffer,
+      // each row sized roundup(blocks_X, 4), which equals the dispatcher's
+      // cumulative per-expert offset.
+      scale_inv_base[tile_y_global * scale_stride_y + tile_x] = scale_inv;
+    }
+    if constexpr (kReturnColwise) {
+      // 2D colwise: rewrite into per-expert sub-block matching cuBLAS grouped
+      // GEMM's per-expert layout (blocks_X, roundup(blocks_y_t, 4)).
+      const size_t local_tile_y = tile_y_global - tensor_block_y_base;
+      const size_t per_expert_stride_t = DIVUP_TO_MULTIPLE(tensor_row_blocks, kScaleColAlign);
+      scale_inv_t_base[expert_offset_t + tile_x * per_expert_stride_t + local_tile_y] = scale_inv;
+    }
+  }
+
+  // ---- Pass 2: quantize from register-staged inputs, emit rowwise + colwise outputs ----
+  // 2D block-scaling uses a per-tile (128x128) scalar scale, so the row-wise and
+  // column-wise quantized bytes are identical -- only the gmem layout differs. The
+  // columnwise buffer is physically transposed (cuBLAS FP8 block-scaling GEMM is
+  // TN-only), so we stage into smem_T and drain to the per-expert (K, M_t) transposed block.
+  if constexpr (kReturnColwise) {
+    constexpr int kSMemTRowStride = kTileDim + 4;
+    __shared__ OType smem_T[kTileDim][kSMemTRowStride];
+    // Same delta for all 8 elements this thread writes since (thr_col*8 + e) >> 3 == thr_col.
+    const int swz_delta_w = smem_t_swz_delta(thr_col * kEltsPerThread);
+#pragma unroll
+    for (int it = 0; it < kIters; ++it) {
+      const int row_local = thr_row + it * kRowsPerIter;
+      const size_t r = global_row_base + row_local;
+      const size_t c = global_col_base + thr_col * kEltsPerThread;
+      OVec qo;
+      quantize_row_vec<IType, OType, CType, kEltsPerThread>(qo, staged[it], scale);
+      if constexpr (kReturnRowwise) {
+        if (c < K) {
+          const size_t count = (c + kEltsPerThread <= K) ? kEltsPerThread : (K - c);
+          qo.store_to_elts(output_base + r * K + c, 0, count);
+        }
+      }
+      const int c_phys = row_local ^ swz_delta_w;
+#pragma unroll
+      for (int e = 0; e < kEltsPerThread; ++e) {
+        smem_T[thr_col * kEltsPerThread + e][c_phys] = qo.data.elt[e];
+      }
+    }
+    __syncthreads();
+
+    const size_t tensor_row_base = tensor_block_y_base * kTileDim;
+    const size_t tensor_M = tensor_row_blocks * kTileDim;
+    drain_smem_t_to_gmem<true, OType, kSMemTRowStride>(
+        smem_T, output_t_base, global_col_base, global_row_base, tensor_row_base, tensor_M, K, tid);
+  } else if constexpr (kReturnRowwise) {
+#pragma unroll
+    for (int it = 0; it < kIters; ++it) {
+      const int row_local = thr_row + it * kRowsPerIter;
+      const size_t r = global_row_base + row_local;
+      const size_t c = global_col_base + thr_col * kEltsPerThread;
+      OVec qo;
+      quantize_row_vec<IType, OType, CType, kEltsPerThread>(qo, staged[it], scale);
+      if (c < K) {
+        const size_t count = (c + kEltsPerThread <= K) ? kEltsPerThread : (K - c);
+        qo.store_to_elts(output_base + r * K + c, 0, count);
+      }
+    }
+  }
+#endif  // __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+}
+
+// ----- 1D block scaling rowwise-only kernel ----------------------------------------------------
+// No smem cache. Each thread loads 16 cols/row, reduces amax across the 8
+// row-mates with shfl_xor, then quantizes and stores.
+
+template <bool kSameBothDims, typename CType, typename IType, typename OType>
+__global__ void __launch_bounds__(kThreadsPerBlock)
+    group_block_scaled_1d_rw_kernel(const IType* __restrict__ input_base,
+                                    OType* __restrict__ output_base,
+                                    CType* __restrict__ scale_inv_base,
+                                    const int64_t* __restrict__ tensor_offsets_ptr,
+                                    const size_t num_tensors, const size_t common_first_dim_blocks,
+                                    const size_t K, const size_t total_row_blocks,
+                                    const size_t R_total, const float epsilon,
+                                    const float* __restrict__ noop_ptr) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  if (noop_ptr != nullptr && noop_ptr[0] == 1.0f) return;
+
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  if (tile_y_global >= total_row_blocks) return;
+
+  const size_t tile_row_stride = static_cast<size_t>(kTileDim) * K;
+  const size_t tensor_id = find_tensor_id_by_block_y<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+  const size_t tensor_block_y_base =
+      kSameBothDims
+          ? (tensor_id * common_first_dim_blocks)
+          : tensor_block_y_base_from_offsets(tensor_id, tensor_offsets_ptr, tile_row_stride);
+  const size_t tensor_row_blocks =
+      kSameBothDims
+          ? common_first_dim_blocks
+          : (tensor_block_y_base_from_offsets(tensor_id + 1, tensor_offsets_ptr, tile_row_stride) -
+             tensor_block_y_base);
+  if (tile_y_global >= tensor_block_y_base + tensor_row_blocks) return;
+
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  // 8 threads per row x 16 cols/thread = one 128 B gmem cache line per row, 4 iters per tile.
+  constexpr int kThreadsPerRow = 8;
+  constexpr int kVec = 16;
+  constexpr int kRowsPerIter = kThreadsPerBlock / kThreadsPerRow;  // 32
+  constexpr int kIters = kTileDim / kRowsPerIter;                  // 4
+
+  const int tid = threadIdx.x;
+  const int thr_col = tid % kThreadsPerRow;  // 0..7
+  const int thr_row = tid / kThreadsPerRow;  // 0..31 (row index within an iter)
+  const size_t c = global_col_base + static_cast<size_t>(thr_col) * kVec;
+
+  Vec<IType, kVec> in_vec[kIters];
+
+#pragma unroll
+  for (int it = 0; it < kIters; ++it) {
+    const int row_local = thr_row + it * kRowsPerIter;
+    const size_t r_global = global_row_base + row_local;
+
+    // Load this thread's 16 cols of row `row_local`.
+    if (c + kVec <= K) {
+      in_vec[it].load_from(input_base + r_global * K + c);
+    } else if (c < K) {
+      in_vec[it].load_from_elts(input_base + r_global * K + c, 0, K - c);
+    } else {
+      in_vec[it].clear();
+    }
+
+    CType amax = compute_row_amax<IType, CType, kVec>(in_vec[it]);
+    amax = subwarp_reduce_max_broadcast<kThreadsPerRow>(amax);
+
+    const CType scale =
+        compute_scale_from_types<IType, OType>(amax, epsilon, /*pow_2_scaling=*/false);
+    const CType scale_inv = 1.f / scale;
+    if (thr_col == 0 && r_global < R_total) {
+      // Per-expert layout: (blocks_X, roundup(M_t, 4)). Compute expert base
+      // offset + local stride matching cuBLAS grouped GEMM's per-expert view.
+      const size_t blocks_X = DIVUP(K, static_cast<size_t>(kTileDim));
+      const size_t expert_offset = expert_scale_offset_1d_rowwise<kSameBothDims>(
+          tensor_id, blocks_X, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+      const size_t tensor_M = tensor_row_blocks * kTileDim;
+      const size_t per_expert_stride = DIVUP_TO_MULTIPLE(tensor_M, kScaleColAlign);
+      const size_t tensor_row_base = tensor_block_y_base * kTileDim;
+      const size_t r_local = r_global - tensor_row_base;
+      scale_inv_base[expert_offset + tile_x * per_expert_stride + r_local] = scale_inv;
+    }
+
+    if (r_global < R_total) {
+      Vec<OType, kVec> out_vec;
+      quantize_row_vec<IType, OType, CType, kVec>(out_vec, in_vec[it], scale);
+      if (c + kVec <= K) {
+        out_vec.store_to(output_base + r_global * K + c);
+      } else if (c < K) {
+        out_vec.store_to_elts(output_base + r_global * K + c, 0, K - c);
+      }
+    }
+  }
+#endif  // __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+}
+
+// ----- 1D block scaling kernel with TMA input ------------------------------------------------
+// CW and BOTH path. TMA fills a 128x128 smem input cache. RW pass reads rows
+// and stores quantized output. CW pass stages a column slice in registers,
+// computes the per-column amax there, then fills smem_T and drains to gmem.
+
+template <bool kSameBothDims, bool kReturnRowwise, bool kReturnColwise, typename CType,
+          typename IType, typename OType>
+__global__ void __launch_bounds__(kThreadsPerBlock) group_block_scaled_1d_tma_kernel(
+    const __grid_constant__ CUtensorMap tensor_map_input, OType* __restrict__ output_base,
+    OType* __restrict__ output_t_base, CType* __restrict__ scale_inv_base,
+    CType* __restrict__ scale_inv_t_base, const int64_t* __restrict__ tensor_offsets_ptr,
+    const size_t num_tensors, const size_t common_first_dim_blocks, const size_t K,
+    const size_t total_row_blocks, const size_t blocks_X, const size_t scale_t_stride_aligned_K,
+    const size_t R_total, const float epsilon, const float* __restrict__ noop_ptr,
+    float* __restrict__ dbias_workspace) {
+#if __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+  if (noop_ptr != nullptr && noop_ptr[0] == 1.0f) return;
+
+  const size_t tile_x = blockIdx.x;
+  const size_t tile_y_global = blockIdx.y;
+  if (tile_y_global >= total_row_blocks) return;
+
+  const size_t tile_row_stride = static_cast<size_t>(kTileDim) * K;
+  const size_t tensor_id = find_tensor_id_by_block_y<kSameBothDims>(
+      tile_y_global, num_tensors, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+  const size_t tensor_block_y_base =
+      kSameBothDims
+          ? (tensor_id * common_first_dim_blocks)
+          : tensor_block_y_base_from_offsets(tensor_id, tensor_offsets_ptr, tile_row_stride);
+  const size_t tensor_row_blocks =
+      kSameBothDims
+          ? common_first_dim_blocks
+          : (tensor_block_y_base_from_offsets(tensor_id + 1, tensor_offsets_ptr, tile_row_stride) -
+             tensor_block_y_base);
+  if (tile_y_global >= tensor_block_y_base + tensor_row_blocks) return;
+
+  const size_t global_row_base = tile_y_global * kTileDim;
+  const size_t global_col_base = tile_x * kTileDim;
+
+  // Dynamic smem: IType[kTileDim][kTileDim], 128 B aligned for TMA. Static smem
+  // (smem_T when CW, tma_mbar) lives outside the dynamic region.
+  extern __shared__ unsigned char smem_raw_1d_tma[];
+  unsigned char* smem_base = common::align_smem_ptr_per_TMA_requirements(smem_raw_1d_tma);
+  IType(*smem)[kTileDim] = reinterpret_cast<IType(*)[kTileDim]>(smem_base);
+
+  __shared__ uint64_t tma_mbar;
+  const int tid = threadIdx.x;
+  const bool leading_thread = (tid == 0);
+
+  // ---- TMA async load of the input tile ----
+  if (leading_thread) {
+    ptx::mbarrier_init(&tma_mbar, 1);
+    // Fence so the TMA engine (async proxy) and the threads (generic proxy)
+    // both observe the just-initialized mbarrier consistently.
+    ptx::fence_proxy_async_shared_cta();
+  }
+  __syncthreads();
+  if (leading_thread) {
+    constexpr uint32_t tx_bytes = kTileDim * kTileDim * sizeof(IType);
+    ptx::mbarrier_arrive_expect_tx(&tma_mbar, tx_bytes);
+    ptx::cp_async_bulk_tensor_2d_global_to_shared_cta(
+        reinterpret_cast<uint64_t*>(smem_base),
+        reinterpret_cast<const uint64_t*>(&tensor_map_input),
+        static_cast<uint32_t>(global_col_base), static_cast<uint32_t>(global_row_base), &tma_mbar);
+  }
+  ptx::mbarrier_wait_parity(&tma_mbar, 0);
+  if (leading_thread) ptx::mbarrier_invalid(&tma_mbar);
+  __syncthreads();
+
+  // ---- Optional dbias: per-tile column sum of the high-precision input (smem-resident) ----
+  if (dbias_workspace != nullptr) {
+    write_tile_dbias_partial<IType>(smem, tid, global_col_base, K, tile_y_global, dbias_workspace);
+  }
+
+  // ---- RW pass (1x128 scale per row) ----
+  // 8 t/row, vec-16 reads from smem; emits rowwise gmem directly. Only entered
+  // when CW is also requested (BOTH) -- RW-only requests use the dedicated
+  // group_block_scaled_1d_rw_kernel which skips the TMA load.
+  if constexpr (kReturnRowwise) {
+    constexpr int kThreadsPerRowRW = 8;
+    constexpr int kVec = 16;
+    constexpr int kRowsPerIterRW = kThreadsPerBlock / kThreadsPerRowRW;  // 32
+    constexpr int kRwIters = kTileDim / kRowsPerIterRW;                  // 4
+
+    const int rw_thr_col = tid % kThreadsPerRowRW;
+    const int rw_thr_row = tid / kThreadsPerRowRW;
+    const int col_local = rw_thr_col * kVec;
+
+#pragma unroll
+    for (int it = 0; it < kRwIters; ++it) {
+      const int row_local = rw_thr_row + it * kRowsPerIterRW;
+      Vec<IType, kVec> in_vec;
+      in_vec.load_from(&smem[row_local][col_local]);
+
+      CType amax = compute_row_amax<IType, CType, kVec>(in_vec);
+      amax = subwarp_reduce_max_broadcast<kThreadsPerRowRW>(amax);
+
+      const CType scale =
+          compute_scale_from_types<IType, OType>(amax, epsilon, /*pow_2_scaling=*/false);
+      const CType scale_inv = 1.f / scale;
+
+      const size_t r_global = global_row_base + row_local;
+      const bool row_in_bounds = (r_global < R_total);
+
+      if (row_in_bounds && rw_thr_col == 0) {
+        // Per-expert layout matches the 1D RW kernel.
+        const size_t blocks_X_eff = DIVUP(K, static_cast<size_t>(kTileDim));
+        const size_t expert_offset = expert_scale_offset_1d_rowwise<kSameBothDims>(
+            tensor_id, blocks_X_eff, common_first_dim_blocks, tile_row_stride, tensor_offsets_ptr);
+        const size_t tensor_M = tensor_row_blocks * kTileDim;
+        const size_t per_expert_stride = DIVUP_TO_MULTIPLE(tensor_M, kScaleColAlign);
+        const size_t tensor_row_base = tensor_block_y_base * kTileDim;
+        const size_t r_local = r_global - tensor_row_base;
+        scale_inv_base[expert_offset + tile_x * per_expert_stride + r_local] = scale_inv;
+      }
+
+      if (row_in_bounds) {
+        const size_t cc = global_col_base + col_local;
+        Vec<OType, kVec> out_vec;
+        quantize_row_vec<IType, OType, CType, kVec>(out_vec, in_vec, scale);
+        if (cc + kVec <= K) {
+          out_vec.store_to(output_base + r_global * K + cc);
+        } else if (cc < K) {
+          out_vec.store_to_elts(output_base + r_global * K + cc, 0, K - cc);
+        }
+      }
+    }
+  }
+
+  if constexpr (kReturnRowwise && kReturnColwise) {
+    __syncthreads();
+  }
+
+  // ---- CW pass (128x1 scale per column) ----
+  // CW-only: 2 t/col, single column pass per CTA, 64-row reg_data per thread.
+  // BOTH:    4 t/col, two column passes per CTA, 32-row reg_data per thread.
+  //
+  // In BOTH, the RW pass's per-expert offset arithmetic raises register
+  // footprint past the 85-reg/thread threshold for 3 CTAs/SM on sm_90, so we
+  // halve the reg_data stage (and accept the extra XOR-reduce stage plus
+  // doubled column pass count) to recover that occupancy. CW-only is not
+  // occupancy-bound, so its 2 t/col path stays — 4 t/col increases the
+  // bank-conflict footprint on the smem load, which costs more than the extra
+  // CTA/SM gains.
+  //
+  // The columnwise buffer is physically transposed (cuBLAS FP8 block-scaling
+  // GEMM is TN-only); we stage in smem_T and drain to the per-expert (K, M_t)
+  // transposed block.
+  if constexpr (kReturnColwise) {
+    constexpr int kSMemTRowStride = kTileDim + 4;
+    __shared__ OType smem_T[kTileDim][kSMemTRowStride];
+
+    constexpr int kThreadsPerColCW = kReturnRowwise ? 4 : 2;
+    constexpr int kRowsPerThreadCW = kTileDim / kThreadsPerColCW;        // 32 (BOTH) / 64 (CW)
+    constexpr int kColsPerCWPass = kThreadsPerBlock / kThreadsPerColCW;  // 64 (BOTH) / 128 (CW)
+    constexpr int kCWPasses = kTileDim / kColsPerCWPass;                 // 2 (BOTH) / 1 (CW)
+
+    const int sub = tid % kThreadsPerColCW;
+    const int col_in_pass = tid / kThreadsPerColCW;
+    const int row_start = sub * kRowsPerThreadCW;
+
+#pragma unroll
+    for (int pass = 0; pass < kCWPasses; ++pass) {
+      const int col_local = pass * kColsPerCWPass + col_in_pass;
+
+      CType reg_data[kRowsPerThreadCW];
+      CType amax = 0.f;
+#pragma unroll
+      for (int e = 0; e < kRowsPerThreadCW; ++e) {
+        reg_data[e] = static_cast<CType>(smem[row_start + e][col_local]);
+        amax = fmaxf(amax, fabsf(reg_data[e]));
+      }
+      amax = subwarp_reduce_max_broadcast<kThreadsPerColCW>(amax);
+
+      const CType scale =
+          compute_scale_from_types<IType, OType>(amax, epsilon, /*pow_2_scaling=*/false);
+      const CType scale_inv = 1.f / scale;
+
+      const size_t c_global = global_col_base + col_local;
+      const bool col_in_bounds = (c_global < K);
+
+      if (col_in_bounds && sub == 0) {
+        scale_inv_t_base[c_global + tile_y_global * scale_t_stride_aligned_K] = scale_inv;
+      }
+
+      if (col_in_bounds) {
+#pragma unroll
+        for (int e = 0; e < kRowsPerThreadCW; ++e) {
+          smem_T[col_local][row_start + e] = static_cast<OType>(reg_data[e] * scale);
+        }
+      }
+    }
+    __syncthreads();
+
+    const size_t tensor_row_base = tensor_block_y_base * kTileDim;
+    const size_t tensor_M = tensor_row_blocks * kTileDim;
+    drain_smem_t_to_gmem<false, OType, kSMemTRowStride>(
+        smem_T, output_t_base, global_col_base, global_row_base, tensor_row_base, tensor_M, K, tid);
+  }
+#endif  // __CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000
+}
+
+// ----- Host-side dispatchers --------------------------------------------------------------------
+
+struct GroupedBlockwiseLaunchInfo {
+  size_t num_tensors;
+  size_t K;
+  size_t R_total;
+  size_t common_first_dim_blocks;
+  size_t total_row_blocks;
+  size_t blocks_X;
+  bool same_both_dims;
+  const int64_t* tensor_offsets_d = nullptr;
+};
+
+inline GroupedBlockwiseLaunchInfo prepare_grouped_blockwise_launch(const GroupedTensor* output) {
+  GroupedBlockwiseLaunchInfo info{};
+  const bool same_both_dims = output->all_same_shape();
+  const bool varying_first_dim = (!output->all_same_first_dim()) && output->all_same_last_dim();
+  NVTE_CHECK(same_both_dims || varying_first_dim,
+             "Grouped FP8 block-scaling supports only SAME_BOTH_DIMS and VARYING_FIRST_DIM "
+             "shape representations.");
+
+  info.same_both_dims = same_both_dims;
+  info.num_tensors = output->num_tensors;
+  info.K = output->get_common_last_dim();
+  NVTE_CHECK(info.K % TMA_GMEM_ALIGNMENT == 0,
+             "Last dim must be a multiple of TMA_GMEM_ALIGNMENT (", TMA_GMEM_ALIGNMENT,
+             ") for FP8 alignment.");
+
+  if (same_both_dims) {
+    const size_t common_first_dim = output->get_common_first_dim();
+    NVTE_CHECK(common_first_dim % kTileDim == 0,
+               "SAME_BOTH_DIMS first dim must be multiple of 128.");
+    info.common_first_dim_blocks = common_first_dim / kTileDim;
+    info.R_total = info.num_tensors * common_first_dim;
+  } else {
+    info.common_first_dim_blocks = 0;
+    info.R_total = output->logical_shape.data[0];
+    info.tensor_offsets_d = reinterpret_cast<const int64_t*>(output->tensor_offsets.dptr);
+    NVTE_CHECK(info.tensor_offsets_d != nullptr,
+               "VARYING_FIRST_DIM requires tensor_offsets to be set on the GroupedTensor.");
+  }
+  info.total_row_blocks = DIVUP(info.R_total, static_cast<size_t>(kTileDim));
+  info.blocks_X = DIVUP(info.K, static_cast<size_t>(kTileDim));
+  return info;
+}
+
+// Public dispatch — 2D block scaling.
+//
+// When `dbias` is non-null, also accumulate the bias gradient into `workspace` (reduced per
+// expert by grouped_reduce_dbias). Two-call protocol: the sizing pass (workspace unallocated)
+// reports the [total_row_blocks, K] fp32 shape and returns without launching.
+inline void group_quantize_blockwise_2d(const GroupedTensor* input, GroupedTensor* output,
+                                        const Tensor* noop, const float epsilon,
+                                        cudaStream_t stream, GroupedTensor* dbias = nullptr,
+                                        Tensor* workspace = nullptr) {
+  const int sm = transformer_engine::cuda::sm_arch();
+  NVTE_CHECK(sm >= 90 && sm < 100,
+             "Grouped FP8 block-scaling quantize is only supported on Hopper (SM90-SM99); "
+             "use MXFP8 on Blackwell (SM100) or newer. Got SM",
+             sm, ".");
+  const bool use_rowwise = output->has_data();
+  const bool use_colwise = output->has_columnwise_data();
+  NVTE_CHECK(use_rowwise || use_colwise,
+             "Either rowwise or columnwise output data must be allocated.");
+  NVTE_CHECK(is_fp8_dtype(output->dtype()), "Output must be FP8.");
+  NVTE_CHECK(input->num_tensors == output->num_tensors,
+             "Input and output must have same num_tensors.");
+
+  auto info = prepare_grouped_blockwise_launch(output);
+  if (info.R_total == 0 || info.K == 0) return;
+
+  float* dbias_workspace = nullptr;
+  if (dbias != nullptr) {
+    NVTE_CHECK(workspace != nullptr, "Workspace required for grouped FP8 block-scaling dbias.");
+    NVTE_CHECK(dbias->dtype() == input->dtype(), "dbias must have the same dtype as the input.");
+    if (workspace->data.dptr == nullptr) {
+      workspace->data.shape = {info.total_row_blocks, info.K};
+      workspace->data.dtype = DType::kFloat32;
+      return;  // sizing pass
+    }
+    dbias_workspace = reinterpret_cast<float*>(workspace->data.dptr);
+  }
+
+  using CType = float;
+  const float* noop_ptr =
+      (noop != nullptr) ? reinterpret_cast<const float*>(noop->data.dptr) : nullptr;
+
+  const size_t scale_stride_y = DIVUP_TO_MULTIPLE(info.blocks_X, 4);
+
+  dim3 grid(info.blocks_X, info.total_row_blocks, 1);
+
+  TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
+      input->dtype(), IType,
+      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(
+          output->dtype(), OType,
+          TRANSFORMER_ENGINE_SWITCH_CONDITION(
+              info.same_both_dims, kSameBothDims,
+              TRANSFORMER_ENGINE_SWITCH_CONDITION(
+                  use_rowwise, kRowwise,
+                  TRANSFORMER_ENGINE_SWITCH_CONDITION(
+                      use_colwise, kColwise, if constexpr (kRowwise || kColwise) {
+                        CUtensorMap tensor_map_input{};
+                        create_2D_tensor_map(tensor_map_input, input->data, info.R_total, info.K,
+                                             kTileDim, kTileDim, info.K, 0, sizeof(IType) * 8);
+                        auto tma_kernel =
+                            group_block_scaled_2d_tma_kernel<kSameBothDims, kRowwise, kColwise,
+                                                             CType, IType, OType>;
+                        const size_t smem_bytes =
+                            kTileDim * kTileDim * sizeof(IType) + TMA_SHMEM_ALIGNMENT - 1;
+                        NVTE_CHECK_CUDA(cudaFuncSetAttribute(
+                            tma_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                            static_cast<int>(smem_bytes)));
+                        tma_kernel<<<grid, kThreadsPerBlock, smem_bytes, stream>>>(
+                            tensor_map_input,
+                            kRowwise ? reinterpret_cast<OType*>(output->data.dptr) : nullptr,
+                            kColwise ? reinterpret_cast<OType*>(output->columnwise_data.dptr)
+                                     : nullptr,
+                            kRowwise ? reinterpret_cast<CType*>(output->scale_inv.dptr) : nullptr,
+                            kColwise ? reinterpret_cast<CType*>(output->columnwise_scale_inv.dptr)
+                                     : nullptr,
+                            info.tensor_offsets_d, info.num_tensors, info.common_first_dim_blocks,
+                            info.K, info.total_row_blocks, info.blocks_X, scale_stride_y, epsilon,
+                            noop_ptr, dbias_workspace);
+                        if (dbias_workspace != nullptr) {
+                          const ShapeRepresentation shape_rep =
+                              info.same_both_dims ? ShapeRepresentation::SAME_BOTH_DIMS
+                                                  : ShapeRepresentation::VARYING_FIRST_DIM;
+                          common::grouped_reduce_dbias<IType>(
+                              shape_rep, info.num_tensors, info.R_total, info.K,
+                              reinterpret_cast<const int64_t*>(output->tensor_offsets.dptr),
+                              reinterpret_cast<const int64_t*>(output->first_dims.dptr),
+                              reinterpret_cast<const int64_t*>(output->last_dims.dptr), dbias,
+                              dbias_workspace, kTileDim, stream);
+                        }
+                      })))));
+
+  NVTE_CHECK_CUDA(cudaGetLastError());
+}
+
+// Public dispatch — 1D block scaling.
+//
+// See group_quantize_blockwise_2d for dbias/workspace semantics. RW-only without dbias uses the
+// no-smem fast path; RW-only with dbias routes through the TMA kernel (input in smem) so the
+// per-tile column partial can be computed.
+inline void group_quantize_blockwise_1d(const GroupedTensor* input, GroupedTensor* output,
+                                        const Tensor* noop, const float epsilon,
+                                        cudaStream_t stream, GroupedTensor* dbias = nullptr,
+                                        Tensor* workspace = nullptr) {
+  const int sm = transformer_engine::cuda::sm_arch();
+  NVTE_CHECK(sm >= 90 && sm < 100,
+             "Grouped FP8 block-scaling quantize is only supported on Hopper (SM90-SM99); "
+             "use MXFP8 on Blackwell (SM100) or newer. Got SM",
+             sm, ".");
+  const bool use_rowwise = output->has_data();
+  const bool use_colwise = output->has_columnwise_data();
+  NVTE_CHECK(use_rowwise || use_colwise,
+             "Either rowwise or columnwise output data must be allocated.");
+  NVTE_CHECK(is_fp8_dtype(output->dtype()), "Output must be FP8.");
+  NVTE_CHECK(input->num_tensors == output->num_tensors,
+             "Input and output must have same num_tensors.");
+
+  auto info = prepare_grouped_blockwise_launch(output);
+  if (info.R_total == 0 || info.K == 0) return;
+
+  float* dbias_workspace = nullptr;
+  if (dbias != nullptr) {
+    NVTE_CHECK(workspace != nullptr, "Workspace required for grouped FP8 block-scaling dbias.");
+    NVTE_CHECK(dbias->dtype() == input->dtype(), "dbias must have the same dtype as the input.");
+    if (workspace->data.dptr == nullptr) {
+      workspace->data.shape = {info.total_row_blocks, info.K};
+      workspace->data.dtype = DType::kFloat32;
+      return;  // sizing pass
+    }
+    dbias_workspace = reinterpret_cast<float*>(workspace->data.dptr);
+  }
+
+  using CType = float;
+  const float* noop_ptr =
+      (noop != nullptr) ? reinterpret_cast<const float*>(noop->data.dptr) : nullptr;
+
+  const size_t scale_t_stride_aligned_K = DIVUP_TO_MULTIPLE(info.K, 4);
+
+  dim3 grid(info.blocks_X, info.total_row_blocks, 1);
+
+  TRANSFORMER_ENGINE_TYPE_SWITCH_INPUT(
+      input->dtype(), IType,
+      TRANSFORMER_ENGINE_TYPE_SWITCH_FP8ONLY(
+          output->dtype(), OType,
+          TRANSFORMER_ENGINE_SWITCH_CONDITION(
+              info.same_both_dims, kSameBothDims,
+              TRANSFORMER_ENGINE_SWITCH_CONDITION(
+                  use_rowwise, kRowwise,
+                  TRANSFORMER_ENGINE_SWITCH_CONDITION(
+                      use_colwise, kColwise,
+                      // RW-only without dbias uses the no-smem fast path; all else uses TMA.
+                      constexpr bool kRwOnly = kRowwise && !kColwise;
+                      const bool use_rw_fast_path = kRwOnly && (dbias_workspace == nullptr);
+                      if (use_rw_fast_path) {
+                        if constexpr (kRwOnly) {
+                          group_block_scaled_1d_rw_kernel<kSameBothDims, CType, IType, OType>
+                              <<<grid, kThreadsPerBlock, 0, stream>>>(
+                                  reinterpret_cast<const IType*>(input->data.dptr),
+                                  reinterpret_cast<OType*>(output->data.dptr),
+                                  reinterpret_cast<CType*>(output->scale_inv.dptr),
+                                  info.tensor_offsets_d, info.num_tensors,
+                                  info.common_first_dim_blocks, info.K, info.total_row_blocks,
+                                  info.R_total, epsilon, noop_ptr);
+                        }
+                      } else if constexpr (kRowwise || kColwise) {
+                        // CW-only, BOTH, or RW-only WITH dbias: smem-cached TMA kernel.
+                        const size_t smem_bytes = kTileDim * kTileDim * sizeof(IType);
+                        constexpr size_t kStaticSmemCWBytes =
+                            (kTileDim * (kTileDim + 4)) * sizeof(OType);
+                        const size_t static_smem_bytes = kColwise ? kStaticSmemCWBytes : 0;
+                        const size_t tma_smem_bytes = smem_bytes + TMA_SHMEM_ALIGNMENT - 1;
+                        const size_t total_smem_tma = tma_smem_bytes + static_smem_bytes;
+                        auto tma_kernel =
+                            group_block_scaled_1d_tma_kernel<kSameBothDims, kRowwise, kColwise,
+                                                             CType, IType, OType>;
+                        if (total_smem_tma >= 48 * 1024) {
+                          NVTE_CHECK_CUDA(cudaFuncSetAttribute(
+                              tma_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                              static_cast<int>(tma_smem_bytes)));
+                        }
+                        CUtensorMap tensor_map_input{};
+                        create_2D_tensor_map(tensor_map_input, input->data, info.R_total, info.K,
+                                             kTileDim, kTileDim, info.K, 0, sizeof(IType) * 8);
+                        tma_kernel<<<grid, kThreadsPerBlock, tma_smem_bytes, stream>>>(
+                            tensor_map_input,
+                            kRowwise ? reinterpret_cast<OType*>(output->data.dptr) : nullptr,
+                            kColwise ? reinterpret_cast<OType*>(output->columnwise_data.dptr)
+                                     : nullptr,
+                            kRowwise ? reinterpret_cast<CType*>(output->scale_inv.dptr) : nullptr,
+                            kColwise ? reinterpret_cast<CType*>(output->columnwise_scale_inv.dptr)
+                                     : nullptr,
+                            info.tensor_offsets_d, info.num_tensors, info.common_first_dim_blocks,
+                            info.K, info.total_row_blocks, info.blocks_X, scale_t_stride_aligned_K,
+                            info.R_total, epsilon, noop_ptr, dbias_workspace);
+                        if (dbias_workspace != nullptr) {
+                          const ShapeRepresentation shape_rep =
+                              info.same_both_dims ? ShapeRepresentation::SAME_BOTH_DIMS
+                                                  : ShapeRepresentation::VARYING_FIRST_DIM;
+                          common::grouped_reduce_dbias<IType>(
+                              shape_rep, info.num_tensors, info.R_total, info.K,
+                              reinterpret_cast<const int64_t*>(output->tensor_offsets.dptr),
+                              reinterpret_cast<const int64_t*>(output->first_dims.dptr),
+                              reinterpret_cast<const int64_t*>(output->last_dims.dptr), dbias,
+                              dbias_workspace, kTileDim, stream);
+                        }
+                      })))));
+
+  NVTE_CHECK_CUDA(cudaGetLastError());
+}
+
+}  // namespace fp8_blockwise
+}  // namespace dispatch
+}  // namespace transformer_engine
+
+#endif  // TRANSFORMER_ENGINE_GROUP_QUANTIZE_FP8_BLOCKWISE_CUH_

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -128,22 +128,22 @@ constexpr bool is_supported_arch() {
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-init
 __device__ __forceinline__ void mbarrier_init(uint64_t *mbar, const uint32_t count) {
-#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint32_t mbar_ptr = __cvta_generic_to_shared(mbar);
   asm volatile("mbarrier.init.shared.b64 [%0], %1;" ::"r"(mbar_ptr), "r"(count) : "memory");
 #else
-  NVTE_DEVICE_ERROR("mbarrier_init is only supported on SM 10.0+.");
-#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  NVTE_DEVICE_ERROR("mbarrier_init is only supported on SM 9.0+.");
+#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-inval
 __device__ __forceinline__ void mbarrier_invalid(uint64_t *mbar) {
-#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint32_t mbar_ptr = __cvta_generic_to_shared(mbar);
   asm volatile("mbarrier.inval.shared.b64 [%0];" ::"r"(mbar_ptr) : "memory");
 #else
-  NVTE_DEVICE_ERROR("mbarrier_invalid is only supported on SM 10.0+.");
-#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  NVTE_DEVICE_ERROR("mbarrier_invalid is only supported on SM 9.0+.");
+#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
 }
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-arrive
@@ -158,13 +158,13 @@ __device__ __forceinline__ void mbarrier_arrive(uint64_t *mbar) {
 
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-arrive
 __device__ __forceinline__ void mbarrier_arrive_expect_tx(uint64_t *mbar, const uint32_t tx_count) {
-#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint32_t mbar_ptr = __cvta_generic_to_shared(mbar);
   asm volatile("mbarrier.arrive.expect_tx.shared.b64 _, [%0], %1;" ::"r"(mbar_ptr), "r"(tx_count)
                : "memory");
 #else
-  NVTE_DEVICE_ERROR("mbarrier_arrive_expect_tx is only supported on SM 10.0+.");
-#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  NVTE_DEVICE_ERROR("mbarrier_arrive_expect_tx is only supported on SM 9.0+.");
+#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
 }
 
 __device__ __forceinline__ void mbarrier_arrive_expect_tx_cta_relaxed_shared_cta(
@@ -230,8 +230,26 @@ __device__ __forceinline__ void cp_async_bulk_tensor_2d_global_to_shared(
 #endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
 }
 
+// global -> shared::cta (no cluster; valid on Hopper sm_90+ and Blackwell with
+// cluster size 1). Used by the FP8 block-scaling grouped quantize kernels.
+__device__ __forceinline__ void cp_async_bulk_tensor_2d_global_to_shared_cta(
+    uint64_t *dst_shmem, const uint64_t *tensor_map_ptr, const uint32_t offset_x,
+    const uint32_t offset_y, uint64_t *mbar) {
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  uint32_t dst_shmem_ptr = __cvta_generic_to_shared(dst_shmem);
+  uint32_t mbar_ptr = __cvta_generic_to_shared(mbar);
+  asm volatile(
+      "cp.async.bulk.tensor.2d.shared::cta.global.tile"
+      ".mbarrier::complete_tx::bytes [%0], [%1, {%2, %3}], [%4];" ::"r"(dst_shmem_ptr),
+      "l"(tensor_map_ptr), "r"(offset_x), "r"(offset_y), "r"(mbar_ptr)
+      : "memory");
+#else
+  NVTE_DEVICE_ERROR("cp_async_bulk_tensor_2d_global_to_shared_cta is only supported on SM 9.0+.");
+#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+}
+
 __device__ __forceinline__ bool mbarrier_try_wait_parity(uint32_t mbar_ptr, const uint32_t parity) {
-#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint32_t waitComplete;
   asm volatile(
       "{\n\t .reg .pred P_OUT; \n\t"
@@ -243,19 +261,19 @@ __device__ __forceinline__ bool mbarrier_try_wait_parity(uint32_t mbar_ptr, cons
       : "memory");
   return static_cast<bool>(waitComplete);
 #else
-  NVTE_DEVICE_ERROR("mbarrier_try_wait_parity is only supported on SM 10.0+.");
-#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  NVTE_DEVICE_ERROR("mbarrier_try_wait_parity is only supported on SM 9.0+.");
+#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   return true;
 }
 
 __device__ __forceinline__ void mbarrier_wait_parity(uint64_t *mbar, const uint32_t parity) {
-#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint32_t mbar_ptr = __cvta_generic_to_shared(mbar);
   while (!mbarrier_try_wait_parity(mbar_ptr, parity)) {
   }
 #else
-  NVTE_DEVICE_ERROR("mbarrier_wait_parity is only supported on SM 10.0+.");
-#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  NVTE_DEVICE_ERROR("mbarrier_wait_parity is only supported on SM 9.0+.");
+#endif  // #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
 }
 
 __device__ __forceinline__ void mbarrier_wait_parity_acquire_cta_shared_cta(uint64_t *mbar,

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -316,6 +316,7 @@ py::object group_quantize(const at::Tensor &tensor, py::handle quantizer, const 
     FP8_CURRENT_SCALING_GROUPED_QUANTIZE,
     MXFP8_GROUPED_QUANTIZE,
     NVFP4_GROUPED_QUANTIZE,
+    FP8_BLOCKWISE_GROUPED_QUANTIZE,
     INVALID_FOR_GROUPED_QUANTIZE
   };
   GroupedQuantizationMode grouped_quantization_mode =
@@ -326,6 +327,8 @@ py::object group_quantize(const at::Tensor &tensor, py::handle quantizer, const 
     grouped_quantization_mode = GroupedQuantizationMode::NVFP4_GROUPED_QUANTIZE;
   } else if (detail::IsFloat8CurrentScalingQuantizers(quantizer.ptr())) {
     grouped_quantization_mode = GroupedQuantizationMode::FP8_CURRENT_SCALING_GROUPED_QUANTIZE;
+  } else if (detail::IsFloat8BlockwiseQuantizers(quantizer.ptr())) {
+    grouped_quantization_mode = GroupedQuantizationMode::FP8_BLOCKWISE_GROUPED_QUANTIZE;
   }
 
   if (empty_input_buffer) {
@@ -371,11 +374,23 @@ py::object group_quantize(const at::Tensor &tensor, py::handle quantizer, const 
       });
       break;
     }
+    case GroupedQuantizationMode::FP8_BLOCKWISE_GROUPED_QUANTIZE: {
+      Float8BlockQuantizer *fp8_block_quantizer_cpp =
+          static_cast<Float8BlockQuantizer *>(quantizer_cpp.get());
+      QuantizationConfigWrapper quant_config_cpp;
+      quant_config_cpp.set_force_pow_2_scales(fp8_block_quantizer_cpp->force_pow_2_scales);
+      quant_config_cpp.set_amax_epsilon(fp8_block_quantizer_cpp->amax_epsilon);
+      NVTE_SCOPED_GIL_RELEASE({
+        nvte_group_quantize(grouped_input_tensor.data(), grouped_output_tensor_cpp.data(),
+                            quant_config_cpp, at::cuda::getCurrentCUDAStream());
+      });
+      break;
+    }
     case GroupedQuantizationMode::INVALID_FOR_GROUPED_QUANTIZE:
     default:
       NVTE_ERROR(
-          "group_quantize: only supports MXFP8, NVFP4, or "
-          "Float8CurrentScalingQuantizer.");
+          "group_quantize: only supports MXFP8, NVFP4, Float8CurrentScalingQuantizer, or "
+          "Float8Blockwise quantizer.");
       break;
   }
 
@@ -479,8 +494,9 @@ py::object bgrad_group_quantize(const at::Tensor &tensor, py::handle quantizer,
 
   bool empty_input_buffer = logical_first_dim == 0 || logical_last_dim == 0;
 
-  NVTE_CHECK(detail::IsMXFP8Quantizers(quantizer.ptr()),
-             "bgrad_group_quantize: only MXFP8 quantizer is supported.");
+  NVTE_CHECK(detail::IsMXFP8Quantizers(quantizer.ptr()) ||
+                 detail::IsFloat8BlockwiseQuantizers(quantizer.ptr()),
+             "bgrad_group_quantize: only MXFP8 and FP8 block-scaling quantizers are supported.");
 
   auto quantizer_cpp = convert_quantizer(quantizer);
 
@@ -587,12 +603,19 @@ py::object group_dequantize(const py::handle &input, transformer_engine::DType o
   // Build input GroupedTensorWrapper.
   // Data tensors are stored as flat 1D buffers; use the quantizer's dtype
   // (e.g. kFloat8E4M3) rather than the raw tensor scalar_type (uint8).
-  auto input_cpp = GroupedTensorWrapper(num_tensors, logical_shape, quantizer->get_scaling_mode());
+  const NVTEScalingMode scaling_mode = quantizer->get_scaling_mode();
+  const bool is_block_scaling =
+      (scaling_mode == NVTE_BLOCK_SCALING_1D || scaling_mode == NVTE_BLOCK_SCALING_2D);
+  const bool is_nvfp4 = (scaling_mode == NVTE_NVFP4_1D_SCALING);
+  const DType scale_dtype = is_block_scaling ? DType::kFloat32
+                            : is_nvfp4       ? DType::kFloat8E4M3
+                                             : DType::kFloat8E8M0;
+  auto input_cpp = GroupedTensorWrapper(num_tensors, logical_shape, scaling_mode);
   if (rowwise_data.has_value()) {
     input_cpp.set_rowwise_data(rowwise_data->data_ptr(), quantizer->dtype,
                                std::vector<size_t>{static_cast<size_t>(rowwise_data->numel())});
     if (rowwise_scale_inv.has_value()) {
-      input_cpp.set_rowwise_scale_inv(rowwise_scale_inv->data_ptr(), DType::kFloat8E8M0,
+      input_cpp.set_rowwise_scale_inv(rowwise_scale_inv->data_ptr(), scale_dtype,
                                       getTensorShape(*rowwise_scale_inv));
     }
   }
@@ -601,7 +624,7 @@ py::object group_dequantize(const py::handle &input, transformer_engine::DType o
         columnwise_data->data_ptr(), quantizer->dtype,
         std::vector<size_t>{static_cast<size_t>(columnwise_data->numel())});
     if (columnwise_scale_inv.has_value()) {
-      input_cpp.set_columnwise_scale_inv(columnwise_scale_inv->data_ptr(), DType::kFloat8E8M0,
+      input_cpp.set_columnwise_scale_inv(columnwise_scale_inv->data_ptr(), scale_dtype,
                                          getTensorShape(*columnwise_scale_inv));
     }
   }

--- a/transformer_engine/pytorch/csrc/quantizer.cpp
+++ b/transformer_engine/pytorch/csrc/quantizer.cpp
@@ -1154,6 +1154,14 @@ std::pair<GroupedTensorWrapper, py::object> Float8BlockQuantizer::create_grouped
     const size_t logical_last_dim) const {
   using namespace pybind11::literals;
 
+  // The fused grouped FP8 block-scaling path uses unconstrained FP32 scales and does not
+  // implement power-of-2 scaling. Reject force_pow_2_scales rather than silently ignoring it;
+  // the unfused per-tensor split-quantize path still honors it.
+  NVTE_CHECK(!force_pow_2_scales,
+             "Fused grouped FP8 block-scaling quantize does not support force_pow_2_scales=True. "
+             "Set force_pow_2_scales=False, or use the unfused split-quantize path "
+             "(NVTE_GROUPED_LINEAR_USE_FUSED_GROUPED_GEMM=0) which supports power-of-2 scales.");
+
   const auto tensor_offsets =
       resolve_grouped_tensor_offsets(num_tensors, first_dims, last_dims, precomputed_tensor_offsets,
                                      logical_first_dim, logical_last_dim);
@@ -1169,18 +1177,36 @@ std::pair<GroupedTensorWrapper, py::object> Float8BlockQuantizer::create_grouped
   std::optional<at::Tensor> columnwise_scale_inv;
   const std::vector<size_t> logical_shape_vec = {logical_first_dim, logical_last_dim};
 
+  // cuBLAS FP8 block-scaling grouped GEMM consumes each expert's scales from a
+  // contiguous per-expert sub-block in the COMPACT (no 128x4 swizzle) layout —
+  // VEC128_32F / BLK128x128_32F, unlike MXFP8/NVFP4 which require the swizzle.
+  // Per-tensor first dims are multiples of 128, so the per-expert padded sizes
+  // sum exactly to `get_scale_shape` of the logical total shape for 1D and
+  // 2D-rowwise. The only case where the per-expert sum can exceed the
+  // totals-based size is 2D columnwise (per-expert roundup(blocks_y_t, 4)),
+  // so reserve a small slack there. Sizing from totals (instead of reading
+  // first_dims on host) keeps allocation CUDA-graph-safe: no device->host copy.
+  constexpr size_t kBlockLen = 128;
+  const size_t blocks_X = ceildiv(logical_last_dim, kBlockLen);
+
+  auto grouped_scale_elems = [&](bool columnwise) -> int64_t {
+    const auto sh = get_scale_shape(logical_shape_vec, columnwise);
+    int64_t total = static_cast<int64_t>(product(sh));
+    if (columnwise && block_scaling_dim == 2 && num_tensors > 1) {
+      // sum_t roundup(blocks_y_t, 4) <= roundup(total_blocks_y, 4) + 4*(num_tensors-1).
+      total += static_cast<int64_t>(blocks_X * 4 * (num_tensors - 1));
+    }
+    return total;
+  };
+
   if (rowwise_usage) {
     rowwise_data = at::empty({total_elements}, uint8_opts);
-    const auto scale_shape = get_scale_shape(logical_shape_vec, false);
-    const int64_t total_scale_elements = static_cast<int64_t>(product(scale_shape));
-    rowwise_scale_inv = at::empty({total_scale_elements}, float_opts);
+    rowwise_scale_inv = at::empty({grouped_scale_elems(false)}, float_opts);
   }
 
   if (columnwise_usage) {
     columnwise_data = at::empty({total_elements}, uint8_opts);
-    const auto scale_shape = get_scale_shape(logical_shape_vec, true);
-    const int64_t total_scale_elements = static_cast<int64_t>(product(scale_shape));
-    columnwise_scale_inv = at::empty({total_scale_elements}, float_opts);
+    columnwise_scale_inv = at::empty({grouped_scale_elems(true)}, float_opts);
   }
 
   GroupedTensorWrapper out_cpp(num_tensors, logical_shape, this->get_scaling_mode());
@@ -1195,6 +1221,8 @@ std::pair<GroupedTensorWrapper, py::object> Float8BlockQuantizer::create_grouped
     out_cpp.set_columnwise_scale_inv(columnwise_scale_inv->data_ptr(), DType::kFloat32,
                                      getTensorShape(*columnwise_scale_inv));
   }
+  // FP8 block-scaling grouped GEMM reads compact scales; never swizzle.
+  out_cpp.set_with_gemm_swizzled_scales(false);
   if (first_dims.has_value()) {
     out_cpp.set_first_dims(first_dims->data_ptr(), DType::kInt64, getTensorShape(*first_dims));
   }
@@ -1431,7 +1459,7 @@ std::vector<size_t> Float8BlockQuantizer::get_scale_shape(const std::vector<size
     }
     scale_shape = {sinv0, sinv1};
   } else {
-    // columnwise scaling factor shape
+    // columnwise scaling factor shape (compact)
     size_t sinv0 = 0;
     size_t sinv1 = 0;
     if (block_scaling_dim == 2) {


### PR DESCRIPTION
# Description

Implements grouped-tensor quantize for the FP8 1D (1x128) and 2D (128x128) block-scaling recipes in row-wise (RW), column-wise (CW) and BOTH quantization directions. A single CUDA kernel launch walks 128x128 tiles across every tensor in the group, with each CTA decoding its owning tensor from the device-side GroupedTensor metadata with (N, R, K) shapes. Supports `SAME_BOTH_DIMS` (all tensors identical) and `VARYING_FIRST_DIM` (constant K, varying R) shape representations. 

Three kernels share the dispatcher in `group_quantize_blockwise_{1d,2d}`:
- `group_block_scaled_1d_rw_kernel` — RW-only dispatch; 8 threads/row, reads global memory directly into vec-16 registers; bypasses TMA because the shared memory roundtrip and `ptx::mbarrier` does not buy anything without re-use in CW path.
- `group_block_scaled_1d_tma_kernel` — CW-only and BOTH dispatch; TMA bulk-load fills shared memory input cache. BOTH runs RW pass first (8 threads/row, vec-16 read from shared memory) then CW pass (2 threads/column, 64-row register stage); CW-only skips the RW pass. CW path writes the transposed-FP8 tile to a shared memory transpose staging buffer, then drains to global memory.
- `group_block_scaled_2d_tma_kernel` — RW-only, CW-only and BOTH dispatch; TMA bulk-load fills shared memory input cache. Pass 1 stages 8 IVecs/thread in registers while computing the per-tile scalar amax. Pass 2 quantizes from registers, emits row-wise output, stages column-wise output to shared memory transpose staging buffer, then drains to global memory.

Kernels are gated to Hopper (sm_90) at the host dispatcher (cuBlasLt grouped GEMM supports FP8 block-scaling only on Hopper).

PR includes PyTorch integration into te.GroupedTensor only.

PyTorch integration into te.GroupedLinear and JAX integration deferred to a follow-up PRs.

Partially resolves #2525

## Performance

Benchmark on H200 with a sweep of grouped tensors in (N, M, K) shapes:
- N ∈ {4, 8, 16, 32, 64, 128} (# of device-local experts)
- M = 4096 @ N = 4 → M = 128 @ N = 128 (# of tokens/expert, scaling inversely with # experts)
- K ∈ {1024, 1792, 2048, 3584, 4096, 7168} (device-local shard of TP-hidden/intermediate-FFN dim)

Two shape families per config:
- **U_MoE** (uniform, `SAME_BOTH_DIMS`): all experts share the (M, K) shape
- **J_MoE** (jagged, `VARYING_FIRST_DIM`): per-expert M drawn from an imbalanced routing, common K

Buckets:
- **Small/Unsaturated (S):** R·K ≤ 32M elements (< 2048 tiles and < 15 waves on H200's 132 SMs)
- **Large/Saturated (L):** R·K > 32M elements (> 2048 tiles, SMs busy across many waves)

Bucket medians across 3 reps. Speedup is grouped vs the split-quantized fallback that loops over the grouped tensor and quantizes each constituent sequentially. % mono is grouped throughput relative to a single non-grouped FP8 block-scaling quantize on the equivalent monolithic (N·M, K) tensor.

| Bucket | Path    | Grouped (ms) | Split (ms) | Speedup | % memcpy tput | % mono tput |
|:------:|:--------|-------------:|-----------:|--------:|--------------:|------------:|
| S | 1D RW   |       0.019 |      0.084 |  4.50× |        64.9 % |     114.9 % |
| S | 1D CW   |       0.022 |      0.090 |  4.17× |        56.4 % |     112.4 % |
| S | 1D BOTH |       0.033 |      0.116 |  3.57× |        50.2 % |     102.8 % |
| S | 2D RW   |       0.018 |      0.076 |  4.19× |        65.9 % |     100.9 % |
| S | 2D CW   |       0.020 |      0.089 |  4.64× |        62.6 % |     126.3 % |
| S | 2D BOTH |       0.027 |      0.089 |  3.68× |        66.3 % |      98.8 % |
| L | 1D RW   |       0.058 |      0.198 |  2.06× |        87.1 % |     118.7 % |
| L | 1D CW   |       0.064 |      0.213 |  2.05× |        77.3 % |     118.5 % |
| L | 1D BOTH |       0.098 |      0.282 |  1.77× |        66.7 % |     108.4 % |
| L | 2D RW   |       0.054 |      0.178 |  1.99× |        87.7 % |     100.1 % |
| L | 2D CW   |       0.058 |      0.213 |  2.20× |        85.3 % |     135.9 % |
| L | 2D BOTH |       0.078 |      0.213 |  1.62× |        85.0 % |     102.4 % |

| # experts (N) | S bucket | L bucket |
|--------------:|---------:|---------:|
|             4 |    1.74× |    1.42× |
|             8 |    2.40× |    1.45× |
|            16 |    4.18× |    1.89× |
|            32 |    5.50× |    2.81× |
|            64 |   10.43× |    7.51× |
|           128 |   19.81× |    8.72× |

### Notes

- % of mono throughput is roughly consistent across buckets for every path, confirming no per-expert overhead in the new kernels.
- Greater-than-100% mono throughput cases come from TMA bulk-loads, register staging, and vec-16 reads that the non-grouped FP8 block-scaling kernels do not have.
- Speedup over split-quantize scales as expected with # of experts (roughly linearly in the unsaturated regime).
- S-bucket % memcpy is lower than L because launch and per-CTA setup are not amortized over a long bandwidth-bound steady state; absolute kernel times are still small (< 35 µs).

## Known Sub-Optimalities

#### 1D CW load bank conflicts on ~35% of load wavefronts (reading from the shared memory input-cache)
- No possible stride padding or XOR swizzle to alleviate.
- TMA hardware swizzle with `CU_TENSOR_MAP_SWIZZLE_128B` has the right pattern but caps FP16/BF16 at 64-elements; does not fit the 128-element tile for FP8 block-scaling without doubling per-tile launch overhead (quadrupling for FP32).
- CW-only stays at 2 t/col. Going to 4 t/col would double the bank-conflict footprint (4 lanes per column at the same row stride instead of 2), and CW-only is not occupancy-bound (3 CTAs/SM regardless), so the restructure costs more than it saves.
- 1D BOTH uses 4 t/col with a 32-row reg_data per thread and two column passes per CTA. The RW pass's per-expert scale-offset arithmetic plus a 64-row reg_data crossed the 85-reg / 3-CTA threshold on sm_90; halving reg_data restores 4 CTAs/SM. The doubled column pass and extra XOR-reduce stage are cheap relative to the occupancy gain.

#### 1D BOTH reads the shared memory input-cache twice
- The RW (8 threads/row) and CW (2 threads/column) passes have different threading.
- Attempted to unify with 8 threads/row for both RW and CW. Caused bank conflicts on ~76% of store wavefronts (writing to the shared memory transpose buffer), reduced to ~43% with a XOR swizzle but not enough to beat separate RW/CW passes.
- Did not pursue the 2 threads/column unification; costs 40x more shfl ops than 8 threads/row attempt, plus a shared memory partial buffer and sync.

#### 2D CW/BOTH has bank conflicts on ~16% of store wavefronts (when writing to the shared memory transpose buffer)
- Already reduced from ~75% via a XOR swizzle, further reduction was not possible.
- Minimal impact (< 5%) on kernel time.

#### No TMA-store
- MXFP8 grouped quantize kernel leverages this by decomposing a 128x128 tile into 32-row sub-stages that each have their own independent 32x1 or 1x32 scale; shared memory footprint is based on a single sub-stage; can be quantized and TMA-stored independently; hides TMA-store of one stage under the compute of next stage.
- FP8 block-scaling 128-element scale-block spans the entire 128-row tile. Cannot decompose into independent sub-stages and pipeline the TMA-stores. Single non-pipelined TMA-store requires holding the transposed staging buffer for the entire tile until all work on tile is finished, blows up shared memory footprint, collapses occupancy to 2CTA/SM. The recipe itself is the roadblock.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes