### PR TITLE
Install cuDNN frontend in GitHub builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y git python3.9 pip cudnn9-cuda-12
-          pip install cmake==3.21.0 pybind11[global] ninja
+          pip install cmake==3.21.0 pybind11[global] ninja "nvidia-cudnn-frontend>=1.25.0"
       - name: 'Checkout'
         uses: actions/checkout@v3
         with:
@@ -77,7 +77,7 @@ jobs:
           docker exec builder bash -c '\
             apt-get update && \
             apt-get install -y git python3.9 pip cudnn9-cuda-12 && \
-            pip install cmake torch ninja pydantic importlib-metadata>=1.0 packaging pybind11 numpy einops onnxscript && \
+            pip install cmake torch ninja pydantic importlib-metadata>=1.0 packaging pybind11 numpy einops onnxscript "nvidia-cudnn-frontend>=1.25.0" && \
             apt-get clean \
           '
 
@@ -96,7 +96,7 @@ jobs:
       options: --user root
     steps:
       - name: 'Dependencies'
-        run: pip install cmake==3.21.0 pybind11[global]
+        run: pip install cmake==3.21.0 pybind11[global] "nvidia-cudnn-frontend>=1.25.0"
       - name: 'Checkout'
         uses: actions/checkout@v3
         with:
@@ -148,7 +148,7 @@ jobs:
       - name: 'Dependencies'
         run: |
           docker exec builder bash -c '\
-            pip install cmake==3.21.0 pybind11[global] einops onnxscript && \
+            pip install cmake==3.21.0 pybind11[global] einops onnxscript "nvidia-cudnn-frontend>=1.25.0" && \
             pip install torch --no-cache-dir --index-url https://download.pytorch.org/whl/cu130
           '
       - name: 'Build'


### PR DESCRIPTION
## Summary

- Install the declared `nvidia-cudnn-frontend>=1.25.0` build dependency in every GitHub Actions build environment.
- Keep the workflow requirement aligned with `pyproject.toml`.

## Root cause

TransformerEngine now resolves cuDNN frontend headers from the installed Python distribution. The GitHub Actions builds use `--no-build-isolation`, so build-system requirements are not installed automatically and metadata generation fails with `PackageNotFoundError`.

## Validation

| Scenario | Result |
| --- | --- |
| Workflow YAML parsing | Passed with PyYAML |
| Diff hygiene | `git diff --check` passed |
| Package availability | Python 3.10 and 3.12 x86_64 wheels are published for the currently resolved 1.26.0 release |
| GitHub Actions | [Build run 28997378989](https://github.com/NVIDIA/TransformerEngine/actions/runs/28997378989) pending |
