### PR TITLE
[PyTorch] Add architecture gate to NVFP4 split_quantize RHT path

### DIFF
--- a/tests/pytorch/nvfp4/test_nvfp4_group_quantize.py
+++ b/tests/pytorch/nvfp4/test_nvfp4_group_quantize.py
@@ -252,3 +252,25 @@ def test_rht_with_quantization_block_tiling_versus_reference(
         with_random_sign_mask=with_random_sign_mask,
         optimize_for_gemm=optimize_for_gemm,
     )
+
+
+@pytest.mark.skipif(not recipe_available, reason=reason_for_no_recipe)
+@pytest.mark.parametrize("quantize_mode", ["rowwise_only", "both_directions", "columnwise_only"])
+def test_rht_split_quantize_matches_per_tensor_reference(quantize_mode: str) -> None:
+    # split_quantize sends RHT-enabled NVFP4 quantizers to the grouped Hadamard
+    # transform kernels, which are implemented for the SM100 family only. On
+    # other architectures it falls back to quantizing each split on its own.
+    # Both routes have to give the same result as per-tensor quantization.
+    split_sections = [128, 128, 128, 128]
+    return_rowwise = quantize_mode in ("rowwise_only", "both_directions")
+    return_transpose = quantize_mode in ("columnwise_only", "both_directions")
+
+    check_group_quantization_nvfp4_versus_reference(
+        x_dtype=torch.bfloat16,
+        M=sum(split_sections),
+        N=256,
+        return_rowwise=return_rowwise,
+        return_transpose=return_transpose,
+        split_sections=split_sections,
+        with_rht=True,
+    )

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -19,6 +19,7 @@
 #include "../extensions.h"
 #include "common.h"
 #include "common/common.h"
+#include "common/util/cuda_runtime.h"
 #include "common/util/system.h"
 #include "pybind.h"
 #include "transformer_engine/multi_tensor.h"
