### PR TITLE
[PyTorch] Fix shape and size() for columnwise-only quantized tensors

### DIFF
--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -780,6 +780,10 @@ class TestQuantizedTensor:
         columnwise-only tensor is where the two can drift apart.
         """
         quantizer = make_quantizer(quantization, device=device)
+        # Row-scaled NVFP4 accepts set_usage(rowwise=False) but rejects the
+        # allocation itself, so it has to be filtered out up front.
+        if getattr(quantizer, "row_scaled_nvfp4", False) and not rowwise:
+            pytest.skip(f"{quantization} requires rowwise usage")
         quantizer.set_usage(rowwise=rowwise, columnwise=columnwise)
         if (quantizer.rowwise_usage, quantizer.columnwise_usage) != (rowwise, columnwise):
             pytest.skip(f"{quantization} does not support this usage combination")

--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -757,6 +757,38 @@ class TestQuantizedTensor:
             f"after setting data to None on {type(x_test).__name__}"
         )
 
+    @pytest.mark.parametrize("quantization", _quantization_list)
+    @pytest.mark.parametrize(
+        "rowwise, columnwise",
+        [(True, True), (True, False), (False, True)],
+        ids=["rowwise_columnwise", "rowwise_only", "columnwise_only"],
+    )
+    def test_shape_matches_size(
+        self,
+        *,
+        quantization: str,
+        rowwise: bool,
+        columnwise: bool,
+        shape: Iterable[int] = (128, 256),
+        dtype: torch.dtype = torch.bfloat16,
+        device: torch.device = "cuda",
+    ) -> None:
+        """shape and size() agree with the requested shape for every usage combination.
+
+        Both are fast paths derived from whichever data buffer is present, and
+        classes that store columnwise data transposed have to undo that. A
+        columnwise-only tensor is where the two can drift apart.
+        """
+        quantizer = make_quantizer(quantization, device=device)
+        quantizer.set_usage(rowwise=rowwise, columnwise=columnwise)
+        if (quantizer.rowwise_usage, quantizer.columnwise_usage) != (rowwise, columnwise):
+            pytest.skip(f"{quantization} does not support this usage combination")
+
+        x = quantizer.make_empty(shape, dtype=dtype, device=device)
+
+        assert tuple(x.shape) == tuple(shape), f"{type(x).__name__}.shape is {tuple(x.shape)}"
+        assert tuple(x.size()) == tuple(shape), f"{type(x).__name__}.size() is {tuple(x.size())}"
+
     @pytest.mark.parametrize(
         "quantization",
         _quantization_list + (["nvfp4_2d"] if nvfp4_available else []),

--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -763,21 +763,23 @@ class TestQuantizedTensor:
         [(True, True), (True, False), (False, True)],
         ids=["rowwise_columnwise", "rowwise_only", "columnwise_only"],
     )
+    @pytest.mark.parametrize("shape", [(128, 256), (4, 128, 256)], ids=["2d", "3d"])
     def test_shape_matches_size(
         self,
         *,
         quantization: str,
         rowwise: bool,
         columnwise: bool,
-        shape: Iterable[int] = (128, 256),
+        shape: Iterable[int],
         dtype: torch.dtype = torch.bfloat16,
         device: torch.device = "cuda",
     ) -> None:
-        """shape and size() agree with the requested shape for every usage combination.
+        """shape, size() and size(dim) stay consistent for every usage combination.
 
-        Both are fast paths derived from whichever data buffer is present, and
-        classes that store columnwise data transposed have to undo that. A
-        columnwise-only tensor is where the two can drift apart.
+        Both shape and size() are derived from whichever data buffer is present,
+        and classes that store columnwise data transposed have to undo that. A
+        columnwise-only tensor is where they can drift apart -- from each other,
+        and from the shape the tensor was allocated with.
         """
         quantizer = make_quantizer(quantization, device=device)
         # Row-scaled NVFP4 accepts set_usage(rowwise=False) but rejects the
@@ -789,9 +791,23 @@ class TestQuantizedTensor:
             pytest.skip(f"{quantization} does not support this usage combination")
 
         x = quantizer.make_empty(shape, dtype=dtype, device=device)
+        name = type(x).__name__
 
