### PR TITLE
[Common] Blackwell skip condition for C++ grouped FP8 block-scaling tests

### DIFF
--- a/tests/cpp/operator/test_cast_float8blockwise_grouped.cu
+++ b/tests/cpp/operator/test_cast_float8blockwise_grouped.cu
@@ -74,7 +74,8 @@ template <typename InputType, typename OutputType>
 void perform_test(ShapeRep shape_rep, BlockDim block_dim, ScalingDir dir,
                   const std::vector<size_t>& first_dims_h, size_t K,
                   bool force_pow_2_scales, float epsilon) {
-  if (getDeviceComputeCapability() < hopperComputeCapability) {
+  if (getDeviceComputeCapability() < hopperComputeCapability ||
+      getDeviceComputeCapability() >= blackwellComputeCapability) {
     GTEST_SKIP();
   }
 


### PR DESCRIPTION
# Description

Corrected condition to skip grouped FP8 block-scaling tests on Blackwell+.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
