### PR TITLE
Enable runtime resolution of CUDA header path for NVRTC

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -360,6 +360,7 @@ target_link_libraries(transformer_engine PUBLIC
                       CUDA::cublas
                       CUDA::cudart
                       CUDNN::cudnn_all)
+target_link_libraries(transformer_engine PRIVATE ${CMAKE_DL_LIBS})
 
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})

--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -371,6 +371,7 @@ target_link_libraries(transformer_engine PUBLIC
                       CUDA::cublas
                       CUDA::cudart
                       CUDNN::cudnn_all)
+target_link_libraries(transformer_engine PRIVATE ${CMAKE_DL_LIBS})
 
 target_include_directories(transformer_engine PRIVATE
                            ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -235,24 +235,49 @@ def _get_sys_extension() -> str:
     raise RuntimeError(f"Unsupported operating system ({system})")
 
 
+def _cuda_runtime_major(cuda_runtime: ctypes.CDLL) -> Optional[int]:
+    """Return the major version of the CUDA runtime loaded with Transformer Engine."""
+
+    runtime_version = ctypes.c_int()
+    get_runtime_version = cuda_runtime.cudaRuntimeGetVersion
+    get_runtime_version.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    get_runtime_version.restype = ctypes.c_int
+    if get_runtime_version(ctypes.byref(runtime_version)) != 0 or runtime_version.value <= 0:
+        return None
+    return runtime_version.value // 1000
+
+
 @functools.lru_cache(maxsize=None)
-def _nvidia_cudart_include_dir() -> str:
+def _nvidia_cudart_include_dir(cuda_major_version: int) -> str:
     """Returns the include directory for cuda_runtime.h if exists in python environment."""
+
+    # This is primarily here to support editable installs. cuda_runtime.cpp handles the
+    # resolution for install via wheel or when using the shared library ABI directly.
 
     try:
         import nvidia
     except ModuleNotFoundError:
         return ""
 
-    # Installing some nvidia-* packages, like nvshmem, create nvidia name, so "import nvidia"
-    # above doesn't throw. However, they don't set "__file__" attribute.
+    # NVIDIA packages may use either a regular package or a namespace package spread
+    # across multiple package roots.
     if nvidia.__file__ is not None:
-        nvidia_root = Path(nvidia.__file__).parent
+        nvidia_roots = (Path(nvidia.__file__).parent,)
     else:
-        nvidia_root = Path(nvidia.__path__[0])  # namespace package
+        nvidia_roots = tuple(Path(path) for path in nvidia.__path__)
 
-    include_dir = nvidia_root / "cuda_runtime"
-    return str(include_dir) if include_dir.exists() else ""
+    layouts = [f"cu{cuda_major_version}"]
+    if cuda_major_version == 12:
+        layouts.append("cuda_runtime")
+
+    for layout in layouts:
+        for nvidia_root in nvidia_roots:
+            cuda_root = nvidia_root / layout
+            if (cuda_root / "cuda_runtime.h").is_file() or (
+                cuda_root / "include" / "cuda_runtime.h"
+            ).is_file():
+                return str(cuda_root)
+    return ""
 
 
 @functools.lru_cache(maxsize=None)
@@ -382,5 +407,8 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
     _TE_LIB_CTYPES = _load_core_library()
 
     # Needed to find the correct headers for NVRTC kernels.
-    if not os.getenv("NVTE_CUDA_INCLUDE_DIR") and _nvidia_cudart_include_dir():
-        os.environ["NVTE_CUDA_INCLUDE_DIR"] = _nvidia_cudart_include_dir()
+    cuda_major_version = _cuda_runtime_major(_TE_LIB_CTYPES)
+    if not os.getenv("NVTE_CUDA_INCLUDE_DIR") and cuda_major_version is not None:
+        cuda_include_dir = _nvidia_cudart_include_dir(cuda_major_version)
+        if cuda_include_dir:
+            os.environ["NVTE_CUDA_INCLUDE_DIR"] = cuda_include_dir

--- a/transformer_engine/common/__init__.py
+++ b/transformer_engine/common/__init__.py
@@ -407,8 +407,8 @@ if "NVTE_PROJECT_BUILDING" not in os.environ or bool(int(os.getenv("NVTE_RELEASE
     _TE_LIB_CTYPES = _load_core_library()
 
     # Needed to find the correct headers for NVRTC kernels.
-    cuda_major_version = _cuda_runtime_major(_TE_LIB_CTYPES)
-    if not os.getenv("NVTE_CUDA_INCLUDE_DIR") and cuda_major_version is not None:
-        cuda_include_dir = _nvidia_cudart_include_dir(cuda_major_version)
+    _cuda_major_version = _cuda_runtime_major(_TE_LIB_CTYPES)
+    if not os.getenv("NVTE_CUDA_INCLUDE_DIR") and _cuda_major_version is not None:
+        cuda_include_dir = _nvidia_cudart_include_dir(_cuda_major_version)
         if cuda_include_dir:
             os.environ["NVTE_CUDA_INCLUDE_DIR"] = cuda_include_dir

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -8,6 +8,8 @@
 
 #include <cublasLt.h>
 
+#include <dlfcn.h>
+
 #include <filesystem>
 #include <fstream>
 #include <mutex>
@@ -25,6 +27,81 @@ namespace {
 
 // String with build-time CUDA include path
 #include "string_path_cuda_include.h"
+
+// Get the runtime directory of the shared library that contains this code
+std::filesystem::path shared_library_directory() {
+  static const char library_anchor = 0;
+  Dl_info library_info{};
+  if (dladdr(static_cast<const void *>(&library_anchor), &library_info) == 0 ||
+      library_info.dli_fname == nullptr) {
+    return {};
+  }
+
+  std::filesystem::path library_path = library_info.dli_fname;
+  if (library_path.is_relative()) {
+    std::error_code error;
+    library_path = std::filesystem::absolute(library_path, error);
+    if (error) {
+      return {};
+    }
+  }
+
+  return library_path.parent_path();
+}
+
+std::string runtime_cuda_major_version() {
+  int runtime_version = 0;
+  // Header discovery is best-effort, so do not throw if the runtime cannot
+  // report its version.
+  if (cudaRuntimeGetVersion(&runtime_version) != cudaSuccess || runtime_version <= 0) {
+    return {};
+  }
+
+  return std::to_string(runtime_version / 1000);
+}
+
+std::filesystem::path python_cuda_directory() {
+  using Path = std::filesystem::path;
+
+  // Find the packages directory by traversing up the directory tree until a known package
+  // directory is found.
+  Path directory = shared_library_directory();
+  while (true) {
+    const auto filename = directory.filename();
+    if (filename == "site-packages" || filename == "dist-packages") {
+      break;
+    }
+
+    const Path parent = directory.parent_path();
+    if (parent == directory) {
+      // Root directory reached
+      return {};
+    }
+
+    directory = parent;
+  }
+
+  const Path nvidia_directory = directory / "nvidia";
+  const auto cuda_major_version = runtime_cuda_major_version();
+  if (cuda_major_version.empty()) {
+    return {};
+  }
+
+  std::error_code error;
+  const Path cuda_directory = nvidia_directory / ("cu" + cuda_major_version);
+  if (std::filesystem::is_directory(cuda_directory, error)) {
+    return cuda_directory;
+  }
+
+  // CUDA 12 Python wheels use the older nvidia/cuda_runtime layout.
+  error.clear();
+  const Path legacy_cuda_directory = nvidia_directory / "cuda_runtime";
+  if (std::filesystem::is_directory(legacy_cuda_directory, error)) {
+    return legacy_cuda_directory;
+  }
+
+  return {};
+}
 
 }  // namespace
 
@@ -152,6 +229,7 @@ const std::string &include_directory(bool required) {
     std::vector<std::pair<std::string, Path>> search_paths = {{"NVTE_CUDA_INCLUDE_DIR", ""},
                                                               {"CUDA_HOME", ""},
                                                               {"CUDA_DIR", ""},
+                                                              {"", python_cuda_directory()},
                                                               {"", string_path_cuda_include},
                                                               {"", "/usr/local/cuda"}};
     for (auto &[env, p] : search_paths) {

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -7,7 +7,6 @@
 #include "../util/cuda_runtime.h"
 
 #include <cublasLt.h>
-
 #include <dlfcn.h>
 
 #include <filesystem>

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -62,25 +62,25 @@ std::string runtime_cuda_major_version() {
 std::filesystem::path python_cuda_directory() {
   using Path = std::filesystem::path;
 
-  // Find the packages directory by traversing up the directory tree until a known package
-  // directory is found.
-  Path directory = shared_library_directory();
+  // Find the Python package root from the installed Transformer Engine package. Do not
+  // assume that the root is named site-packages or dist-packages since valid installs
+  // may use an arbitrary target directory.
+  Path te_package_directory = shared_library_directory();
   while (true) {
-    const auto filename = directory.filename();
-    if (filename == "site-packages" || filename == "dist-packages") {
+    if (te_package_directory.filename() == "transformer_engine") {
       break;
     }
 
-    const Path parent = directory.parent_path();
-    if (parent == directory) {
+    const Path parent = te_package_directory.parent_path();
+    if (parent == te_package_directory) {
       // Root directory reached
       return {};
     }
 
-    directory = parent;
+    te_package_directory = parent;
   }
 
-  const Path nvidia_directory = directory / "nvidia";
+  const Path nvidia_directory = te_package_directory.parent_path() / "nvidia";
   const auto cuda_major_version = runtime_cuda_major_version();
   if (cuda_major_version.empty()) {
     return {};

--- a/transformer_engine/common/util/cuda_runtime.cpp
+++ b/transformer_engine/common/util/cuda_runtime.cpp
@@ -93,10 +93,12 @@ std::filesystem::path python_cuda_directory() {
   }
 
   // CUDA 12 Python wheels use the older nvidia/cuda_runtime layout.
-  error.clear();
-  const Path legacy_cuda_directory = nvidia_directory / "cuda_runtime";
-  if (std::filesystem::is_directory(legacy_cuda_directory, error)) {
-    return legacy_cuda_directory;
+  if (cuda_major_version == "12") {
+    error.clear();
+    const Path legacy_cuda_directory = nvidia_directory / "cuda_runtime";
+    if (std::filesystem::is_directory(legacy_cuda_directory, error)) {
+      return legacy_cuda_directory;
+    }
   }
 
   return {};


### PR DESCRIPTION
# Description

NVRTC relies on having CUDA toolkit headers available at runtime for JIT compilation. The following directories are searched:
1. `${NVTE_CUDA_INCLUDE_DIR}`
2. `${CUDA_HOME}`
3. `${CUDA_DIR}`
4. The **build-time** header path
5. `/usr/local/cuda`

The build-time path may coincidentally line up with the runtime path, but may be incorrect when building TE on another machine or environment, or when building TE with build isolation enabled. This enables searching site-packages at runtime for the headers, allowing them to be resolved in more environments. If checked paths don't exist, then this will fall back to the existing behavior.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Enable runtime resolution of CUDA toolkit headers in site-packages for NVRTC

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