-        assert tuple(x.shape) == tuple(shape), f"{type(x).__name__}.shape is {tuple(x.shape)}"
-        assert tuple(x.size()) == tuple(shape), f"{type(x).__name__}.size() is {tuple(x.size())}"
+        # shape and size() must describe the same tensor, whichever buffer they
+        # end up reading.
+        assert tuple(x.shape) == tuple(x.size()), f"{name}: {tuple(x.shape)} vs {tuple(x.size())}"
+
+        # size(dim) must agree with the full shape, including negative indices.
+        # It cannot be served by forwarding dim to a transposed buffer.
+        for dim in range(len(x.shape)):
+            assert x.size(dim) == x.shape[dim], f"{name}.size({dim}) is {x.size(dim)}"
+            neg = dim - len(x.shape)
+            assert x.size(neg) == x.shape[neg], f"{name}.size({neg}) is {x.size(neg)}"
+
+        # NVFP4 deliberately reports columnwise-only tensors flattened to 2D and
+        # warns about it, so only the ranks it preserves are checked here.
+        if not (isinstance(quantizer, NVFP4Quantizer) and not rowwise and len(shape) > 2):
+            assert tuple(x.shape) == tuple(shape), f"{name}.shape is {tuple(x.shape)}"
 
     @pytest.mark.parametrize(
         "quantization",

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -552,8 +552,10 @@ class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):
             return self._rowwise_data.shape
         if self._columnwise_data is not None:
             # Columnwise data is stored transposed, matching size() in the storage.
-            dims = list(self._columnwise_data.shape)
-            return torch.Size(dims[1:] + dims[:1])
+            dims = self._columnwise_data.shape
+            if len(dims) == 2:
+                return torch.Size((dims[1], dims[0]))
+            return torch.Size(tuple(dims[1:]) + (dims[0],))
         return torch.Tensor.size(self)
 
     @property

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -551,7 +551,9 @@ class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):
         if self._rowwise_data is not None:
             return self._rowwise_data.shape
         if self._columnwise_data is not None:
-            return self._columnwise_data.shape
+            # Columnwise data is stored transposed, matching size() in the storage.
+            dims = list(self._columnwise_data.shape)
+            return torch.Size(dims[1:] + dims[:1])
         return torch.Tensor.size(self)
 
     @property

--- a/transformer_engine/pytorch/tensor/storage/float8_blockwise_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_blockwise_tensor_storage.py
@@ -317,12 +317,15 @@ class Float8BlockwiseQTensorStorage(QuantizedTensorStorage):
         # pylint: disable=missing-function-docstring
         if self._rowwise_data is not None:
             return self._rowwise_data.size(*args, **kwargs)
