### PR TITLE
[Common] Remove `nv-internal-*` comments

### DIFF
--- a/transformer_engine/common/hadamard_transform/graph_safe_group_row_cast_col_hadamard_transform_cast_fusion.cu
+++ b/transformer_engine/common/hadamard_transform/graph_safe_group_row_cast_col_hadamard_transform_cast_fusion.cu
@@ -746,7 +746,7 @@ __launch_bounds__(512, 1) __global__ static void group_row_col_rht_gemm_device_g
 
         cutlass::arch::NamedBarrier::sync(NumEpilogueColQuantThreadCount,
                                           cutlass::arch::ReservedNamedBarriers::EpilogueBarrier);
-        // Aligning with TensorEngine's recipe to generate scale factors // {$nv-internal-release}
+        // Aligning with TensorEngine's recipe to generate scale factors
         static constexpr float fp4_max = 6.0f;
         static constexpr float fp8_max = 448.0f;
         static constexpr float fp4_max_inv = 1.0f / fp4_max;
@@ -1003,7 +1003,7 @@ __launch_bounds__(512, 1) __global__ static void group_row_col_rht_gemm_device_g
             shape_rep, num_tensors, (scheduler.tile_n_base() * size<1>(epilogue_tiler)) * M,
             packed_N, M, offsets);
         float a_global_amax_val = shared_storage.global_a_amax[group_idx];
-        // Aligning with TensorEngine's recipe to generate scale factors // {$nv-internal-release}
+        // Aligning with TensorEngine's recipe to generate scale factors
         static constexpr float fp4_max = 6.0f;
         static constexpr float fp8_max = 448.0f;
         static constexpr float fp4_max_inv = 1.0f / fp4_max;

--- a/transformer_engine/common/hadamard_transform/group_row_cast_col_hadamard_transform_cast_fusion.cu
+++ b/transformer_engine/common/hadamard_transform/group_row_cast_col_hadamard_transform_cast_fusion.cu
@@ -728,7 +728,7 @@ __launch_bounds__(512, 1) __global__ static void group_row_col_rht_gemm_device(
 
         cutlass::arch::NamedBarrier::sync(NumEpilogueColQuantThreadCount,
                                           cutlass::arch::ReservedNamedBarriers::EpilogueBarrier);
-        // Aligning with TensorEngine's recipe to generate scale factors // {$nv-internal-release}
+        // Aligning with TensorEngine's recipe to generate scale factors
         static constexpr float fp4_max = 6.0f;
         static constexpr float fp8_max = 448.0f;
         static constexpr float fp4_max_inv = 1.0f / fp4_max;
@@ -980,7 +980,7 @@ __launch_bounds__(512, 1) __global__ static void group_row_col_rht_gemm_device(
 
         int group_idx = GetGroupIdx(&args, scheduler.tile_n_base() * size<1>(epilogue_tiler));
         float a_global_amax_val = shared_storage.global_a_amax[group_idx];
-        // Aligning with TensorEngine's recipe to generate scale factors // {$nv-internal-release}
+        // Aligning with TensorEngine's recipe to generate scale factors
         static constexpr float fp4_max = 6.0f;
         static constexpr float fp8_max = 448.0f;
         static constexpr float fp4_max_inv = 1.0f / fp4_max;

--- a/transformer_engine/common/hadamard_transform/row_cast_col_hadamard_transform_cast_fusion.cu
+++ b/transformer_engine/common/hadamard_transform/row_cast_col_hadamard_transform_cast_fusion.cu
@@ -709,7 +709,7 @@ __global__ static void row_col_rht_gemm_device(
       auto thr_t2r   = tiled_t2r.get_slice(local_thread_idx);
       auto thr_r2g = tiled_r2g.get_slice(local_thread_idx);
 
-      // Aligning with TensorEngine's recipe to generate scale factors // {$nv-internal-release}
+      // Aligning with TensorEngine's recipe to generate scale factors
       static constexpr float fp4_max = 6.0f;
       static constexpr float fp8_max = 448.0f;
       float const fp4_max_inv = 1.0f / fp4_max;
@@ -905,7 +905,7 @@ __global__ static void row_col_rht_gemm_device(
       cute::Tensor tQArSFA = make_tensor_like(tQAgSFA(_, _, _, _0{}, _0{}));
       cute::Tensor tQApSFA = thr_s2r.partition_D(pSFA_mn);
 
-      // Aligning with TensorEngine's recipe to generate scale factors // {$nv-internal-release}
+      // Aligning with TensorEngine's recipe to generate scale factors
       static constexpr float fp4_max = 6.0f;
       static constexpr float fp8_max = 448.0f;
       float const fp4_max_inv = 1.0f / fp4_max;


### PR DESCRIPTION
# Description

Remove `nv-internal-*` comments.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Remove `nv-internal-*` comments.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
