### PR TITLE
[ALL] Support int32 topk_idx in TE EP

### DIFF
--- a/tests/pytorch/distributed/run_ep.py
+++ b/tests/pytorch/distributed/run_ep.py
@@ -481,19 +481,6 @@ class TestEP(unittest.TestCase):
         torch.testing.assert_close(out.float(), tokens.float(), atol=5e-2, rtol=5e-2)
         torch.testing.assert_close(tokens_p.grad.float(), tokens.float(), atol=5e-2, rtol=5e-2)
 
-    # Input validation
-
-    def test_topk_int32_raises_clear_error(self):
-        buf = self._make_buffer()
-        topk_idx_int32 = torch.zeros(
-            TOKENS_PER_RANK, TOP_K, dtype=torch.int32, device=self.cfg.device
-        )
-        with self.assertRaises(RuntimeError) as cm:
-            ep_prepare(buf, topk_idx_int32)
-        msg = str(cm.exception)
-        self.assertIn("topk_idx", msg)
-        self.assertIn(".long()", msg)
-
 
 def _init_distributed():
     dist.init_process_group(backend="nccl")

--- a/transformer_engine/jax/cpp_extensions/ep.py
+++ b/transformer_engine/jax/cpp_extensions/ep.py
@@ -197,17 +197,12 @@ class EpPreparePrimitive(BasePrimitive):
         leading = _ep_leading_dims(is_outer)
         token_counts_aval = jax.core.ShapedArray(leading + (num_local_experts,), jnp.int32)
         handle_mem_aval = jax.core.ShapedArray(leading + (handle_mem_size,), jnp.uint8)
-        # FFI scratch for the int32 -> int64 topk_idx upcast. int32 with last
-        # dim doubled to keep the int64 byte count without JAX_ENABLE_X64.
-        # TODO(phuong): drop once NCCL EP supports int32 topk_idx.
-        workspace_shape = topk_idx_aval.shape[:-1] + (topk_idx_aval.shape[-1] * 2,)
-        workspace_aval = jax.core.ShapedArray(workspace_shape, jnp.int32)
-        return token_counts_aval, handle_mem_aval, workspace_aval
+        return token_counts_aval, handle_mem_aval
 
     @staticmethod
     def outer_abstract(*args, **kwargs):
         kwargs["is_outer"] = True
-        return EpPreparePrimitive.abstract(*args, **kwargs)[:2]  # pylint: disable=missing-kwoa
+        return EpPreparePrimitive.abstract(*args, **kwargs)  # pylint: disable=missing-kwoa
 
     @staticmethod
     def lowering(ctx, topk_idx, *, top_k, dispatch_output_per_expert_alignment, is_outer):
@@ -222,7 +217,7 @@ class EpPreparePrimitive(BasePrimitive):
     @staticmethod
     def impl(topk_idx, top_k, dispatch_output_per_expert_alignment, is_outer):
         assert EpPreparePrimitive.inner_primitive is not None
