### PR TITLE
Opt in trusted FA CI checkpoints to pickle loading

### DIFF
--- a/qa/L3_pytorch_FA_versions_test/test.sh
+++ b/qa/L3_pytorch_FA_versions_test/test.sh
@@ -77,6 +77,8 @@ do
   XML_ATTN="$XML_LOG_DIR/pytest_test_attention_fa${fa_tag}.xml"
   XML_CP="$XML_LOG_DIR/pytest_test_attention_with_cp_fa${fa_tag}.xml"
 
+  # test_attention.py reloads its own trusted delayed-scaling FP8 checkpoint,
+  # whose legacy extra state requires an explicit pickle opt-in.
   if [ "$fa_version" = "$CP_FA_VERSION" ]; then
     echo "Running CP tests with FA $fa_version (CP version for sm$sm_arch)"
     if [ "$NUM_GPUS" -ge 5 ]; then
@@ -84,7 +86,7 @@ do
       CP_GPUS=$(seq -s, 1 $CP_NUM_GPUS)
       echo "Running tests in parallel: test_attention.py on GPU 0, test_attention_with_cp.py on GPUs $CP_GPUS ($CP_NUM_GPUS GPUs)"
 
-      CUDA_VISIBLE_DEVICES=0 NVTE_TORCH_COMPILE=0 python3 -m pytest -v -s \
+      CUDA_VISIBLE_DEVICES=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1 python3 -m pytest -v -s \
         --junitxml=$XML_ATTN \
         $TE_PATH/tests/pytorch/attention/test_attention.py &
       PID_ATTN=$!
@@ -98,12 +100,12 @@ do
       wait $PID_CP || test_fail "test_attention_with_cp.py (FA $fa_version)"
     else
       echo "Running tests sequentially: need >=5 GPUs for parallel execution (1 for test_attention + 4 for test_attention_with_cp)"
-      NVTE_TORCH_COMPILE=0 python3 -m pytest -v -s --junitxml=$XML_ATTN $TE_PATH/tests/pytorch/attention/test_attention.py || test_fail "test_attention.py (FA $fa_version)"
+      NVTE_TORCH_COMPILE=0 NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1 python3 -m pytest -v -s --junitxml=$XML_ATTN $TE_PATH/tests/pytorch/attention/test_attention.py || test_fail "test_attention.py (FA $fa_version)"
       NVTE_TORCH_COMPILE=0 python3 -m pytest -v -s --junitxml=$XML_CP $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py || test_fail "test_attention_with_cp.py (FA $fa_version)"
     fi
   else
     echo "Skipping CP tests for FA $fa_version (CP only runs with FA $CP_FA_VERSION on sm$sm_arch)"
-    NVTE_TORCH_COMPILE=0 python3 -m pytest -v -s --junitxml=$XML_ATTN $TE_PATH/tests/pytorch/attention/test_attention.py || test_fail "test_attention.py (FA $fa_version)"
+    NVTE_TORCH_COMPILE=0 NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1 python3 -m pytest -v -s --junitxml=$XML_ATTN $TE_PATH/tests/pytorch/attention/test_attention.py || test_fail "test_attention.py (FA $fa_version)"
   fi
 done
 


### PR DESCRIPTION
# Description

The L3 FA-version tests create and reload trusted delayed-scaling FP8 checkpoints, but their launcher did not opt into legacy pickle extra-state loading. This caused the FP16 and BF16 checkpoint cases to fail across the FA version matrix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infra/Build change

## Changes

- Enable `NVTE_ALLOW_UNSAFE_PICKLE_EXTRA_STATE=1` for every L3 `test_attention.py` execution path.
- Keep the opt-in scoped to trusted test-generated checkpoints; runtime defaults and CP-only tests are unchanged.

## Validation

| Scenario | Result |
|---|---|
| Shell syntax | `bash -n qa/L3_pytorch_FA_versions_test/test.sh` passed |
| QA launcher audit | Every direct `test_attention.py` launcher has the trusted-checkpoint opt-in |
| Full GPU FA matrix | Pending [PR checks](https://github.com/NVIDIA/TransformerEngine/pull/3247/checks) |

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable: CI-only fix)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (covered by the existing FA-version matrix)
- [ ] New and existing unit tests pass locally with my changes (requires GPU CI)
