### PR TITLE
[Common] Fix NVFP4 stochastic rounding on architectures without cvt.rs

### DIFF
--- a/tests/pytorch/nvfp4/test_nvfp4_sr_quantize.py
+++ b/tests/pytorch/nvfp4/test_nvfp4_sr_quantize.py
@@ -431,3 +431,39 @@ def test_group_stochastic_rounding_quantization_versus_reference(
         num_splits=num_splits,
         use_tex_split_quantize=use_tex_split_quantize,
     )
+
+
+@pytest.mark.skipif(not recipe_available, reason=reason_for_no_recipe)
+@pytest.mark.parametrize("x_dtype", [torch.float32, torch.bfloat16], ids=str)
+@pytest.mark.parametrize("use_2D", [False, True], ids=str)
+def test_stochastic_rounding_picks_an_adjacent_fp4_value(
+    x_dtype: torch.dtype, use_2D: bool
+) -> None:
+    device = "cuda"
+    torch.manual_seed(seed)
+    M, N = 512, 1024
+    x = torch.randn((M, N), dtype=x_dtype, device=device)
+    amax = torch.max(torch.abs(x)).float()
+
+    q, s, q_t, s_t = quantize_fp4(x, use_stochastic_rounding=True, use_2D=use_2D, use_RHT=False)
+    q_redraw, _, q_t_redraw, _ = quantize_fp4(
+        x, use_stochastic_rounding=True, use_2D=use_2D, use_RHT=False
+    )
+    assert not torch.equal(q, q_redraw), "two stochastic rounding draws are identical"
+    assert not torch.equal(q_t, q_t_redraw), "two stochastic rounding draws are identical"
+
+    def check_adjacent(qx: torch.Tensor, sx: torch.Tensor, reference: torch.Tensor) -> None:
+        # The kernel rounds reference / block_scale onto the E2M1 grid, so every
+        # output has to be one of the two grid values that bracket it, i.e. within
+        # one grid step. An all-zero output fails this everywhere the input is not
+        # already near zero.
+        block_scale = sx.repeat_interleave(16, dim=1).view(torch.float8_e4m3fn).to(torch.float32)
+        block_scale = block_scale[: reference.shape[0], : reference.shape[1]] * (amax / (6.0 * 448))
+        exact = (reference.float() / block_scale).clamp(-6.0, 6.0)
+        magnitude = exact.abs()
+        step = torch.where(magnitude >= 4.0, 2.0, torch.where(magnitude >= 2.0, 1.0, 0.5))
+        gap = (fp4_to_fp32(unpack_fp4(qx)) - exact).abs()
+        assert torch.all(gap <= step * 1.0001), f"largest gap to the exact value is {gap.max()}"
+
+    check_adjacent(q, s, x)
+    check_adjacent(q_t, s_t, x.t().contiguous())

--- a/transformer_engine/common/transpose/quantize_transpose_vector_blockwise_fp4.cu
+++ b/transformer_engine/common/transpose/quantize_transpose_vector_blockwise_fp4.cu
@@ -269,11 +269,11 @@ __device__ __forceinline__ __nv_fp4x4_e2m1 cvt_fp32_to_fp4_4x_with_stochastic_ro
         : "f"(in01.y), "f"(in01.x), "f"(in23.y), "f"(in23.x), "r"(rbits));
     return *reinterpret_cast<__nv_fp4x4_e2m1*>(&out_4x);
   } else {
-    NVTE_DEVICE_ERROR(
-        "FP4 cvt.rs PTX instructions are architecture-specific. "
-        "Try recompiling with sm_XXXa instead of sm_XXX.");
-    uint16_t dummy = 0;
-    return *reinterpret_cast<__nv_fp4x4_e2m1*>(&dummy);
+    const float q0 = ptx::stochastic_round_fp4_e2m1(in01.x, rbits);
+    const float q1 = ptx::stochastic_round_fp4_e2m1(in01.y, rbits >> 8);
+    const float q2 = ptx::stochastic_round_fp4_e2m1(in23.x, rbits >> 16);
+    const float q3 = ptx::stochastic_round_fp4_e2m1(in23.y, rbits >> 24);
+    return __nv_fp4x4_e2m1(make_float4(q0, q1, q2, q3));
   }
 }
 

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -600,6 +600,35 @@ __device__ __forceinline__ void mul_cvt_4x(fp4e2m1x4 &out, const Tx2 &in01, cons
   out = fp4e2m1x4(make_float4(x0, x1, x2, x3));
 }
 
