### PR TITLE
[PyTorch] Make quantized-tensor __repr__ safe

### DIFF
--- a/transformer_engine/pytorch/tensor/_quantization_helpers.py
+++ b/transformer_engine/pytorch/tensor/_quantization_helpers.py
@@ -10,7 +10,6 @@ the quantization machinery.
 
 from __future__ import annotations
 from typing import Callable, Optional, Tuple, Any, Dict, TYPE_CHECKING
-import warnings
 import torch
 
 if TYPE_CHECKING:
@@ -86,22 +85,11 @@ def _stride_from_shape(shape: list[int]):
     return list(reversed(rstride))
 
 
-def _is_fake_data_access_error(error):
-    """Heuristic: is this the error PyTorch raises when a repr tries to read the
-    data pointer of a fake/functional tensor (e.g. under torch.compile tracing)?
-
-    The exact exception type and message are not contractual across PyTorch
-    versions, so match defensively on the message text. Anything that is not
-    recognized is treated as an unexpected error worth surfacing.
-    """
-    message = str(error).lower()
-    return "data pointer" in message or "faketensor" in message or "functionaltensor" in message
-
-
 def safe_quantized_repr(obj, cls_name, extras=None, error=None):
     """Metadata-only repr fallback for quantized tensors whose data cannot be
-    materialized (e.g. a FakeTensor under torch.compile tracing, where
-    dequantize()/.item() would access a data pointer).
+    materialized for any reason.
+
+    Each attribute access is guarded so that ``__repr__`` never raises.
 
     Parameters
     ----------
@@ -110,18 +98,10 @@ def safe_quantized_repr(obj, cls_name, extras=None, error=None):
         ``{"is_2D_scaled": self._is_2D_scaled}``. Values are inserted after
         ``fp8_dtype`` and before ``shape``.
     error : BaseException, optional
-        The exception that triggered the fallback. The expected trigger is the
-        data-pointer access error PyTorch raises for fake/functional tensors;
-        anything else is surfaced as a warning so that real eager-path failures
-        (e.g. CUDA OOM, shape bugs) are not silently swallowed by ``__repr__``.
+        The exception that triggered the fallback. When given, its type and
+        message are included in the ``data=`` field so that it is visible *why*
+        the data could not be materialized.
     """
-    if error is not None and not _is_fake_data_access_error(error):
-        warnings.warn(
-            f"{cls_name}.__repr__ fell back to a metadata-only representation "
-            "because an unexpected error occurred while materializing data: "
-            f"{type(error).__name__}: {error}",
-            stacklevel=2,
-        )
     parts = []
     fp8_dtype = getattr(obj, "_fp8_dtype", None)
     if fp8_dtype is not None:
@@ -137,5 +117,8 @@ def safe_quantized_repr(obj, cls_name, extras=None, error=None):
         parts.append(f"dtype={obj.dtype}")
     except Exception:  # pylint: disable=broad-except
         pass
-    parts.append("data=<unmaterialized>")
+    if error is not None:
+        parts.append(f"data=<unmaterialized: {type(error).__name__}: {error}>")
+    else:
+        parts.append("data=<unmaterialized>")
     return f"{cls_name}({', '.join(parts)})"

--- a/transformer_engine/pytorch/tensor/_quantization_helpers.py
+++ b/transformer_engine/pytorch/tensor/_quantization_helpers.py
@@ -10,6 +10,7 @@ the quantization machinery.
 
 from __future__ import annotations
 from typing import Callable, Optional, Tuple, Any, Dict, TYPE_CHECKING
+import warnings
 import torch
 
 if TYPE_CHECKING:
@@ -83,3 +84,58 @@ def _stride_from_shape(shape: list[int]):
     for d in reversed(shape[1:]):
         rstride.append(rstride[-1] * d)
     return list(reversed(rstride))
+
+
+def _is_fake_data_access_error(error):
+    """Heuristic: is this the error PyTorch raises when a repr tries to read the
+    data pointer of a fake/functional tensor (e.g. under torch.compile tracing)?
+
+    The exact exception type and message are not contractual across PyTorch
+    versions, so match defensively on the message text. Anything that is not
+    recognized is treated as an unexpected error worth surfacing.
+    """
+    message = str(error).lower()
+    return "data pointer" in message or "faketensor" in message or "functionaltensor" in message
+
+
+def safe_quantized_repr(obj, cls_name, extras=None, error=None):
+    """Metadata-only repr fallback for quantized tensors whose data cannot be
+    materialized (e.g. a FakeTensor under torch.compile tracing, where
+    dequantize()/.item() would access a data pointer).
+
+    Parameters
+    ----------
+    extras : dict, optional
+        Additional plain-Python (non-tensor) attributes to include, e.g.
+        ``{"is_2D_scaled": self._is_2D_scaled}``. Values are inserted after
+        ``fp8_dtype`` and before ``shape``.
+    error : BaseException, optional
+        The exception that triggered the fallback. The expected trigger is the
+        data-pointer access error PyTorch raises for fake/functional tensors;
+        anything else is surfaced as a warning so that real eager-path failures
+        (e.g. CUDA OOM, shape bugs) are not silently swallowed by ``__repr__``.
+    """
+    if error is not None and not _is_fake_data_access_error(error):
+        warnings.warn(
+            f"{cls_name}.__repr__ fell back to a metadata-only representation "
+            f"because an unexpected error occurred while materializing data: "
+            f"{type(error).__name__}: {error}",
+            stacklevel=2,
+        )
+    parts = []
+    fp8_dtype = getattr(obj, "_fp8_dtype", None)
+    if fp8_dtype is not None:
+        parts.append(f"fp8_dtype={fp8_dtype}")
+    if extras:
+        for key, value in extras.items():
+            parts.append(f"{key}={value}")
+    try:
+        parts.append(f"shape={tuple(obj.shape)}")
+    except Exception:  # pylint: disable=broad-except
+        pass
+    try:
+        parts.append(f"dtype={obj.dtype}")
+    except Exception:  # pylint: disable=broad-except
+        pass
+    parts.append("data=<unmaterialized>")
+    return f"{cls_name}({', '.join(parts)})"

