### PR TITLE
Build Fix: Avoid invalid make -j 0 in NCCL EP submodule build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,8 +272,9 @@ def build_nccl_ep_submodule() -> str:
                 env=env,
             )
         print(f"[NCCL EP] Building libnccl_ep.a (gencode='{gencode}')")
+        make_jobs = f"-j{nproc}" if nproc else "-j"
         subprocess.check_call(
-            ["make", "-j", str(nproc), "-C", "nccl_ep", "lib"],
+            ["make", make_jobs, "-C", "nccl_ep", "lib"],
             cwd=str(nccl_root),
             env=env,
         )


### PR DESCRIPTION
# Description

Avoid invalid make -j 0 in NCCL EP submodule build

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
