### PR TITLE
grouped linear single param fixes

### DIFF
--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -1113,6 +1113,64 @@ class TestGroupedMLPFusedOp:
             activation=activation,
         )
 
+    @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+    def test_single_grouped_weight_eval_preserves_columnwise_usage(
+        self,
+        *,
+        dtype: torch.dtype = torch.bfloat16,
+        device: torch.device = "cuda",
+        group_size: int = 2,
+        hidden_size: int = 128,
+    ) -> None:
+        """Eager eval must not drop storage still used by captured training dgrad."""
+
+        if not te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported():
+            pytest.skip("MXFP8 fused grouped MLP is not supported on this system")
+
+        split_sizes = torch.full(
+            (group_size,),
+            128,
+            dtype=torch.int64,
+            device=device,
+        )
+        num_tokens = int(split_sizes.sum())
+        recipe = make_recipe("mxfp8")
+
+        with te.quantized_model_init(enabled=True, recipe=recipe):
+            fc1 = te.ops.GroupedLinear(
+                group_size,
+                hidden_size,
+                2 * hidden_size,
+                device=device,
+                dtype=dtype,
+                single_grouped_weight=True,
+            )
+            fc2 = te.ops.GroupedLinear(
+                group_size,
+                hidden_size,
+                hidden_size,
+                device=device,
+                dtype=dtype,
+                single_grouped_weight=True,
+            )
+            module = te.ops.Sequential(
+                fc1,
+                te.ops.ScaledSwiGLU(glu_interleave_size=32),
+                fc2,
+            )
+
+        x = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype, requires_grad=True)
+        probs = torch.ones(num_tokens, device=device, dtype=dtype)
+        with te.autocast(enabled=True, recipe=recipe):
+            module(x, split_sizes, probs, split_sizes)
+        assert fc1.weight.quantizer.columnwise_usage
+        assert fc2.weight.quantizer.columnwise_usage
+
+        with torch.no_grad(), te.autocast(enabled=True, recipe=recipe):
+            module(x.detach(), split_sizes, probs, split_sizes)
+        assert fc1.weight.quantizer.columnwise_usage
+        assert fc2.weight.quantizer.columnwise_usage
+
     @pytest.mark.parametrize("quantization", _grouped_mlp_quantization_list)
     @pytest.mark.parametrize("single_grouped_weight", (False, True))
     @pytest.mark.parametrize("accumulate_into_main_grad", (False, True))

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -248,10 +248,10 @@ class TestGroupedLinearOp:
         # Mirror an external caller attaching the grouped parent after constructing
         # the parameterless shell, then verify delayed-wgrad metadata is applied.
         grouped_weight = torch.nn.Parameter(torch.empty(2, 16, 16, device="meta"))
+        assert not hasattr(grouped_weight, "skip_backward_post_hook")
         op.register_parameter("weight", grouped_weight)
         for group_idx in range(op.num_groups):
             op.register_parameter(f"weight{group_idx}", None)
