### PR TITLE
Bugfix spec check for DP+FSDP configurations

### DIFF
--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -17,6 +17,17 @@ from utils import assert_allclose, is_devices_enough, is_devices_equal
 
 def generate_configs():
     configs = []
+    if is_devices_enough(8):
+        configs.append(
+            pytest.param(
+                8,
+                (2, 2, 2),
+                ("dp", "fsdp", "tpsp"),
+                MeshResource(dp_resource="dp", fsdp_resource="fsdp", tpsp_resource="tpsp"),
+                id="n8_dp2_fsdp2_tp2",
+            )
+        )
+
     if is_devices_enough(4):
         configs.append(
             pytest.param(

--- a/tests/jax/test_distributed_dense.py
+++ b/tests/jax/test_distributed_dense.py
@@ -48,6 +48,9 @@ def _get_sharding_for_gemm(mesh, mesh_resource, partition_layout="rowwise"):
     dp_axis = mesh_resource.dp_resource
     tp_axis = mesh_resource.tpsp_resource
 
+    if mesh_resource.fsdp_resource is not None:
+        dp_axis = (mesh_resource.dp_resource, mesh_resource.fsdp_resource)
+
     if partition_layout == "colwise":
         x_spec = PartitionSpec(dp_axis, None, None)
         weight_spec = PartitionSpec(None, tp_axis)

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -969,7 +969,8 @@ class GemmPrimitive(BasePrimitive):
             for spec in lhs_non_cspecs:
                 flattened_lhs_non_cspecs.extend(spec if isinstance(spec, tuple) else [spec])
             rhs_non_cspecs = tuple(
-                None if spec in flattened_lhs_non_cspecs else spec for spec in rhs_non_cspecs
+                None if spec in flattened_lhs_non_cspecs or spec in lhs_non_cspecs else spec
+                for spec in rhs_non_cspecs
             )
 
         else:
@@ -1001,7 +1002,8 @@ class GemmPrimitive(BasePrimitive):
             for spec in rhs_non_cspecs:
                 flattened_rhs_non_cspecs.extend(spec if isinstance(spec, tuple) else [spec])
             lhs_non_cspecs = tuple(
-                None if spec in flattened_rhs_non_cspecs else spec for spec in lhs_non_cspecs
+                None if spec in flattened_rhs_non_cspecs or spec in rhs_non_cspecs else spec
+                for spec in lhs_non_cspecs
             )
 
         out_specs = lhs_non_cspecs + rhs_non_cspecs

--- a/transformer_engine/jax/cpp_extensions/gemm.py
+++ b/transformer_engine/jax/cpp_extensions/gemm.py
@@ -964,8 +964,12 @@ class GemmPrimitive(BasePrimitive):
             # Non-contracting dims of RHS always needs to be gathered, i.e. for TP + activation_hidden
             # No batch-dim check needed as `rhs_non_cspecs` never contains batch-dim.
             # In `rhs_specs`, the batch dim appears only in Wgrad GEMM under `rhs_cspecs`.
+            # Flatten cspecs since a single element can be a tuple of mesh axes (e.g. ("data", "fsdp")).
+            flattened_lhs_non_cspecs = []
+            for spec in lhs_non_cspecs:
+                flattened_lhs_non_cspecs.extend(spec if isinstance(spec, tuple) else [spec])
             rhs_non_cspecs = tuple(
-                None if spec in lhs_non_cspecs else spec for spec in rhs_non_cspecs
+                None if spec in flattened_lhs_non_cspecs else spec for spec in rhs_non_cspecs
             )
 
         else:
@@ -992,8 +996,12 @@ class GemmPrimitive(BasePrimitive):
             # Non-contracting dims of LHS to be gathered along the SP axis.
             # Minor note: This causes MaxText TP (= Megatron TP + activation_hidden sharding) gathering x for
             # dW1 = x^T * dY1 which is unexpected. This is a known issue and no solution has found yet.
+            # Flatten cspecs since a single element can be a tuple of mesh axes (e.g. ("data", "fsdp")).
+            flattened_rhs_non_cspecs = []
+            for spec in rhs_non_cspecs:
+                flattened_rhs_non_cspecs.extend(spec if isinstance(spec, tuple) else [spec])
             lhs_non_cspecs = tuple(
-                None if spec in rhs_non_cspecs else spec for spec in lhs_non_cspecs
+                None if spec in flattened_rhs_non_cspecs else spec for spec in lhs_non_cspecs
             )
 
         out_specs = lhs_non_cspecs + rhs_non_cspecs


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.
In the collective GEMM code, there is a small bug where the code misses the general case that `(lhs|rhs)_non_cspecs` can have elements that are tuples when a dimension in sharded on multiple resource axes (e.g. `(data, fsdp)` on the batch dimension).

This leads to an incorrect check which results in a sharding in which a tensor is sharded on the same device axis twice.
```
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/maxtext/src/maxtext/trainers/pre_train/train.py", line 988, in <module>
  File "/usr/local/lib/python3.12/dist-packages/absl/app.py", line 410, in run
  File "/usr/local/lib/python3.12/dist-packages/absl/app.py", line 355, in _run_main
  File "/opt/maxtext/src/maxtext/trainers/pre_train/train.py", line 984, in main
  File "/opt/maxtext/src/maxtext/trainers/pre_train/train.py", line 974, in train_func
  File "/opt/maxtext/src/maxtext/trainers/pre_train/train.py", line 944, in run
  File "/opt/maxtext/src/maxtext/trainers/pre_train/train.py", line 817, in train_loop
  File "/opt/jax/jax/_src/stages.py", line 593, in compile
  File "/opt/jax/jax/_src/interpreters/pxla.py", line 1260, in compile
  File "/opt/jax/jax/_src/interpreters/pxla.py", line 1757, in from_hlo
  File "/opt/jax/jax/_src/interpreters/pxla.py", line 1537, in _cached_compilation
  File "/opt/jax/jax/_src/compiler.py", line 464, in compile_or_get_cached
  File "/opt/jax/jax/_src/compiler.py", line 729, in _compile_and_write_cache
  File "/opt/jax/jax/_src/profiler.py", line 420, in wrapper
  File "/opt/jax/jax/_src/compiler.py", line 350, in backend_compile_and_load
  File "/opt/jax/jax/_src/custom_partitioning.py", line 160, in _custom_partitioning_partition
  File "/usr/local/lib/python3.12/dist-packages/transformer_engine/jax/cpp_extensions/gemm.py", line 1139, in partition
  File "/opt/jax/jax/_src/named_sharding.py", line 515, in check_pspec
  File "/opt/jax/jax/_src/named_sharding.py", line 544, in _check_unique_resources
DuplicateSpecError: A single NamedSharding spec specification can map every mesh axis to at most one positional dimension, but P(('data', 'fsdp'), 'tensor_sequence', 'fsdp') has duplicate entries for `fsdp`
```

The change in this PR resolves that problem by flattening the tuple so that dimensions that are sharded on multiple device mesh axes are considered correctly.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fixes sharding spec check so that tuple elements are checked appropriately.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
