### PR TITLE
[CI] Pin JAX image to 2026-07-21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
     name: 'JAX'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/nvidia/jax:jax
+      image: ghcr.io/nvidia/jax:jax-2026-07-21
       options: --user root
     steps:
       - name: 'Dependencies'
@@ -143,7 +143,7 @@ jobs:
 
       - name: Start named container
         run: |
-          docker run -v $(pwd):$(pwd) -w $(pwd) --name builder -d ghcr.io/nvidia/jax:jax sleep infinity
+          docker run -v $(pwd):$(pwd) -w $(pwd) --name builder -d ghcr.io/nvidia/jax:jax-2026-07-21 sleep infinity
 
       - name: 'Dependencies'
         run: |


### PR DESCRIPTION
# Description

CI tests on GH runners are failing because they pull the latest, rolling `ghcr.io/nvidia/jax:jax` image tag. This poses a couple of problems:
* You never really know what you're testing against until the image is pulled (varies day to day)
* When upstream pushes a broken release (see [last night's release](https://github.com/nvidia/JAX-Toolbox/pkgs/container/jax/1058745858?tag=jax-2026-07-22) where only an arm64 image was pushed), it breaks CI pipelines

This locks the image to `ghcr.io/nvidia/jax:jax-2026-07-21`. The tradeoff here is that the image will need to be periodically updated. IMO this should be pinned further, but locking it to the 07/21 image should get CI unblocked.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Lock the jax image to `ghcr.io/nvidia/jax:jax-2026-07-21`

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