-        token_counts, handle_mem, _workspace = EpPreparePrimitive.inner_primitive.bind(
+        token_counts, handle_mem = EpPreparePrimitive.inner_primitive.bind(
             topk_idx,
             top_k=top_k,
             dispatch_output_per_expert_alignment=dispatch_output_per_expert_alignment,
@@ -300,7 +295,8 @@ class EpDispatchPrimitive(BasePrimitive):
     ):
         # is_outer=True: global leading dim = (dp*ep,) (or (ep,) with no DP);
         # False: per-shard = (1,).
-        del topk_weights_aval, top_k, dispatch_output_per_expert_alignment, handle_mem_aval
+        del topk_idx_aval, topk_weights_aval, top_k, dispatch_output_per_expert_alignment
+        del handle_mem_aval
         assert (
             len(tokens_aval.shape) >= 2
         ), f"tokens must be at least 2D [..., H], got shape {tokens_aval.shape}"
@@ -310,15 +306,12 @@ class EpDispatchPrimitive(BasePrimitive):
         leading = _ep_leading_dims(is_outer)
         recv_tokens_aval = jax.core.ShapedArray(leading + (recv_pr, hidden_dim), tok_dtype)
         recv_topk_weights_aval = jax.core.ShapedArray(leading + (recv_pr,), jnp.float32)
-        # int32 with last dim doubled to keep the int64 byte count without JAX_ENABLE_X64.
-        workspace_shape = topk_idx_aval.shape[:-1] + (topk_idx_aval.shape[-1] * 2,)
-        workspace_aval = jax.core.ShapedArray(workspace_shape, jnp.int32)
-        return (recv_tokens_aval, recv_topk_weights_aval, workspace_aval)
+        return (recv_tokens_aval, recv_topk_weights_aval)
 
     @staticmethod
     def outer_abstract(*args, **kwargs):
         kwargs["is_outer"] = True
-        return EpDispatchPrimitive.abstract(*args, **kwargs)[:2]  # pylint: disable=missing-kwoa
+        return EpDispatchPrimitive.abstract(*args, **kwargs)  # pylint: disable=missing-kwoa
 
     @staticmethod
     def lowering(
@@ -356,7 +349,7 @@ class EpDispatchPrimitive(BasePrimitive):
         is_outer,
     ):
         assert EpDispatchPrimitive.inner_primitive is not None
-        recv_tokens, recv_topk_weights, _workspace = EpDispatchPrimitive.inner_primitive.bind(
+        recv_tokens, recv_topk_weights = EpDispatchPrimitive.inner_primitive.bind(
             handle_mem,
             topk_idx,
             tokens,

--- a/transformer_engine/jax/csrc/extensions/ep.cpp
+++ b/transformer_engine/jax/csrc/extensions/ep.cpp
@@ -197,7 +197,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(EpInstantiateHandler, EpInstantiateImpl, FFI::Bind
 
 Error_Type EpPrepareFFI(cudaStream_t stream, EpInstanceState* ep_state, Buffer_Type topk_idx,
                         Result_Type recv_tokens_per_expert, Result_Type handle_mem,
-                        Result_Type workspace, EpConfig config) {
+                        EpConfig config) {
   (void)ep_state;  // lifetime only.
   auto topk_dims = topk_idx.dimensions();
   NVTE_CHECK(topk_dims.size() >= 2,
@@ -208,19 +208,8 @@ Error_Type EpPrepareFFI(cudaStream_t stream, EpInstanceState* ep_state, Buffer_T
 
   std::vector<size_t> topk_shape = {product(topk_dims, 0, topk_dims.size() - 1),
                                     static_cast<size_t>(topk_dims.back())};
-  // NCCL EP currently requires int64 topk_idx; upcast int32 on-stream.
-  // TODO(phuong): drop once NCCL EP accepts int32.
-  void* topk_idx_data = topk_idx.untyped_data();
-  if (idx_etype == ::xla::ffi::DataType::S32) {
-    const size_t n = topk_shape[0] * topk_shape[1];
-    NVTE_CHECK(static_cast<size_t>(workspace->element_count()) >= n,
-               "workspace too small for int32 → int64 upcast: element_count=",
-               workspace->element_count(), " < required ", n);
-    int64_t* ws = reinterpret_cast<int64_t*>(workspace->untyped_data());
-    nvte_convert_int32_to_int64(reinterpret_cast<const int32_t*>(topk_idx_data), ws, n, stream);
-    topk_idx_data = ws;
-  }
-  auto topk_idx_ = TensorWrapper(topk_idx_data, topk_shape, DType::kInt64);
+  auto topk_idx_ = TensorWrapper(topk_idx.untyped_data(), topk_shape,
+                                 convert_ffi_datatype_to_te_dtype(idx_etype));
 
   std::vector<size_t> tc_shape = {static_cast<size_t>(recv_tokens_per_expert->element_count())};
   auto recv_tokens_per_expert_ =
@@ -245,7 +234,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(EpPrepareHandler, EpPrepareFFI,
                                   .Arg<Buffer_Type>()                         // topk_idx
                                   .Ret<Buffer_Type>()  // recv_tokens_per_expert
                                   .Ret<Buffer_Type>()  // handle_mem
-                                  .Ret<Buffer_Type>()  // workspace (FFI scratch)
                                   .Attrs<EpConfig>(),
                               FFI_CudaGraph_Traits);
 
@@ -253,8 +241,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(EpPrepareHandler, EpPrepareFFI,
 
 Error_Type EpDispatchFFI(cudaStream_t stream, EpInstanceState* ep_state, Buffer_Type handle_mem,
                          Buffer_Type topk_idx, Buffer_Type tokens, Buffer_Type topk_weights,
-                         Result_Type recv_tokens, Result_Type recv_topk_weights,
-                         Result_Type workspace, EpConfig config) {
+                         Result_Type recv_tokens, Result_Type recv_topk_weights, EpConfig config) {
   (void)ep_state;
   auto token_dims = tokens.dimensions();
   NVTE_CHECK(token_dims.size() >= 2,
@@ -273,19 +260,8 @@ Error_Type EpDispatchFFI(cudaStream_t stream, EpInstanceState* ep_state, Buffer_
              ") must match topk_idx last dim (", idx_dims.back(), ")");
   std::vector<size_t> idx_shape = {product(idx_dims, 0, idx_dims.size() - 1),
                                    static_cast<size_t>(idx_dims.back())};
-  // NCCL EP currently requires int64 topk_idx; upcast int32 on-stream.
-  // TODO(phuong): drop once NCCL EP accepts int32.
-  void* topk_idx_data = topk_idx.untyped_data();
-  if (idx_etype == ::xla::ffi::DataType::S32) {
-    const size_t n = idx_shape[0] * idx_shape[1];
-    NVTE_CHECK(static_cast<size_t>(workspace->element_count()) >= n,
-               "workspace too small for int32 → int64 upcast: element_count=",
-               workspace->element_count(), " < required ", n);
-    int64_t* ws = reinterpret_cast<int64_t*>(workspace->untyped_data());
-    nvte_convert_int32_to_int64(reinterpret_cast<const int32_t*>(topk_idx_data), ws, n, stream);
-    topk_idx_data = ws;
-  }
-  auto topk_idx_ = TensorWrapper(topk_idx_data, idx_shape, DType::kInt64);
+  auto topk_idx_ = TensorWrapper(topk_idx.untyped_data(), idx_shape,
+                                 convert_ffi_datatype_to_te_dtype(idx_etype));
 
   const size_t T_flat = product(token_dims, 0, token_dims.size() - 1);
   const size_t H = static_cast<size_t>(token_dims.back());
@@ -336,7 +312,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(EpDispatchHandler, EpDispatchFFI,
                                   .Arg<Buffer_Type>()                         // topk_weights
                                   .Ret<Buffer_Type>()                         // recv_tokens
                                   .Ret<Buffer_Type>()                         // recv_topk_weights
-                                  .Ret<Buffer_Type>()  // workspace (FFI scratch)
                                   .Attrs<EpConfig>(),
                               FFI_CudaGraph_Traits);
 

--- a/transformer_engine/pytorch/csrc/extensions/ep.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/ep.cpp
@@ -104,13 +104,12 @@ void check_symm_mem_required(const at::Tensor& t, const char* name) {
 #endif
 }
 
-// The backend only accepts int64 topk_idx. The PyTorch wrapper enforces this
-// at the boundary so the per-step ops don't need an upcast workspace.
-void check_topk_idx_int64(at::Tensor topk_idx) {
+// Validates topk_idx is int32 or int64 and returns the matching TE dtype.
+DType check_topk_idx_dtype(at::Tensor topk_idx) {
   NVTE_CHECK(topk_idx.is_contiguous(), "topk_idx must be contiguous");
-  NVTE_CHECK(topk_idx.scalar_type() == at::kLong,
-             "topk_idx must be int64; got dtype=", c10::toString(topk_idx.scalar_type()),
-             ". Cast with topk_idx.long() before calling.");
+  NVTE_CHECK(topk_idx.scalar_type() == at::kLong || topk_idx.scalar_type() == at::kInt,
+             "topk_idx must be int32 or int64; got dtype=", c10::toString(topk_idx.scalar_type()));
+  return GetTransformerEngineDType(topk_idx.scalar_type());
 }
 
 using Shape = std::vector<size_t>;
@@ -185,12 +184,12 @@ void ep_prepare(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor token_cou
                 int64_t dispatch_output_per_expert_alignment) {
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   NVTE_CHECK(topk_idx.dim() >= 2, "topk_idx must be at least 2D [..., top_k]");
-  check_topk_idx_int64(topk_idx);
+  auto idx_dtype = check_topk_idx_dtype(topk_idx);
   const size_t T_flat = topk_idx.numel() / topk_idx.size(-1);
   const size_t topk_n = static_cast<size_t>(topk_idx.size(-1));
 
   auto topk_idx_te =
-      makeTransformerEngineTensor(topk_idx.data_ptr(), Shape{T_flat, topk_n}, DType::kInt64);
+      makeTransformerEngineTensor(topk_idx.data_ptr(), Shape{T_flat, topk_n}, idx_dtype);
   auto token_counts_te = makeTransformerEngineTensor(
       token_counts.data_ptr(), Shape{static_cast<size_t>(token_counts.numel())}, DType::kInt32);
   auto handle_mem_te = makeTransformerEngineTensor(
@@ -208,7 +207,7 @@ void ep_dispatch(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor tokens,
   NVTE_CHECK(topk_idx.dim() >= 2, "topk_idx must be at least 2D [..., top_k]");
   NVTE_CHECK(topk_weights.dim() >= 2, "topk_weights must be at least 2D [..., top_k]");
   NVTE_CHECK(recv_tokens.dim() >= 2, "recv_tokens must be at least 2D [..., recv_pr, H]");
-  check_topk_idx_int64(topk_idx);
+  auto idx_dtype = check_topk_idx_dtype(topk_idx);
   NVTE_CHECK(tokens.is_contiguous(), "tokens must be contiguous");
   NVTE_CHECK(topk_weights.is_contiguous(), "topk_weights must be contiguous");
   NVTE_CHECK(recv_tokens.is_contiguous(), "recv_tokens must be contiguous");
@@ -237,7 +236,7 @@ void ep_dispatch(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor tokens,
   auto handle_mem_te = makeTransformerEngineTensor(
       handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
   auto topk_idx_te =
-      makeTransformerEngineTensor(topk_idx.data_ptr(), Shape{T_flat, topk_n}, DType::kInt64);
+      makeTransformerEngineTensor(topk_idx.data_ptr(), Shape{T_flat, topk_n}, idx_dtype);
   auto tokens_te = makeTransformerEngineTensor(tokens.data_ptr(), Shape{T_flat, H}, tok_dtype);
   auto topk_w_te =
       makeTransformerEngineTensor(topk_weights.data_ptr(), Shape{T_flat, topk_n}, DType::kFloat32);

--- a/transformer_engine/pytorch/ep.py
+++ b/transformer_engine/pytorch/ep.py
@@ -368,7 +368,7 @@ def _(*_args, **_kw):
 def ep_prepare(buffer: "EpBuffer", topk_idx: torch.Tensor) -> torch.Tensor:
     """AllGather the routing map; fills ``buffer.handle_mem`` and returns
     ``buffer.token_counts`` (int32, shape [num_local_experts]). topk_idx must
-    be int64.
+    be int32 or int64.
     """
     torch.ops.transformer_engine_ep.prepare(
         buffer.handle_mem, buffer.top_k, topk_idx, buffer.token_counts, buffer.alignment
@@ -545,7 +545,7 @@ def ep_dispatch(
     topk_idx: torch.Tensor,
     topk_weights: torch.Tensor,
 ):
-    """Prepare + dispatch with autograd. topk_idx must be int64.
+    """Prepare + dispatch with autograd. topk_idx must be int32 or int64.
 
     recv_tokens comes from the EpBuffer (caller-supplied or buffer-owned under
     zero-copy) or is allocated in-flight (normal mode). recv_topk_weights is always


### PR DESCRIPTION
# Description

NCCL EP now accepts `int32` or `int64` `topk_idx`. This bumps the NCCL EP submodule to `2.31.0a14` and passes `topk_idx` through unchanged instead of forcing int64.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Testing
- `tests/pytorch/distributed/run_ep.py` (removed the stale int32-rejection test).
- JAX EP test already feeds int32 `topk_idx`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
