### PR TITLE
fix(pytorch): add missing f-string prefixes to error messages

### DIFF
--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -708,7 +708,7 @@ class QuantizedTensor(torch.Tensor):
 
         # View op
         if func == torch.ops.aten.view.default:
-            raise NotImplementedError("{cls.__name__} class does not support tensor views")
+            raise NotImplementedError(f"{cls.__name__} class does not support tensor views")
 
         # New empty op (used by DCP async staging to create CPU copies)
         if func == torch.ops.aten.new_empty.default:

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -673,7 +673,9 @@ class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
         # View op
         if func == aten.view.default:
             if len(args) != 2:
-                raise RuntimeError(f"Unexpected args for view op (expected 2 args, got {len(args)})")
+                raise RuntimeError(
+                    f"Unexpected args for view op (expected 2 args, got {len(args)})"
+                )
             tensor = args[0]
             shape = args[1]
             if shape == list(tensor.size()):

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -673,7 +673,7 @@ class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
         # View op
         if func == aten.view.default:
             if len(args) != 2:
-                raise RuntimeError("Unexpected args for view op (expected 2 args, got {len(args)})")
+                raise RuntimeError(f"Unexpected args for view op (expected 2 args, got {len(args)})")
             tensor = args[0]
             shape = args[1]
             if shape == list(tensor.size()):


### PR DESCRIPTION
Fix two error messages that print literal placeholders instead of the intended values.

- In `QuantizedTensor.__torch_dispatch__`, the placeholder `{cls.__name__}` was not interpolated because the string was missing the `f` prefix. Users calling `.view()` on a quantized tensor would see the literal text instead of the class name.

- In `NVFP4Tensor.__torch_dispatch__`, the placeholder `{len(args)}` was not interpolated for the same reason, making the arg-count diagnostic misleading.

Both fixes are one-character additions of the missing `f` prefix, restoring the intended error diagnostics.