+// Software stochastic rounding onto the e2m1 grid, for architectures without
+// cvt.rs. Takes 8 random bits per element, which is what
+// cvt.rs.satfinite.e2m1x4.f32 takes from its rbits operand. Follows satfinite
+// for the edges: NaN becomes positive MAX_NORM and larger magnitudes clamp to
+// MAX_NORM with the sign kept. The result is exactly representable in e2m1, so
+// packing it is lossless.
+__device__ __forceinline__ float stochastic_round_fp4_e2m1(const float x, const uint32_t rbits8) {
+  constexpr float max_norm = 6.0f;
+  if (isnan(x)) {
+    return max_norm;
+  }
+  const float u = static_cast<float>(rbits8 & 0xFFu) * (1.0f / 256.0f);
+  const float a = fabsf(x);
+  // Grid step at |x|: 0.5 below 2, 1 in [2, 4), 2 in [4, 6].
+  const float step = (a >= 4.0f) ? 2.0f : ((a >= 2.0f) ? 1.0f : 0.5f);
+  const float t = fmaf(u, step, a);
+  float q;
+  if (t >= max_norm) {
+    q = max_norm;
+  } else if (t >= 4.0f) {
+    q = 4.0f;
+  } else if (t >= 2.0f) {
+    q = 2.0f + floorf(t - 2.0f);
+  } else {
+    q = floorf(t * 2.0f) * 0.5f;
+  }
+  return copysignf(q, x);
+}
+
 __device__ __forceinline__ fp4e2m1x4 mul_cvt_bf16_to_fp4_4x_with_stochastic_rounding(
     const uint64_t in_4x, const float2 scale, const uint32_t rbits) {
   uint16_t out_4x = 0;
@@ -633,9 +662,14 @@ __device__ __forceinline__ fp4e2m1x4 mul_cvt_bf16_to_fp4_4x_with_stochastic_roun
         : "=h"(out_4x)
         : "l"(in_4x), "l"(reinterpret_cast<const uint64_t &>(scale)), "r"(rbits));
   } else {
-    NVTE_DEVICE_ERROR(
-        "FP4 cvt PTX instructions are architecture-specific. "
-        "Try recompiling with sm_XXXa instead of sm_XXX.");
+    // mul.f32x2 above applies scale.x to the even elements and scale.y to the odd ones.
+    const bf16 *vals = reinterpret_cast<const bf16 *>(&in_4x);
+    const float q0 = stochastic_round_fp4_e2m1(static_cast<float>(vals[0]) * scale.x, rbits);
+    const float q1 = stochastic_round_fp4_e2m1(static_cast<float>(vals[1]) * scale.y, rbits >> 8);
+    const float q2 = stochastic_round_fp4_e2m1(static_cast<float>(vals[2]) * scale.x, rbits >> 16);
+    const float q3 = stochastic_round_fp4_e2m1(static_cast<float>(vals[3]) * scale.y, rbits >> 24);
+    const fp4e2m1x4 packed(make_float4(q0, q1, q2, q3));
+    out_4x = *reinterpret_cast<const uint16_t *>(&packed);
   }
   return *reinterpret_cast<fp4e2m1x4 *>(&out_4x);
 }
@@ -725,9 +759,12 @@ __device__ __forceinline__ fp4e2m1x4 mul_cvt_fp32_to_fp4_4x_with_stochastic_roun
           "l"(reinterpret_cast<const uint64_t &>(in23)),
           "l"(reinterpret_cast<const uint64_t &>(scale)), "r"(rbits));
   } else {
-    NVTE_DEVICE_ERROR(
-        "FP4 cvt PTX instructions are architecture-specific. "
-        "Try recompiling with sm_XXXa instead of sm_XXX.");
+    const float q0 = stochastic_round_fp4_e2m1(in01.x * scale.x, rbits);
+    const float q1 = stochastic_round_fp4_e2m1(in01.y * scale.y, rbits >> 8);
+    const float q2 = stochastic_round_fp4_e2m1(in23.x * scale.x, rbits >> 16);
+    const float q3 = stochastic_round_fp4_e2m1(in23.y * scale.y, rbits >> 24);
+    const fp4e2m1x4 packed(make_float4(q0, q1, q2, q3));
+    out_4x = *reinterpret_cast<const uint16_t *>(&packed);
   }
   return *reinterpret_cast<fp4e2m1x4 *>(&out_4x);
 }
