### PR TITLE
Acquire the GIL in lazy init_extension

### DIFF
--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -121,6 +121,7 @@ void init_grouped_tensor_extension() {
 
 void init_extension() {
   std::call_once(extension_init_flag, []() {
+    pybind11::gil_scoped_acquire gil;
     init_float8_extension();
     init_mxfp8_extension();
     init_float8blockwise_extension();

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -120,8 +120,8 @@ void init_grouped_tensor_extension() {
 }
 
 void init_extension() {
+  pybind11::gil_scoped_acquire gil;
   std::call_once(extension_init_flag, []() {
-    pybind11::gil_scoped_acquire gil;
     init_float8_extension();
     init_mxfp8_extension();
     init_float8blockwise_extension();


### PR DESCRIPTION
# Description

`init_extension()` imports Python modules via `py::module_::import`, which requires the GIL. Several bindings that can trigger this lazy initialization are declared with `call_guard<py::gil_scoped_release>` — if one of them is the first `transformer_engine_torch` call in the process, initialization runs without the GIL and segfaults. Typical runs don't hit this because a GIL-holding call (e.g. a quantize) usually comes first.

Deterministic repro on main:

```python
import torch
import transformer_engine.pytorch
import transformer_engine_torch as tex

x = torch.randint(0, 255, (64, 64), dtype=torch.uint8, device="cuda")
tex.fp8_transpose(x, tex.DType.kFloat8E4M3, out=None)  # first tex call in the process
```

```
!!!!!!! Segfault encountered !!!!!!!
  ... in PyObject_Malloc
  ... in PyImport_ImportModule
  ... in transformer_engine::pytorch::init_float8_extension()
  ... in std::call_once<transformer_engine::pytorch::init_extension()::{lambda()#1}> ...
  ... in transformer_engine::pytorch::init_extension()
  ... in transformer_engine::pytorch::fp8_transpose(at::Tensor, transformer_engine::DType, std::optional<at::Tensor>)
  ... in pybind11::cpp_function::dispatcher
```

Running any GIL-holding tex call first (e.g. `tex.quantize`) and then `fp8_transpose` works, confirming the GIL state is the only difference.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Acquire the GIL inside `init_extension()`'s `std::call_once` initializer before importing Python modules.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