@@ -1630,6 +1631,25 @@ void split_quantize_nvfp4_impl(const TensorWrapper &input,
 
   // CUDA stream
   auto stream = at::cuda::getCurrentCUDAStream();
+
+  // The RHT helper dispatches to grouped Hadamard transform kernels that are
+  // implemented for the SM100 family only. On other architectures, where
+  // NVFP4Quantizer::is_eligible_for_rht_cast_fusion is false as well, quantize
+  // each split on its own instead. That takes the generic unfused RHT path.
+  const int sm = transformer_engine::cuda::sm_arch();
+  const bool grouped_rht_supported = sm >= 100 && sm <= 110;
+  if (quantizer.with_rht && !grouped_rht_supported) {
+    NVTE_CHECK(input.dtype() == DType::kBFloat16, "RHT is only supported for bfloat16 input");
+    NVTE_SCOPED_GIL_RELEASE({
+      for (size_t i = 0; i < num_tensors; ++i) {
+        if (input_list[i].numel() == 0) {
+          continue;
+        }
+        quantizers[i]->quantize(input_list[i], output_list[i], std::nullopt);
+      }
+    });
+    return;
+  }
 
   // Perform multi-tensor quantization
   NVTE_SCOPED_GIL_RELEASE({

--- a/transformer_engine/pytorch/csrc/extensions/cast.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/cast.cpp
@@ -1632,33 +1632,30 @@ void split_quantize_nvfp4_impl(const TensorWrapper &input,
   // CUDA stream
   auto stream = at::cuda::getCurrentCUDAStream();
 
-  // The RHT helper dispatches to grouped Hadamard transform kernels that are
-  // implemented for the SM100 family only. On other architectures, where
+  // The grouped Hadamard transform kernels are implemented for the SM100 family
+  // only. On other architectures, where
   // NVFP4Quantizer::is_eligible_for_rht_cast_fusion is false as well, quantize
   // each split on its own instead. That takes the generic unfused RHT path.
   const int sm = transformer_engine::cuda::sm_arch();
   const bool grouped_rht_supported = sm >= 100 && sm <= 110;
-  if (quantizer.with_rht && !grouped_rht_supported) {
-    NVTE_CHECK(input.dtype() == DType::kBFloat16, "RHT is only supported for bfloat16 input");
-    NVTE_SCOPED_GIL_RELEASE({
-      for (size_t i = 0; i < num_tensors; ++i) {
-        if (input_list[i].numel() == 0) {
-          continue;
-        }
-        quantizers[i]->quantize(input_list[i], output_list[i], std::nullopt);
-      }
-    });
-    return;
-  }
 
   // Perform multi-tensor quantization
   NVTE_SCOPED_GIL_RELEASE({
     if (quantizer.with_rht) {  // Quantize row-wise data, RHT+quantize column-wise data
       // Check that config is supported
       NVTE_CHECK(input.dtype() == DType::kBFloat16, "RHT is only supported for bfloat16 input");
-      // Fuse the rowwise and colwise into one when the kernel is ready
-      split_quantize_nvfp4_impl_with_rht_helper(input, input_list, output_list, split_sections,
-                                                quantizers, stream);
+      if (grouped_rht_supported) {
+        // Fuse the rowwise and colwise into one when the kernel is ready
+        split_quantize_nvfp4_impl_with_rht_helper(input, input_list, output_list, split_sections,
+                                                  quantizers, stream);
+      } else {
+        for (size_t i = 0; i < num_tensors; ++i) {
+          if (input_list[i].numel() == 0) {
+            continue;
+          }
+          quantizers[i]->quantize(input_list[i], output_list[i], std::nullopt);
+        }
+      }
     } else {  // NVFP4 quantize
       // Fuse the rowwise and colwise into one when the kernel is ready
       split_quantize_nvfp4_impl_helper(input, input_list, output_list, split_sections, quantizers,


### PR DESCRIPTION
# Description

`GroupedLinear` under the NVFP4 recipe fails at runtime on sm_120/sm_121. `split_quantize` with RHT-enabled quantizers goes straight to `split_quantize_nvfp4_impl_with_rht_helper`, which calls the grouped Hadamard transform kernels. Those are SM100 only, so the launch fails:

```
RuntimeError: .../group_row_cast_col_hadamard_transform_cast_fusion.cu:1276 in function group_row_col_rht_gemm_ntt_w_sfc: CUDA Error: invalid argument
```

The single-tensor path does not have this problem. `NVFP4Quantizer` checks `is_eligible_for_rht_cast_fusion`, which gates on `100 <= sm_arch <= 110`, and uses the unfused RHT kernels otherwise. This adds the same check to `split_quantize_nvfp4_impl` and quantizes the splits per tensor when it fails. That is slower than a fused grouped kernel would be, but it makes the configuration work.

I repeated the band instead of calling `is_eligible_for_rht_cast_fusion` because that function also checks shape alignment, and reusing it would change SM100 behavior. Happy to factor the band into a shared helper if you prefer.

Fixes #3219

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `transformer_engine/pytorch/csrc/extensions/cast.cpp`: architecture gate and per-tensor fallback in `split_quantize_nvfp4_impl`.
- `tests/pytorch/nvfp4/test_nvfp4_group_quantize.py`: test that RHT split_quantize matches per-tensor quantization, on either dispatch route.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

No documentation changes needed. On the last box, see below.

# Testing done

GB10 (DGX Spark), sm_121a, CUDA 13.1, driver 580.95.05, main @ f1d5f8d5222b built with `NVTE_CUDA_ARCHS=121a`. cpplint, black and clang-format are clean on the changed files.

The new test fails on all three parametrizations without the fix and passes with it. It is not gated on architecture, so it exercises the grouped kernels on SM100 and the fallback elsewhere.

The rest of `tests/pytorch/nvfp4/test_nvfp4_group_quantize.py` goes from 274 failures to 120. The 154 that start passing are the RHT cases with `optimize_for_gemm=False`, which is what this patch covers.

The 120 that remain fail before the patch too, for a different reason. They are all `optimize_for_gemm=True`: swizzled scale factor emission is gated on the same architecture band, so the outputs here carry compact scale factors, but the test swizzles the reference whenever `optimize_for_gemm` is set.

`tests/pytorch/nvfp4/test_nvfp4_rht_quantize_exact.py` is 16 failures and 284 passes both before and after, so the single-tensor path is unaffected. Those 16 are small numeric mismatches already on main.

The reproducer in #3219 fails before the patch and passes after: per-split rowwise dequant cos 0.995463 to 0.995507, norm ratio 0.999135 to 1.001009.

cc @zhongbozhu @cael-ling

