### PR TITLE
[JAX] Keep MoE aux-loss cotangent scalar

### DIFF
--- a/transformer_engine/jax/router.py
+++ b/transformer_engine/jax/router.py
@@ -342,12 +342,11 @@ def _fused_moe_aux_loss_fwd(probs, tokens_per_expert, topk, coeff):
 def _fused_moe_aux_loss_bwd(topk, coeff, residuals, g):
     del topk, coeff
     const_buf, tokens_per_expert, num_tokens = residuals
-    grad_aux_loss = g.reshape(1)
 
     grad_probs = fused_moe_aux_loss_bwd(
         const_buf,
         tokens_per_expert,
-        grad_aux_loss,
+        g,
         num_tokens,
     )
     return grad_probs, None


### PR DESCRIPTION
# Description
Fix the distributed JAX MoE auxiliary-loss backward pass by preserving its scalar cotangent instead of reshaping it to (1,).
The Shardy rule correctly declares this operand as rank 0, so the reshape caused distributed lowering to fail with a rank mismatch. The FFI already accepts a scalar buffer.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes
removing reshape of cotangent in MoE aux loss bwd pass to (1,)

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
