### PR TITLE
[PyTorch] Support FA3/FA4 with pad_between_seqs=True

### DIFF
--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -13,7 +13,10 @@ from transformer_engine.pytorch.attention.dot_product_attention.context_parallel
     get_cu_seqlens_on_cp_rank,
     get_thd_partitioned_indices,
 )
-from transformer_engine.pytorch.attention.dot_product_attention.utils import combine_and_quantize
+from transformer_engine.pytorch.attention.dot_product_attention.utils import (
+    combine_and_quantize,
+    get_thd_padding_mask,
+)
 from transformer_engine.pytorch import DType
 from test_attention_with_cp import (
     model_configs_flash_attn,
@@ -696,11 +699,18 @@ def run_dpa_with_cp(
             num_pads_kv = (cu_seqlens_kv_padded - cu_seqlens_kv)[1:] - (
                 cu_seqlens_kv_padded - cu_seqlens_kv
             )[:-1]
-            # FA3 leaves garbage at padding positions despite seqused_q/k (tile spillover).
-            # Forward out_ can't be pre-zeroed because FA3's custom op returns out_ as an
-            # output rather than mutating it in-place, triggering PyTorch's aliasing constraint.
-            # Backward dq/dk/dv CAN be pre-zeroed because FA3 marks them as mutated inputs.
+            # FA3/FA4 kernels may leave physically padded rows unwritten. The CP
+            # implementation must clean them after partial-output/gradient merges.
             if fa_pad_between_seqs == "True":
+                out_padding_mask = get_thd_padding_mask(
+                    out_.shape[0], cu_seqlens_q, cu_seqlens_q_padded
+                )
+                nnz = torch.count_nonzero(out_[out_padding_mask]).item()
+                assert nnz == 0, (
+                    f"out_ has {nnz} nonzero values in THD padding — "
+                    "context_parallel.py should zero padding positions"
+                )
+
                 # out_ is a view inside the CP custom autograd Function, so in-place
                 # zeroing is blocked by PyTorch. Clone to break the view relationship.
                 out_ = out_.clone()

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -1352,6 +1352,26 @@ def _run_dot_product_attention(
             return out, max_logit, (None, None, None, d_softmax_offset)
     if backend in ["FusedAttention", "FlashAttention"]:
         if qkv_format == "thd" and pad_between_seqs:
+            tensors_and_boundaries = [("out", out, cu_seqlens_q_after_pad)]
+            if is_training:
+                tensors_and_boundaries.extend(
+                    [
+                        ("dq", q.grad, cu_seqlens_q_after_pad),
+                        ("dk", k.grad, cu_seqlens_kv_after_pad),
+                        ("dv", v.grad, cu_seqlens_kv_after_pad),
+                    ]
+                )
+            for tensor_name, tensor, cu_seqlens_after_pad in tensors_and_boundaries:
+                for i in range(1, config.batch_size + 1):
+                    pad_range = (
+                        cu_seqlens_after_pad[i] - pad_len[i - 1],
+                        cu_seqlens_after_pad[i],
+                    )
+                    assert torch.count_nonzero(tensor[pad_range[0] : pad_range[1]]).item() == 0, (
+                        f"{backend} left nonzero values in {tensor_name} padding for sequence "
+                        f"{i - 1}"
+                    )
+
             out_orig = torch.Tensor([]).to(device="cuda", dtype=dtype)
             if is_training:
                 q_grad_orig = torch.Tensor([]).to(device="cuda", dtype=dtype)

--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -32,6 +32,7 @@ from transformer_engine.pytorch.attention.dot_product_attention.utils import (
     FlashAttentionUtils,
     _get_supported_versions,
     check_set_window_size,
+    get_thd_padding_mask,
 )
 from transformer_engine.pytorch.attention import RotaryPositionEmbedding
 import transformer_engine.pytorch.cpp_extensions as ext
@@ -127,6 +128,124 @@ def test_flash_attention_supported_version_message():
         )
         == ">= 2.1.1, < 2.8.4"
     )
+
+
+@pytest.mark.parametrize(
+    "cu_seqlens,cu_seqlens_padded,expected",
+    [
+        ([0, 3, 8], [0, 4, 12], [False] * 3 + [True] + [False] * 5 + [True] * 3),
+        ([0, 3, 8], [0, 4, 12], [False] * 3 + [True] + [False] * 5 + [True] * 7),
+        ([0, 3, 8], [0, 3, 8], [False] * 8 + [True] * 4),
+        ([0, 0, 3, 3, 5], [0, 0, 4, 4, 8], [False] * 3 + [True] + [False] * 2 + [True] * 4),
+    ],
+)
+def test_thd_padding_mask_capacity(cu_seqlens, cu_seqlens_padded, expected):
+    """Cover sequence gaps, reserved buffer tails, and zero-length sequences."""
+    actual = get_thd_padding_mask(
+        len(expected),
+        torch.tensor(cu_seqlens, dtype=torch.int32, device="cuda"),
+        torch.tensor(cu_seqlens_padded, dtype=torch.int32, device="cuda"),
+    )
+    torch.testing.assert_close(actual, torch.tensor(expected, dtype=torch.bool, device="cuda"))
+
+
+@pytest.mark.parametrize("fa_version", [3, 4])
+def test_dpa_flash_thd_padding_capacity_cuda_graph(fa_version, monkeypatch):
+    """Check padded outputs and gradients, including buffer tails, in eager and raw graphs."""
+    if fa_version == 3 and (
+        device_compute_capability != (9, 0) or not FlashAttentionUtils.v3_is_installed
+    ):
+        pytest.skip("FlashAttention 3 on Hopper is required.")
+    if fa_version == 4 and (
+        not (10, 0) <= device_compute_capability < (12, 0)
+        or not FlashAttentionUtils.v4_is_installed
+    ):
+        pytest.skip("FlashAttention 4 on SM100/SM110 is required.")
+    for key, value in {
+        "NVTE_FLASH_ATTN": "1",
+        "NVTE_FUSED_ATTN": "0",
+        "NVTE_UNFUSED_ATTN": "0",
+        "NVTE_FLASH_ATTN_V2": "0",
+        "NVTE_FLASH_ATTN_V3": str(int(fa_version == 3)),
+        "NVTE_FLASH_ATTN_V4": str(int(fa_version == 4)),
+    }.items():
+        monkeypatch.setenv(key, value)
+    # Restore the complete backend cache along with the environment at test teardown.
+    for key, value in _attention_backends.items():
+        monkeypatch.setitem(_attention_backends, key, value)
+    _attention_backends["backend_selection_requires_update"] = True
+    reset_rng_states()
+    cu_q, cu_kv, padded_q, padded_kv = [
+        torch.tensor(offsets, dtype=torch.int32, device="cuda")
+        for offsets in ([0, 61, 96], [0, 45, 118], [0, 64, 112], [0, 64, 160])
+    ]
+    # Expected valid rows are independent of get_thd_padding_mask.
+    q_rows = torch.tensor(list(range(61)) + list(range(64, 99)), device="cuda")
+    kv_rows = torch.tensor(list(range(45)) + list(range(64, 137)), device="cuda")
+    qkv = [
+        torch.randn(tokens, 4, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        for tokens in (128, 192, 192)
+    ]
+    grad_output = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    block = DotProductAttention(
+        4,
+        64,
+        qkv_format="thd",
+        attn_mask_type="padding",
+        attention_type="cross",
+        attention_dropout=0.0,
+    ).cuda()
+
+    def run(inputs, grad, padded):
+        """Run the selected FlashAttention backend and differentiate Q/K/V."""
+        output = block(
+            *inputs,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_kv=cu_kv,
+            cu_seqlens_q_padded=padded_q if padded else None,
+            cu_seqlens_kv_padded=padded_kv if padded else None,
+            max_seqlen_q=128,
+            max_seqlen_kv=128,
+            pad_between_seqs=padded,
+        )
+        assert _attention_backends["use_flash_attention"]
+        assert _attention_backends["flash_attention_backend"].major == fa_version
+        assert not _attention_backends["use_fused_attention"]
+        assert not _attention_backends["use_unfused_attention"]
+        return (output, *torch.autograd.grad(output, inputs, grad))
+
+    def check(actual):
+        """Compare valid rows with compact attention and require exact-zero padding."""
+        compact_qkv = [
+            tensor.detach()[rows].requires_grad_()
+            for tensor, rows in zip(qkv, (q_rows, kv_rows, kv_rows))
+        ]
+        expected = run(compact_qkv, grad_output[q_rows], False)
+        for tensor, reference, rows in zip(actual, expected, (q_rows, q_rows, kv_rows, kv_rows)):
+            assert tensor.shape[0] == (128 if rows is q_rows else 192)
+            torch.testing.assert_close(tensor[rows], reference, atol=1.5e-2, rtol=1.5e-2)
+            padding = torch.ones(tensor.shape[0], dtype=torch.bool, device="cuda")
+            padding[rows] = False
+            assert torch.count_nonzero(tensor[padding]).item() == 0
+
+    check(run(qkv, grad_output, True))
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            run(qkv, grad_output, True)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        captured = run(qkv, grad_output, True)
+    for _ in range(2):
+        # Replays must consume fresh inputs and upstream gradients at the same addresses.
+        with torch.no_grad():
+            for tensor in (*qkv, grad_output):
+                tensor.normal_()
+        graph.replay()
+        check(captured)
 
 
 # Define F16 data types to test
@@ -1560,6 +1679,22 @@ def run_dot_product_attention(
 
     if backend in ["UnfusedDotProductAttention"]:
         return out, max_logit, (q_grad, k_grad, v_grad, d_softmax_offset)
+    if backend == "FlashAttention" and qkv_format == "thd" and pad_between_seqs:
+        tensors_and_boundaries = [("out", out, cu_seqlens_q, cu_seqlens_q_after_pad)]
+        if is_training:
+            tensors_and_boundaries.extend(
+                [
+                    ("dq", q_grad, cu_seqlens_q, cu_seqlens_q_after_pad),
+                    ("dk", k_grad, cu_seqlens_kv, cu_seqlens_kv_after_pad),
+                    ("dv", v_grad, cu_seqlens_kv, cu_seqlens_kv_after_pad),
+                ]
+            )
+        for tensor_name, tensor, cu_seqlens, cu_seqlens_padded in tensors_and_boundaries:
+            padding_mask = get_thd_padding_mask(tensor.shape[0], cu_seqlens, cu_seqlens_padded)
+            assert (
+                torch.count_nonzero(tensor[padding_mask]).item() == 0
+            ), f"{backend} left nonzero values in {tensor_name} padding"
+
     if backend in ["FusedAttention", "FlashAttention"]:
         if qkv_format == "thd" and pad_between_seqs:
             out_orig = torch.Tensor([]).to(device="cuda", dtype=dtype)

--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -768,6 +768,62 @@ class _PrepareQKVForFA(torch.autograd.Function):
         return dq, dk, dv
 
 
+def _get_thd_valid_token_mask(
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_padded: torch.Tensor,
+    total_tokens: int,
+) -> torch.Tensor:
+    """Build a mask for valid tokens in a physically padded THD tensor.
+
+    ``cu_seqlens`` contains the cumulative valid lengths, while
+    ``cu_seqlens_padded`` contains the physical sequence boundaries in the
+    input tensor. Padding is always at the end of each physical sequence.
+    """
+    num_sequences = cu_seqlens.numel() - 1
+    assert num_sequences > 0
+    assert cu_seqlens_padded.numel() == cu_seqlens.numel()
+
+    token_idx = torch.arange(
+        total_tokens,
+        dtype=cu_seqlens_padded.dtype,
+        device=cu_seqlens_padded.device,
+    )
+    physical_ends = cu_seqlens_padded[1:]
+    seq_idx = torch.searchsorted(physical_ends, token_idx, right=True)
+    valid_seq = seq_idx < num_sequences
+    seq_idx = seq_idx.clamp(max=num_sequences - 1)
+    physical_starts = cu_seqlens_padded[:-1].gather(0, seq_idx)
+    valid_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).gather(0, seq_idx)
+    return (
+        valid_seq & (token_idx >= physical_starts) & (token_idx - physical_starts < valid_lengths)
+    )
+
+
+def _mask_thd_padding(tensor: torch.Tensor, valid_token_mask: torch.Tensor) -> torch.Tensor:
+    """Return ``tensor`` with invalid THD token rows zeroed."""
+    mask = valid_token_mask.view(valid_token_mask.shape[0], *([1] * (tensor.ndim - 1)))
+    return tensor.masked_fill(~mask, 0)
+
+
+class _MaskTHDPaddingGrad(torch.autograd.Function):
+    """Identity in forward and zero THD padding rows in backward.
+
+    FA3 and FA4 may leave unwritten padding rows in their gradient buffers.
+    Applying this identity to Q/K/V avoids an extra forward copy while
+    guaranteeing that those rows are zero before gradients reach the caller.
+    """
+
+    @staticmethod
+    def forward(ctx, tensor: torch.Tensor, valid_token_mask: torch.Tensor) -> torch.Tensor:
+        ctx.save_for_backward(valid_token_mask)
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (valid_token_mask,) = ctx.saved_tensors
+        return _mask_thd_padding(grad_output, valid_token_mask), None
+
+
 class FlashAttention(torch.nn.Module):
     """Dot product attention, using HazyResearch flash-attn package:
     https://github.com/Dao-AILab/flash-attention
@@ -1015,6 +1071,21 @@ class FlashAttention(torch.nn.Module):
         use_flash_attn_3 = (
             flash_attention_backend is not None and flash_attention_backend.major == 3
         )
+        q_valid_token_mask = None
+        if pad_between_seqs and qkv_format == "thd" and not context_parallel:
+            assert cu_seqlens_q_padded is not None and cu_seqlens_kv_padded is not None, (
+                "cu_seqlens_q_padded and cu_seqlens_kv_padded are required when "
+                "pad_between_seqs=True"
+            )
+            q_valid_token_mask = _get_thd_valid_token_mask(
+                cu_seqlens_q, cu_seqlens_q_padded, query_layer.shape[0]
+            )
+            kv_valid_token_mask = _get_thd_valid_token_mask(
+                cu_seqlens_kv, cu_seqlens_kv_padded, key_layer.shape[0]
+            )
+            query_layer = _MaskTHDPaddingGrad.apply(query_layer, q_valid_token_mask)
+            key_layer = _MaskTHDPaddingGrad.apply(key_layer, kv_valid_token_mask)
+            value_layer = _MaskTHDPaddingGrad.apply(value_layer, kv_valid_token_mask)
         if context_parallel and all(
             not isinstance(x, Float8Tensor) for x in [query_layer, key_layer, value_layer]
         ):
@@ -1113,10 +1184,21 @@ class FlashAttention(torch.nn.Module):
                     if inference_params is None:
                         fa_4_optional_forward_kwargs["deterministic"] = self.deterministic
                     if func is flash_attn_varlen_func_v4:
-                        fa_4_optional_forward_kwargs["cu_seqlens_q"] = cu_seqlens_q
-                        fa_4_optional_forward_kwargs["cu_seqlens_k"] = cu_seqlens_kv
+                        fa_4_optional_forward_kwargs["cu_seqlens_q"] = (
+                            cu_seqlens_q_padded if pad_between_seqs else cu_seqlens_q
+                        )
+                        fa_4_optional_forward_kwargs["cu_seqlens_k"] = (
+                            cu_seqlens_kv_padded if pad_between_seqs else cu_seqlens_kv
+                        )
                         fa_4_optional_forward_kwargs["max_seqlen_q"] = max_seqlen_q
                         fa_4_optional_forward_kwargs["max_seqlen_k"] = max_seqlen_kv
+                        if pad_between_seqs:
+                            fa_4_optional_forward_kwargs["seqused_q"] = (
+                                cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+                            )
+                            fa_4_optional_forward_kwargs["seqused_k"] = (
+                                cu_seqlens_kv[1:] - cu_seqlens_kv[:-1]
+                            )
                     output = func(
                         query_layer,
                         key_layer,
@@ -1127,6 +1209,8 @@ class FlashAttention(torch.nn.Module):
                     )
                     if isinstance(output, (List, Tuple)):
                         output = output[0]
+                    if q_valid_token_mask is not None:
+                        output = _mask_thd_padding(output, q_valid_token_mask)
                 elif not use_flash_attn_3:
                     fa_optional_forward_kwargs = {}
                     if fa_utils.v2_3_plus:
@@ -1238,6 +1322,8 @@ class FlashAttention(torch.nn.Module):
 
                     if fp8:
                         output = output.to(dtype=torch_orig_dtype)
+                    if q_valid_token_mask is not None:
+                        output = _mask_thd_padding(output, q_valid_token_mask)
                     if fp8 and fp8_output:
                         O_quantizer = quantizers["scaling_fwd"][META_O]
                         output = O_quantizer(output)

--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -844,6 +844,33 @@ def _unalias_cu_seqlens(cu_q: torch.Tensor, cu_kv: torch.Tensor):
     return cu_q, cu_kv
 
 
+def _mask_thd_padding(tensor: torch.Tensor, padding_mask: torch.Tensor) -> torch.Tensor:
+    """Return ``tensor`` with invalid THD token rows zeroed."""
+    mask = padding_mask.view(padding_mask.shape[0], *([1] * (tensor.ndim - 1)))
+    return tensor.masked_fill(mask, 0)
+
+
+class _MaskTHDPaddingGrad(torch.autograd.Function):
+    """Identity in forward and zero THD padding rows in backward.
+
+    FA3 and FA4 may leave padding rows unwritten in their gradient buffers.
+    Keeping the forward as an identity avoids copying Q/K/V, while the custom
+    backward guarantees zero padding rows before gradients reach the caller.
+    """
+
+    @staticmethod
+    def forward(ctx, tensor: torch.Tensor, padding_mask: torch.Tensor) -> torch.Tensor:
+        """Save the padding mask and return the input without copying."""
+        ctx.save_for_backward(padding_mask)
+        return tensor
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        """Zero padding rows before propagating the input gradient."""
+        (padding_mask,) = ctx.saved_tensors
+        return _mask_thd_padding(grad_output, padding_mask), None
+
+
 class FlashAttention(torch.nn.Module):
     """Dot product attention, using HazyResearch flash-attn package:
     https://github.com/Dao-AILab/flash-attention
@@ -1092,6 +1119,21 @@ class FlashAttention(torch.nn.Module):
         use_flash_attn_3 = (
             flash_attention_backend is not None and flash_attention_backend.major == 3
         )
+        q_padding_mask = None
+        if pad_between_seqs and qkv_format == "thd" and not context_parallel:
+            assert cu_seqlens_q_padded is not None and cu_seqlens_kv_padded is not None, (
+                "cu_seqlens_q_padded and cu_seqlens_kv_padded are required when "
+                "pad_between_seqs=True"
+            )
+            q_padding_mask = dpa_utils.get_thd_padding_mask(
+                query_layer.shape[0], cu_seqlens_q, cu_seqlens_q_padded
+            )
+            kv_padding_mask = dpa_utils.get_thd_padding_mask(
+                key_layer.shape[0], cu_seqlens_kv, cu_seqlens_kv_padded
+            )
+            query_layer = _MaskTHDPaddingGrad.apply(query_layer, q_padding_mask)
+            key_layer = _MaskTHDPaddingGrad.apply(key_layer, kv_padding_mask)
+            value_layer = _MaskTHDPaddingGrad.apply(value_layer, kv_padding_mask)
         if (
             use_flash_attn_4
             and (10, 0) <= get_device_compute_capability() < (12, 0)
@@ -1229,6 +1271,8 @@ class FlashAttention(torch.nn.Module):
                     )
                     if isinstance(output, (List, Tuple)):
                         output = output[0]
+                    if q_padding_mask is not None:
+                        output = _mask_thd_padding(output, q_padding_mask)
                 elif not use_flash_attn_3:
                     fa_optional_forward_kwargs = {}
                     if fa_utils.v2_3_plus:
@@ -1340,6 +1384,8 @@ class FlashAttention(torch.nn.Module):
 
                     if fp8:
                         output = output.to(dtype=torch_orig_dtype)
+                    if q_padding_mask is not None:
+                        output = _mask_thd_padding(output, q_padding_mask)
                     if fp8 and fp8_output:
                         O_quantizer = quantizers["scaling_fwd"][META_O]
                         output = O_quantizer(output)

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -2270,6 +2270,9 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         softmax_lse_in_packed_format,
                     )
         out = out.view(post_a2a_o_shape)
+        if qkv_format == "thd" and pad_between_seqs and not use_fused_attention:
+            # Partial-output correction can write FA3/FA4 padding rows.
+            _zero_thd_padding((out,), cu_seqlens_q_per_step[0], cu_seqlens_q_padded)
         out_part = out.to(fwd_nominal_dtype)
 
         if cp_size_a2a > 1:
@@ -4918,6 +4921,10 @@ class AttnFuncWithCPAndQKVOA2A(torch.autograd.Function):
             aux_ctx_tensors = [softmax_lse, rng_state]
             out_part = out_
 
+            # Clean FA3/FA4 padding before inverse A2A changes sequence order.
+            if qkv_format == "thd" and pad_between_seqs:
+                _zero_thd_padding((out_,), cu_seqlens_q, cu_seqlens_q_padded)
+
         # a2a: split s and gather h
         # [b, s, h//cp, d] -> [b*s//cp, h, d]
         # [s, b, h//cp, d] -> [s//cp*b, h, d]
@@ -5314,6 +5321,11 @@ class AttnFuncWithCPAndQKVOA2A(torch.autograd.Function):
                     *fa_backward_args_thd,
                     **fa_backward_kwargs,
                 )