-        op._apply_delay_wgrad_param_hooks()
 
         assert grouped_weight.skip_backward_post_hook
 

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -228,6 +228,33 @@ def make_reference_and_test_tensors(
 class TestGroupedLinearOp:
     """Tests for advanced features with grouped linear basic op"""
 
+    def test_meta_single_grouped_weight_with_delayed_wgrad(self, monkeypatch) -> None:
+        """A deferred op shell must not access its grouped parent before it is attached."""
+        monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
+
+        op = te.ops.GroupedLinear(
+            2,
+            16,
+            16,
+            device="meta",
+            dtype=torch.bfloat16,
+            single_grouped_weight=True,
+            delay_wgrad_compute=True,
+        )
+
+        assert op._parameters.get("weight") is None
+        assert op.weight0.device.type == "meta"
+
+        # Mirror an external caller attaching the grouped parent after constructing
+        # the parameterless shell, then verify delayed-wgrad metadata is applied.
+        grouped_weight = torch.nn.Parameter(torch.empty(2, 16, 16, device="meta"))
+        op.register_parameter("weight", grouped_weight)
+        for group_idx in range(op.num_groups):
+            op.register_parameter(f"weight{group_idx}", None)
+        op._apply_delay_wgrad_param_hooks()
+
+        assert grouped_weight.skip_backward_post_hook
+
     @pytest.mark.parametrize("bias", (False, True))
     @pytest.mark.parametrize("dtype", _dtypes)
     @pytest.mark.parametrize("quantization", _quantization_list)

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -650,6 +650,8 @@ def test_sanity_grouped_linear(
     loss = out.sum()
     loss.backward()
     assert out.shape == (num_tokens, ffn_hidden_size)
+    if single_param:
+        assert te_grouped_linear.weight.grad is not None
 
 
 @pytest.mark.parametrize("dtype", param_types)
@@ -1152,6 +1154,78 @@ def test_quantized_model_init_high_precision_init_val():
     assert not hasattr(
         weight, "._high_precision_init_val"
     ), "clear_high_precision_init_val() not work"
+
+
+@pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+def test_grouped_linear_single_param_preserves_high_precision_init(monkeypatch):
+    """Packing MXFP8 weights preserves the values used to initialize optimizer masters."""
+    monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
+    init_value = 0.125
+
+    def init_method(tensor):
+        return torch.nn.init.constant_(tensor, init_value)
+
+    with quantized_model_init(
+        enabled=True,
+        recipe=recipe.MXFP8BlockScaling(),
+        preserve_high_precision_init_val=True,
+    ):
+        module = GroupedLinear(
+            num_gemms=3,
+            in_features=32,
+            out_features=64,
+            bias=False,
+            init_method=init_method,
+            params_dtype=torch.bfloat16,
+            single_grouped_weight=True,
+        ).cuda()
+
+    weight = module.weight
+    assert hasattr(weight, "get_high_precision_init_val")
+    assert hasattr(weight, "clear_high_precision_init_val")
+    high_precision_init = weight.get_high_precision_init_val()
+    assert high_precision_init.device.type == "cpu"
+    assert high_precision_init.shape == weight.shape
+    torch.testing.assert_close(
+        high_precision_init,
+        torch.full_like(high_precision_init, init_value),
+        rtol=0,
+        atol=0,
+    )
+
+    weight.clear_high_precision_init_val()
+    assert weight.get_high_precision_init_val() is None
+
+
+@pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+def test_grouped_linear_single_param_legacy_fused_wgrad(monkeypatch):
+    """Legacy GroupedLinear accumulates MXFP8 member wgrads into the grouped parent."""
+    monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
+    monkeypatch.setenv("NVTE_GROUPED_LINEAR_USE_FUSED_GROUPED_GEMM", "0")
+    dtype = torch.bfloat16
+
+    with quantized_model_init(enabled=True, recipe=recipe.MXFP8BlockScaling()):
+        module = GroupedLinear(
+            num_gemms=2,
+            in_features=32,
+            out_features=64,
+            bias=False,
+            params_dtype=dtype,
+            fuse_wgrad_accumulation=True,
+            single_grouped_weight=True,
+        ).cuda()
+
+    weight = module.weight
+    weight.main_grad = torch.zeros(weight.shape, dtype=dtype, device="cuda")
+    weight.grad_added_to_main_grad = False
+    inp = torch.randn(32, 32, dtype=dtype, device="cuda", requires_grad=True)
+
+    with autocast(enabled=True, recipe=recipe.MXFP8BlockScaling()):
+        module(inp, [16, 16]).sum().backward()
+
+    assert weight.grad_added_to_main_grad
+    assert weight.grad is not None
+    assert torch.count_nonzero(weight.main_grad).item() > 0
 
 
 def test_sanity_checkpointing_on_callables():

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -3,6 +3,7 @@
 # See LICENSE for license information.
 
 from typing import Optional, List
+from unittest import mock
 
 import torch
 import pytest
@@ -36,6 +37,7 @@ from transformer_engine.pytorch import (
 )
 from transformer_engine.common import recipe
 from transformer_engine.pytorch.cpp_extensions import general_gemm
+from transformer_engine.pytorch.module import grouped_linear as grouped_linear_module
 from transformer_engine.pytorch.tensor.utils import replace_raw_data
 from utils import ModelConfig, recipe_id, skip_unsupported_backward_override
 
@@ -1258,12 +1260,18 @@ def test_grouped_linear_single_param_legacy_fused_wgrad(monkeypatch):
     weight.grad_added_to_main_grad = False
     inp = torch.randn(32, 32, dtype=dtype, device="cuda", requires_grad=True)
 
-    with autocast(enabled=True, recipe=recipe.MXFP8BlockScaling()):
-        module(inp, [16, 16]).sum().backward()
+    with mock.patch.object(
+        grouped_linear_module,
+        "get_dummy_wgrad",
+        wraps=grouped_linear_module.get_dummy_wgrad,
+    ) as dummy_wgrad:
+        with autocast(enabled=True, recipe=recipe.MXFP8BlockScaling()):
+            module(inp, [16, 16]).sum().backward()
 
     assert weight.grad_added_to_main_grad
     assert weight.grad is not None
     assert torch.count_nonzero(weight.main_grad).item() > 0
+    dummy_wgrad.assert_any_call(list(weight.shape), weight.dtype, zero=False)
 
 
 def test_sanity_checkpointing_on_callables():

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -1158,43 +1158,81 @@ def test_quantized_model_init_high_precision_init_val():
 
 @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
 def test_grouped_linear_single_param_preserves_high_precision_init(monkeypatch):
-    """Packing MXFP8 weights preserves the values used to initialize optimizer masters."""
+    """Grouped MXFP8 and discrete weights produce identical FP32 master initialization."""
     monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
-    init_value = 0.125
+    num_gemms = 3
 
-    def init_method(tensor):
-        return torch.nn.init.constant_(tensor, init_value)
+    def make_module(single_grouped_weight):
+        torch.manual_seed(1234)
+        torch.cuda.manual_seed(1234)
+        with quantized_model_init(
+            enabled=True,
+            recipe=recipe.MXFP8BlockScaling(),
+            preserve_high_precision_init_val=True,
+        ):
+            return GroupedLinear(
+                num_gemms=num_gemms,
+                in_features=32,
+                out_features=64,
+                bias=False,
+                params_dtype=torch.bfloat16,
+                single_grouped_weight=single_grouped_weight,
+            ).cuda()
 
+    discrete_module = make_module(False)
+    grouped_module = make_module(True)
+    discrete_init_vals = [
+        getattr(discrete_module, f"weight{i}").get_high_precision_init_val()
+        for i in range(num_gemms)
+    ]
+    expected_grouped_init = torch.stack(discrete_init_vals, dim=0)
+
+    grouped_weight = grouped_module.weight
+    assert hasattr(grouped_weight, "get_high_precision_init_val")
+    assert hasattr(grouped_weight, "clear_high_precision_init_val")
+    grouped_init = grouped_weight.get_high_precision_init_val()
+    assert grouped_init.device.type == "cpu"
+    assert grouped_init.shape == grouped_weight.shape
+    torch.testing.assert_close(
+        grouped_init,
+        expected_grouped_init,
+        rtol=0,
+        atol=0,
+    )
+
+    # This is the exact layout consumed when constructing the FP32 optimizer master.
+    discrete_master = expected_grouped_init.float()
+    grouped_master = grouped_init.float()
+    torch.testing.assert_close(grouped_master, discrete_master, rtol=0, atol=0)
+
+    grouped_weight.clear_high_precision_init_val()
+    assert grouped_weight.get_high_precision_init_val() is None
+
+
+@pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+def test_grouped_linear_rejects_partial_high_precision_init(monkeypatch):
+    """Packing fails rather than mixing preserved and dequantized initialization."""
+    monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
     with quantized_model_init(
         enabled=True,
         recipe=recipe.MXFP8BlockScaling(),
         preserve_high_precision_init_val=True,
     ):
         module = GroupedLinear(
-            num_gemms=3,
+            num_gemms=2,
             in_features=32,
             out_features=64,
             bias=False,
-            init_method=init_method,
             params_dtype=torch.bfloat16,
-            single_grouped_weight=True,
+            single_grouped_weight=False,
         ).cuda()
 
-    weight = module.weight
-    assert hasattr(weight, "get_high_precision_init_val")
-    assert hasattr(weight, "clear_high_precision_init_val")
-    high_precision_init = weight.get_high_precision_init_val()
-    assert high_precision_init.device.type == "cpu"
-    assert high_precision_init.shape == weight.shape
-    torch.testing.assert_close(
-        high_precision_init,
-        torch.full_like(high_precision_init, init_value),
-        rtol=0,
-        atol=0,
-    )
-
-    weight.clear_high_precision_init_val()
-    assert weight.get_high_precision_init_val() is None
+    module.weight0.clear_high_precision_init_val()
+    with pytest.raises(
+        RuntimeError,
+        match="inconsistent high-precision initialization state",
+    ):
+        module.make_grouped_weights()
 
 
 @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -3,7 +3,6 @@
 # See LICENSE for license information.
 
 from typing import Optional, List
-from unittest import mock
 
 import torch
 import pytest
@@ -37,7 +36,6 @@ from transformer_engine.pytorch import (
 )
 from transformer_engine.common import recipe
 from transformer_engine.pytorch.cpp_extensions import general_gemm
-from transformer_engine.pytorch.module import grouped_linear as grouped_linear_module
 from transformer_engine.pytorch.tensor.utils import replace_raw_data
 from utils import ModelConfig, recipe_id, skip_unsupported_backward_override
 
@@ -1238,40 +1236,78 @@ def test_grouped_linear_rejects_partial_high_precision_init(monkeypatch):
 
 
 @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
-def test_grouped_linear_single_param_legacy_fused_wgrad(monkeypatch):
-    """Legacy GroupedLinear accumulates MXFP8 member wgrads into the grouped parent."""
+@pytest.mark.parametrize("fuse_wgrad_accumulation", (False, True))
+def test_grouped_linear_single_param_legacy_wgrad_matches_discrete(
+    monkeypatch,
+    fuse_wgrad_accumulation,
+):
+    """Single-grouped and discrete MXFP8 weights produce identical legacy wgrads."""
     monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
     monkeypatch.setenv("NVTE_GROUPED_LINEAR_USE_FUSED_GROUPED_GEMM", "0")
     dtype = torch.bfloat16
+    num_gemms = 2
 
-    with quantized_model_init(enabled=True, recipe=recipe.MXFP8BlockScaling()):
-        module = GroupedLinear(
-            num_gemms=2,
-            in_features=32,
-            out_features=64,
-            bias=False,
-            params_dtype=dtype,
-            fuse_wgrad_accumulation=True,
-            single_grouped_weight=True,
-        ).cuda()
+    def make_module(single_grouped_weight):
+        torch.manual_seed(1234)
+        torch.cuda.manual_seed(1234)
+        with quantized_model_init(enabled=True, recipe=recipe.MXFP8BlockScaling()):
+            return GroupedLinear(
+                num_gemms=num_gemms,
+                in_features=32,
+                out_features=64,
+                bias=False,
+                params_dtype=dtype,
+                fuse_wgrad_accumulation=fuse_wgrad_accumulation,
+                single_grouped_weight=single_grouped_weight,
+            ).cuda()
 
-    weight = module.weight
-    weight.main_grad = torch.zeros(weight.shape, dtype=dtype, device="cuda")
-    weight.grad_added_to_main_grad = False
-    inp = torch.randn(32, 32, dtype=dtype, device="cuda", requires_grad=True)
+    discrete_module = make_module(False)
+    grouped_module = make_module(True)
 
-    with mock.patch.object(
-        grouped_linear_module,
-        "get_dummy_wgrad",
-        wraps=grouped_linear_module.get_dummy_wgrad,
-    ) as dummy_wgrad:
+    if fuse_wgrad_accumulation:
+        for index in range(num_gemms):
+            weight = getattr(discrete_module, f"weight{index}")
+            weight.main_grad = torch.zeros(
+                tuple(weight.shape), dtype=weight.dtype, device=weight.device
+            )
+            weight.grad_added_to_main_grad = False
+        grouped_module.weight.main_grad = torch.zeros(
+            tuple(grouped_module.weight.shape),
+            dtype=grouped_module.weight.dtype,
+            device=grouped_module.weight.device,
+        )
+        grouped_module.weight.grad_added_to_main_grad = False
+
+    torch.manual_seed(5678)
+    torch.cuda.manual_seed(5678)
+    inp = torch.randn(64, 32, dtype=dtype, device="cuda")
+    grad_output = torch.randn(64, 64, dtype=dtype, device="cuda")
+
+    def run_backward(module):
+        module_input = inp.detach().clone().requires_grad_(True)
         with autocast(enabled=True, recipe=recipe.MXFP8BlockScaling()):
-            module(inp, [16, 16]).sum().backward()
+            output = module(module_input, [32, 32])
+        output.backward(grad_output)
 
-    assert weight.grad_added_to_main_grad
-    assert weight.grad is not None
-    assert torch.count_nonzero(weight.main_grad).item() > 0
-    dummy_wgrad.assert_any_call(list(weight.shape), weight.dtype, zero=False)
+    run_backward(discrete_module)
+    run_backward(grouped_module)
+
+    if fuse_wgrad_accumulation:
+        discrete_wgrads = [
+            getattr(discrete_module, f"weight{i}").main_grad for i in range(num_gemms)
+        ]
+        grouped_wgrad = grouped_module.weight.main_grad
+        assert grouped_module.weight.grad_added_to_main_grad
+    else:
+        discrete_wgrads = [
+            getattr(discrete_module, f"weight{i}").grad for i in range(num_gemms)
+        ]
+        grouped_wgrad = grouped_module.weight.grad
+
+    assert all(wgrad is not None for wgrad in discrete_wgrads)
+    assert grouped_wgrad is not None
+    discrete_wgrad = torch.stack(discrete_wgrads)
+    torch.testing.assert_close(grouped_wgrad, discrete_wgrad, rtol=0, atol=0)
 
 
 def test_sanity_checkpointing_on_callables():

--- a/tests/pytorch/test_sanity.py
+++ b/tests/pytorch/test_sanity.py
@@ -1299,9 +1299,7 @@ def test_grouped_linear_single_param_legacy_wgrad_matches_discrete(
         grouped_wgrad = grouped_module.weight.main_grad
         assert grouped_module.weight.grad_added_to_main_grad
     else:
-        discrete_wgrads = [
-            getattr(discrete_module, f"weight{i}").grad for i in range(num_gemms)
-        ]
+        discrete_wgrads = [getattr(discrete_module, f"weight{i}").grad for i in range(num_gemms)]
         grouped_wgrad = grouped_module.weight.grad
 
     assert all(wgrad is not None for wgrad in discrete_wgrads)

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -87,6 +87,27 @@ _MIN_STREAM_PRIORITY, _MAX_STREAM_PRIORITY = None, None
 layers_atomic_ring_exchange = []
 
 
+def _get_high_precision_init_val(parameter: torch.Tensor) -> Optional[torch.Tensor]:
+    """Return temporary pre-quantization initialization stored on a parameter."""
+    return getattr(parameter, "_high_precision_init_val", None)
+
+
+def _clear_high_precision_init_val(parameter: torch.Tensor) -> None:
+    """Release temporary pre-quantization initialization stored on a parameter."""
+    if hasattr(parameter, "_high_precision_init_val"):
+        del parameter._high_precision_init_val
+
+
+def _attach_high_precision_init_val(
+    parameter: torch.Tensor,
+    high_precision_init_val: torch.Tensor,
+) -> None:
+    """Attach TE's temporary high-precision initialization contract to a parameter."""
+    parameter._high_precision_init_val = high_precision_init_val
+    parameter.get_high_precision_init_val = MethodType(_get_high_precision_init_val, parameter)
+    parameter.clear_high_precision_init_val = MethodType(_clear_high_precision_init_val, parameter)
+
+
 def is_ub_initialized() -> bool:
     """Whether the Userbuffers communicators have been initialized."""
     return _ub_initialized
@@ -1787,21 +1808,10 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 #   should call `clear_high_precision_init_val` to remove it after master weight
                 #   is initialized.
 
-                def get(self):
-                    if hasattr(self, "_high_precision_init_val"):
-                        return self._high_precision_init_val
-                    return None
-
-                def clear(self):
-                    if hasattr(self, "_high_precision_init_val"):
-                        del self._high_precision_init_val
-
                 # DTensor.from_local() does not preserve object identity,
                 # so attach to the DTensor's local tensor when applicable.
                 target = dtensor_param._local_tensor if is_dtensor else param
-                target._high_precision_init_val = high_precision_init_val
-                target.get_high_precision_init_val = MethodType(get, target)
-                target.clear_high_precision_init_val = MethodType(clear, target)
+                _attach_high_precision_init_val(target, high_precision_init_val)
 
             if not is_dtensor:
                 self.module_setattr(name, param)

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -80,6 +80,8 @@ class _GroupedWeightAutogradBridge(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, grouped_weight: torch.Tensor, fuse_wgrad_accumulation: bool):
+        # Backward only needs the parent's identity/attributes, not saved tensor values;
+        # use a weakref to avoid extending its lifetime or creating a reference cycle.
         ctx.grouped_weight_ref = weakref.ref(grouped_weight)
         ctx.fuse_wgrad_accumulation = bool(fuse_wgrad_accumulation)
         members = grouped_weight.quantized_tensors

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -7,6 +7,7 @@
 from typing import Union, Optional, Callable, Tuple, List
 from itertools import chain
 import os
+from types import MethodType
 import warnings
 import weakref
 
@@ -66,6 +67,76 @@ from ...debug.pytorch.debug_quantization import DebugQuantizer
 from ...debug.pytorch.debug_state import TEDebugState
 
 __all__ = ["GroupedLinear"]
+
+
+def _get_high_precision_init_val(
+    grouped_weight: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    """Return the pre-quantization initialization preserved on a grouped parameter."""
+    return getattr(grouped_weight, "_high_precision_init_val", None)
+
+
+def _clear_high_precision_init_val(grouped_weight: torch.Tensor) -> None:
+    """Release a grouped parameter's temporary high-precision initialization."""
+    if hasattr(grouped_weight, "_high_precision_init_val"):
+        del grouped_weight._high_precision_init_val
+
+
+class _GroupedWeightAutogradBridge(torch.autograd.Function):
+    """Connect cached per-GEMM views to their registered grouped parameter.
+
+    The legacy GroupedLinear autograd function consumes cached member tensors. Those
+    tensors are storage views, not registered parameters, so using them directly drops
+    the autograd edge to the grouped parent. This bridge makes the parent the autograd
+    input while preserving the member objects required by the grouped GEMM kernels.
+    """
+
+    @staticmethod
+    def forward(ctx, grouped_weight: torch.Tensor, fuse_wgrad_accumulation: bool):
+        ctx.grouped_weight_ref = weakref.ref(grouped_weight)
+        ctx.fuse_wgrad_accumulation = bool(fuse_wgrad_accumulation)
+        members = grouped_weight.quantized_tensors
+        if members is None:
+            members = grouped_weight.split_into_quantized_tensors()
+        return tuple(members)
+
+    @staticmethod
+    def backward(ctx, *member_grads):
+        grouped_weight = ctx.grouped_weight_ref()
+        if grouped_weight is None:
+            raise RuntimeError("Grouped weight was released before backward completed")
+
+        if ctx.fuse_wgrad_accumulation:
+            # GroupedLinear has already written each wgrad into a view of the parent's
+            # main_grad. Trigger the parent's accumulator/DDP hook with a zero dummy
+            # gradient and tell MCore not to add that dummy to main_grad.
+            if hasattr(grouped_weight, "grad_added_to_main_grad"):
+                grouped_weight.grad_added_to_main_grad = True
+            grouped_grad = torch.zeros(
+                tuple(grouped_weight.shape),
+                dtype=grouped_weight.dtype,
+                device=grouped_weight.device,
+            )
+        else:
+            members = grouped_weight.quantized_tensors
+            if members is None:
+                members = grouped_weight.split_into_quantized_tensors()
+            grouped_grad = torch.stack(
+                [
+                    (
+                        grad
+                        if grad is not None
+                        else torch.zeros(
+                            tuple(member.shape),
+                            dtype=grouped_weight.dtype,
+                            device=grouped_weight.device,
+                        )
+                    )
+                    for member, grad in zip(members, member_grads)
+                ],
+                dim=0,
+            )
+        return grouped_grad, None
 
 
 class _GroupedLinear(torch.autograd.Function):
@@ -1467,6 +1538,22 @@ class GroupedLinear(TransformerEngineBaseModule):
 
         weights = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
 
+        # TE preserves the original BF16/FP16 initialization on each quantized
+        # parameter so distributed optimizers can construct lossless FP32 masters.
+        # Packing the parameters must transfer those values to the new registered
+        # grouped parameter; otherwise its master is initialized by dequantizing
+        # MXFP8 and starts from a different value than the discrete-weight layout.
+        high_precision_init_vals = []
+        for weight in weights:
+            getter = getattr(weight, "get_high_precision_init_val", None)
+            high_precision_init_vals.append(getter() if callable(getter) else None)
+        if any(value is not None for value in high_precision_init_vals) and not all(
+            value is not None for value in high_precision_init_vals
+        ):
+            raise RuntimeError(
+                "Grouped weights have inconsistent high-precision initialization state"
+            )
+
         # Create the weight storage.
         grouped_weights = GroupedTensor.make_grouped_tensor_with_shapes(
             num_tensors=self.num_gemms,
@@ -1490,9 +1577,27 @@ class GroupedLinear(TransformerEngineBaseModule):
             and (weight_quantizers[0] is None or not weight_quantizers[0].internal)
         ):
             raise RuntimeError("Found internal quantizer with `single_grouped_weight=True`.")
+        grouped_parameter = torch.nn.Parameter(grouped_weights)
+        for member in grouped_parameter.quantized_tensors:
+            member.requires_grad_(grouped_parameter.requires_grad)
+        if all(value is not None for value in high_precision_init_vals):
+            grouped_parameter._high_precision_init_val = torch.stack(
+                high_precision_init_vals, dim=0
+            )
+            grouped_parameter.get_high_precision_init_val = MethodType(
+                _get_high_precision_init_val, grouped_parameter
+            )
+            grouped_parameter.clear_high_precision_init_val = MethodType(
+                _clear_high_precision_init_val, grouped_parameter
+            )
+            for weight in weights:
+                clear = getattr(weight, "clear_high_precision_init_val", None)
+                if callable(clear):
+                    clear()
+
         self.register_parameter(
             "weight",
-            torch.nn.Parameter(grouped_weights),
+            grouped_parameter,
             init_fn=self.init_method,
             get_rng_state_tracker=self.get_rng_state_tracker,
             fp8_meta_index=self._offsets["weight"],
@@ -1904,6 +2009,28 @@ class GroupedLinear(TransformerEngineBaseModule):
             if weight_tensors is None:
                 # TODO(ksivaman): Remove this after GEMM integration.
                 weight_tensors = grouped_weight.split_into_quantized_tensors()
+            if torch.is_grad_enabled() and grouped_weight.requires_grad:
+                weight_tensors = list(
+                    _GroupedWeightAutogradBridge.apply(grouped_weight, self.fuse_wgrad_accumulation)
+                )
+                # Quantized tensor subclasses preserve the cached wrapper's original
+                # requires_grad bit when a custom autograd Function returns an alias.
+                # The grouped parent is trainable, so make that state explicit on the
+                # bridged member outputs consumed by legacy GroupedLinear autograd.
+                for weight in weight_tensors:
+                    weight.requires_grad_(True)
+                if self.fuse_wgrad_accumulation:
+                    grouped_main_grad = getattr(grouped_weight, "main_grad", None)
+                    for index, weight in enumerate(weight_tensors):
+                        if grouped_main_grad is not None:
+                            weight.main_grad = grouped_main_grad[index]
+                        for attr in (
+                            "grad_added_to_main_grad",
+                            "overwrite_main_grad",
+                            "zero_out_wgrad",
+                        ):
+                            if hasattr(grouped_weight, attr):
+                                setattr(weight, attr, getattr(grouped_weight, attr))
         else:
             weight_tensors = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
         if not self.fp8 and any(isinstance(w, QuantizedTensorStorage) for w in weight_tensors):

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -7,7 +7,6 @@
 from typing import Union, Optional, Callable, Tuple, List
 from itertools import chain
 import os
-from types import MethodType
 import warnings
 import weakref
 
@@ -28,6 +27,7 @@ from .base import (
     _2X_ACC_FPROP,
     _2X_ACC_DGRAD,
     _2X_ACC_WGRAD,
+    _attach_high_precision_init_val,
 )
 from ._common import WeightGradStore
 from ..quantization import FP8GlobalStateManager, QuantizerRole
@@ -67,19 +67,6 @@ from ...debug.pytorch.debug_quantization import DebugQuantizer
 from ...debug.pytorch.debug_state import TEDebugState
 
 __all__ = ["GroupedLinear"]
-
-
-def _get_high_precision_init_val(
-    grouped_weight: torch.Tensor,
-) -> Optional[torch.Tensor]:
-    """Return the pre-quantization initialization preserved on a grouped parameter."""
-    return getattr(grouped_weight, "_high_precision_init_val", None)
-
-
-def _clear_high_precision_init_val(grouped_weight: torch.Tensor) -> None:
-    """Release a grouped parameter's temporary high-precision initialization."""
-    if hasattr(grouped_weight, "_high_precision_init_val"):
-        del grouped_weight._high_precision_init_val
 
 
 class _GroupedWeightAutogradBridge(torch.autograd.Function):
@@ -1581,14 +1568,9 @@ class GroupedLinear(TransformerEngineBaseModule):
         for member in grouped_parameter.quantized_tensors:
             member.requires_grad_(grouped_parameter.requires_grad)
         if all(value is not None for value in high_precision_init_vals):
-            grouped_parameter._high_precision_init_val = torch.stack(
-                high_precision_init_vals, dim=0
-            )
-            grouped_parameter.get_high_precision_init_val = MethodType(
-                _get_high_precision_init_val, grouped_parameter
-            )
-            grouped_parameter.clear_high_precision_init_val = MethodType(
-                _clear_high_precision_init_val, grouped_parameter
+            _attach_high_precision_init_val(
+                grouped_parameter,
+                torch.stack(high_precision_init_vals, dim=0),
             )
             for weight in weights:
                 clear = getattr(weight, "clear_high_precision_init_val", None)

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -28,6 +28,8 @@ from .base import (
     _2X_ACC_DGRAD,
     _2X_ACC_WGRAD,
     _attach_high_precision_init_val,
+    _clear_high_precision_init_val,
+    _get_high_precision_init_val,
 )
 from ._common import WeightGradStore
 from ..quantization import FP8GlobalStateManager, QuantizerRole
@@ -1533,10 +1535,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         # Packing the parameters must transfer those values to the new registered
         # grouped parameter; otherwise its master is initialized by dequantizing
         # MXFP8 and starts from a different value than the discrete-weight layout.
-        high_precision_init_vals = []
-        for weight in weights:
-            getter = getattr(weight, "get_high_precision_init_val", None)
-            high_precision_init_vals.append(getter() if callable(getter) else None)
+        high_precision_init_vals = [_get_high_precision_init_val(weight) for weight in weights]
         if any(value is not None for value in high_precision_init_vals) and not all(
             value is not None for value in high_precision_init_vals
         ):
@@ -1576,9 +1575,7 @@ class GroupedLinear(TransformerEngineBaseModule):
                 torch.stack(high_precision_init_vals, dim=0),
             )
             for weight in weights:
-                clear = getattr(weight, "clear_high_precision_init_val", None)
-                if callable(clear):
-                    clear()
+                _clear_high_precision_init_val(weight)
 
         self.register_parameter(
             "weight",

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -1921,10 +1921,19 @@ class GroupedLinear(TransformerEngineBaseModule):
         with get_nvtx_range_context("_GroupedLinear_wgrad"):
             (_, grad_biases_, _), tensor_list = self.wgrad_store.pop()
             wgrad_list = tensor_list[2]
-            weight_params = self._get_weight_tensors()
             if not self.fuse_wgrad_accumulation:
-                for i in range(self.num_gemms):
-                    weight_params[i].grad = wgrad_list[i].to(weight_params[i].dtype)
+                if self.single_grouped_weight:
+                    # Write straight to the registered grouped parameter's .grad. Do NOT
+                    # route through _get_weight_tensors(): in this grad-enabled scope it
+                    # returns ephemeral _GroupedWeightAutogradBridge outputs, so assigning
+                    # .grad there is discarded and the optimizer never sees the gradient.
+                    self.weight.grad = torch.stack(
+                        [wgrad.to(self.weight.dtype) for wgrad in wgrad_list], dim=0
+                    )
+                else:
+                    for i in range(self.num_gemms):
+                        weight_i = getattr(self, f"weight{i}")
+                        weight_i.grad = wgrad_list[i].to(weight_i.dtype)
             has_grad_biases = [
                 grad_bias is not None and grad_bias.numel() != 0 for grad_bias in grad_biases_
             ]
@@ -2013,6 +2022,14 @@ class GroupedLinear(TransformerEngineBaseModule):
                         ):
                             if hasattr(grouped_weight, attr):
                                 setattr(weight, attr, getattr(grouped_weight, attr))
+            else:
+                # Bridge skipped (inference, or the grouped weight was frozen after
+                # construction). The cached members keep the requires_grad bit set at
+                # construction time, so sync them to the parent; otherwise a frozen
+                # grouped weight still makes legacy GroupedLinear autograd build and
+                # retain a wgrad graph for a parameter that should receive no gradient.
+                for weight in weight_tensors:
+                    weight.requires_grad_(grouped_weight.requires_grad)
         else:
             weight_tensors = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
         if not self.fp8 and any(isinstance(w, QuantizedTensorStorage) for w in weight_tensors):

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -97,15 +97,16 @@ class _GroupedWeightAutogradBridge(torch.autograd.Function):
 
         if ctx.fuse_wgrad_accumulation:
             # GroupedLinear has already written each wgrad into a view of the parent's
-            # main_grad. Trigger the parent's accumulator/DDP hook with a zero dummy
-            # gradient and tell MCore not to add that dummy to main_grad.
+            # main_grad. Trigger the parent's accumulator/DDP hook with TE's cached
+            # dummy wgrad and tell MCore not to add that dummy to main_grad.
+            grouped_grad = None
             if hasattr(grouped_weight, "grad_added_to_main_grad"):
                 grouped_weight.grad_added_to_main_grad = True
-            grouped_grad = torch.zeros(
-                tuple(grouped_weight.shape),
-                dtype=grouped_weight.dtype,
-                device=grouped_weight.device,
-            )
+                grouped_grad = get_dummy_wgrad(
+                    list(grouped_weight.shape),
+                    grouped_weight.dtype,
+                    zero=getattr(grouped_weight, "zero_out_wgrad", False),
+                )
         else:
             members = grouped_weight.quantized_tensors
             if members is None:

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -224,11 +224,7 @@ class GroupedLinear(BasicOperation):
         # A single-grouped-weight op may be constructed on the meta device and
         # receive its grouped parent later. Mark that parent at attachment time,
         # before DDP/FSDP inspects the parameter to install backward hooks.
-        if (
-            name == "weight"
-            and param is not None
-            and getattr(self, "single_grouped_weight", False)
-        ):
+        if name == "weight" and param is not None and getattr(self, "single_grouped_weight", False):
             wgrad_store = getattr(self, "wgrad_store", None)
             if wgrad_store is not None and wgrad_store.delay_wgrad_compute():
                 param.skip_backward_post_hook = True

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -213,6 +213,26 @@ class GroupedLinear(BasicOperation):
 
         self._apply_delay_wgrad_param_hooks()
 
+    def register_parameter(
+        self,
+        name: str,
+        param: Optional[torch.nn.Parameter],
+    ) -> None:
+        """Register a parameter and apply delayed-wgrad metadata when needed."""
+        super().register_parameter(name, param)
+
+        # A single-grouped-weight op may be constructed on the meta device and
+        # receive its grouped parent later. Mark that parent at attachment time,
+        # before DDP/FSDP inspects the parameter to install backward hooks.
+        if (
+            name == "weight"
+            and param is not None
+            and getattr(self, "single_grouped_weight", False)
+        ):
+            wgrad_store = getattr(self, "wgrad_store", None)
+            if wgrad_store is not None and wgrad_store.delay_wgrad_compute():
+                param.skip_backward_post_hook = True
+
     def _apply_delay_wgrad_param_hooks(self) -> None:
         """Set ``skip_backward_post_hook`` on weights when delaying wgrad (bias uses main backward)."""
         if not self.wgrad_store.delay_wgrad_compute():

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -218,7 +218,12 @@ class GroupedLinear(BasicOperation):
         if not self.wgrad_store.delay_wgrad_compute():
             return
         if self.single_grouped_weight:
-            self.weight.skip_backward_post_hook = True
+            # A meta-device op may be created as a parameterless shell and have its
+            # grouped parent attached after construction. In that case there is no
+            # ``weight`` parameter to mark yet.
+            weight = self._parameters.get("weight")
+            if weight is not None:
+                weight.skip_backward_post_hook = True
         else:
             for group_idx in range(self.num_groups):
                 getattr(self, f"weight{group_idx}").skip_backward_post_hook = True

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -949,7 +949,16 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                     "FC1 expected GroupedTensor weight with single_grouped_weight=True."
                 )
             if fc1_op.weight.quantizer is not None:
-                fc1_weight_quantizer.set_usage(rowwise=True, columnwise=input_requires_grad)
+                # Full-iteration CUDA graph replay does not rerun this Python metadata
+                # update. Remember that a grad-enabled forward requested columnwise
+                # storage so eager eval cannot drop buffers still used by captured dgrad.
+                fc1_op._keep_primary_weight_columnwise = (
+                    input_requires_grad
+                    or getattr(fc1_op, "_keep_primary_weight_columnwise", False)
+                )
+                fc1_weight_quantizer.set_usage(
+                    rowwise=True, columnwise=fc1_op._keep_primary_weight_columnwise
+                )
                 fc1_op.weight.quantizer = fc1_weight_quantizer
                 grouped_fc1_weight = fc1_op.weight
             else:
@@ -981,7 +990,13 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                     "FC2 expected GroupedTensor weight with single_grouped_weight=True."
                 )
             if fc2_op.weight.quantizer is not None:
-                fc2_weight_quantizer.set_usage(rowwise=True, columnwise=input_requires_grad)
+                fc2_op._keep_primary_weight_columnwise = (
+                    input_requires_grad
+                    or getattr(fc2_op, "_keep_primary_weight_columnwise", False)
+                )
+                fc2_weight_quantizer.set_usage(
+                    rowwise=True, columnwise=fc2_op._keep_primary_weight_columnwise
+                )
                 fc2_op.weight.quantizer = fc2_weight_quantizer
                 grouped_fc2_weight = fc2_op.weight
             else:

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -952,9 +952,8 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                 # Full-iteration CUDA graph replay does not rerun this Python metadata
                 # update. Remember that a grad-enabled forward requested columnwise
                 # storage so eager eval cannot drop buffers still used by captured dgrad.
-                fc1_op._keep_primary_weight_columnwise = (
-                    input_requires_grad
-                    or getattr(fc1_op, "_keep_primary_weight_columnwise", False)
+                fc1_op._keep_primary_weight_columnwise = input_requires_grad or getattr(
+                    fc1_op, "_keep_primary_weight_columnwise", False
                 )
                 fc1_weight_quantizer.set_usage(
                     rowwise=True, columnwise=fc1_op._keep_primary_weight_columnwise
@@ -990,9 +989,8 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                     "FC2 expected GroupedTensor weight with single_grouped_weight=True."
                 )
             if fc2_op.weight.quantizer is not None:
-                fc2_op._keep_primary_weight_columnwise = (
-                    input_requires_grad
-                    or getattr(fc2_op, "_keep_primary_weight_columnwise", False)
+                fc2_op._keep_primary_weight_columnwise = input_requires_grad or getattr(
+                    fc2_op, "_keep_primary_weight_columnwise", False
                 )
                 fc2_weight_quantizer.set_usage(
                     rowwise=True, columnwise=fc2_op._keep_primary_weight_columnwise

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -952,11 +952,9 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                 # Full-iteration CUDA graph replay does not rerun this Python metadata
                 # update. Remember that a grad-enabled forward requested columnwise
                 # storage so eager eval cannot drop buffers still used by captured dgrad.
-                fc1_op._keep_primary_weight_columnwise = input_requires_grad or getattr(
-                    fc1_op, "_keep_primary_weight_columnwise", False
-                )
                 fc1_weight_quantizer.set_usage(
-                    rowwise=True, columnwise=fc1_op._keep_primary_weight_columnwise
+                    rowwise=True,
+                    columnwise=input_requires_grad or fc1_weight_quantizer.columnwise_usage,
                 )
                 fc1_op.weight.quantizer = fc1_weight_quantizer
                 grouped_fc1_weight = fc1_op.weight
@@ -989,11 +987,9 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                     "FC2 expected GroupedTensor weight with single_grouped_weight=True."
                 )
             if fc2_op.weight.quantizer is not None:
-                fc2_op._keep_primary_weight_columnwise = input_requires_grad or getattr(
-                    fc2_op, "_keep_primary_weight_columnwise", False
-                )
                 fc2_weight_quantizer.set_usage(
-                    rowwise=True, columnwise=fc2_op._keep_primary_weight_columnwise
+                    rowwise=True,
+                    columnwise=input_requires_grad or fc2_weight_quantizer.columnwise_usage,
                 )
                 fc2_op.weight.quantizer = fc2_weight_quantizer
                 grouped_fc2_weight = fc2_op.weight


### PR DESCRIPTION
# Description

These changes fix convergence for grouped linear single param.
Issues encountered:

Without the TE fused ops path: causes the experts to get requires_grad=0 and the parent to not receive updates from the individual experts.

With TE fused ops: discards the high precision metadata, so the master weights were starting from dequantized mxfp8 weights, rather than the original high precision weights

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

These changes resolve the immediate issue, but cleaner medium- to long-term solutions would require broader changes.
In particular, the bug could likely have been avoided if Transformer Engine supported packing expert weights before quantization. The current flow quantizes each expert separately and then packs the resulting parameters, requiring the packing code to manually preserve and transfer FP8 initialization metadata. This stretches the metadata lifecycle and makes it easy to lose information needed to construct the optimizer’s high-precision master weights. Packing the high-precision weights first and quantizing the grouped parameter once would provide a cleaner and more robust ownership model.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
