### PR TITLE
test(pytorch): cover QuantizedTensor view NotImplementedError

### DIFF
--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -716,7 +716,9 @@ class TestQuantizedTensor:
     def test_view_not_implemented(self) -> None:
         """QuantizedTensor base class does not support tensor views."""
         qt = QuantizedTensor((128, 128), torch.bfloat16)
-        with pytest.raises(NotImplementedError, match="QuantizedTensor class does not support tensor views"):
+        with pytest.raises(
+            NotImplementedError, match="QuantizedTensor class does not support tensor views"
+        ):
             qt.view(-1)
 
     @pytest.mark.parametrize("quantization", _quantization_list)

--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -713,6 +713,12 @@ class TestQuantizedTensor:
             y_test = y_test.to(dtype=torch.float64, device="cpu")
             torch.testing.assert_close(y_test, y_ref, **tols)
 
+    def test_view_not_implemented(self) -> None:
+        """QuantizedTensor base class does not support tensor views."""
+        qt = QuantizedTensor((128, 128), torch.bfloat16)
+        with pytest.raises(NotImplementedError, match="QuantizedTensor class does not support tensor views"):
+            qt.view(-1)
+
     @pytest.mark.parametrize("quantization", _quantization_list)
     def test_shape_with_none_data(
         self,


### PR DESCRIPTION
Add a unit test for the previously uncovered error path in QuantizedTensor.__torch_dispatch__ when .view() is called on the base QuantizedTensor class.

This complements the fix in #3256 by ensuring the NotImplementedError is raised with the correct, interpolated message.
