### PR TITLE
[Common] Fix int32 overflow in multi_tensor_apply tensor sizes for numel > INT_MAX

### DIFF
--- a/transformer_engine/common/multi_tensor/adam.cu
+++ b/transformer_engine/common/multi_tensor/adam.cu
@@ -382,7 +382,7 @@ struct AdamFunctor {
 
 template <typename T, typename FULL_T, typename MOMENT_T>
 struct AdamCapturableFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *noop_gmem,
                                              TensorListMetadata<4> &tl,  // NOLINT(*)
                                              const float beta1, const float beta2, const int *step,
                                              const int bias_correction, const float epsilon,
@@ -402,7 +402,7 @@ struct AdamCapturableFunctor {
     // int tensor_num = tl.start_tensor_this_launch + tensor_loc;
 
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     T *g = reinterpret_cast<T *>(tl.addresses[0][tensor_loc]);
     g += chunk_idx * chunk_size;
@@ -476,7 +476,7 @@ struct AdamCapturableFunctor {
 
 template <typename T, typename FULL_T, typename MOMENT_T>
 struct AdamCapturableMasterFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *noop_gmem,
                                              TensorListMetadata<5> &tl,  // NOLINT(*)
                                              const float beta1, const float beta2, const int *step,
                                              const int bias_correction, const float epsilon,
@@ -496,7 +496,7 @@ struct AdamCapturableMasterFunctor {
     // int tensor_num = tl.start_tensor_this_launch + tensor_loc;
 
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     T *g = reinterpret_cast<T *>(tl.addresses[0][tensor_loc]);
     g += chunk_idx * chunk_size;

--- a/transformer_engine/common/multi_tensor/compute_scale.cu
+++ b/transformer_engine/common/multi_tensor/compute_scale.cu
@@ -24,7 +24,7 @@ namespace multi_tensor_compute_scale {
 #define BLOCK_SIZE 256
 
 struct ComputeScaleAndScaleInvFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *noop_gmem,
                                              TensorListMetadata<3> &tl,  // NOLINT(*)
                                              float max_fp8, bool force_pow_2_scales,
                                              float epsilon) {
@@ -34,7 +34,7 @@ struct ComputeScaleAndScaleInvFunctor {
 
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     float *amax = reinterpret_cast<float *>(tl.addresses[0][tensor_loc]);
     amax += chunk_idx * chunk_size;
@@ -57,11 +57,11 @@ struct ComputeScaleAndScaleInvFunctor {
 };
 
 struct ComputeScaleInvE8M0Functor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *unused,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *unused,
                                              TensorListMetadata<2> &tl) {
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     bf16 *amax = reinterpret_cast<bf16 *>(tl.addresses[0][tensor_loc]);
     amax += chunk_idx * chunk_size;

--- a/transformer_engine/common/multi_tensor/l2norm.cu
+++ b/transformer_engine/common/multi_tensor/l2norm.cu
@@ -113,7 +113,7 @@ reduce_block_into_lanes_max_op(T *x, T val, int lanes = 1,
 
 template <typename x_t>
 struct L2NormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *noop_gmem,
                                              TensorListMetadata<1> &tl,  // NOLINT(*),
                                              float *output, float *output_per_tensor,
                                              bool per_tensor, int max_chunks_per_tensor) {
@@ -123,7 +123,7 @@ struct L2NormFunctor {
 
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     x_t *x = reinterpret_cast<x_t *>(tl.addresses[0][tensor_loc]);
     x += chunk_idx * chunk_size;
@@ -182,7 +182,7 @@ struct L2NormFunctor {
 
 template <typename x_t>
 struct UnscaleL2NormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *noop_gmem,
                                              TensorListMetadata<1> &tl,  // NOLINT(*),
                                              const float *inv_scale, float *output,
                                              float *output_per_tensor, bool per_tensor,
@@ -193,7 +193,7 @@ struct UnscaleL2NormFunctor {
 
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     x_t *x = reinterpret_cast<x_t *>(tl.addresses[0][tensor_loc]);
     x += chunk_idx * chunk_size;
@@ -253,7 +253,7 @@ struct UnscaleL2NormFunctor {
 // Probably better to template, but since we are not likely to support other norm
 template <typename x_t>
 struct MaxNormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *noop_gmem,
                                              TensorListMetadata<1> &tl,  // NOLINT(*),
                                              float *output, float *output_per_tensor,
                                              bool per_tensor, int max_chunks_per_tensor) {
@@ -263,7 +263,7 @@ struct MaxNormFunctor {
 
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     x_t *x = reinterpret_cast<x_t *>(tl.addresses[0][tensor_loc]);
     x += chunk_idx * chunk_size;

--- a/transformer_engine/common/multi_tensor/multi_tensor_apply.cuh
+++ b/transformer_engine/common/multi_tensor/multi_tensor_apply.cuh
@@ -21,7 +21,7 @@ constexpr int depth_to_max_blocks[6] = {320, 320, 320, 320, 320, 320};
 template <int n, bool USE_FP8 = false>
 struct TensorListMetadataBase {
   void *addresses[n][depth_to_max_tensors[n - 1]];
-  int sizes[depth_to_max_tensors[n - 1]];
+  int64_t sizes[depth_to_max_tensors[n - 1]];
   unsigned char block_to_tensor[depth_to_max_blocks[n - 1]];
   int block_to_chunk[depth_to_max_blocks[n - 1]];
   int start_tensor_this_launch;

--- a/transformer_engine/common/multi_tensor/scale.cu
+++ b/transformer_engine/common/multi_tensor/scale.cu
@@ -38,7 +38,7 @@ __device__ __forceinline__ float get_scale_value(float scale) { return scale; }
 __device__ __forceinline__ float get_scale_value(const float *scale_ptr) { return *scale_ptr; }
 
 template <typename in_t, typename out_t, typename scale_t>
-__device__ __forceinline__ void scale_chunk(int chunk_size, volatile int *is_infinite_gmem,
+__device__ __forceinline__ void scale_chunk(int64_t chunk_size, volatile int *is_infinite_gmem,
                                             TensorListMetadata<2> &tl, scale_t scale_arg) {
   // I'd like this kernel to propagate infs/nans.
   // if(*noop_gmem == 1)
@@ -46,7 +46,7 @@ __device__ __forceinline__ void scale_chunk(int chunk_size, volatile int *is_inf
   const float scale = get_scale_value(scale_arg);
   int tensor_loc = tl.block_to_tensor[blockIdx.x];
   int chunk_idx = tl.block_to_chunk[blockIdx.x];
-  int n = tl.sizes[tensor_loc];
+  int64_t n = tl.sizes[tensor_loc];
 
   in_t *in = reinterpret_cast<in_t *>(tl.addresses[0][tensor_loc]);
   in += chunk_idx * chunk_size;
@@ -104,7 +104,7 @@ __device__ __forceinline__ void scale_chunk(int chunk_size, volatile int *is_inf
 
 template <typename in_t, typename out_t>
 struct ScaleFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *is_infinite_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *is_infinite_gmem,
                                              TensorListMetadata<2> &tl,  // NOLINT(*)
                                              float scale) {
     scale_chunk<in_t, out_t>(chunk_size, is_infinite_gmem, tl, scale);
@@ -113,7 +113,7 @@ struct ScaleFunctor {
 
 template <typename in_t, typename out_t>
 struct ScalePtrFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int *is_infinite_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int *is_infinite_gmem,
                                              TensorListMetadata<2> &tl,  // NOLINT(*)
                                              float *scale_ptr) {
     scale_chunk<in_t, out_t>(chunk_size, is_infinite_gmem, tl, scale_ptr);

--- a/transformer_engine/common/multi_tensor/sgd.cu
+++ b/transformer_engine/common/multi_tensor/sgd.cu
@@ -35,7 +35,7 @@ namespace multi_tensor_sgd {
  **/
 template <int N, typename T_grad, typename T_weight>
 struct SGDFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem,
+  __device__ __forceinline__ void operator()(int64_t chunk_size, volatile int* noop_gmem,
                                              TensorListMetadata<N>& tl,  // NOLINT(*)
                                              float wd, float momentum, float dampening, float lr,
                                              bool nesterov, bool first_run, bool wd_after_momentum,
@@ -45,7 +45,7 @@ struct SGDFunctor {
 
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    int64_t n = tl.sizes[tensor_loc];
 
     T_grad* grad_in = reinterpret_cast<T_grad*>(tl.addresses[0][tensor_loc]);
     grad_in += chunk_idx * chunk_size;


### PR DESCRIPTION
# Description

`TensorListMetadataBase::sizes` in `multi_tensor_apply.cuh` is declared as `int` (int32) but populated from `Tensor::numel()`, which is 64-bit. A tensor with `numel() > INT_MAX` truncates to a negative size, and the consumer kernels then compute out-of-bounds element offsets from it, raising an illegal memory access at the next CUDA sync. This is hit by any model with a single parameter over 2.14B elements (large-vocab embeddings, tied output layers) feeding TE's multi-tensor utilities, e.g. through Megatron's `calc_params_l2_norm`.

Fixes #2918

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Store `TensorListMetadataBase::sizes` as `int64_t` in `multi_tensor_apply.cuh`.
- Read each size into an `int64_t` (or the existing templated `index_t` in the Adam kernels) before the `n -= chunk_idx * chunk_size` subtraction in `adam.cu`, `compute_scale.cu`, `l2norm.cu`, `scale.cu`, and `sgd.cu`.
- Widen the `chunk_size` kernel argument to `int64_t` in every consumer that took it as `int` (the `AdamCapturable`/`AdamCapturableMaster` functors plus the non-Adam kernels) so the `chunk_idx * chunk_size` element offset is computed in 64-bit. The already-templated Adam kernels keep `index_t` chunk_size.

No public API change. The widening is confined to the multi_tensor metadata and the kernel index arithmetic.

## Testing

Verified statically on a box without a GPU: the size and chunk_size paths are now 64-bit, so values above INT_MAX no longer wrap negative. I could not run the runtime repro here, since reproducing the `numel > INT_MAX` path needs a multi-GB GPU allocation. Happy to add a guarded large-tensor regression test for `multi_tensor_l2norm` if maintainers want one gated behind sufficient device memory.

Signed-off-by: Javier de Jesus <javier.dejesusj9@gmail.com>