@@ -950,9 +987,26 @@ __device__ __forceinline__ uint32_t mul_cvt_bf16_to_fp4_8x_stochastic_rounding(
       NVTE_DEVICE_ERROR("Not supported scaling coefficient type.");
     }
   } else {
-    NVTE_DEVICE_ERROR(
-        "FP4 cvt PTX instructions are architecture-specific. "
-        "Try recompiling with sm_XXXa instead of sm_XXX.");
+    constexpr bool known_coeff = std::is_same<SCALING_COEFFICIENT_TYPE, bf16>::value ||
+                                 std::is_same<SCALING_COEFFICIENT_TYPE, float>::value;
+    if constexpr (known_coeff) {
+      const float coeff = static_cast<float>(scaling_coefficient);
+      const bf16 *vals03 = reinterpret_cast<const bf16 *>(&in03);
+      const bf16 *vals47 = reinterpret_cast<const bf16 *>(&in47);
+      float q[8];
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        q[i] = stochastic_round_fp4_e2m1(static_cast<float>(vals03[i]) * coeff, rbits03 >> (8 * i));
+        q[i + 4] =
+            stochastic_round_fp4_e2m1(static_cast<float>(vals47[i]) * coeff, rbits47 >> (8 * i));
+      }
+      const fp4e2m1x4 lo(make_float4(q[0], q[1], q[2], q[3]));
+      const fp4e2m1x4 hi(make_float4(q[4], q[5], q[6], q[7]));
+      out_8x = static_cast<uint32_t>(*reinterpret_cast<const uint16_t *>(&lo)) |
+               (static_cast<uint32_t>(*reinterpret_cast<const uint16_t *>(&hi)) << 16);
+    } else {
+      NVTE_DEVICE_ERROR("Not supported scaling coefficient type.");
+    }
   }
   return out_8x;
 }

