### PR TITLE
Work around nvcc 13.0 parse failure in group_quantize_fp8.cuh

### DIFF
--- a/transformer_engine/common/cast/fp8/group_quantize_fp8.cuh
+++ b/transformer_engine/common/cast/fp8/group_quantize_fp8.cuh
@@ -1100,12 +1100,15 @@ void group_quantize(const GroupedTensor *input, const Tensor *noop, GroupedTenso
                     const size_t rows_per_tensor = first_logical_dim / num_tensors;
                     if constexpr (SCALING_TYPE == ScalingType::ROWWISE) {
                       constexpr size_t flat_nvec = ROWWISE_FLAT_LOAD_SIZE_BYTES / sizeof(IType);
-                      using IVecT = Vec<IType, flat_nvec>;
-                      using OVecT = Vec<OType, flat_nvec>;
+                      // nvcc 13.0 fails to parse `using` type aliases inside this
+                      // macro-expanded block in some TUs (activation/glu.cu); use
+                      // the equivalent byte counts (Vec<T, N>::BYTES == N * sizeof(T)).
+                      constexpr size_t flat_in_vec_bytes = flat_nvec * sizeof(IType);
+                      constexpr size_t flat_out_vec_bytes = flat_nvec * sizeof(OType);
                       const size_t elems_per_tensor = rows_per_tensor * last_logical_dim;
                       const bool flat_aligned =
-                          reinterpret_cast<uintptr_t>(input->data.dptr) % IVecT::BYTES == 0 &&
-                          reinterpret_cast<uintptr_t>(output->data.dptr) % OVecT::BYTES == 0;
+                          reinterpret_cast<uintptr_t>(input->data.dptr) % flat_in_vec_bytes == 0 &&
+                          reinterpret_cast<uintptr_t>(output->data.dptr) % flat_out_vec_bytes == 0;
                       if (elems_per_tensor % flat_nvec == 0 && flat_aligned) {
                         const size_t vecs_per_tensor = elems_per_tensor / flat_nvec;
                         const dim3 flat_block(ROWWISE_FLAT_THREADS);
@@ -1156,12 +1159,15 @@ void group_quantize(const GroupedTensor *input, const Tensor *noop, GroupedTenso
                     if constexpr (SCALING_TYPE == ScalingType::ROWWISE) {
                       const size_t total_elements = first_logical_dim * last_logical_dim;
                       constexpr size_t flat_nvec = ROWWISE_FLAT_LOAD_SIZE_BYTES / sizeof(IType);
-                      using IVecT = Vec<IType, flat_nvec>;
-                      using OVecT = Vec<OType, flat_nvec>;
+                      // nvcc 13.0 fails to parse `using` type aliases inside this
+                      // macro-expanded block in some TUs (activation/glu.cu); use
+                      // the equivalent byte counts (Vec<T, N>::BYTES == N * sizeof(T)).
+                      constexpr size_t flat_in_vec_bytes = flat_nvec * sizeof(IType);
+                      constexpr size_t flat_out_vec_bytes = flat_nvec * sizeof(OType);
                       const bool flat_aligned =
                           last_logical_dim % flat_nvec == 0 &&
-                          reinterpret_cast<uintptr_t>(input->data.dptr) % IVecT::BYTES == 0 &&
-                          reinterpret_cast<uintptr_t>(output->data.dptr) % OVecT::BYTES == 0;
+                          reinterpret_cast<uintptr_t>(input->data.dptr) % flat_in_vec_bytes == 0 &&
+                          reinterpret_cast<uintptr_t>(output->data.dptr) % flat_out_vec_bytes == 0;
                       // Only vector-aligned inputs are supported. A non-multiple
                       // row length or a misaligned base pointer would force
                       // uncoalesced scalar access, which we deliberately do not


### PR DESCRIPTION
## Scenario

Building with CUDA 13.0 (nvcc V13.0.88, sm100) fails in every TU that includes `group_quantize_fp8.cuh` (e.g. `activation/glu.cu`):

```
error: template argument 2 is invalid
error: 'IVecT' has not been declared
```

Root cause is an nvcc 13.0 cudafe++ bug: inside the macro-expanded `TRANSFORMER_ENGINE_*_SWITCH` block, the discarded `if constexpr` branch constant-folds the `constexpr size_t flat_nvec` template argument and emits an ill-formed two-token functional cast `unsigned long((8))` into the intermediate C++, which the host compiler then rejects. Reproduces with both g++-12 and g++-13 hosts; the identical code hand-expanded (no macro) compiles fine. Confirmed with a 29-line minimal repro.

## Fix

Replace the `using IVecT/OVecT = Vec<IType/OType, flat_nvec>` aliases (only used for `::BYTES` in the alignment checks) with the equivalent `constexpr size_t` byte counts (`Vec<T, N>::BYTES == N * sizeof(T)`, utils.cuh). Semantics-identical, host-side only, no kernel change. Verified: sm100 wheel builds clean on CUDA 13.0 and the NVFP4/FP8 paths run end-to-end.