-        dims = list(self._columnwise_data.size(*args, **kwargs))
-        reordered = []
-        for i in range(1, len(dims)):
-            reordered.append(dims[i])
-        reordered.append(dims[0])
-        return torch.Size(reordered)
+        # Columnwise data is stored transposed, so a dim argument cannot be
+        # forwarded to it: rebuild the logical shape first, then index into it.
+        dims = self._columnwise_data.shape
+        if len(dims) == 2:
+            shape = torch.Size((dims[1], dims[0]))
+        else:
+            shape = torch.Size(tuple(dims[1:]) + (dims[0],))
+        dim = args[0] if args else kwargs.get("dim")
+        return shape if dim is None else shape[dim]
 
     def view(self, shape):
         """Reshape the leading (token) dims without dequantizing.

--- a/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
@@ -5,7 +5,6 @@
 """Mixin class holding data specific for Float8Tensor"""
 
 from __future__ import annotations
-import math
 from typing import Any, Dict, Optional, Tuple, Union
 import torch
 
@@ -179,8 +178,16 @@ class Float8TensorStorage(QuantizedTensorStorage):
         # pylint: disable=missing-function-docstring
         if self._data is not None:
             return self._data.size(*args, **kwargs)
-        size = self._transpose.size(*args, **kwargs)
-        return torch.Size([size[-1], math.prod(size[:-1])])
+        # The transpose is stored as [last, *leading], so a dim argument cannot
+        # be forwarded to it: rebuild the logical shape first, then index into
+        # it. This matches the shape property on Float8Tensor.
+        dims = self._transpose.shape
+        if len(dims) == 2:
+            shape = torch.Size((dims[1], dims[0]))
+        else:
+            shape = torch.Size(tuple(dims[1:]) + (dims[0],))
+        dim = args[0] if args else kwargs.get("dim")
+        return shape if dim is None else shape[dim]
 
     @property
     def device(self):


### PR DESCRIPTION
# Description

`Float8BlockwiseQTensor.shape`, `Float8TensorStorage.size()` and `Float8BlockwiseQTensorStorage.size()` all report the logical shape of a tensor whose data is only stored columnwise/transposed. Each of the three gets it wrong in a different way.

**1. `Float8BlockwiseQTensor.shape` returns the transposed buffer shape.** Blockwise stores columnwise data transposed, and the fast path added in 9dac78e76 ("CPU Overhead Optimizations", #2559) does not undo that, so the property disagrees with both `size()` and the wrapper metadata:

```python
q.set_usage(rowwise=False, columnwise=True)
t = q.make_empty((128, 256), dtype=torch.bfloat16, device="cuda")

t.shape                                  # (256, 128)  <- wrong
t.size()                                 # (128, 256)
torch._C.TensorBase.shape.__get__(t)     # (128, 256)
```

That commit added the equivalent property to four classes at once; `Float8Tensor` and `NVFP4Tensor` undo the reordering. `MXFP8Tensor` reads the same but is already correct, since it stores columnwise data untransposed.

**2. `size(dim)` raises `TypeError` on the columnwise-only path, for FP8 and blockwise alike.** Both storages forward `*args` to the underlying buffer and then reorder the result. `size(dim)` returns an `int`, which the reorder then indexes:

```python
t.size(0)   # TypeError: 'int' object is not subscriptable   (FP8)
t.size(0)   # TypeError: 'int' object is not iterable        (blockwise)
```

Forwarding `dim` is also wrong in principle here, because buffer dim `i` is not logical dim `i` under a transposed layout. This predates #2559 — it came in with the classes themselves (#1505, #1513).

**3. `Float8TensorStorage.size()` flattens to 2D**, which contradicts `dim()` and `Float8Tensor.shape` for rank ≥ 3:

```python
t = q.quantize(x)                                        # x is (4, 128, 256)
t.update_usage(rowwise_usage=False, columnwise_usage=True)

t.dim()      # 3
t.shape      # (4, 128, 256)
t.size()     # (128, 1024)   <- 2 entries
```

All of this is reachable from `quantize()` followed by `update_usage(rowwise_usage=False)`, which is the normal way to release rowwise data once it is no longer needed.

NVFP4 is deliberately left alone: it reports columnwise-only tensors flattened and warns about it, and its `shape` and `size()` agree with each other.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `Float8BlockwiseQTensor.shape` undoes the columnwise transpose, with a 2D fast path.
- `Float8BlockwiseQTensorStorage.size()` and `Float8TensorStorage.size()` rebuild the full logical shape before applying a `dim` argument, instead of forwarding it to the buffer.
- `Float8TensorStorage.size()` applies the same rotation as `Float8Tensor.shape` rather than flattening to 2D.
- `test_shape_matches_size` in `tests/pytorch/test_quantized_tensor.py` covers every entry of `_quantization_list`, three usage combinations and 2D/3D shapes, asserting that `shape` and `size()` describe the same tensor and that `size(dim)` agrees with it for positive and negative dims.

## Note on CPU overhead

#2559 introduced the `shape` property specifically to cut CPU overhead, so the fix keeps the rowwise path untouched and adds a 2D fast path on the columnwise-only branch. Measured on an RTX Ada, `make_empty((128, 256))`, columnwise-only, ns/call:

| variant | ns |
|---|---|
| before (returns the wrong shape) | 75 |
| this PR: 2D fast path, index into `torch.Size` | 186 |
| `torch.Tensor.size(self)` (wrapper metadata) | 197 |
| intermediate `list()` + slices | 311 |
| `Float8BlockwiseQTensorStorage.size()` before this PR | 456 |

`.shape` therefore stays cheaper than the `size()` that already computed the same rotation. Reading the wrapper metadata benchmarks similarly but was avoided: buffers are reassigned after construction in a number of places, and the metadata would not follow.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

Note on local verification: my workstation is an RTX Ada, so `fp8_blockwise`, `mxfp8` and `nvfp4` are not in `_quantization_list` there and only the `fp8` variants of the new test ran locally. The other paths were verified by direct measurement across all seven quantizers, three usage combinations and both ranks, using `make_empty`, which allocates regardless of arch support. `test_numerics` shows 28 failures both with and without these changes, so they are pre-existing on this GPU.

One thing worth watching in CI: making `Float8TensorStorage.size()` rank-preserving changes the rank it returns for transpose-only tensors of rank ≥ 3. If anything in the stack relied on the 2D flattening, it would only surface on Hopper+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
