### PR TITLE
Disable cuDNN 9.23.0/9.23.1 for MXFP8 attention

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -631,9 +631,7 @@ def get_attention_backend(
                     use_fused_attention = False
                 elif cudnn_version in ((9, 23, 0), (9, 23, 1)):
                     # 9.23.0/9.23.1: known bugs with MXFP8 SDPA
-                    logger.debug(
-                        "Disabling FusedAttention for MXFP8 with cuDNN 9.23.0/9.23.1"
-                    )
+                    logger.debug("Disabling FusedAttention for MXFP8 with cuDNN 9.23.0/9.23.1")
                     use_fused_attention = False
                 elif qkv_format == "thd":
                     logger.debug("Disabling FusedAttention for MXFP8 with qkv_format = thd")

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -629,6 +629,12 @@ def get_attention_backend(
                 if cudnn_version < (9, 21, 0):
                     logger.debug("Disabling FusedAttention for MXFP8 with cuDNN < 9.21.0")
                     use_fused_attention = False
+                elif cudnn_version in ((9, 23, 0), (9, 23, 1)):
+                    # 9.23.0/9.23.1: known bugs with MXFP8 SDPA
+                    logger.debug(
+                        "Disabling FusedAttention for MXFP8 with cuDNN 9.23.0/9.23.1"
+                    )
+                    use_fused_attention = False
                 elif qkv_format == "thd":
                     logger.debug("Disabling FusedAttention for MXFP8 with qkv_format = thd")
                     use_fused_attention = False


### PR DESCRIPTION
# Description

There are some Inf/Nan issues with MXFP8 attention when running with cuDNN 9.23.0 and 9.23.1. They are fixed in 9.23.2.

https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html#cudnn-9-23-2

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

See Description.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
