### PR TITLE
Fix the numerical issue with the Fused CE loss

### DIFF
--- a/tests/pytorch/test_parallel_cross_entropy.py
+++ b/tests/pytorch/test_parallel_cross_entropy.py
@@ -188,3 +188,48 @@ def test_non_contiguous_transposed_input():
     assert torch.allclose(
         loss_t, loss_c
     ), f"Non-contiguous transposed input gave wrong results: {loss_t} vs {loss_c}"
+
+
+def test_bfloat16_unreduced_external_grad():
+    """Apply per-token loss scaling before rounding the BF16 input gradient."""
+    logits = torch.zeros(2, 2, 3, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    target = torch.tensor([[0, 1], [2, -100]], device="cuda")
+    logits_before = logits.detach().clone()
+    external_grad = torch.tensor([[0.01, 0.03], [0.1, 0.7]], device="cuda")
+    saved_tensors = []
+
+    def pack_hook(tensor):
+        saved_tensors.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        loss = parallel_cross_entropy(logits, target, 0.0, False, None)
+
+    assert len(saved_tensors) == 1
+    assert saved_tensors[0].dtype == torch.float32
+    torch.testing.assert_close(logits, logits_before, rtol=0.0, atol=0.0)
+    loss.backward(external_grad)
+
+    ref_logits = logits_before.float().requires_grad_()
+    ref_loss = torch.nn.functional.cross_entropy(
+        ref_logits.reshape(-1, ref_logits.size(-1)), target.reshape(-1), reduction="none"
+    ).reshape_as(target)
+    ref_loss.backward(external_grad)
+    expected_grad = ref_logits.grad.to(torch.bfloat16)
+
+    torch.testing.assert_close(logits.grad, expected_grad, rtol=0.0, atol=0.0)
+
+
+def test_bfloat16_loss_matches_float32_input():
+    """BF16 and exactly equivalent FP32 logits should produce nearly identical losses."""
+    torch.manual_seed(42)
+    logits = torch.randn(1, 64, 64000, dtype=torch.bfloat16, device="cuda")
+    target = torch.randint(0, logits.size(-1), logits.shape[:-1], device="cuda")
+
+    bf16_loss = parallel_cross_entropy(logits, target, 0.0, False, None)
+    fp32_loss = parallel_cross_entropy(logits.float(), target, 0.0, False, None)
+
+    # The input values are identical, but dtype-specialized Triton reductions may
+    # differ by a small number of FP32 rounding steps.
+    fp32_eps = torch.finfo(torch.float32).eps
+    torch.testing.assert_close(bf16_loss, fp32_loss, rtol=2 * fp32_eps, atol=2 * fp32_eps)

--- a/transformer_engine/common/triton/cross_entropy.py
+++ b/transformer_engine/common/triton/cross_entropy.py
@@ -86,6 +86,8 @@ def online_softmax_kernel(
 def cross_entropy_kernel(
     X_ptr,
     X_stride,
+    grad_input_ptr,
+    grad_input_stride,
     Y_ptr,
     Y_stride,
     loss_ptr,
@@ -108,6 +110,8 @@ def cross_entropy_kernel(
     Parameters:
     X_ptr: Pointer to input tensor.
     X_stride (int): The stride of the input tensor.
+    grad_input_ptr: Pointer to the FP32 tensor that stores the input gradient.
+    grad_input_stride (int): The stride of the input gradient tensor.
     Y_ptr: Pointer to target tensor.
     Y_stride (int): The stride of the target tensor.
     loss_ptr: Pointer to tensor to store the loss.
@@ -129,16 +133,17 @@ def cross_entropy_kernel(
 
     # locate the start index
     X_ptr += program_id * X_stride
+    grad_input_ptr += program_id * grad_input_stride
 
     # Load Y_ptr
     Y_ptr += program_id * Y_stride
     y = tl.load(Y_ptr)
 
     if y == ignore_idx:
-        # set all X_ptr as 0
+        # Set the input gradient to zero.
         for i in range(0, n_cols, BLOCK_SIZE):
             X_offsets = i + tl.arange(0, BLOCK_SIZE)
-            tl.store(X_ptr + X_offsets, 0.0, mask=X_offsets < n_cols)
+            tl.store(grad_input_ptr + X_offsets, 0.0, mask=X_offsets < n_cols)
         return
 
     loss_ptr += program_id * loss_stride
@@ -175,7 +180,6 @@ def cross_entropy_kernel(
     for i in range(0, n_cols, BLOCK_SIZE):
         X_offsets = i + tl.arange(0, BLOCK_SIZE)
         X_block = tl.load(X_ptr + X_offsets, mask=X_offsets < n_cols, other=float("-inf"))
-        grad_dtype = X_block.dtype
         X_block = X_block.to(tl.float32)
         if label_smoothing > 0:
             # scale X beforehand to avoid overflow
@@ -187,9 +191,9 @@ def cross_entropy_kernel(
             X_block = (tl.exp(X_block - m) / d - eps) / (n_non_ignore)
         else:
             X_block = tl.exp(X_block - m) / d - eps
-        tl.store(X_ptr + X_offsets, X_block.to(grad_dtype), mask=X_offsets < n_cols)
+        tl.store(grad_input_ptr + X_offsets, X_block, mask=X_offsets < n_cols)
 
-    # We need tl.debug_barrier() to ensure the new result of X_ptr is written
+    # Ensure the gradient is written before updating the target-token element.
     tl.debug_barrier()
 
     # 5. Calculate the loss
@@ -213,13 +217,13 @@ def cross_entropy_kernel(
     vocab_end_idx = (rank + 1) * n_cols
     if y >= vocab_start_idx:
         if y < vocab_end_idx:
-            X_y = tl.load(X_ptr + y - vocab_start_idx)
+            X_y = tl.load(grad_input_ptr + y - vocab_start_idx)
             # Apply the same conditional scaling logic for the target token
             if reduce_loss:
                 X_y += -(1 - label_smoothing) / (n_non_ignore)
             else:
                 X_y += -(1 - label_smoothing)
-            tl.store(X_ptr + y - vocab_start_idx, X_y)
+            tl.store(grad_input_ptr + y - vocab_start_idx, X_y)
 
     tl.store(loss_ptr, loss)
 

--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -18,9 +18,9 @@ __all__ = [
 
 class CrossEntropyFunction(torch.autograd.Function):
     """
-    This class implements a custom autograd function for the Cross Entropy loss. The input tensor can be in BF16/FP32, the
-    loss and gradient calculation happens in FP32 only. The returned loss is always in FP32, the input gradients are upcasted
-    to the dataype of the input.
+    This class implements a custom autograd function for the Cross Entropy loss. The input
+    tensor can be in BF16/FP32, and loss and gradient calculations happen in FP32. The
+    returned loss is always in FP32.
     """
 
     @staticmethod
@@ -50,7 +50,7 @@ class CrossEntropyFunction(torch.autograd.Function):
         Returns:
         tensor: The computed loss.
         """
-        loss, inp = triton_cross_entropy.cross_entropy_forward(
+        loss, grad_input = triton_cross_entropy.cross_entropy_forward(
             inp,
             target,
             label_smoothing,
@@ -59,7 +59,7 @@ class CrossEntropyFunction(torch.autograd.Function):
             ignore_idx,
         )
 
-        ctx.save_for_backward(inp.detach())
+        ctx.save_for_backward(grad_input.detach())
         ctx.is_cg_capturable = is_cg_capturable
         return loss
 
@@ -75,10 +75,12 @@ class CrossEntropyFunction(torch.autograd.Function):
         Returns:
         tuple: A tuple with the gradients with respect to the inputs. The elements are tensors or None.
         """
-        (inp,) = ctx.saved_tensors
-        inp = triton_cross_entropy.cross_entropy_backward(inp, grad_output, ctx.is_cg_capturable)
+        (grad_input,) = ctx.saved_tensors
+        grad_input = triton_cross_entropy.cross_entropy_backward(
+            grad_input, grad_output, ctx.is_cg_capturable
+        )
         return (
-            inp,
+            grad_input,
             None,
             None,
             None,
@@ -102,9 +104,8 @@ def parallel_cross_entropy(
     """
     Cross Entropy loss with optional distributed reduction.
 
-    The input tensor can be in BF16/FP32, the loss and gradient calculation happens in
-    FP32 only. The returned loss is always in FP32, the input gradients are upcasted
-    to the datatype of the input.
+    The input tensor can be in BF16/FP32, and loss and gradient calculations happen in
+    FP32. The returned loss is always in FP32.
 
     If ``dist_process_group`` is passed for distributed loss calculation, the input to each
     distributed rank should be ``(*, V/world_size)``. Note that each of the ranks should

--- a/transformer_engine/pytorch/triton/cross_entropy.py
+++ b/transformer_engine/pytorch/triton/cross_entropy.py
@@ -54,6 +54,9 @@ def cross_entropy_forward(
     if target.stride(-1) != 1:
         target = target.contiguous()
 
+    # Store the input gradient in FP32 so it is not quantized before backward.
+    grad_input = torch.empty_like(_input, dtype=torch.float32)
+
     rank = 0 if dist_process_group is None else dist.get_rank(dist_process_group)
 
     online_softmax_kernel[(n_rows,)](
@@ -86,6 +89,8 @@ def cross_entropy_forward(
     cross_entropy_kernel[(n_rows,)](
         X_ptr=_input,
         X_stride=_input.stride(-2),
+        grad_input_ptr=grad_input,
+        grad_input_stride=grad_input.stride(-2),
         Y_ptr=target,
         Y_stride=target.stride(-1),
         loss_ptr=loss_1d,
@@ -108,11 +113,11 @@ def cross_entropy_forward(
         torch.reshape(loss_1d, (B, SQ)) if not reduce_loss else (torch.sum(loss_1d) / n_non_ignore)
     )
 
-    return loss, _input
+    return loss, grad_input
 
 
 def cross_entropy_backward(
-    _input: torch.Tensor, grad_output: torch.Tensor, is_cg_capturable: bool = False
+    grad_input: torch.Tensor, grad_output: torch.Tensor, is_cg_capturable: bool = False
 ):
     """Backward implementation of cross entropy loss kernel"""
 
@@ -123,13 +128,13 @@ def cross_entropy_backward(
     ):
         pass
     else:
-        B, SQ, V = _input.shape
+        B, SQ, V = grad_input.shape
         n_rows = B * SQ
         BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
 
         element_mul_kernel[(n_rows,)](
-            _input,
-            _input.stride(-2),
+            grad_input,
+            grad_input.stride(-2),
             grad_output.contiguous(),
             1 if grad_output.numel() > 1 else 0,
             V,
@@ -137,4 +142,4 @@ def cross_entropy_backward(
             num_warps=32,
         )
 
-    return _input
+    return grad_input


### PR DESCRIPTION
# Description

Fixes the numerical issue coming from reusing the input buffer to store the intermediate gradient data (which could result in the loss of precision).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
