### PR TITLE
[Common] Make MXFP8 specialized kernel respect noop flag as well

### DIFF
--- a/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
@@ -692,7 +692,8 @@ void quantize(const Tensor &input, const Tensor *act_input, const Tensor *noop, 
                     kernel<<<grid, block, traits::smem, stream>>>(
                         reinterpret_cast<typename traits::IType *>(input.data.dptr),
                         reinterpret_cast<typename traits::OType *>(output->data.dptr),
-                        scales_rowwise_ptr, rows, cols, scale_stride_rowwise, scale_stride_colwise);
+                        scales_rowwise_ptr, noop_ptr, rows, cols, scale_stride_rowwise,
+                        scale_stride_colwise);
 
                     break;
                   }
@@ -729,8 +730,8 @@ void quantize(const Tensor &input, const Tensor *act_input, const Tensor *noop, 
                               (rows + traits::blockDIM::M - 1) / traits::blockDIM::M);
                     kernel<<<grid, block, traits::smem, stream>>>(
                         tensor_map_input, tensor_map_rowwise_output, tensor_map_colwise_output,
-                        scales_rowwise_ptr, scales_colwise_ptr, rows, cols, scale_stride_rowwise,
-                        scale_stride_colwise);
+                        scales_rowwise_ptr, scales_colwise_ptr, noop_ptr, rows, cols,
+                        scale_stride_rowwise, scale_stride_colwise);
 
                     break;
                   }

--- a/transformer_engine/common/cast/mxfp8/specialized/quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/specialized/quantize_mxfp8.cuh
@@ -170,10 +170,14 @@ template <typename CastTraits,
           std::enable_if_t<CastTraits::isRowwise && !CastTraits::isColwise, int> = 0>
 __global__ void quantize_mxfp8_kernel_cast_only(typename CastTraits::IType *__restrict__ input,
                                                 typename CastTraits::OType *__restrict__ output,
-                                                e8m0_t *__restrict__ scales_rowwise, int32_t rows,
-                                                int32_t cols, int32_t scale_stride_rowwise,
+                                                e8m0_t *__restrict__ scales_rowwise,
+                                                const float *noop, int32_t rows, int32_t cols,
+                                                int32_t scale_stride_rowwise,
                                                 int32_t scale_stride_colwise) {
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  if (noop != nullptr && noop[0] == 1.0f) {
+    return;
+  }
   using IType = typename CastTraits::IType;
   using OType = typename CastTraits::OType;
   using inputUnitType = typename CastTraits::inputUnitType;
@@ -679,9 +683,12 @@ __global__ void quantize_mxfp8_kernel_cast_only(
     const __grid_constant__ CUtensorMap tensor_map_input,
     const __grid_constant__ CUtensorMap tensor_map_rowwise_output,
     const __grid_constant__ CUtensorMap tensor_map_colwise_output,
-    e8m0_t *__restrict__ scales_rowwise, e8m0_t *__restrict__ scales_colwise, int32_t rows,
-    int32_t cols, int32_t scale_stride_rowwise, int32_t scale_stride_colwise) {
+    e8m0_t *__restrict__ scales_rowwise, e8m0_t *__restrict__ scales_colwise, const float *noop,
+    int32_t rows, int32_t cols, int32_t scale_stride_rowwise, int32_t scale_stride_colwise) {
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  if (noop != nullptr && noop[0] == 1.0f) {
+    return;
+  }
   using IType = typename CastTraits::IType;
   using OType = typename CastTraits::OType;
   using inputUnitType = typename CastTraits::inputUnitType;
@@ -1150,9 +1157,12 @@ __global__ void quantize_mxfp8_kernel_cast_only(
     const __grid_constant__ CUtensorMap tensor_map_input,
     const __grid_constant__ CUtensorMap tensor_map_rowwise_output,
     const __grid_constant__ CUtensorMap tensor_map_colwise_output, e8m0_t *scales_rowwise,
-    e8m0_t *scales_colwise, int32_t rows, int32_t cols, int32_t scale_stride_rowwise,
-    int32_t scale_stride_colwise) {
+    e8m0_t *scales_colwise, const float *noop, int32_t rows, int32_t cols,
+    int32_t scale_stride_rowwise, int32_t scale_stride_colwise) {
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  if (noop != nullptr && noop[0] == 1.0f) {
+    return;
+  }
   using IType = typename CastTraits::IType;
   using OType = typename CastTraits::OType;
   using inputUnitType = typename CastTraits::inputUnitType;


### PR DESCRIPTION
# Description

Ask the specialized MXFP8 quantization kernel to respect the noop flag for CUDA graphs.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Pass the noop tensor to specialized MXFP8 kernels as well
- Let specialized MXFP8 kernels skip execution if noop tensor is not nullptr and is 1.0f

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Validation script:
```
import os
import torch
import transformer_engine.pytorch  # noqa: F401  (sets up lib loading)
import transformer_engine_torch as tex
from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer

torch.manual_seed(0)
x = torch.randn(256, 256, dtype=torch.bfloat16, device="cuda").contiguous()
noop = torch.zeros(1, dtype=torch.float32, device="cuda")  # fixed-address flag

for rowwise, colwise, name in [(True, False, "rowwise"), (True, True, "bidim")]:
    q = MXFP8Quantizer(fp8_dtype=tex.DType.kFloat8E4M3, rowwise=rowwise, columnwise=colwise)
    dst = q(x)                       # allocate the quantized tensor once (fixed buffers)
    data = dst._rowwise_data

    def call():
        q.update_quantized(x, dst, noop_flag=noop)

    noop.fill_(0.0)                  # warmup (required before capture)
    for _ in range(3):
        call()
    torch.cuda.synchronize()

    g = torch.cuda.CUDAGraph()       # capture once
    with torch.cuda.graph(g):
        call()

    # replay the SAME graph with the flag flipped -> branch must respond per replay
    data.zero_(); noop.fill_(0.0); g.replay(); torch.cuda.synchronize()
    ran = data.view(torch.uint8).any().item()
    data.zero_(); noop.fill_(1.0); g.replay(); torch.cuda.synchronize()
    skipped = not data.view(torch.uint8).any().item()
    print(f"CUDA {name}: graph noop=0 wrote={ran}, noop=1 skipped={skipped}, OK={ran and skipped}")
```
Prints:
```
CUDA rowwise: graph noop=0 wrote=1, noop=1 skipped=True, OK=True
CUDA bidim: graph noop=0 wrote=1, noop=1 skipped=True, OK=True
```