### PR TITLE
[CI] Fix old NVCC dependency in GH CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,16 @@ jobs:
     name: 'Core'
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/cuda:12.1.0-devel-ubuntu22.04
+      image: nvcr.io/nvidia/cuda:12.9.2-devel-ubuntu22.04
       options: --user root
     steps:
       - name: 'Dependencies'
         run: |
           apt-get update
-          apt-get install -y git python3.9 pip cudnn9-cuda-12
+          apt-mark unhold libnccl2 libnccl-dev
+          apt-get install -y git python3 python3-pip cudnn9-cuda-12 \
+            libnccl2=2.30.7-1+cuda12.9 \
+            libnccl-dev=2.30.7-1+cuda12.9
           pip install cmake==3.21.0 pybind11[global] ninja "nvidia-cudnn-frontend>=1.25.0"
       - name: 'Checkout'
         uses: actions/checkout@v3
@@ -70,13 +73,16 @@ jobs:
 
       - name: Start named container
         run: |
-          docker run -v $(pwd):$(pwd) -w $(pwd) --name builder -d nvcr.io/nvidia/cuda:12.8.0-devel-ubuntu22.04 sleep infinity
+          docker run -v $(pwd):$(pwd) -w $(pwd) --name builder -d nvcr.io/nvidia/cuda:12.9.2-devel-ubuntu22.04 sleep infinity
 
       - name: 'Dependencies'
         run: |
           docker exec builder bash -c '\
             apt-get update && \
-            apt-get install -y git python3.9 pip cudnn9-cuda-12 && \
+            apt-mark unhold libnccl2 libnccl-dev && \
+            apt-get install -y git python3 python3-pip cudnn9-cuda-12 \
+              libnccl2=2.30.7-1+cuda12.9 \
+              libnccl-dev=2.30.7-1+cuda12.9 && \
             pip install cmake torch ninja pydantic importlib-metadata>=1.0 packaging pybind11 numpy einops onnxscript "nvidia-cudnn-frontend>=1.25.0" && \
             apt-get clean \
           '


### PR DESCRIPTION
# Description

CI is failing because the NVCC version in the CUDA container image used is too old. Newer container images don't include a sufficiently new version of NVCC.

This installs the dependency via apt. This is less than ideal, but it unblocks CI while I work on a better solution.

**Note**: this fixes the `fatal error: nccl_device.h: No such file or directory` compilation issue, but pipelines still won't pass due to issues farther down in the build process (compilation choking out the runner agent process, runners failing to compile everything within 6 hour limit, etc).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Install nvcc via apt, bypassing old nvcc version in base image.
- Fixed setup installing python3-llfuse instead of just python

    ````console
    $ docker run --rm -it --entrypoint sh nvcr.io/nvidia/cuda:12.9.2-devel-ubuntu22.04 -c "apt update > /dev/null && apt-cache search python3.9"

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

    python3-llfuse - Python 3 bindings for the low-level FUSE API
    ````

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