--- a/transformer_engine/pytorch/tensor/_quantization_helpers.py
+++ b/transformer_engine/pytorch/tensor/_quantization_helpers.py
@@ -118,7 +118,7 @@ def safe_quantized_repr(obj, cls_name, extras=None, error=None):
     if error is not None and not _is_fake_data_access_error(error):
         warnings.warn(
             f"{cls_name}.__repr__ fell back to a metadata-only representation "
-            f"because an unexpected error occurred while materializing data: "
+            "because an unexpected error occurred while materializing data: "
             f"{type(error).__name__}: {error}",
             stacklevel=2,
         )

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -14,7 +14,7 @@ import transformer_engine_torch as tex
 from transformer_engine.common.recipe import Float8BlockScaling, Recipe
 from .storage.float8_blockwise_tensor_storage import Float8BlockwiseQTensorStorage
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 from ..constants import DType
 from ..utils import devices_match, round_up_to_nearest_multiple
 
@@ -267,11 +267,19 @@ class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):
         return instance
 
     def __repr__(self, *, tensor_contents=None):
-        return (
-            f"Float8BlockwiseQTensor(fp8_dtype={self._fp8_dtype},"
-            f" is_2D_scaled={self._is_2D_scaled},"
-            f" data={self.dequantize()})"
-        )
+        try:
+            return (
+                f"Float8BlockwiseQTensor(fp8_dtype={self._fp8_dtype},"
+                f" is_2D_scaled={self._is_2D_scaled},"
+                f" data={self.dequantize()})"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(
+                self,
+                "Float8BlockwiseQTensor",
+                extras={"is_2D_scaled": self._is_2D_scaled},
+                error=exc,
+            )
 
     def quantize_(
         self,

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -18,7 +18,7 @@ from transformer_engine.common.recipe import (
 from ..utils import canonicalize_process_group, devices_match
 from .storage.float8_tensor_storage import Float8TensorStorage, _FromFloat8Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 from ..constants import dist_group_type, DType
 
 aten = torch.ops.aten
@@ -412,13 +412,16 @@ class Float8Tensor(Float8TensorStorage, QuantizedTensor):
     """
 
     def __repr__(self, *, tensor_contents=None):
-        return (
-            "Float8Tensor("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"scale_inv={self._scale_inv.item()}, "
-            f"data={self.dequantize()}"
-            ")"
-        )
+        try:
+            return (
+                "Float8Tensor("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"scale_inv={self._scale_inv.item()}, "
+                f"data={self.dequantize()}"
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "Float8Tensor", error=exc)
 
     def dequantize(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -18,7 +18,7 @@ from ..constants import MXFP8_BLOCK_SCALING_SIZE, DType
 from ..utils import devices_match, round_up_to_nearest_multiple
 from .storage.mxfp8_tensor_storage import MXFP8TensorStorage, _FromMXFP8Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 
 aten = torch.ops.aten
 
@@ -233,7 +233,10 @@ class MXFP8Tensor(MXFP8TensorStorage, QuantizedTensor):
         )
 
     def __repr__(self, *, tensor_contents=None):
-        return f"MXFP8Tensor(fp8_dtype={self._fp8_dtype}, data={self.dequantize()})"
+        try:
+            return f"MXFP8Tensor(fp8_dtype={self._fp8_dtype}, data={self.dequantize()})"
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "MXFP8Tensor", error=exc)
 
     def dequantize(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -23,7 +23,7 @@ from ..utils import (
 
 from .storage.nvfp4_tensor_storage import NVFP4TensorStorage, _FromNVFP4Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 
 aten = torch.ops.aten
 
@@ -398,7 +398,10 @@ class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
         return instance
 
     def __repr__(self, *, tensor_contents=None):
-        return f"NVFP4Tensor, data={self.dequantize()})"
+        try:
+            return f"NVFP4Tensor, data={self.dequantize()})"
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "NVFP4Tensor", error=exc)
 
     def dequantize(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """

--- a/transformer_engine/pytorch/tensor/storage/float8_blockwise_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_blockwise_tensor_storage.py
@@ -12,6 +12,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType_To_Torch, DType
 
@@ -354,17 +355,25 @@ class Float8BlockwiseQTensorStorage(QuantizedTensorStorage):
             del _old_data
 
     def __repr__(self):
-        if self._rowwise_data is not None:
-            data = self.dequantize()
-            descriptor = "rowwise"
-        else:
-            data = self.dequantize()
-            descriptor = "columnwise"
-        return (
-            "Float8BlockwiseQTensorStorage("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"{descriptor}_scaled_data={data})"
-        )
+        try:
+            if self._rowwise_data is not None:
+                data = self.dequantize()
+                descriptor = "rowwise"
+            else:
+                data = self.dequantize()
+                descriptor = "columnwise"
+            return (
+                "Float8BlockwiseQTensorStorage("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"{descriptor}_scaled_data={data})"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(
+                self,
+                "Float8BlockwiseQTensorStorage",
+                extras={"is_2D_scaled": self._is_2D_scaled},
+                error=exc,
+            )
 
     def update_usage(
         self, rowwise_usage: Optional[bool] = None, columnwise_usage: Optional[bool] = None

--- a/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
@@ -12,6 +12,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType as torch_to_transformer_engine_dtype, TE_DType_To_Torch, DType
 
@@ -209,13 +210,16 @@ class Float8TensorStorage(QuantizedTensorStorage):
         )
 
     def __repr__(self):
-        return (
-            "Float8TensorStorage("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"scale_inv={self._scale_inv.item()}, "
-            f"data={self.dequantize()}"
-            ")"
-        )
+        try:
+            return (
+                "Float8TensorStorage("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"scale_inv={self._scale_inv.item()}, "
+                f"data={self.dequantize()}"
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "Float8TensorStorage", error=exc)
 
     def _create_transpose(self):
         """Update FP8 transpose cache"""

--- a/transformer_engine/pytorch/tensor/storage/mxfp8_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/mxfp8_tensor_storage.py
@@ -13,6 +13,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType as torch_to_transformer_engine_dtype, DType
 
@@ -257,15 +258,18 @@ class MXFP8TensorStorage(QuantizedTensorStorage):
         )
 
     def __repr__(self):
-        data_rowwise = self.dequantize()
+        try:
+            data_rowwise = self.dequantize()
 
-        return (
-            "MXFP8TensorStorage("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"rowwise_scaled_data={data_rowwise}"
-            f"rowwise_scale_inv={self._rowwise_scale_inv}, "
-            ")"
-        )
+            return (
+                "MXFP8TensorStorage("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"rowwise_scaled_data={data_rowwise}"
+                f"rowwise_scale_inv={self._rowwise_scale_inv}, "
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "MXFP8TensorStorage", error=exc)
 
     def update_usage(
         self,

--- a/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
@@ -16,6 +16,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType as torch_to_transformer_engine_dtype, DType
 from ...utils import _empty_tensor
@@ -340,16 +341,19 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
         )
 
     def __repr__(self):
-        data_rowwise = self.dequantize()
+        try:
+            data_rowwise = self.dequantize()
 
-        return (
-            "NVFP4TensorStorage("
-            f"rowwise_scaled_data={data_rowwise},"
-            f"rowwise_scale_inv={self._rowwise_scale_inv},"
-            f"amax_rowwise={self._amax_rowwise},"
-            f"amax_columnwise={self._amax_columnwise},"
-            ")"
-        )
+            return (
+                "NVFP4TensorStorage("
+                f"rowwise_scaled_data={data_rowwise},"
+                f"rowwise_scale_inv={self._rowwise_scale_inv},"
+                f"amax_rowwise={self._amax_rowwise},"
+                f"amax_columnwise={self._amax_columnwise},"
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "NVFP4TensorStorage", error=exc)
 
     def update_usage(
         self,


### PR DESCRIPTION
# Description

I've encountered multiple situations when there was some error in the code inside __repr__. 
It's very annoying, so I created this PR to fallback to some safe repr, when dequantize is not possible.

Also in some torch.compile logic in pytorch __repr__ is called for Float8Tensor with fake tensors inside, which obviously fails on `.deqauntize()`.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add a shared helper `safe_quantized_repr(obj, cls_name)` in `transformer_engine/pytorch/tensor/_quantization_helpers.py` (a safe leaf module importing only `torch`) that builds a metadata-only repr (`fp8_dtype`, `shape`, `dtype`, `data=<unmaterialized>`), defensively guarding each attribute access.
- Wrap each data-touching `__repr__` body in `try/except Exception` and fall back to `safe_quantized_repr` when data cannot be materialized. Affected classes: `Float8Tensor`, `Float8BlockwiseQTensor`, `MXFP8Tensor`, `NVFP4Tensor`, and their `*Storage` counterparts (`Float8TensorStorage`, `Float8BlockwiseQTensorStorage`, `MXFP8TensorStorage`, `NVFP4TensorStorage`).
- The eager (non-fake) repr strings are left exactly as before; the existing (malformed) `NVFP4Tensor` eager string is intentionally preserved in the try branch and not "fixed".


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

*AI assistance: this PR was prepared with the help of Claude (Anthropic) under my review.*
