### PR TITLE
[PyTorch] Allow multi-version Flash Attention tests to use checkpoints with pickles

### DIFF
--- a/qa/L3_pytorch_FA_versions_test/test.sh
+++ b/qa/L3_pytorch_FA_versions_test/test.sh
@@ -25,6 +25,9 @@ pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 # Limit parallel build jobs to avoid overwhelming system resources
 export MAX_JOBS=32
 
+# Checkpoint for FP8 delayed scaling uses pickle
+export NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1
+
 # Iterate over Flash Attention versions
 sm_arch=`python3 -c "import torch; sm = torch.cuda.get_device_capability(0); print(sm[0]*10+sm[1])"`
 export FLASH_ATTN_CUDA_ARCHS=$sm_arch


### PR DESCRIPTION
# Description

https://github.com/NVIDIA/TransformerEngine/pull/3123 added a guard to avoid using pickle in checkpoints. However, the legacy FP8 delayed scaling format still requires pickle. This causes failures in the multi-version Flash Attention tests. The fix is to allow checkpoints with pickles.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring
- [x] Tests

## Changes

- Allow multi-version Flash Attention tests to use checkpoints with pickles.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