--- a/transformer_engine/common/util/ptx.cuh
+++ b/transformer_engine/common/util/ptx.cuh
@@ -608,25 +608,19 @@ __device__ __forceinline__ void mul_cvt_4x(fp4e2m1x4 &out, const Tx2 &in01, cons
 // packing it is lossless.
 __device__ __forceinline__ float stochastic_round_fp4_e2m1(const float x, const uint32_t rbits8) {
   constexpr float max_norm = 6.0f;
-  if (isnan(x)) {
-    return max_norm;
-  }
   const float u = static_cast<float>(rbits8 & 0xFFu) * (1.0f / 256.0f);
   const float a = fabsf(x);
   // Grid step at |x|: 0.5 below 2, 1 in [2, 4), 2 in [4, 6].
   const float step = (a >= 4.0f) ? 2.0f : ((a >= 2.0f) ? 1.0f : 0.5f);
   const float t = fmaf(u, step, a);
-  float q;
-  if (t >= max_norm) {
-    q = max_norm;
-  } else if (t >= 4.0f) {
-    q = 4.0f;
-  } else if (t >= 2.0f) {
-    q = 2.0f + floorf(t - 2.0f);
-  } else {
-    q = floorf(t * 2.0f) * 0.5f;
-  }
-  return copysignf(q, x);
+  // The jitter can carry t across one region boundary, so the rounding step
+  // derives from t. Flooring in units of that step lands on the e2m1 grid in
+  // every region, and the saturation also maps a NaN t to max_norm, which the
+  // sign select keeps positive.
+  const float step_t = (t >= 4.0f) ? 2.0f : ((t >= 2.0f) ? 1.0f : 0.5f);
+  const float inv_step_t = (t >= 4.0f) ? 0.5f : ((t >= 2.0f) ? 1.0f : 2.0f);
+  const float q = fminf(floorf(t * inv_step_t) * step_t, max_norm);
+  return copysignf(q, (x != x) ? 1.0f : x);
 }
 
 __device__ __forceinline__ fp4e2m1x4 mul_cvt_bf16_to_fp4_4x_with_stochastic_rounding(


### PR DESCRIPTION
# Description

NVFP4 quantization with stochastic rounding returns all-zero data on sm_120 and sm_121.

The four e2m1 stochastic rounding helpers gate on `ARCH_HAS_STOCHASTIC_ROUNDING`, which is `ArchSpecific<100>` and `ArchSpecific<103>`, matching where the `cvt.rs` instruction exists. The other branch is `NVTE_DEVICE_ERROR`, which is `printf` plus `assert(0)`. Release builds define `NDEBUG`, so the assert is compiled out, the helper returns its zero-initialized output, and each thread prints:

```
.../common/util/ptx.cuh:953 in function mul_cvt_bf16_to_fp4_8x_stochastic_rounding (thread (0,0,0), block (1,0,0)): FP4 cvt PTX instructions are architecture-specific. Try recompiling with sm_XXXa instead of sm_XXX.
```

`NVFP4BlockScaling` sets `stochastic_rounding` on gradient quantization by default and `_compute_nvfp4_support()` reports NVFP4 for every device at compute capability 10.0 or above, so on these parts the default recipe trains on zeroed gradients while the NVFP4 GEMMs themselves work. The message is also not actionable here: the build already used `NVTE_CUDA_ARCHS=121a`, and `cvt.rs` does not exist at any feature level on this family.

This replaces that branch with a software e2m1 stochastic rounder. It takes 8 random bits per element, which is what `cvt.rs.satfinite.e2m1x4.f32` takes from its `rbits` operand, adds `u * step` where `step` is the grid step at that magnitude, and truncates onto the grid, so a value rounds up with probability equal to its fractional position between its two neighbours. The `if constexpr` is unchanged, so architectures with `cvt.rs` keep the asm path and nothing else in the helpers moves.

The edges follow the PTX ISA text for `.satfinite`, under `cvt`, Floating Point Notes: for `.e2m1x4` destinations, "NaN results are converted to positive MAX_NORM", and an input above MAX_NORM in absolute value gives "sign-preserved MAX_NORM of the destination format". So NaN gives +6 and overflow gives ±6.

A fallback rather than refusing stochastic rounding on these architectures: `_compute_nvfp4_support()` already advertises NVFP4 here and the default recipe turns SR on, so a capability gate would replace a silent wrong answer with a hard failure of the default recipe on hardware that otherwise runs it. The fallback keeps recipe parity.

The fallback is not bit identical to `cvt.rs` and cannot be. `cvt.rs` adds `rbits` to the mantissa bits the conversion discards and rounds on the carry out; this adds a scaled uniform to the value and truncates. Both are stochastic rounding at the same per-element entropy, and their round-up probabilities agree to the 1/256 that 8 bits resolve. There is no `cvt.rs` behaviour on sm_120 or sm_121 to differ from, and stochastic rounding is not reproducible across architectures in any case.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `transformer_engine/common/util/ptx.cuh`: add `stochastic_round_fp4_e2m1` and use it in the non-`cvt.rs` branch of `mul_cvt_bf16_to_fp4_4x_with_stochastic_rounding`, `mul_cvt_fp32_to_fp4_4x_with_stochastic_rounding` and `mul_cvt_bf16_to_fp4_8x_stochastic_rounding`.
- `transformer_engine/common/transpose/quantize_transpose_vector_blockwise_fp4.cu`: the same in `cvt_fp32_to_fp4_4x_with_stochastic_rounding`.
- `tests/pytorch/nvfp4/test_nvfp4_sr_quantize.py`: test that every stochastically rounded value sits on one of the two E2M1 grid values that bracket the exact one, and that two draws differ.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

No documentation changes needed. On the last box, see below.

# Testing done

GB10 (DGX Spark), sm_121a, CUDA 13.1, driver 580.95.05, main @ 0ee1320e84f0, built with `NVTE_CUDA_ARCHS=121a`. clang-format 18.1.6, cpplint 1.6.0 and black 24.4.2 are clean on the changed files, and there are no compiler warnings in the build.

The new test is not gated on architecture, so it exercises `cvt.rs` where the instruction exists and this branch here. All four parametrizations fail without the patch and pass with it, on separate unpatched and patched builds of the same tree, twice each. Together they reach three of the four helpers: `cvt_fp32_to_fp4_4x_with_stochastic_rounding` for FP32 input, `mul_cvt_bf16_to_fp4_8x_stochastic_rounding` for BF16 with 1D scaling, and `mul_cvt_bf16_to_fp4_4x_with_stochastic_rounding` for BF16 with 2D. I could not reach `mul_cvt_fp32_to_fp4_4x_with_stochastic_rounding` from any NVFP4 entry point on this hardware; it is the FP32 twin of the same columnwise loop and is fixed the same way.

`tests/pytorch/nvfp4/test_nvfp4_sr_quantize.py` is 6 failed, 22 passed, 4 skipped with the patch, in 37 seconds. Without it the same file does not finish: I stopped it at 61 minutes, since the error path prints once per thread and this file quantizes 8192x8192 tensors 50 times per case.

The 6 that fail are `test_group_stochastic_rounding_quantization_versus_reference` with `use_tex_split_quantize=True`, and they are not this path. They fail at `group_row_cast_col_hadamard_transform_cast_fusion.cu:1276 in function group_row_col_rht_gemm_ntt_w_sfc: CUDA Error: invalid argument`, which is the grouped RHT dispatch reported in #3219. `tex.split_quantize` with RHT-enabled NVFP4 quantizers raises the same error on an unpatched build of this tree.

On one 256x256 BF16 tensor, dequantized cosine against the input is 0.000000 before and 0.990767 after, against 0.995495 for round to nearest on the same tensor. Stochastic rounding sitting slightly below round to nearest on a single draw is the expected direction.

If there is anything else you want checked on sm_121, I can run it.

cc @Oleg-Goncharov @ptrendx
