### PR TITLE
[Common/PyTorch] Guard FP8 per-tensor scaling grouped GEMM on Hopper behind cuBLAS 13.5+

### DIFF
--- a/tests/cpp/operator/test_grouped_gemm.cu
+++ b/tests/cpp/operator/test_grouped_gemm.cu
@@ -234,6 +234,8 @@ std::vector<std::tuple<size_t, size_t, size_t>> make_shapes(ShapeCase scase) {
 
 constexpr size_t kCublasGroupedGemmVersion = 130300;        // Blackwell-only grouped GEMM
 constexpr size_t kCublasGroupedGemmHopperVersion = 130400;  // adds Hopper support
+// FP8 per-tensor scaling grouped GEMM on Hopper requires cuBLAS 13.5+
+constexpr size_t kCublasFp8TensorScalingGroupedGemmHopperVersion = 130500;
 constexpr size_t kCublasWorkspaceBytes = 32ull * 1024 * 1024;
 
 inline std::string grouped_gemm_skip_reason(const TestParams& params) {
@@ -256,8 +258,15 @@ inline std::string grouped_gemm_skip_reason(const TestParams& params) {
     const bool is_blackwell_plus = cc >= blackwellComputeCapability;
     const bool fp8_block = is_fp8_block_recipe(params.recipe);
     if (!is_blackwell_plus && !fp8_block) {
-      return std::string(recipe_name(params.recipe)) +
-             " grouped GEMM requires Blackwell (SM100) or newer, " + cc_suffix;
+      if (params.recipe == InputRecipe::kFP8Current) {
+        if (cublas_ver < kCublasFp8TensorScalingGroupedGemmHopperVersion) {
+          return "FP8 per-tensor scaling grouped GEMM on Hopper (SM90) requires cuBLAS 13.5+, "
+                 "but run-time cuBLAS version is " + std::to_string(cublas_ver) + ".";
+        }
+      } else {
+        return std::string(recipe_name(params.recipe)) +
+               " grouped GEMM requires Blackwell (SM100) or newer, " + cc_suffix;
+      }
     }
     if (is_blackwell_plus && fp8_block) {
       return "FP8 block scaling grouped GEMM is only supported on Hopper (SM90), " + cc_suffix;

--- a/tests/pytorch/test_grouped_linear.py
+++ b/tests/pytorch/test_grouped_linear.py
@@ -1615,6 +1615,8 @@ def test_grouped_linear_grouped_tensor_path_matches_legacy(
     cublaslt_version = tex.get_cublasLt_version()
     if device_capability < (10, 0) and cublaslt_version < 130400:
         pytest.skip("Grouped GEMM on Hopper requires cuBLAS 13.4+.")
+    if is_current_scaling and device_capability < (10, 0) and cublaslt_version < 130500:
+        pytest.skip("FP8 per-tensor scaling grouped GEMM on Hopper requires cuBLAS 13.5+.")
     if cublaslt_version < 130300:
         pytest.skip("Grouped GEMM requires cuBLAS 13.3+.")
 
@@ -1830,6 +1832,8 @@ def test_grouped_linear_fused_path_cuda_graph_safe(fp8_recipe, bias, monkeypatch
     cublaslt_version = tex.get_cublasLt_version()
     if device_capability < (10, 0) and cublaslt_version < 130400:
         pytest.skip("Grouped GEMM on Hopper requires cuBLAS 13.4+.")
+    if is_current_scaling and device_capability < (10, 0) and cublaslt_version < 130500:
+        pytest.skip("FP8 per-tensor scaling grouped GEMM on Hopper requires cuBLAS 13.5+.")
     if cublaslt_version < 130300:
         pytest.skip("Grouped GEMM requires cuBLAS 13.3+.")
 

--- a/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_grouped_gemm.cu
@@ -43,6 +43,10 @@ inline void CreateCublasHandle(cublasLtHandle_t *handle) {
 // FP8 block scaling support for grouped GEMM requires cuBLAS 13.4+
 #define CUBLAS_FP8_BLOCK_GROUPED_GEMM_VERSION 130400
 
+// FP8 tensor scaling (per-tensor current/delayed scaling) support for grouped GEMM
+// on Hopper (SM90) requires cuBLAS 13.5+
+#define CUBLAS_FP8_TENSOR_SCALING_GROUPED_GEMM_HOPPER_VERSION 130500
+
 // BF16 support for grouped GEMM requires cuBLAS 13.3+
 #define CUBLAS_GROUPED_GEMM_VERSION 130300
 
@@ -1054,6 +1058,14 @@ inline void execute_grouped_gemm(const GroupedGemmSetupWorkspace &setup_workspac
                                          setup_workspace.b_scale_inv_ptrs, A_sel.scaling_mode,
                                          B_sel.scaling_mode);
   } else if (config.use_fp8) {
+    const int sm = transformer_engine::cuda::sm_arch(transformer_engine::cuda::current_device());
+    if (sm < 100) {
+      NVTE_CHECK(transformer_engine::cuda::cublas_version() >=
+                     CUBLAS_FP8_TENSOR_SCALING_GROUPED_GEMM_HOPPER_VERSION,
+                 "FP8 tensor scaling grouped GEMM on Hopper (SM90) requires cuBLAS 13.5+, "
+                 "but run-time cuBLAS version is ",
+                 transformer_engine::cuda::cublas_version());
+    }
     set_fp8_scale_pointers(matmulDesc, setup_workspace.a_scale_inv_ptrs,
                            setup_workspace.b_scale_inv_ptrs);
   }

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -108,6 +108,8 @@ class _GroupedLinear(torch.autograd.Function):
           per-tensor current scaling.
         FP8 delayed scaling and FP8 block scaling are not supported because the
         corresponding grouped quantization kernels are missing.
+        Grouped GEMM requires cuBLAS 13.3+ (13.4+ on Hopper, 13.5+ for FP8
+        per-tensor current scaling on Hopper); otherwise the legacy path is used.
         Non-RHT NVFP4 falls back to the legacy path because graph-safe grouped quantization
         currently requires RHT.
 
@@ -126,8 +128,14 @@ class _GroupedLinear(torch.autograd.Function):
             or save_original_input
         ):
             return False
-        # 3. Filter by compute capability
-        if not (9, 0) <= get_device_compute_capability() <= (11, 0):
+        # 3. Filter by compute capability and cuBLAS version
+        device_capability = get_device_compute_capability()
+        if not (9, 0) <= device_capability <= (11, 0):
+            return False
+        cublaslt_version = tex.get_cublasLt_version()
+        if cublaslt_version < 130300:
+            return False
+        if device_capability < (10, 0) and cublaslt_version < 130400:
             return False
         # 4. Output quantization is not supported.
         if any(q is not None for q in output_quantizers):
@@ -135,9 +143,12 @@ class _GroupedLinear(torch.autograd.Function):
         # 5. Filter by quantization recipes.
         if fp8:
             if all(isinstance(q, Float8CurrentScalingQuantizer) for q in input_quantizers):
+                # FP8 per-tensor scaling grouped GEMM on Hopper requires cuBLAS 13.5+.
+                if device_capability < (10, 0) and cublaslt_version < 130500:
+                    return False
                 return True
             # MXFP8 and NVFP4 require Blackwell+.
-            if not (10, 0) <= get_device_compute_capability() <= (11, 0):
+            if not (10, 0) <= device_capability <= (11, 0):
                 return False
             return all(isinstance(q, MXFP8Quantizer) for q in input_quantizers) or all(
                 isinstance(q, NVFP4Quantizer) and q.with_rht for q in input_quantizers

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -790,8 +790,14 @@ class GroupedLinear(BasicOperation):
             return False
         if with_quantized_compute:
             # FP8 per-tensor current scaling runs on the Hopper and Blackwell grouped GEMM
-            # path; the compute-capability range was already checked above.
+            # path; the compute-capability range was already checked above. On Hopper it
+            # requires cuBLAS 13.5+; fall back to the legacy flow on older cuBLAS.
             if all(isinstance(q, Float8CurrentScalingQuantizer) for q in input_quantizers):
+                if (
+                    get_device_compute_capability() < (10, 0)
+                    and tex.get_cublasLt_version() < 130500
+                ):
+                    return False
                 return True
             # MXFP8 and NVFP4 grouped quantization kernels require Blackwell.
             if not (10, 0) <= get_device_compute_capability() <= (11, 0):


### PR DESCRIPTION
# Description

FP8 per-tensor (current/delayed scaling) grouped GEMM on Hopper requires cuBLAS 13.5+: cuBLAS 13.4 has no SM90 grouped GEMM algorithms for the `PER_BATCH_SCALAR_32F` scale mode, so `cublasLtMatmulAlgoGetHeuristic` returns `CUBLAS_STATUS_NOT_SUPPORTED` and the user gets a cryptic "Unable to find suitable cuBLAS grouped GEMM algorithm" error. This is exactly what happens in #3176 (NGC PyTorch 26.04 ships cuBLAS 13.4.0; reproduced on H100 — fails on cuBLAS 13.4.0, passes on 13.5.1 and 13.6.0). BF16 and FP8 block-scaling grouped GEMMs on Hopper work on 13.4 and keep their existing 13.4 gate.

This PR makes GroupedLinear fall back to the legacy multi-stream path when the fused grouped GEMM is not available for the current cuBLAS version, adds a dedicated version guard with a clear error message in the common library, and closes the test-coverage gap: the `FP8Current` grouped GEMM C++ tests were skipped on Hopper as Blackwell-only, so the only coverage of this path on SM90 was the PyTorch GroupedLinear tests, which CI runs on containers with cuBLAS 13.6.

Fixes #3176

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- `cublaslt_grouped_gemm.cu`: add `CUBLAS_FP8_TENSOR_SCALING_GROUPED_GEMM_HOPPER_VERSION` (130500) and a runtime `NVTE_CHECK` on the FP8 tensor-scaling path for SM < 100 with an actionable error message.
- `transformer_engine/pytorch/module/grouped_linear.py` and `transformer_engine/pytorch/ops/basic/grouped_linear.py`: route to the legacy multi-stream path instead of the fused GroupedTensor path when cuBLAS is too old (13.3+ general, 13.4+ Hopper, 13.5+ FP8 per-tensor scaling on Hopper).
- `tests/cpp/operator/test_grouped_gemm.cu`: run `FP8Current` cases on Hopper with cuBLAS 13.5+ (previously skipped as Blackwell-only); skip with a clear reason on older cuBLAS.
- `tests/pytorch/test_grouped_linear.py`: skip FP8 current scaling GroupedTensor tests on Hopper when cuBLAS < 13.5.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)