+
+            # Clean FA3/FA4 padding before inverse A2A changes sequence order.
+            if ctx.dqkv_format == "thd" and ctx.pad_between_seqs:
+                _zero_thd_padding((dq,), cu_seqlens_q, cu_seqlens_q_padded)
+                _zero_thd_padding((dk, dv), cu_seqlens_kv, cu_seqlens_kv_padded)
 
         # dq, dk, dv:
         # FP8DS: torch.uint8

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -976,16 +976,13 @@ def get_attention_backend(
     # Filter: QKV layout
     if qkv_format == "thd":
         if pad_between_seqs:
-            if (  # pylint: disable=too-many-boolean-expressions
-                use_flash_attention_2 and FlashAttentionUtils.is_installed
-            ) or (use_flash_attention_4 and FlashAttentionUtils.v4_is_installed):
+            if use_flash_attention_2 and FlashAttentionUtils.is_installed:
                 logger.debug(
-                    "Disabling FlashAttention 2 and 4 for qkv_format = thd when there is "
+                    "Disabling FlashAttention 2 for qkv_format = thd when there is "
                     "padding between sequences, i.e. [a, a, PAD, b, b, b, PAD, c, PAD]"
                 )
             use_flash_attention_2 = False
-            use_flash_attention_4 = False
-            # FA3 supports pad_between_seqs via seqused_q/seqused_k
+            # FA3 and FA4 support pad_between_seqs via seqused_q/seqused_k.
             if use_unfused_attention:
                 logger.debug("Disabling UnfusedDotProductAttention for pad_between_seqs = True")
             use_unfused_attention = False

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -1706,11 +1706,15 @@ def get_attention_backend(
 
 @torch.no_grad()
 def get_thd_padding_mask(num_tokens, cu_seqlens, cu_seqlens_padded):
-    """Identify inter-sequence padding in a flattened packed THD buffer."""
+    """Identify inter-sequence and tail padding in a flattened packed THD buffer."""
     rows = torch.arange(num_tokens, device=cu_seqlens_padded.device)
     sequence = torch.searchsorted(cu_seqlens_padded[1:], rows, right=True)
-    valid_end = cu_seqlens_padded[sequence] + cu_seqlens[sequence + 1] - cu_seqlens[sequence]
-    return rows >= valid_end
+    valid_ends = cu_seqlens_padded[:-1] + cu_seqlens[1:] - cu_seqlens[:-1]
+    # Tail rows map to sequence == batch_size. Append a zero-length sequence
+    # at the final physical boundary so that index is valid, even for an empty
+    # batch. All operations stay on device for CUDA Graph capture and replay.
+    valid_ends = torch.cat((valid_ends, cu_seqlens_padded[-1:]))
+    return rows >= valid_ends[sequence]
 
 
 @torch.no_grad()


### PR DESCRIPTION
## Description

Support FA3/FA4 with `pad_between_seqs=True` in THD attention, including non-CP, P2P CP, and all-to-all (A2A) CP.

This support requires attention output and Q/K/V gradients to be exactly zero at physical padding positions. FA3/FA4 can leave these positions unwritten, and CP partial-output merges can write them again. This PR adds the necessary padding cleanup and correctness checks.

The padding mask also handles reserved buffer capacity after the final padded sequence boundary. `num_tokens` is the full physical buffer capacity and may exceed `cu_seqlens_padded[-1]`; all positions beyond that boundary are treated as padding. For example, a 16-token buffer with `cu_seqlens=[0,3,8]` and `cu_seqlens_padded=[0,4,12]` includes tail padding at positions `[12,16)`, which map to a zero-length sentinel sequence instead of indexing beyond the sequence metadata.

## Changes

- Mask non-CP FlashAttention output padding and use an autograd identity to zero Q/K/V-gradient padding without copying forward inputs.
- Clean P2P output padding after merging partial outputs, and A2A output/gradient padding before inverse communication changes token order. Added cleanup is confined to FlashAttention.
- Make the shared THD padding mask safe for reserved buffer tails using device-side operations.
- Add exact-zero assertions and focused padding/CUDA Graph regression tests with an independently compacted reference. Query `get_attention_backend` to skip unsupported configurations while asserting that the requested FA version actually runs.

Padding cleanup must remain CUDA-graph-capturable in both non-CP and supported CP paths. The added in-tree capture/replay regression covers non-CP attention with raw CUDA Graph capture. CP capture uses TE's existing `make_graphed_callables` path; this PR does not extend raw-capture support for CP.

FA4 backend selection and varlen metadata plumbing already exist on the base branch. FA2 with inter-sequence padding and the unsupported padded A2A+P2P combination remain outside this change.
