### PR TITLE
[Bugfix][PyTorch][FlashAttention][CP] Honor requested FA padding in CP tests

### DIFF
--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -209,6 +209,13 @@ def run_dpa_with_cp(
     logging.root.setLevel(log_level)
     # When is_training is False, gradient outputs are None.
     is_training = is_training == "True"
+    pad_between_seqs = None
+    if qkv_format == "thd":
+        # Keep this in sync with generate_input_shapes so DPA gets the explicit
+        # padding state without a GPU-to-CPU sync.
+        pad_between_seqs = (
+            kernel_backend == "FusedAttention" or fa_pad_between_seqs == "True"
+        )
 
     # set up environment variables and config
     if deterministic == "True":
@@ -411,13 +418,7 @@ def run_dpa_with_cp(
             cu_seqlens_kv=cu_seqlens_kv,
             cu_seqlens_q_padded=cu_seqlens_q_padded,
             cu_seqlens_kv_padded=cu_seqlens_kv_padded,
-            # Test runner sets cu_seqlens_q == cu_seqlens_q_padded for the
-            # FlashAttention path, i.e. no inter-sequence padding. Declare this
-            # explicitly so the sync-free auto-detect (which conservatively
-            # picks True when padded cu_seqlens are present) does not disable FA.
-            pad_between_seqs=(
-                (kernel_backend != "FlashAttention") if qkv_format == "thd" else None
-            ),
+            pad_between_seqs=pad_between_seqs,
             fp8_output=fp8_mha,
         )
         if config.return_max_logit:
@@ -535,12 +536,7 @@ def run_dpa_with_cp(
             cu_seqlens_kv=cu_seqlens_kv,
             cu_seqlens_q_padded=cu_seqlens_q_padded,
             cu_seqlens_kv_padded=cu_seqlens_kv_padded,
-            # See note above (non-CP branch): same explicit declaration so
-            # FlashAttention isn't disabled by the conservative sync-free
-            # auto-detect when this test path constructs no inter-seq padding.
-            pad_between_seqs=(
-                (kernel_backend != "FlashAttention") if qkv_format == "thd" else None
-            ),
+            pad_between_seqs=pad_between_seqs,
             fp8_output=fp8_mha,
         )
         if config.return_max_logit:

--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -213,9 +213,7 @@ def run_dpa_with_cp(
     if qkv_format == "thd":
         # Keep this in sync with generate_input_shapes so DPA gets the explicit
         # padding state without a GPU-to-CPU sync.
-        pad_between_seqs = (
-            kernel_backend == "FusedAttention" or fa_pad_between_seqs == "True"
-        )
+        pad_between_seqs = kernel_backend == "FusedAttention" or fa_pad_between_seqs == "True"
 
     # set up environment variables and config
     if deterministic == "True":


### PR DESCRIPTION
The CP test runner creates inter-sequence padding when the FlashAttention padding case is requested, but it unconditionally told DPA that FlashAttention THD inputs had no padding. That mismatch left CP backward padding uninitialized.

Derive the explicit padding state from the same condition used to generate the inputs and reuse it for both reference and CP calls, preserving the sync-free CUDA-graph path for non-padding cases.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
