### PR TITLE
Enable THD with hierarchical context parallelism

### DIFF
--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -336,11 +336,6 @@ def test_cp_with_flash_attention(cp_pool, dtype, model, qkv_format, cp_comm_type
     if config.attn_bias_type != "no_bias" and cp_comm_type in ["all_gather", "a2a", "a2a+p2p"]:
         pytest.skip("No support for bias with cp_comm_type={all_gather, a2a, a2a+p2p}!")
 
-    if qkv_format == "thd" and cp_comm_type == "a2a+p2p":
-        pytest.skip(
-            "CP implementation with QKVO A2A+P2P (Hierarchical A2A) does not support THD format"
-            " yet!"
-        )
     if (
         qkv_format == "thd"
         and cp_comm_type == "all_gather"
@@ -557,12 +552,6 @@ def test_cp_with_fused_attention(
         pytest.skip("No support for bias with THD format!")
     if config.attn_bias_type != "no_bias" and cp_comm_type in ["all_gather", "a2a", "a2a+p2p"]:
         pytest.skip("No support for bias with cp_comm_type={all_gather, a2a, a2a+p2p}!")
-
-    if qkv_format == "thd" and cp_comm_type == "a2a+p2p":
-        pytest.skip(
-            "CP implementation with QKVO A2A+P2P (Hierarchical A2A) does not support THD format"
-            " yet!"
-        )
 
     if (config.window_size[0] != -1 or config.window_size[1] not in [-1, 0]) and cp_comm_type in [
         "p2p",

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -5019,9 +5019,6 @@ def attn_forward_func_with_cp(
             isinstance(cp_group, list) and len(cp_group) == 2
         ), "CP implementation a2a+p2p requires cp_group = [a2a_cp_group, p2p_cp_group]!"
         assert (
-            qkv_format != "thd"
-        ), f"{qkv_format} format is not supported with hierarchical CP implementation yet!"
-        assert (
             attn_bias_type == "no_bias"
         ), f"{attn_bias_type} bias type is not supported with hierarchical CP implementation yet!"
         if get_distributed_world_size(cp_group[0]) == 1:

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -1231,13 +1231,6 @@ def get_attention_backend(
                 cp_comm_type,
             )
             use_fused_attention = False
-        elif qkv_format == "thd" and cp_comm_type in ["a2a+p2p"]:
-            logger.debug(
-                "Disabling FusedAttention as it does not support context parallelism with THD"
-                " format and cp_comm_type = %s",
-                cp_comm_type,
-            )
-            use_fused_attention = False
         elif (
             window_size is not None
             and (window_size[0] != -1 or window_size[1] not in [-1, 0])


### PR DESCRIPTION


# Description

The THD-aware A2A and P2P paths already compose correctly and match the non-CP reference in forward and backward passes. Remove the stale runtime and backend gates, and enable the existing FlashAttention and FusedAttention test coverage for this combination.
Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

Only removes filters which are no longer necessary

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
