### PR TITLE
[PyTorch] Fix GIL/refcount abort in Comm+GEMM overlap and NCCL-EP init bindings

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/ep.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/ep.cpp
@@ -145,7 +145,13 @@ void ep_initialize(uintptr_t comm_ptr, const std::string& group_name, int64_t nu
       .max_token_dtype = static_cast<NVTEDType>(GetTransformerEngineDType(torch_dtype)),
       .zero_copy = zero_copy ? 1 : 0,
   };
-  nvte_ep_initialize(static_cast<void*>(ep_comm), &cfg);
+  // Release the GIL only around the native init. It must stay held while pybind11 casts
+  // the ``max_token_dtype`` object above and destroys the by-value ``pybind11::object``
+  // parameter on return; releasing it across those trips pybind11's dec_ref GIL assertion.
+  {
+    pybind11::gil_scoped_release nogil;
+    nvte_ep_initialize(static_cast<void*>(ep_comm), &cfg);
+  }
   g_zero_copy_enabled.store(zero_copy, std::memory_order_relaxed);
   g_ep_initialized = true;
   g_ep_group_name = group_name;
@@ -366,8 +372,7 @@ void register_ep_bindings(pybind11::module_& m) {
         "Initialize the EP backend; borrows torch's NCCL comm pointed to by ``comm_ptr``.",
         py::arg("comm_ptr"), py::arg("group_name"), py::arg("num_experts"),
         py::arg("max_tokens_per_rank"), py::arg("max_recv_tokens_per_rank"), py::arg("hidden_dim"),
-        py::arg("max_num_sms") = 0, py::arg("max_token_dtype"), py::arg("zero_copy") = false,
-        py::call_guard<py::gil_scoped_release>());
+        py::arg("max_num_sms") = 0, py::arg("max_token_dtype"), py::arg("zero_copy") = false);
   m.def("ep_finalize", &ep_finalize, "Tear down the EP backend. Idempotent.",
         py::call_guard<py::gil_scoped_release>());
   m.def("ep_get_zero_copy", &ep_get_zero_copy, "Return the current EP zero-copy toggle state.");

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -716,6 +716,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                        int num_max_streams, int comm_cga_size, int gemm_priority, int comm_priority,
                        int num_comm_sm, bool set_sm_margin, bool atomic_gemm,
                        bool rs_overlap_first_gemm) {
+             // Release the GIL only around the native construction (blocking collectives) to avoid
+             // tripping pybind11's inc_ref/dec_ref GIL assertions.
+             py::gil_scoped_release nogil;
              if (use_cublasmp) {
                return std::make_shared<CommOverlap>(helper, helper->mylocal, tp_size, comm_type,
                                                     buffer_shape, buffer_dtype, num_comm_sm,
@@ -726,8 +729,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                  comm_cga_size, gemm_priority, comm_priority, num_comm_sm, set_sm_margin,
                  atomic_gemm, rs_overlap_first_gemm);
            }),
-           py::call_guard<py::gil_scoped_release>(), py::arg("buffer_shape"),
-           py::arg("buffer_dtype"), py::arg("helper"), py::arg("tp_size"),
+           py::arg("buffer_shape"), py::arg("buffer_dtype"), py::arg("helper"), py::arg("tp_size"),
            py::arg("use_cublasmp") = false,
            py::arg("comm_type") = transformer_engine::CommOverlapType::RS,
            py::arg("num_splits") = 4, py::arg("num_max_streams") = NVTE_COMM_OVERLAP_MAX_STREAMS,
@@ -751,6 +753,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                        int comm_cga_size, int gemm_priority, int comm_priority, int num_comm_sm,
                        bool set_sm_margin, bool atomic_gemm, bool use_ce, bool aggregate,
                        bool use_cublasmp) {
+             // Release the GIL only around the native construction (blocking collectives) to avoid
+             // tripping pybind11's inc_ref/dec_ref GIL assertions.
+             py::gil_scoped_release nogil;
              if (use_cublasmp) {
                return std::make_shared<CommOverlapP2P>(helper, helper->mylocal, tp_size, comm_type,
                                                        buffer_shape, buffer_dtype, num_comm_sm,
@@ -761,12 +766,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                                                      gemm_priority, comm_priority, num_comm_sm,
                                                      set_sm_margin, atomic_gemm, use_ce, aggregate);
            }),
-           py::call_guard<py::gil_scoped_release>(), py::arg("buffer_shape"),
-           py::arg("buffer_dtype"), py::arg("helper"), py::arg("tp_size"), py::arg("comm_type"),
-           py::arg("num_max_streams") = NVTE_COMM_OVERLAP_MAX_STREAMS, py::arg("comm_cga_size") = 1,
-           py::arg("gemm_priority") = 0, py::arg("comm_priority") = 0, py::arg("num_comm_sm") = 1,
-           py::arg("set_sm_margin") = false, py::arg("atomic_gemm") = false,
-           py::arg("use_ce") = true, py::arg("aggregate") = false, py::arg("use_cublasmp") = false)
+           py::arg("buffer_shape"), py::arg("buffer_dtype"), py::arg("helper"), py::arg("tp_size"),
+           py::arg("comm_type"), py::arg("num_max_streams") = NVTE_COMM_OVERLAP_MAX_STREAMS,
+           py::arg("comm_cga_size") = 1, py::arg("gemm_priority") = 0, py::arg("comm_priority") = 0,
+           py::arg("num_comm_sm") = 1, py::arg("set_sm_margin") = false,
+           py::arg("atomic_gemm") = false, py::arg("use_ce") = true, py::arg("aggregate") = false,
+           py::arg("use_cublasmp") = false)
       .def("copy_into_buffer",
            static_cast<void (CommOverlapP2P::*)(const at::Tensor &, bool)>(
                &CommOverlapP2P::copy_into_buffer),


### PR DESCRIPTION
# Description

The factory `py::init` bindings for `CommOverlap`/`CommOverlapP2P` and the `ep_initialize` binding were registered with an outer `py::call_guard<py::gil_scoped_release>()`, which releases the GIL for the entire call -- including regions where pybind11 performs Python reference-count operations that require the GIL to be held. This triggers a pybind11 GIL/ref-count hazard assert when TE is compiled with `NVTE_BUILD_DEBUG=1`.

PR fixes the bug by dropping the outer call guard and releasing the GIL narrowly, only around the blocking C++ native constructor/initializer. The GIL is reacquired before pybind11 casts the arguments, registers the holder and destroys the by-value object parameters.

Fixes # 3199

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
