### PR TITLE
[PTQ] Store FP32 global scaling factors (absmax or scale_inv) for all quantized activations and weights.

### DIFF
--- a/examples/pytorch/mnist/main.py
+++ b/examples/pytorch/mnist/main.py
@@ -76,7 +76,10 @@ def calibrate(model, device, test_loader, fp8):
     with torch.no_grad():
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
-            with te.autocast(enabled=fp8, calibrating=True):
+            with te.autocast(
+                enabled=fp8,
+                calibration_config=te.QuantizationCalibrationConfig(),
+            ):
                 output = model(data)
 
 

--- a/qa/L0_pytorch_unittest/test.sh
+++ b/qa/L0_pytorch_unittest/test.sh
@@ -41,6 +41,7 @@ python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_nvfp4.xml $TE_PA
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_mxfp8.xml $TE_PATH/tests/pytorch/mxfp8 || test_fail "test_mxfp8"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_weight_swizzle_in_layers.xml $TE_PATH/tests/pytorch/test_weight_swizzle_in_layers.py || test_fail "test_weight_swizzle_in_layers.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_quantized_tensor.xml $TE_PATH/tests/pytorch/test_quantized_tensor.py || test_fail "test_quantized_tensor.py"
+python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_ptq_calibration_metadata_buffering.xml $TE_PATH/tests/pytorch/test_ptq_calibration_metadata_buffering.py || test_fail "test_ptq_calibration_metadata_buffering.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_torch_compile.xml $TE_PATH/tests/pytorch/test_torch_compile.py || test_fail "test_torch_compile.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_float8blockwisetensor.xml $TE_PATH/tests/pytorch/test_float8blockwisetensor.py || test_fail "test_float8blockwisetensor.py"
 python3 -m pytest --tb=auto --junitxml=$XML_LOG_DIR/pytest_test_float8_blockwise_scaling_exact.xml $TE_PATH/tests/pytorch/test_float8_blockwise_scaling_exact.py || test_fail "test_float8_blockwise_scaling_exact.py"

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from transformer_engine.pytorch.module import _common
+from transformer_engine.pytorch.module import grouped_linear
+
+
+@pytest.mark.parametrize(
+    ("recipe", "metadata_name", "expected_value"),
+    (
+        ("fp8_current_scaling", "scale_inv", 0.25),
+        ("fp8_delayed_scaling", "amax", 448.0),
+        ("nvfp4", "amax", 2688.0),
+        ("nvfp4_rowwise", "amax_rowwise", 1344.0),
+    ),
+)
+def test_scale_buffer_info_selects_recipe_metadata(
+    monkeypatch, recipe, metadata_name, expected_value
+):
+    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: recipe)
+    tensor = SimpleNamespace(
+        _scale_inv=torch.tensor([0.25], dtype=torch.float32),
+        _amax_rowwise=torch.tensor(
+            [2688.0 if recipe == "nvfp4" else 1344.0], dtype=torch.float32
+        ),
+    )
+    quantizer = SimpleNamespace(amax=torch.tensor([448.0], dtype=torch.float32))
+
+    buffer_name, value = _common._get_scale_buffer_info("input", tensor, quantizer)
+
+    assert buffer_name == f"input_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
+    torch.testing.assert_close(value, torch.tensor([expected_value]))
+
+
+@pytest.mark.parametrize("recipe", ("mxfp8", "fp8_block_scaling"))
+def test_scale_buffer_info_skips_non_global_scaling_recipes(monkeypatch, recipe):
+    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: recipe)
+    tensor = SimpleNamespace(_rowwise_scale_inv=torch.ones(2, 2))
+
+    assert _common._get_scale_buffer_info("input", tensor, object()) is None
+
+
+def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
+    monkeypatch.setattr(
+        _common, "get_quantization_recipe_name", lambda _: "fp8_current_scaling"
+    )
+    inputs = [
+        SimpleNamespace(_scale_inv=torch.tensor([0.25])),
+        SimpleNamespace(_scale_inv=torch.tensor([0.5])),
+    ]
+    weights = [
+        SimpleNamespace(_scale_inv=torch.tensor([0.75])),
+        SimpleNamespace(_scale_inv=torch.tensor([1.0])),
+    ]
+    scale_buffers = {}
+
+    grouped_linear._update_grouped_scale_buffers(
+        scale_buffers,
+        inputs,
+        weights,
+        object(),
+        object(),
+        activation_scale_decay=0.0,
+    )
+
+    assert set(scale_buffers) == {
+        "input_gemm0_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
+        "input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
+        "weight_gemm0_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
+        "weight_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
+    }
+    torch.testing.assert_close(
+        scale_buffers[
+            "input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+        ],
+        torch.tensor([0.5]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("observed_scale", "expected_scale"),
+    (
+        # Decayed max is greater than the observed.
+        (1.0, 2.0),
+        # Decayed max is less than the observed.
+        (3.0, 3.0),
+    ),
+)
+def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_scale):
+    name = "input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+    scale_buffers = {name: torch.tensor([4.0])}
+
+    _common._update_scale_buffers(
+        scale_buffers,
+        {name: torch.tensor([observed_scale])},
+        activation_scale_decay=0.5,
+    )
+    torch.testing.assert_close(scale_buffers[name], torch.tensor([expected_scale]))

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -26,9 +26,7 @@ def test_scale_buffer_info_selects_recipe_metadata(
     monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: recipe)
     tensor = SimpleNamespace(
         _scale_inv=torch.tensor([0.25], dtype=torch.float32),
-        _amax_rowwise=torch.tensor(
-            [2688.0 if recipe == "nvfp4" else 1344.0], dtype=torch.float32
-        ),
+        _amax_rowwise=torch.tensor([2688.0 if recipe == "nvfp4" else 1344.0], dtype=torch.float32),
     )
     quantizer = SimpleNamespace(amax=torch.tensor([448.0], dtype=torch.float32))
 
@@ -47,9 +45,7 @@ def test_scale_buffer_info_skips_non_global_scaling_recipes(monkeypatch, recipe)
 
 
 def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
-    monkeypatch.setattr(
-        _common, "get_quantization_recipe_name", lambda _: "fp8_current_scaling"
-    )
+    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: "fp8_current_scaling")
     inputs = [
         SimpleNamespace(_scale_inv=torch.tensor([0.25])),
         SimpleNamespace(_scale_inv=torch.tensor([0.5])),
@@ -76,9 +72,7 @@ def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
         "weight_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
     }
     torch.testing.assert_close(
-        scale_buffers[
-            "input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
-        ],
+        scale_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"],
         torch.tensor([0.5]),
     )
 

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
 
@@ -87,7 +87,7 @@ def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
     ),
 )
 def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_scale):
-    name = "input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+    name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
     scale_buffers = {name: torch.tensor([4.0])}
 
     _common._update_scale_buffers(

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -96,3 +96,25 @@ def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_
         activation_scale_decay=0.5,
     )
     torch.testing.assert_close(scale_buffers[name], torch.tensor([expected_scale]))
+
+
+@pytest.mark.parametrize("activation_scale_decay", (0.0, 0.5))
+@pytest.mark.parametrize("initial_scale", (None, 4.0))
+def test_nan_activation_scale_does_not_update_buffer(
+    activation_scale_decay, initial_scale
+):
+    name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+    scale_buffers = {}
+    if initial_scale is not None:
+        scale_buffers[name] = torch.tensor([initial_scale])
+
+    _common._update_scale_buffers(
+        scale_buffers,
+        {name: torch.tensor([float("nan")])},
+        activation_scale_decay=activation_scale_decay,
+    )
+
+    if initial_scale is None:
+        assert name not in scale_buffers
+    else:
+        torch.testing.assert_close(scale_buffers[name], torch.tensor([initial_scale]))

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -2,13 +2,222 @@
 #
 # See LICENSE for license information.
 
+import dataclasses
+import inspect
 from types import SimpleNamespace
 
 import pytest
 import torch
 
+from transformer_engine.common.recipe import Float8CurrentScaling
+from transformer_engine.pytorch import is_fp8_available, is_nvfp4_available
+from transformer_engine.pytorch.constants import DType
+from transformer_engine.pytorch.graph import make_graphed_callables
+from transformer_engine.pytorch.module import GroupedLinear, LayerNormLinear, LayerNormMLP, Linear
 from transformer_engine.pytorch.module import _common
 from transformer_engine.pytorch.module import grouped_linear
+from transformer_engine.pytorch.quantization import (
+    FP8GlobalStateManager,
+    FP8GlobalState,
+    TEAutocastState,
+    QuantizationCalibrationConfig,
+    autocast,
+    fp8_autocast,
+)
+from transformer_engine.pytorch.quantized_tensor import Quantizer
+from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockQuantizer
+from transformer_engine.pytorch.tensor.float8_tensor import (
+    Float8CurrentScalingQuantizer,
+    Float8Quantizer,
+)
+from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
+from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
+from transformer_engine.pytorch.tensor.utils import get_quantization_recipe_name
+
+nvfp4_available, reason_for_no_nvfp4 = is_nvfp4_available(return_reason=True)
+fp8_available, reason_for_no_fp8 = is_fp8_available(return_reason=True)
+
+
+@pytest.fixture(autouse=True)
+def reset_quantization_state():
+    yield
+    FP8GlobalStateManager.reset()
+
+
+def test_calibration_api_additions_preserve_existing_parameter_order():
+    state_fields = [field.name for field in dataclasses.fields(FP8GlobalState)]
+    assert state_fields[-1] == "calibration_config"
+    assert state_fields[:2] == ["fp8_enabled", "fp8_calibration"]
+
+    assert list(inspect.signature(FP8GlobalStateManager.autocast_enter).parameters) == [
+        "enabled",
+        "calibrating",
+        "fp8_recipe",
+        "fp8_group",
+        "_graph",
+        "calibration_config",
+    ]
+    assert list(inspect.signature(autocast).parameters) == [
+        "enabled",
+        "calibrating",
+        "recipe",
+        "amax_reduction_group",
+        "_graph",
+        "calibration_config",
+    ]
+    assert list(inspect.signature(fp8_autocast).parameters) == [
+        "enabled",
+        "calibrating",
+        "fp8_recipe",
+        "fp8_group",
+        "_graph",
+        "calibration_config",
+    ]
+    assert list(inspect.signature(make_graphed_callables).parameters)[-2:] == [
+        "capture_time_hooks",
+        "calibration_config",
+    ]
+    assert not inspect.signature(FP8GlobalStateManager.get_autocast_state).parameters
+    assert list(inspect.signature(FP8GlobalStateManager.set_autocast_state).parameters) == ["state"]
+    autocast_state = FP8GlobalStateManager.get_autocast_state()
+    assert isinstance(autocast_state, TEAutocastState)
+    assert [field.name for field in dataclasses.fields(autocast_state)] == [
+        "fp8_enabled",
+        "fp8_calibration",
+        "calibration_config",
+        "fp8_recipe",
+        "fp8_distributed_group",
+        "is_first_fp8_module",
+        "fp8_graph_capturing",
+    ]
+
+
+def test_calibrating_argument_enables_default_calibration_config():
+    assert FP8GlobalStateManager.get_calibration_config() is None
+    with autocast(enabled=False, calibrating=True):
+        assert FP8GlobalStateManager.quantization_state.fp8_calibration
+        assert FP8GlobalStateManager.get_calibration_config() == QuantizationCalibrationConfig()
+    assert FP8GlobalStateManager.get_calibration_config() is None
+
+
+def test_explicit_calibration_config_is_active_in_autocast():
+    config = QuantizationCalibrationConfig(activation_scale_decay=0.5)
+    with autocast(enabled=False, calibration_config=config):
+        assert FP8GlobalStateManager.quantization_state.fp8_calibration
+        assert FP8GlobalStateManager.get_calibration_config() is config
+        assert FP8GlobalStateManager.get_autocast_state().calibration_config is config
+
+
+def test_nested_autocast_restores_custom_calibration_config():
+    config = QuantizationCalibrationConfig(activation_scale_decay=0.5)
+    with autocast(enabled=False, calibration_config=config):
+        with autocast(enabled=False):
+            assert FP8GlobalStateManager.get_calibration_config() is None
+        assert FP8GlobalStateManager.get_calibration_config() is config
+
+
+def test_global_calibration_boolean_enables_default_config():
+    qstate = FP8GlobalStateManager.quantization_state
+    qstate.fp8_calibration = True
+    try:
+        assert FP8GlobalStateManager.get_calibration_config() == QuantizationCalibrationConfig()
+    finally:
+        qstate.fp8_calibration = False
+
+
+def test_autocast_enter_preserves_calibrating_boolean_api():
+    saved_state = FP8GlobalStateManager.get_autocast_state()
+    try:
+        FP8GlobalStateManager.autocast_enter(False, True)
+        assert FP8GlobalStateManager.is_fp8_calibration()
+        assert FP8GlobalStateManager.get_calibration_config() == QuantizationCalibrationConfig()
+    finally:
+        FP8GlobalStateManager.autocast_exit(False, False)
+        FP8GlobalStateManager.set_autocast_state(saved_state)
+
+
+def test_calibrating_argument_accepts_explicit_calibration_config():
+    config = QuantizationCalibrationConfig(activation_scale_decay=0.5)
+    with autocast(
+        enabled=False,
+        calibrating=True,
+        calibration_config=config,
+    ):
+        assert FP8GlobalStateManager.get_calibration_config() is config
+
+
+def test_calibration_config_rejects_negative_decay():
+    with pytest.raises(ValueError, match="activation_scale_decay must be non-negative"):
+        QuantizationCalibrationConfig(activation_scale_decay=-0.1)
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize(
+    ("module_name", "expected_buffer_count"),
+    (
+        ("linear", 2),
+        ("layernorm_linear", 2),
+        ("layernorm_mlp", 4),
+        ("grouped_linear", 4),
+    ),
+)
+@pytest.mark.parametrize("enabled", (False, True))
+def test_calibration_config_registers_module_scaling_factor_buffers(
+    module_name, expected_buffer_count, enabled
+):
+    module_kwargs = {
+        "params_dtype": torch.bfloat16,
+        "device": "cuda",
+        "bias": False,
+    }
+    if module_name == "linear":
+        module = Linear(32, 32, **module_kwargs)
+    elif module_name == "layernorm_linear":
+        module = LayerNormLinear(32, 32, **module_kwargs)
+    elif module_name == "layernorm_mlp":
+        module = LayerNormMLP(32, 32, **module_kwargs)
+    else:
+        module = GroupedLinear(2, 32, 32, use_grouped_tensor=False, **module_kwargs)
+
+    inp = torch.randn((16, 32), dtype=torch.bfloat16, device="cuda")
+    with autocast(
+        enabled=enabled,
+        recipe=Float8CurrentScaling(),
+        calibration_config=QuantizationCalibrationConfig(),
+    ):
+        if module_name == "grouped_linear":
+            module(inp, [8, 8])
+        else:
+            module(inp)
+
+    buffers = {
+        name: value
+        for name, value in module.named_buffers()
+        if name.endswith("_te_ptq_calibrated")
+    }
+    assert len(buffers) == expected_buffer_count
+    assert all(torch.isfinite(value).all() for value in buffers.values())
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+def test_calibrating_boolean_registers_scaling_factor_buffers():
+    module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
+    inp = torch.randn((16, 32), dtype=torch.bfloat16, device="cuda")
+
+    with autocast(
+        enabled=False,
+        calibrating=True,
+        recipe=Float8CurrentScaling(),
+    ):
+        module(inp)
+
+    assert len(
+        [
+            name
+            for name, _ in module.named_buffers()
+            if name.endswith("_te_ptq_calibrated")
+        ]
+    ) == 2
 
 
 @pytest.mark.parametrize(
@@ -21,31 +230,73 @@ from transformer_engine.pytorch.module import grouped_linear
     ),
 )
 def test_scale_buffer_info_selects_recipe_metadata(
-    monkeypatch, recipe, metadata_name, expected_value
+    recipe, metadata_name, expected_value
 ):
-    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: recipe)
     tensor = SimpleNamespace(
         _scale_inv=torch.tensor([0.25], dtype=torch.float32),
         _amax_rowwise=torch.tensor([2688.0 if recipe == "nvfp4" else 1344.0], dtype=torch.float32),
     )
-    quantizer = SimpleNamespace(amax=torch.tensor([448.0], dtype=torch.float32))
+    if recipe == "fp8_delayed_scaling":
+        quantizer = object.__new__(Float8Quantizer)
+        quantizer.amax = torch.tensor([0.0], dtype=torch.float32)
+        tensor = torch.tensor([expected_value])
+    elif recipe == "fp8_current_scaling":
+        quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    else:
+        quantizer = object.__new__(NVFP4Quantizer)
+        quantizer.row_scaled_nvfp4 = recipe == "nvfp4_rowwise"
 
-    buffer_name, value = _common._get_scale_buffer_info("input", tensor, quantizer)
+    assert get_quantization_recipe_name(quantizer) == recipe
+    quantizer.calibrate(tensor)
+    buffers = _common._get_scale_buffer_info("input", quantizer)
+    buffer_name = f"input_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
+    value = buffers[buffer_name]
 
-    assert buffer_name == f"input_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
     torch.testing.assert_close(value, torch.tensor([expected_value]))
+    assert value is quantizer._calibration_state[metadata_name]
 
 
 @pytest.mark.parametrize("recipe", ("mxfp8", "fp8_block_scaling"))
-def test_scale_buffer_info_skips_non_global_scaling_recipes(monkeypatch, recipe):
-    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: recipe)
+def test_scale_buffer_info_skips_non_global_scaling_recipes(recipe):
     tensor = SimpleNamespace(_rowwise_scale_inv=torch.ones(2, 2))
+    quantizer_cls = MXFP8Quantizer if recipe == "mxfp8" else Float8BlockQuantizer
+    quantizer = object.__new__(quantizer_cls)
 
-    assert _common._get_scale_buffer_info("input", tensor, object()) is None
+    assert get_quantization_recipe_name(quantizer) == recipe
+    quantizer.calibrate(tensor)
+    assert not _common._get_scale_buffer_info("input", quantizer)
 
 
-def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
-    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: "fp8_current_scaling")
+def test_custom_quantizer_defaults_to_no_calibration_metadata():
+    quantizer = Quantizer(rowwise=True, columnwise=False)
+
+    assert get_quantization_recipe_name(quantizer) == ""
+    assert not _common._get_scale_buffer_info("input", quantizer)
+
+
+def test_resolve_calibration_quantizer_prefers_tensor_owner_and_unwraps_parent():
+    parent_quantizer = object()
+    tensor_quantizer = SimpleNamespace(parent_quantizer=parent_quantizer)
+    tensor = SimpleNamespace(_quantizer=tensor_quantizer)
+
+    assert (
+        _common._resolve_calibration_quantizer(tensor, object())
+        is parent_quantizer
+    )
+
+
+def test_quantizer_calibration_state_is_keyed_by_quantized_metadata():
+    quantizer = Quantizer(rowwise=True, columnwise=False)
+
+    quantizer._update_calibration_value("amax", torch.tensor([2.0]), decay=0.0)
+    quantizer._update_calibration_value("scale_inv", torch.tensor([0.5]), decay=0.0)
+
+    assert set(quantizer._calibration_state) == {"amax", "scale_inv"}
+    torch.testing.assert_close(quantizer._calibration_state["amax"], torch.tensor([2.0]))
+    torch.testing.assert_close(quantizer._calibration_state["scale_inv"], torch.tensor([0.5]))
+
+
+def test_grouped_scale_buffers_are_per_gemm():
     inputs = [
         SimpleNamespace(_scale_inv=torch.tensor([0.25])),
         SimpleNamespace(_scale_inv=torch.tensor([0.5])),
@@ -54,15 +305,29 @@ def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
         SimpleNamespace(_scale_inv=torch.tensor([0.75])),
         SimpleNamespace(_scale_inv=torch.tensor([1.0])),
     ]
+    input_quantizers = [
+        object.__new__(Float8CurrentScalingQuantizer),
+        object.__new__(Float8CurrentScalingQuantizer),
+    ]
+    weight_quantizers = [
+        object.__new__(Float8CurrentScalingQuantizer),
+        object.__new__(Float8CurrentScalingQuantizer),
+    ]
     scale_buffers = {}
 
+    grouped_linear._calibrate_grouped_tensors(
+        inputs,
+        weights,
+        input_quantizers,
+        weight_quantizers,
+        activation_scale_decay=0.0,
+    )
     grouped_linear._update_grouped_scale_buffers(
         scale_buffers,
         inputs,
         weights,
-        [object(), object()],
-        [object(), object()],
-        activation_scale_decay=0.0,
+        input_quantizers,
+        weight_quantizers,
     )
 
     assert set(scale_buffers) == {
@@ -75,23 +340,57 @@ def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
         scale_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"],
         torch.tensor([0.5]),
     )
+    assert (
+        scale_buffers[
+            "input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+        ]
+        is input_quantizers[1]._calibration_state["scale_inv"]
+    )
 
 
-def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax(monkeypatch):
-    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: "fp8_delayed_scaling")
-    quantizers = [
-        SimpleNamespace(amax=torch.tensor([1.0])),
-        SimpleNamespace(amax=torch.tensor([2.0])),
-    ]
+def test_grouped_calibration_applies_decay_only_to_activations():
+    input_quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    input_quantizer._calibration_state = {"scale_inv": torch.tensor([4.0])}
+    weight_quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    weight_quantizer._calibration_state = {"scale_inv": torch.tensor([4.0])}
+
+    grouped_linear._calibrate_grouped_tensors(
+        [SimpleNamespace(_scale_inv=torch.tensor([1.0]))],
+        [SimpleNamespace(_scale_inv=torch.tensor([1.0]))],
+        [input_quantizer],
+        [weight_quantizer],
+        activation_scale_decay=0.5,
+    )
+
+    torch.testing.assert_close(
+        input_quantizer._calibration_state["scale_inv"], torch.tensor([2.0])
+    )
+    torch.testing.assert_close(
+        weight_quantizer._calibration_state["scale_inv"], torch.tensor([1.0])
+    )
+
+
+def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax():
+    quantizers = []
+    for amax in (1.0, 2.0):
+        quantizer = object.__new__(Float8Quantizer)
+        quantizer.amax = torch.tensor([amax])
+        quantizers.append(quantizer)
     scale_buffers = {}
 
-    grouped_linear._update_grouped_scale_buffers(
-        scale_buffers,
-        [object(), object()],
-        [object(), object()],
+    grouped_linear._calibrate_grouped_tensors(
+        [torch.tensor([1.0]), torch.tensor([2.0])],
+        [torch.tensor([1.0]), torch.tensor([2.0])],
         quantizers,
         quantizers,
         activation_scale_decay=0.0,
+    )
+    grouped_linear._update_grouped_scale_buffers(
+        scale_buffers,
+        [torch.tensor([1.0]), torch.tensor([2.0])],
+        [torch.tensor([1.0]), torch.tensor([2.0])],
+        quantizers,
+        quantizers,
     )
 
     torch.testing.assert_close(
@@ -115,31 +414,230 @@ def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax(monkeypatch):
 )
 def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_scale):
     name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
-    scale_buffers = {name: torch.tensor([4.0])}
-
-    _common._update_scale_buffers(
-        scale_buffers,
-        {name: torch.tensor([observed_scale])},
-        activation_scale_decay=0.5,
+    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    initial_buffer = torch.tensor([4.0])
+    quantizer._calibration_state = {"scale_inv": initial_buffer}
+    quantizer.calibrate(
+        SimpleNamespace(_scale_inv=torch.tensor([observed_scale])),
+        decay=0.5,
     )
-    torch.testing.assert_close(scale_buffers[name], torch.tensor([expected_scale]))
+    buffers = _common._get_scale_buffer_info("fc1_input", quantizer)
+    value = buffers[name]
+
+    torch.testing.assert_close(value, torch.tensor([expected_scale]))
+    assert value is initial_buffer
+    assert value is quantizer._calibration_state["scale_inv"]
+
+
+def test_zero_decay_keeps_observed_metadata_reference():
+    observed_scale = torch.tensor([2.0])
+    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+
+    quantizer.calibrate(SimpleNamespace(_scale_inv=observed_scale), decay=0.0)
+
+    assert quantizer._calibration_state["scale_inv"] is observed_scale
+
+
+def test_decaying_calibration_rejects_metadata_shape_change():
+    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    quantizer._calibration_state = {"scale_inv": torch.ones(1)}
+
+    with pytest.raises(RuntimeError, match="calibration value shape changed"):
+        quantizer.calibrate(SimpleNamespace(_scale_inv=torch.ones(2)), decay=0.5)
 
 
 @pytest.mark.parametrize("activation_scale_decay", (0.0, 0.5))
 @pytest.mark.parametrize("initial_scale", (None, 4.0))
 def test_nan_activation_scale_does_not_update_buffer(activation_scale_decay, initial_scale):
-    name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
-    scale_buffers = {}
+    quantizer = object.__new__(Float8CurrentScalingQuantizer)
     if initial_scale is not None:
-        scale_buffers[name] = torch.tensor([initial_scale])
+        quantizer._calibration_state = {"scale_inv": torch.tensor([initial_scale])}
 
-    _common._update_scale_buffers(
-        scale_buffers,
-        {name: torch.tensor([float("nan")])},
-        activation_scale_decay=activation_scale_decay,
+    quantizer.calibrate(
+        SimpleNamespace(_scale_inv=torch.tensor([float("nan")])),
+        decay=activation_scale_decay,
     )
+    result = _common._get_scale_buffer_info("fc1_input", quantizer)
 
     if initial_scale is None:
-        assert name not in scale_buffers
+        assert not result
+        assert not quantizer._calibration_state
     else:
-        torch.testing.assert_close(scale_buffers[name], torch.tensor([initial_scale]))
+        value = result[
+            "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+        ]
+        torch.testing.assert_close(value, torch.tensor([initial_scale]))
+
+
+def test_current_scaling_calibrates_from_high_precision_tensor():
+    quantizer = Float8CurrentScalingQuantizer(
+        fp8_dtype=DType.kFloat8E4M3,
+        device=torch.device("cpu"),
+    )
+
+    quantizer.calibrate(torch.tensor([-112.0, 224.0]))
+    value = quantizer._calibration_state["scale_inv"]
+
+    torch.testing.assert_close(value, torch.tensor([0.5]))
+
+
+@pytest.mark.parametrize("input_value", (0.0, float("inf")))
+@pytest.mark.parametrize("force_pow_2_scales", (False, True))
+def test_current_scaling_calibration_handles_non_finite_scale(
+    input_value, force_pow_2_scales
+):
+    quantizer = Float8CurrentScalingQuantizer(
+        fp8_dtype=DType.kFloat8E4M3,
+        device=torch.device("cpu"),
+        force_pow_2_scales=force_pow_2_scales,
+    )
+
+    quantizer.calibrate(torch.tensor([input_value]))
+
+    torch.testing.assert_close(quantizer._calibration_state["scale_inv"], torch.ones(1))
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize("fp8_dtype", (DType.kFloat8E4M3, DType.kFloat8E5M2))
+def test_delayed_scaling_high_precision_calibration_matches_quantization(fp8_dtype):
+    torch.manual_seed(123)
+    tensor = torch.randn((32, 32), dtype=torch.bfloat16, device="cuda")
+
+    active_quantizer = Float8Quantizer(
+        scale=torch.ones(1, dtype=torch.float32, device="cuda"),
+        amax=torch.zeros(1, dtype=torch.float32, device="cuda"),
+        fp8_dtype=fp8_dtype,
+        rowwise=True,
+        columnwise=False,
+    )
+    quantized_tensor = active_quantizer(tensor)
+    active_quantizer.calibrate(quantized_tensor)
+
+    calibration_quantizer = Float8Quantizer(
+        scale=torch.ones(1, dtype=torch.float32, device="cuda"),
+        amax=torch.zeros(1, dtype=torch.float32, device="cuda"),
+        fp8_dtype=fp8_dtype,
+        rowwise=True,
+        columnwise=False,
+    )
+    calibration_quantizer.calibrate(tensor)
+    assert (
+        calibration_quantizer.copy()._calibration_state
+        is calibration_quantizer._calibration_state
+    )
+
+    torch.testing.assert_close(
+        active_quantizer._calibration_state["amax"],
+        active_quantizer.amax,
+        atol=0.0,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(
+        calibration_quantizer._calibration_state["amax"],
+        active_quantizer.amax,
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize("fp8_dtype", (DType.kFloat8E4M3, DType.kFloat8E5M2))
+@pytest.mark.parametrize("force_pow_2_scales", (False, True))
+@pytest.mark.parametrize("amax_epsilon", (0.0, 4.0))
+def test_current_scaling_high_precision_calibration_matches_quantization(
+    fp8_dtype, force_pow_2_scales, amax_epsilon
+):
+    torch.manual_seed(123)
+    tensor = torch.randn((32, 32), dtype=torch.bfloat16, device="cuda")
+    quantizer_kwargs = {
+        "fp8_dtype": fp8_dtype,
+        "device": torch.device("cuda"),
+        "rowwise": True,
+        "columnwise": False,
+        "force_pow_2_scales": force_pow_2_scales,
+        "amax_epsilon": amax_epsilon,
+    }
+
+    active_quantizer = Float8CurrentScalingQuantizer(**quantizer_kwargs)
+    quantized_tensor = active_quantizer(tensor)
+    active_quantizer.calibrate(quantized_tensor)
+
+    calibration_quantizer = Float8CurrentScalingQuantizer(**quantizer_kwargs)
+    calibration_quantizer.calibrate(tensor)
+
+    torch.testing.assert_close(
+        active_quantizer._calibration_state["scale_inv"],
+        quantized_tensor._scale_inv,
+        atol=0.0,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(
+        calibration_quantizer._calibration_state["scale_inv"],
+        quantized_tensor._scale_inv,
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+@pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4)
+@pytest.mark.parametrize(
+    ("row_scaled_nvfp4", "with_rht", "with_post_rht_amax", "with_random_sign_mask"),
+    (
+        (False, False, False, False),
+        (False, True, False, False),
+        (False, True, True, False),
+        (False, True, True, True),
+        (True, False, False, False),
+    ),
+)
+def test_nvfp4_high_precision_calibration_matches_quantization(
+    row_scaled_nvfp4, with_rht, with_post_rht_amax, with_random_sign_mask
+):
+    torch.manual_seed(123)
+    tensor = torch.randn((32, 32), dtype=torch.bfloat16, device="cuda")
+    quantizer_kwargs = {
+        "rowwise": True,
+        "columnwise": not row_scaled_nvfp4,
+        "with_rht": with_rht,
+        "with_post_rht_amax": with_post_rht_amax,
+        "row_scaled_nvfp4": row_scaled_nvfp4,
+        "with_random_sign_mask": with_random_sign_mask,
+    }
+
+    active_quantizer = NVFP4Quantizer(**quantizer_kwargs)
+    quantized_tensor = active_quantizer(tensor)
+    active_quantizer.calibrate(quantized_tensor)
+    calibration_quantizer = NVFP4Quantizer(**quantizer_kwargs)
+    calibration_quantizer.calibrate(tensor)
+    assert (
+        calibration_quantizer.copy()._calibration_state
+        is calibration_quantizer._calibration_state
+    )
+
+    expected_metadata_name = "amax_rowwise" if row_scaled_nvfp4 else "amax"
+    active_amax = active_quantizer._calibration_state[expected_metadata_name]
+    calibrated_amax = calibration_quantizer._calibration_state[expected_metadata_name]
+    torch.testing.assert_close(
+        active_amax,
+        quantized_tensor._amax_rowwise,
+        atol=0.0,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(
+        calibrated_amax,
+        quantized_tensor._amax_rowwise,
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+def test_shallow_quantizer_copy_shares_calibration_state():
+    quantizer = Float8CurrentScalingQuantizer(
+        fp8_dtype=DType.kFloat8E4M3,
+        device=torch.device("cpu"),
+    )
+    copied_quantizer = quantizer.copy()
+    copied_quantizer.calibrate(torch.tensor([-112.0, 224.0]))
+    value = copied_quantizer._calibration_state["scale_inv"]
+
+    assert quantizer._calibration_state["scale_inv"] is value

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from transformer_engine.common.recipe import Float8CurrentScaling
+from transformer_engine.common.recipe import DelayedScaling, Float8CurrentScaling
 from transformer_engine.pytorch import is_fp8_available, is_nvfp4_available
 from transformer_engine.pytorch.constants import DType
 from transformer_engine.pytorch.graph import make_graphed_callables
@@ -24,12 +24,14 @@ from transformer_engine.pytorch.quantization import (
     autocast,
     fp8_autocast,
 )
-from transformer_engine.pytorch.quantized_tensor import Quantizer
+from transformer_engine.pytorch.quantized_tensor import QuantizedTensorStorage, Quantizer
 from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockQuantizer
 from transformer_engine.pytorch.tensor.float8_tensor import (
     Float8CurrentScalingQuantizer,
     Float8Quantizer,
 )
+from transformer_engine.pytorch.tensor.hybrid_tensor import HybridQuantizer
+from transformer_engine.pytorch.tensor.identity_tensor import IdentityQuantizer
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
 from transformer_engine.pytorch.tensor.utils import get_quantization_recipe_name
@@ -42,6 +44,21 @@ fp8_available, reason_for_no_fp8 = is_fp8_available(return_reason=True)
 def reset_quantization_state():
     yield
     FP8GlobalStateManager.reset()
+
+
+def _make_test_quantizer(quantizer_cls):
+    """Construct a quantizer without allocating recipe-specific CUDA state."""
+    quantizer = object.__new__(quantizer_cls)
+    Quantizer.__init__(quantizer, rowwise=True, columnwise=False)
+    return quantizer
+
+
+def _make_test_quantized_storage(**metadata):
+    """Construct bare quantized storage carrying only the requested metadata."""
+    storage = QuantizedTensorStorage()
+    for name, value in metadata.items():
+        setattr(storage, name, value)
+    return storage
 
 
 def test_calibration_api_additions_preserve_existing_parameter_order():
@@ -101,7 +118,7 @@ def test_calibrating_argument_enables_default_calibration_config():
 
 
 def test_explicit_calibration_config_is_active_in_autocast():
-    config = QuantizationCalibrationConfig(activation_scale_decay=0.5)
+    config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
     with autocast(enabled=False, calibration_config=config):
         assert FP8GlobalStateManager.quantization_state.fp8_calibration
         assert FP8GlobalStateManager.get_calibration_config() is config
@@ -109,7 +126,7 @@ def test_explicit_calibration_config_is_active_in_autocast():
 
 
 def test_nested_autocast_restores_custom_calibration_config():
-    config = QuantizationCalibrationConfig(activation_scale_decay=0.5)
+    config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
     with autocast(enabled=False, calibration_config=config):
         with autocast(enabled=False):
             assert FP8GlobalStateManager.get_calibration_config() is None
@@ -137,7 +154,7 @@ def test_autocast_enter_preserves_calibrating_boolean_api():
 
 
 def test_calibrating_argument_accepts_explicit_calibration_config():
-    config = QuantizationCalibrationConfig(activation_scale_decay=0.5)
+    config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
     with autocast(
         enabled=False,
         calibrating=True,
@@ -147,8 +164,11 @@ def test_calibrating_argument_accepts_explicit_calibration_config():
 
 
 def test_calibration_config_rejects_negative_decay():
-    with pytest.raises(ValueError, match="activation_scale_decay must be non-negative"):
-        QuantizationCalibrationConfig(activation_scale_decay=-0.1)
+    with pytest.raises(
+        ValueError,
+        match="transformer_engine_calibration_decay must be non-negative",
+    ):
+        QuantizationCalibrationConfig(transformer_engine_calibration_decay=-0.1)
 
 
 @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
@@ -198,6 +218,65 @@ def test_calibration_config_registers_module_scaling_factor_buffers(
 
 
 @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+def test_linear_calibration_config_applies_activation_decay_only():
+    module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
+    calibration_config = QuantizationCalibrationConfig(
+        transformer_engine_calibration_decay=0.5
+    )
+    buffer_suffix = "_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+
+    with autocast(
+        enabled=False,
+        recipe=Float8CurrentScaling(),
+        calibration_config=calibration_config,
+    ):
+        module(torch.full((16, 32), 448.0, dtype=torch.bfloat16, device="cuda"))
+
+    torch.testing.assert_close(
+        module.get_buffer(f"input{buffer_suffix}"), torch.ones(1, device="cuda")
+    )
+    weight_scale = module.get_buffer(f"weight{buffer_suffix}").clone()
+
+    with autocast(
+        enabled=False,
+        recipe=Float8CurrentScaling(),
+        calibration_config=calibration_config,
+    ):
+        module(torch.full((16, 32), 112.0, dtype=torch.bfloat16, device="cuda"))
+
+    torch.testing.assert_close(
+        module.get_buffer(f"input{buffer_suffix}"), torch.full((1,), 0.5, device="cuda")
+    )
+    torch.testing.assert_close(module.get_buffer(f"weight{buffer_suffix}"), weight_scale)
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+def test_linear_calibration_config_buffers_delayed_scaling_amax():
+    module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
+
+    with autocast(
+        enabled=False,
+        recipe=DelayedScaling(),
+        calibration_config=QuantizationCalibrationConfig(),
+    ):
+        module(torch.full((16, 32), 2.0, dtype=torch.bfloat16, device="cuda"))
+
+    calibration_buffers = {
+        name: value
+        for name, value in module.named_buffers()
+        if name.endswith("_te_ptq_calibrated")
+    }
+    assert set(calibration_buffers) == {
+        "input_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated",
+        "weight_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated",
+    }
+    torch.testing.assert_close(
+        calibration_buffers["input_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
+        torch.full((1,), 2.0, device="cuda"),
+    )
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
 def test_calibrating_boolean_registers_scaling_factor_buffers():
     module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
     inp = torch.randn((16, 32), dtype=torch.bfloat16, device="cuda")
@@ -225,23 +304,23 @@ def test_calibrating_boolean_registers_scaling_factor_buffers():
     ),
 )
 def test_scale_buffer_info_selects_recipe_metadata(recipe, metadata_name, expected_value):
-    tensor = SimpleNamespace(
+    tensor = _make_test_quantized_storage(
         _scale_inv=torch.tensor([0.25], dtype=torch.float32),
         _amax_rowwise=torch.tensor([2688.0 if recipe == "nvfp4" else 1344.0], dtype=torch.float32),
     )
     if recipe == "fp8_delayed_scaling":
-        quantizer = object.__new__(Float8Quantizer)
+        quantizer = _make_test_quantizer(Float8Quantizer)
         quantizer.amax = torch.tensor([0.0], dtype=torch.float32)
         tensor = torch.tensor([expected_value])
     elif recipe == "fp8_current_scaling":
-        quantizer = object.__new__(Float8CurrentScalingQuantizer)
+        quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
     else:
-        quantizer = object.__new__(NVFP4Quantizer)
+        quantizer = _make_test_quantizer(NVFP4Quantizer)
         quantizer.row_scaled_nvfp4 = recipe == "nvfp4_rowwise"
 
     assert get_quantization_recipe_name(quantizer) == recipe
     quantizer.calibrate(tensor)
-    buffers = _common._get_scale_buffer_info("input", quantizer)
+    buffers = _common._get_calibration_metadata_buffers("input", quantizer)
     buffer_name = f"input_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
     value = buffers[buffer_name]
 
@@ -253,18 +332,28 @@ def test_scale_buffer_info_selects_recipe_metadata(recipe, metadata_name, expect
 def test_scale_buffer_info_skips_non_global_scaling_recipes(recipe):
     tensor = SimpleNamespace(_rowwise_scale_inv=torch.ones(2, 2))
     quantizer_cls = MXFP8Quantizer if recipe == "mxfp8" else Float8BlockQuantizer
-    quantizer = object.__new__(quantizer_cls)
+    quantizer = _make_test_quantizer(quantizer_cls)
 
     assert get_quantization_recipe_name(quantizer) == recipe
     quantizer.calibrate(tensor)
-    assert not _common._get_scale_buffer_info("input", quantizer)
+    assert not _common._get_calibration_metadata_buffers("input", quantizer)
 
 
 def test_custom_quantizer_defaults_to_no_calibration_metadata():
     quantizer = Quantizer(rowwise=True, columnwise=False)
 
     assert get_quantization_recipe_name(quantizer) == ""
-    assert not _common._get_scale_buffer_info("input", quantizer)
+    assert not _common._get_calibration_metadata_buffers("input", quantizer)
+
+
+def test_hybrid_quantizer_rejects_calibration():
+    quantizer = HybridQuantizer(
+        rowwise_quantizer=IdentityQuantizer(),
+        columnwise_quantizer=IdentityQuantizer(),
+    )
+
+    with pytest.raises(NotImplementedError, match="not yet supported for HybridQuantizer"):
+        quantizer.calibrate(torch.ones(1))
 
 
 def test_resolve_calibration_quantizer_prefers_tensor_owner_and_unwraps_parent():
@@ -278,76 +367,80 @@ def test_resolve_calibration_quantizer_prefers_tensor_owner_and_unwraps_parent()
 def test_quantizer_calibration_state_is_keyed_by_quantized_metadata():
     quantizer = Quantizer(rowwise=True, columnwise=False)
 
-    quantizer._update_calibration_value("amax", torch.tensor([2.0]), decay=0.0)
-    quantizer._update_calibration_value("scale_inv", torch.tensor([0.5]), decay=0.0)
+    quantizer._update_calibration_value(
+        "amax", torch.tensor([2.0]), calibration_decay=0.0
+    )
+    quantizer._update_calibration_value(
+        "scale_inv", torch.tensor([0.5]), calibration_decay=0.0
+    )
 
     assert set(quantizer._calibration_state) == {"amax", "scale_inv"}
     torch.testing.assert_close(quantizer._calibration_state["amax"], torch.tensor([2.0]))
     torch.testing.assert_close(quantizer._calibration_state["scale_inv"], torch.tensor([0.5]))
 
 
-def test_grouped_scale_buffers_are_per_gemm():
+def test_grouped_calibration_metadata_buffers_are_per_gemm():
     inputs = [
-        SimpleNamespace(_scale_inv=torch.tensor([0.25])),
-        SimpleNamespace(_scale_inv=torch.tensor([0.5])),
+        _make_test_quantized_storage(_scale_inv=torch.tensor([0.25])),
+        _make_test_quantized_storage(_scale_inv=torch.tensor([0.5])),
     ]
     weights = [
-        SimpleNamespace(_scale_inv=torch.tensor([0.75])),
-        SimpleNamespace(_scale_inv=torch.tensor([1.0])),
+        _make_test_quantized_storage(_scale_inv=torch.tensor([0.75])),
+        _make_test_quantized_storage(_scale_inv=torch.tensor([1.0])),
     ]
     input_quantizers = [
-        object.__new__(Float8CurrentScalingQuantizer),
-        object.__new__(Float8CurrentScalingQuantizer),
+        _make_test_quantizer(Float8CurrentScalingQuantizer),
+        _make_test_quantizer(Float8CurrentScalingQuantizer),
     ]
     weight_quantizers = [
-        object.__new__(Float8CurrentScalingQuantizer),
-        object.__new__(Float8CurrentScalingQuantizer),
+        _make_test_quantizer(Float8CurrentScalingQuantizer),
+        _make_test_quantizer(Float8CurrentScalingQuantizer),
     ]
-    scale_buffers = {}
+    calibration_buffers = {}
 
     grouped_linear._calibrate_grouped_tensors(
         inputs,
         weights,
         input_quantizers,
         weight_quantizers,
-        activation_scale_decay=0.0,
+        transformer_engine_calibration_decay=0.0,
     )
-    grouped_linear._update_grouped_scale_buffers(
-        scale_buffers,
+    grouped_linear._update_grouped_calibration_metadata_buffers(
+        calibration_buffers,
         inputs,
         weights,
         input_quantizers,
         weight_quantizers,
     )
 
-    assert set(scale_buffers) == {
+    assert set(calibration_buffers) == {
         "input_gemm0_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
         "input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
         "weight_gemm0_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
         "weight_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated",
     }
     torch.testing.assert_close(
-        scale_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"],
+        calibration_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"],
         torch.tensor([0.5]),
     )
     assert (
-        scale_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"]
+        calibration_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"]
         is input_quantizers[1]._calibration_state["scale_inv"]
     )
 
 
 def test_grouped_calibration_applies_decay_only_to_activations():
-    input_quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    input_quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
     input_quantizer._calibration_state = {"scale_inv": torch.tensor([4.0])}
-    weight_quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    weight_quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
     weight_quantizer._calibration_state = {"scale_inv": torch.tensor([4.0])}
 
     grouped_linear._calibrate_grouped_tensors(
-        [SimpleNamespace(_scale_inv=torch.tensor([1.0]))],
-        [SimpleNamespace(_scale_inv=torch.tensor([1.0]))],
+        [_make_test_quantized_storage(_scale_inv=torch.tensor([1.0]))],
+        [_make_test_quantized_storage(_scale_inv=torch.tensor([1.0]))],
         [input_quantizer],
         [weight_quantizer],
-        activation_scale_decay=0.5,
+        transformer_engine_calibration_decay=0.5,
     )
 
     torch.testing.assert_close(input_quantizer._calibration_state["scale_inv"], torch.tensor([2.0]))
@@ -356,23 +449,41 @@ def test_grouped_calibration_applies_decay_only_to_activations():
     )
 
 
-def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax():
+def test_calibration_supports_legacy_custom_quantizer_signature():
+    class LegacyCustomQuantizer:
+        def calibrate(self, tensor):
+            self.observed_tensor = tensor
+
+    tensor = torch.tensor([1.0])
+    quantizer = LegacyCustomQuantizer()
+    grouped_linear._calibrate_grouped_tensors(
+        [tensor],
+        [],
+        [quantizer],
+        [],
+        transformer_engine_calibration_decay=0.5,
+    )
+
+    assert quantizer.observed_tensor is tensor
+
+
+def test_grouped_calibration_metadata_uses_per_gemm_delayed_scaling_amax():
     quantizers = []
     for amax in (1.0, 2.0):
-        quantizer = object.__new__(Float8Quantizer)
+        quantizer = _make_test_quantizer(Float8Quantizer)
         quantizer.amax = torch.tensor([amax])
         quantizers.append(quantizer)
-    scale_buffers = {}
+    calibration_buffers = {}
 
     grouped_linear._calibrate_grouped_tensors(
         [torch.tensor([1.0]), torch.tensor([2.0])],
         [torch.tensor([1.0]), torch.tensor([2.0])],
         quantizers,
         quantizers,
-        activation_scale_decay=0.0,
+        transformer_engine_calibration_decay=0.0,
     )
-    grouped_linear._update_grouped_scale_buffers(
-        scale_buffers,
+    grouped_linear._update_grouped_calibration_metadata_buffers(
+        calibration_buffers,
         [torch.tensor([1.0]), torch.tensor([2.0])],
         [torch.tensor([1.0]), torch.tensor([2.0])],
         quantizers,
@@ -380,11 +491,11 @@ def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax():
     )
 
     torch.testing.assert_close(
-        scale_buffers["input_gemm0_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
+        calibration_buffers["input_gemm0_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
         torch.tensor([1.0]),
     )
     torch.testing.assert_close(
-        scale_buffers["input_gemm1_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
+        calibration_buffers["input_gemm1_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
         torch.tensor([2.0]),
     )
 
@@ -400,14 +511,14 @@ def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax():
 )
 def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_scale):
     name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
-    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
     initial_buffer = torch.tensor([4.0])
     quantizer._calibration_state = {"scale_inv": initial_buffer}
     quantizer.calibrate(
-        SimpleNamespace(_scale_inv=torch.tensor([observed_scale])),
-        decay=0.5,
+        _make_test_quantized_storage(_scale_inv=torch.tensor([observed_scale])),
+        calibration_decay=0.5,
     )
-    buffers = _common._get_scale_buffer_info("fc1_input", quantizer)
+    buffers = _common._get_calibration_metadata_buffers("fc1_input", quantizer)
     value = buffers[name]
 
     torch.testing.assert_close(value, torch.tensor([expected_scale]))
@@ -417,33 +528,41 @@ def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_
 
 def test_zero_decay_keeps_observed_metadata_reference():
     observed_scale = torch.tensor([2.0])
-    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
 
-    quantizer.calibrate(SimpleNamespace(_scale_inv=observed_scale), decay=0.0)
+    quantizer.calibrate(
+        _make_test_quantized_storage(_scale_inv=observed_scale),
+        calibration_decay=0.0,
+    )
 
     assert quantizer._calibration_state["scale_inv"] is observed_scale
 
 
 def test_decaying_calibration_rejects_metadata_shape_change():
-    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+    quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
     quantizer._calibration_state = {"scale_inv": torch.ones(1)}
 
     with pytest.raises(RuntimeError, match="calibration value shape changed"):
-        quantizer.calibrate(SimpleNamespace(_scale_inv=torch.ones(2)), decay=0.5)
+        quantizer.calibrate(
+            _make_test_quantized_storage(_scale_inv=torch.ones(2)),
+            calibration_decay=0.5,
+        )
 
 
-@pytest.mark.parametrize("activation_scale_decay", (0.0, 0.5))
+@pytest.mark.parametrize("transformer_engine_calibration_decay", (0.0, 0.5))
 @pytest.mark.parametrize("initial_scale", (None, 4.0))
-def test_nan_activation_scale_does_not_update_buffer(activation_scale_decay, initial_scale):
-    quantizer = object.__new__(Float8CurrentScalingQuantizer)
+def test_nan_activation_scale_does_not_update_buffer(
+    transformer_engine_calibration_decay, initial_scale
+):
+    quantizer = _make_test_quantizer(Float8CurrentScalingQuantizer)
     if initial_scale is not None:
         quantizer._calibration_state = {"scale_inv": torch.tensor([initial_scale])}
 
     quantizer.calibrate(
-        SimpleNamespace(_scale_inv=torch.tensor([float("nan")])),
-        decay=activation_scale_decay,
+        _make_test_quantized_storage(_scale_inv=torch.tensor([float("nan")])),
+        calibration_decay=transformer_engine_calibration_decay,
     )
-    result = _common._get_scale_buffer_info("fc1_input", quantizer)
+    result = _common._get_calibration_metadata_buffers("fc1_input", quantizer)
 
     if initial_scale is None:
         assert not result

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -191,9 +191,7 @@ def test_calibration_config_registers_module_scaling_factor_buffers(
             module(inp)
 
     buffers = {
-        name: value
-        for name, value in module.named_buffers()
-        if name.endswith("_te_ptq_calibrated")
+        name: value for name, value in module.named_buffers() if name.endswith("_te_ptq_calibrated")
     }
     assert len(buffers) == expected_buffer_count
     assert all(torch.isfinite(value).all() for value in buffers.values())
@@ -211,13 +209,10 @@ def test_calibrating_boolean_registers_scaling_factor_buffers():
     ):
         module(inp)
 
-    assert len(
-        [
-            name
-            for name, _ in module.named_buffers()
-            if name.endswith("_te_ptq_calibrated")
-        ]
-    ) == 2
+    assert (
+        len([name for name, _ in module.named_buffers() if name.endswith("_te_ptq_calibrated")])
+        == 2
+    )
 
 
 @pytest.mark.parametrize(
@@ -229,9 +224,7 @@ def test_calibrating_boolean_registers_scaling_factor_buffers():
         ("nvfp4_rowwise", "amax_rowwise", 1344.0),
     ),
 )
-def test_scale_buffer_info_selects_recipe_metadata(
-    recipe, metadata_name, expected_value
-):
+def test_scale_buffer_info_selects_recipe_metadata(recipe, metadata_name, expected_value):
     tensor = SimpleNamespace(
         _scale_inv=torch.tensor([0.25], dtype=torch.float32),
         _amax_rowwise=torch.tensor([2688.0 if recipe == "nvfp4" else 1344.0], dtype=torch.float32),
@@ -279,10 +272,7 @@ def test_resolve_calibration_quantizer_prefers_tensor_owner_and_unwraps_parent()
     tensor_quantizer = SimpleNamespace(parent_quantizer=parent_quantizer)
     tensor = SimpleNamespace(_quantizer=tensor_quantizer)
 
-    assert (
-        _common._resolve_calibration_quantizer(tensor, object())
-        is parent_quantizer
-    )
+    assert _common._resolve_calibration_quantizer(tensor, object()) is parent_quantizer
 
 
 def test_quantizer_calibration_state_is_keyed_by_quantized_metadata():
@@ -341,9 +331,7 @@ def test_grouped_scale_buffers_are_per_gemm():
         torch.tensor([0.5]),
     )
     assert (
-        scale_buffers[
-            "input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
-        ]
+        scale_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"]
         is input_quantizers[1]._calibration_state["scale_inv"]
     )
 
@@ -362,9 +350,7 @@ def test_grouped_calibration_applies_decay_only_to_activations():
         activation_scale_decay=0.5,
     )
 
-    torch.testing.assert_close(
-        input_quantizer._calibration_state["scale_inv"], torch.tensor([2.0])
-    )
+    torch.testing.assert_close(input_quantizer._calibration_state["scale_inv"], torch.tensor([2.0]))
     torch.testing.assert_close(
         weight_quantizer._calibration_state["scale_inv"], torch.tensor([1.0])
     )
@@ -463,9 +449,7 @@ def test_nan_activation_scale_does_not_update_buffer(activation_scale_decay, ini
         assert not result
         assert not quantizer._calibration_state
     else:
-        value = result[
-            "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
-        ]
+        value = result["fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"]
         torch.testing.assert_close(value, torch.tensor([initial_scale]))
 
 
@@ -483,9 +467,7 @@ def test_current_scaling_calibrates_from_high_precision_tensor():
 
 @pytest.mark.parametrize("input_value", (0.0, float("inf")))
 @pytest.mark.parametrize("force_pow_2_scales", (False, True))
-def test_current_scaling_calibration_handles_non_finite_scale(
-    input_value, force_pow_2_scales
-):
+def test_current_scaling_calibration_handles_non_finite_scale(input_value, force_pow_2_scales):
     quantizer = Float8CurrentScalingQuantizer(
         fp8_dtype=DType.kFloat8E4M3,
         device=torch.device("cpu"),
@@ -522,8 +504,7 @@ def test_delayed_scaling_high_precision_calibration_matches_quantization(fp8_dty
     )
     calibration_quantizer.calibrate(tensor)
     assert (
-        calibration_quantizer.copy()._calibration_state
-        is calibration_quantizer._calibration_state
+        calibration_quantizer.copy()._calibration_state is calibration_quantizer._calibration_state
     )
 
     torch.testing.assert_close(
@@ -610,8 +591,7 @@ def test_nvfp4_high_precision_calibration_matches_quantization(
     calibration_quantizer = NVFP4Quantizer(**quantizer_kwargs)
     calibration_quantizer.calibrate(tensor)
     assert (
-        calibration_quantizer.copy()._calibration_state
-        is calibration_quantizer._calibration_state
+        calibration_quantizer.copy()._calibration_state is calibration_quantizer._calibration_state
     )
 
     expected_metadata_name = "amax_rowwise" if row_scaled_nvfp4 else "amax"

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -220,9 +220,7 @@ def test_calibration_config_registers_module_scaling_factor_buffers(
 @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
 def test_linear_calibration_config_applies_activation_decay_only():
     module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
-    calibration_config = QuantizationCalibrationConfig(
-        transformer_engine_calibration_decay=0.5
-    )
+    calibration_config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
     buffer_suffix = "_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
 
     with autocast(
@@ -262,9 +260,7 @@ def test_linear_calibration_config_buffers_delayed_scaling_amax():
         module(torch.full((16, 32), 2.0, dtype=torch.bfloat16, device="cuda"))
 
     calibration_buffers = {
-        name: value
-        for name, value in module.named_buffers()
-        if name.endswith("_te_ptq_calibrated")
+        name: value for name, value in module.named_buffers() if name.endswith("_te_ptq_calibrated")
     }
     assert set(calibration_buffers) == {
         "input_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated",
@@ -346,14 +342,15 @@ def test_custom_quantizer_defaults_to_no_calibration_metadata():
     assert not _common._get_calibration_metadata_buffers("input", quantizer)
 
 
-def test_hybrid_quantizer_rejects_calibration():
+def test_hybrid_quantizer_calibration_is_noop():
     quantizer = HybridQuantizer(
         rowwise_quantizer=IdentityQuantizer(),
         columnwise_quantizer=IdentityQuantizer(),
     )
 
-    with pytest.raises(NotImplementedError, match="not yet supported for HybridQuantizer"):
-        quantizer.calibrate(torch.ones(1))
+    quantizer.calibrate(torch.ones(1))
+
+    assert not quantizer._calibration_state
 
 
 def test_resolve_calibration_quantizer_prefers_tensor_owner_and_unwraps_parent():
@@ -367,12 +364,8 @@ def test_resolve_calibration_quantizer_prefers_tensor_owner_and_unwraps_parent()
 def test_quantizer_calibration_state_is_keyed_by_quantized_metadata():
     quantizer = Quantizer(rowwise=True, columnwise=False)
 
-    quantizer._update_calibration_value(
-        "amax", torch.tensor([2.0]), calibration_decay=0.0
-    )
-    quantizer._update_calibration_value(
-        "scale_inv", torch.tensor([0.5]), calibration_decay=0.0
-    )
+    quantizer._update_calibration_value("amax", torch.tensor([2.0]), calibration_decay=0.0)
+    quantizer._update_calibration_value("scale_inv", torch.tensor([0.5]), calibration_decay=0.0)
 
     assert set(quantizer._calibration_state) == {"amax", "scale_inv"}
     torch.testing.assert_close(quantizer._calibration_state["amax"], torch.tensor([2.0]))

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -60,8 +60,8 @@ def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
         scale_buffers,
         inputs,
         weights,
-        object(),
-        object(),
+        [object(), object()],
+        [object(), object()],
         activation_scale_decay=0.0,
     )
 
@@ -74,6 +74,33 @@ def test_grouped_scale_buffers_are_per_gemm(monkeypatch):
     torch.testing.assert_close(
         scale_buffers["input_gemm1_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"],
         torch.tensor([0.5]),
+    )
+
+
+def test_grouped_scale_buffers_use_per_gemm_delayed_scaling_amax(monkeypatch):
+    monkeypatch.setattr(_common, "get_quantization_recipe_name", lambda _: "fp8_delayed_scaling")
+    quantizers = [
+        SimpleNamespace(amax=torch.tensor([1.0])),
+        SimpleNamespace(amax=torch.tensor([2.0])),
+    ]
+    scale_buffers = {}
+
+    grouped_linear._update_grouped_scale_buffers(
+        scale_buffers,
+        [object(), object()],
+        [object(), object()],
+        quantizers,
+        quantizers,
+        activation_scale_decay=0.0,
+    )
+
+    torch.testing.assert_close(
+        scale_buffers["input_gemm0_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
+        torch.tensor([1.0]),
+    )
+    torch.testing.assert_close(
+        scale_buffers["input_gemm1_tensor_amax_fp8_delayed_scaling_te_ptq_calibrated"],
+        torch.tensor([2.0]),
     )
 
 

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -8,14 +8,17 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from torch.utils.checkpoint import checkpoint
 
 from transformer_engine.common.recipe import DelayedScaling, Float8CurrentScaling
 from transformer_engine.pytorch import is_fp8_available, is_nvfp4_available
+from transformer_engine.pytorch import distributed as te_distributed
 from transformer_engine.pytorch.constants import DType
 from transformer_engine.pytorch.graph import make_graphed_callables
 from transformer_engine.pytorch.module import GroupedLinear, LayerNormLinear, LayerNormMLP, Linear
 from transformer_engine.pytorch.module import _common
 from transformer_engine.pytorch.module import grouped_linear
+from transformer_engine.pytorch.module import layernorm_mlp
 from transformer_engine.pytorch.quantization import (
     FP8GlobalStateManager,
     FP8GlobalState,
@@ -107,6 +110,16 @@ def test_calibration_api_additions_preserve_existing_parameter_order():
         "is_first_fp8_module",
         "fp8_graph_capturing",
     ]
+
+
+def test_activation_recompute_detection_uses_te_marker(monkeypatch):
+    monkeypatch.setattr(
+        te_distributed,
+        "in_fp8_activation_recompute_phase",
+        lambda: True,
+    )
+
+    assert _common._is_in_activation_recompute_phase()
 
 
 def test_calibrating_argument_enables_default_calibration_config():
@@ -246,6 +259,113 @@ def test_linear_calibration_config_applies_activation_decay_only():
         module.get_buffer(f"input{buffer_suffix}"), torch.full((1,), 0.5, device="cuda")
     )
     torch.testing.assert_close(module.get_buffer(f"weight{buffer_suffix}"), weight_scale)
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize("use_reentrant", (False, True))
+def test_external_activation_recomputation_does_not_update_calibration(use_reentrant):
+    module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
+    calibration_config = QuantizationCalibrationConfig(
+        transformer_engine_calibration_decay=0.5
+    )
+    recipe = Float8CurrentScaling()
+    buffer_name = "input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+
+    with (
+        torch.no_grad(),
+        autocast(enabled=False, recipe=recipe, calibration_config=calibration_config),
+    ):
+        module(torch.full((16, 32), 448.0, dtype=torch.bfloat16, device="cuda"))
+
+    def checkpointed_forward(inp):
+        with autocast(enabled=False, recipe=recipe, calibration_config=calibration_config):
+            return module(inp)
+
+    inp = torch.full(
+        (16, 32),
+        56.0,
+        dtype=torch.bfloat16,
+        device="cuda",
+        requires_grad=True,
+    )
+    out = checkpoint(checkpointed_forward, inp, use_reentrant=use_reentrant)
+    scale_after_forward = module.get_buffer(buffer_name).clone()
+    torch.testing.assert_close(scale_after_forward, torch.full((1,), 0.5, device="cuda"))
+
+    out.sum().backward()
+
+    torch.testing.assert_close(module.get_buffer(buffer_name), scale_after_forward)
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+def test_layernorm_mlp_recomputation_does_not_update_calibration(monkeypatch):
+    recomputation_states = []
+    is_in_recompute = _common._is_in_activation_recompute_phase
+
+    def record_recomputation_state():
+        state = is_in_recompute()
+        recomputation_states.append(state)
+        return state
+
+    monkeypatch.setattr(
+        layernorm_mlp,
+        "_is_in_activation_recompute_phase",
+        record_recomputation_state,
+    )
+    module = LayerNormMLP(
+        32,
+        32,
+        params_dtype=torch.bfloat16,
+        device="cuda",
+        bias=False,
+        checkpoint=True,
+    )
+    calibration_config = QuantizationCalibrationConfig(
+        transformer_engine_calibration_decay=0.5
+    )
+    torch.manual_seed(123)
+    calibration_input = torch.randn((16, 32), dtype=torch.bfloat16, device="cuda")
+    with torch.no_grad():
+        module.layer_norm_weight.fill_(448.0)
+    with (
+        torch.no_grad(),
+        autocast(
+            enabled=False,
+            recipe=Float8CurrentScaling(),
+            calibration_config=calibration_config,
+        ),
+    ):
+        module(calibration_input)
+
+    buffer_name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
+    previous_scale = module.get_buffer(buffer_name).clone()
+    with torch.no_grad():
+        module.layer_norm_weight.fill_(56.0)
+    inp = calibration_input.detach().clone().requires_grad_()
+
+    with autocast(
+        enabled=False,
+        recipe=Float8CurrentScaling(),
+        calibration_config=calibration_config,
+    ):
+        out = module(inp)
+
+    calibration_buffers = {
+        name: value.clone()
+        for name, value in module.named_buffers()
+        if name.endswith("_te_ptq_calibrated")
+    }
+    assert calibration_buffers
+    torch.testing.assert_close(
+        calibration_buffers[buffer_name],
+        previous_scale * 0.5,
+    )
+
+    out.sum().backward()
+
+    assert any(recomputation_states)
+    for name, value in calibration_buffers.items():
+        torch.testing.assert_close(module.get_buffer(name), value)
 
 
 @pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -265,9 +265,7 @@ def test_linear_calibration_config_applies_activation_decay_only():
 @pytest.mark.parametrize("use_reentrant", (False, True))
 def test_external_activation_recomputation_does_not_update_calibration(use_reentrant):
     module = Linear(32, 32, params_dtype=torch.bfloat16, device="cuda", bias=False)
-    calibration_config = QuantizationCalibrationConfig(
-        transformer_engine_calibration_decay=0.5
-    )
+    calibration_config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
     recipe = Float8CurrentScaling()
     buffer_name = "input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
 
@@ -320,9 +318,7 @@ def test_layernorm_mlp_recomputation_does_not_update_calibration(monkeypatch):
         bias=False,
         checkpoint=True,
     )
-    calibration_config = QuantizationCalibrationConfig(
-        transformer_engine_calibration_decay=0.5
-    )
+    calibration_config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
     torch.manual_seed(123)
     calibration_input = torch.randn((16, 32), dtype=torch.bfloat16, device="cuda")
     with torch.no_grad():

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -127,9 +127,7 @@ def test_activation_scale_buffer_uses_decaying_maximum(observed_scale, expected_
 
 @pytest.mark.parametrize("activation_scale_decay", (0.0, 0.5))
 @pytest.mark.parametrize("initial_scale", (None, 4.0))
-def test_nan_activation_scale_does_not_update_buffer(
-    activation_scale_decay, initial_scale
-):
+def test_nan_activation_scale_does_not_update_buffer(activation_scale_decay, initial_scale):
     name = "fc1_input_tensor_scale_inv_fp8_current_scaling_te_ptq_calibrated"
     scale_buffers = {}
     if initial_scale is not None:

--- a/tests/pytorch/test_ptq_calibration_metadata_buffering.py
+++ b/tests/pytorch/test_ptq_calibration_metadata_buffering.py
@@ -316,6 +316,7 @@ def test_layernorm_mlp_recomputation_does_not_update_calibration(monkeypatch):
         params_dtype=torch.bfloat16,
         device="cuda",
         bias=False,
+        activation="relu",
         checkpoint=True,
     )
     calibration_config = QuantizationCalibrationConfig(transformer_engine_calibration_decay=0.5)
@@ -644,7 +645,8 @@ def test_zero_decay_keeps_observed_metadata_reference():
         calibration_decay=0.0,
     )
 
-    assert quantizer._calibration_state["scale_inv"] is observed_scale
+    calibrated_scale = quantizer._calibration_state["scale_inv"]
+    assert calibrated_scale.data_ptr() == observed_scale.data_ptr()
 
 
 def test_decaying_calibration_rejects_metadata_shape_change():
@@ -793,7 +795,6 @@ def test_current_scaling_high_precision_calibration_matches_quantization(
     ("row_scaled_nvfp4", "with_rht", "with_post_rht_amax", "with_random_sign_mask"),
     (
         (False, False, False, False),
-        (False, True, False, False),
         (False, True, True, False),
         (False, True, True, True),
         (True, False, False, False),

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -2022,6 +2022,7 @@ _FALLBACK_CASES = [
     "fuse_wgrad_accumulation",
     "delayed_wgrad",
     "quantized_input",
+    "scale_buffering",
 ]
 
 
@@ -2032,6 +2033,8 @@ def _fallback_case(case, dtype, device):
         model_kwargs["fuse_wgrad_accumulation"] = True
     elif case == "delayed_wgrad":
         model_kwargs["delay_wgrad_compute"] = True
+    elif case == "scale_buffering":
+        model_kwargs["buffer_quantized_scaling_factors"] = True
     model = te.Linear(64, 32, params_dtype=dtype, device=device, **model_kwargs)
 
     if case == "fp8_output_differentiable":
@@ -2055,6 +2058,14 @@ def _fallback_case(case, dtype, device):
                 return model(inp)
 
         return model, fn, "no_grad", None, "a quantized input tensor"
+    if case == "scale_buffering":
+        fp8_recipe = recipe.Float8CurrentScaling()
+
+        def fn(inp):
+            with te.autocast(recipe=fp8_recipe):
+                return model(inp)
+
+        return model, fn, "bwd", None, "quantized scaling-factor buffering"
     raise ValueError(case)
 
 

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -2066,7 +2066,7 @@ def _fallback_case(case, dtype, device):
             ):
                 return model(inp)
 
-        return model, fn, "bwd", None, "quantized scaling-factor buffering"
+        return model, fn, "bwd", None, "Transformer Engine calibration metadata buffering"
     raise ValueError(case)
 
 
@@ -2125,6 +2125,21 @@ def test_te_linear_compile_eager_fallback(case):
                 model.weight.grad, model_ref.weight.grad, atol=_EAGER_ATOL, rtol=_EAGER_RTOL
             )
     torch.testing.assert_close(out.detach(), out_ref.detach(), atol=_EAGER_ATOL, rtol=_EAGER_RTOL)
+    if case == "scale_buffering":
+        calibration_buffers_ref = {
+            name: value
+            for name, value in model_ref.named_buffers()
+            if name.endswith("_te_ptq_calibrated")
+        }
+        calibration_buffers = {
+            name: value
+            for name, value in model.named_buffers()
+            if name.endswith("_te_ptq_calibrated")
+        }
+        assert calibration_buffers
+        assert calibration_buffers.keys() == calibration_buffers_ref.keys()
+        for name, value in calibration_buffers.items():
+            torch.testing.assert_close(value, calibration_buffers_ref[name])
 
     torch._dynamo.reset()
     compiled_fg = torch.compile(fn, fullgraph=True)

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -2033,8 +2033,6 @@ def _fallback_case(case, dtype, device):
         model_kwargs["fuse_wgrad_accumulation"] = True
     elif case == "delayed_wgrad":
         model_kwargs["delay_wgrad_compute"] = True
-    elif case == "scale_buffering":
-        model_kwargs["buffer_quantized_scaling_factors"] = True
     model = te.Linear(64, 32, params_dtype=dtype, device=device, **model_kwargs)
 
     if case == "fp8_output_differentiable":
@@ -2062,7 +2060,10 @@ def _fallback_case(case, dtype, device):
         fp8_recipe = recipe.Float8CurrentScaling()
 
         def fn(inp):
-            with te.autocast(recipe=fp8_recipe):
+            with te.autocast(
+                recipe=fp8_recipe,
+                calibration_config=te.QuantizationCalibrationConfig(),
+            ):
                 return model(inp)
 
         return model, fn, "bwd", None, "quantized scaling-factor buffering"

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -1442,6 +1442,7 @@ def test_quantizer_value_object(factory):
     rebuilt = eval(repr_str, dict(globals_))  # pylint: disable=eval-used
     assert rebuilt == a and rebuilt is not a
     assert hash(rebuilt) == hash(a)
+    assert rebuilt._calibration_state == {}
     # The deprecated amax-reduction group is never part of the value.
     assert getattr(rebuilt, "amax_reduction_group", None) is None
 

--- a/transformer_engine/debug/features/log_fp8_tensor_stats.py
+++ b/transformer_engine/debug/features/log_fp8_tensor_stats.py
@@ -23,33 +23,10 @@ from transformer_engine.pytorch.tensor.float8_tensor import (
 )
 from transformer_engine.pytorch.tensor.mxfp8_tensor import MXFP8Quantizer
 from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockQuantizer
-
-try:
-    from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
-
-    _nvfp4_available = True
-except ImportError:
-    _nvfp4_available = False
-    NVFP4Quantizer = None
+from transformer_engine.pytorch.tensor.utils import get_quantization_recipe_name
 
 
 ALL_RECIPE_NAMES = ["fp8_delayed_scaling", "fp8_current_scaling", "mxfp8", "fp8_block_scaling"]
-
-
-def _get_recipe_name(quantizer: Optional[Quantizer]):
-    if quantizer is None:
-        return ""
-    if isinstance(quantizer, Float8Quantizer):
-        return "fp8_delayed_scaling"
-    if isinstance(quantizer, Float8CurrentScalingQuantizer):
-        return "fp8_current_scaling"
-    if isinstance(quantizer, MXFP8Quantizer):
-        return "mxfp8"
-    if isinstance(quantizer, Float8BlockQuantizer):
-        return "fp8_block_scaling"
-    if _nvfp4_available and isinstance(quantizer, NVFP4Quantizer):
-        return "nvfp4"
-    raise ValueError(f"Unsupported quantizer type: {type(quantizer)}")
 
 
 def _get_new_quantizer(recipe_name, fp8_dtype):
@@ -336,7 +313,9 @@ class LogFp8TensorStats(BaseLogTensorStats):
             )
             return
 
-        recipe_name = _get_recipe_name(quantizer)
+        recipe_name = get_quantization_recipe_name(quantizer)
+        if recipe_name == "nvfp4_rowwise":
+            recipe_name = "nvfp4"
 
         for stat in config["stats"]:
             self.check_if_stat_is_supported(

--- a/transformer_engine/debug/pytorch/debug_quantization.py
+++ b/transformer_engine/debug/pytorch/debug_quantization.py
@@ -429,9 +429,8 @@ class DebugQuantizer(Quantizer):
                 return True
         return False
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0):
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0):
         """Calibration override, should not be invoked."""
-        del tensor, decay
         raise RuntimeError("[NVTORCH-INSPECT ERROR] Calibration with debug is not supported")
 
     def update_quantized(

--- a/transformer_engine/debug/pytorch/debug_quantization.py
+++ b/transformer_engine/debug/pytorch/debug_quantization.py
@@ -429,8 +429,9 @@ class DebugQuantizer(Quantizer):
                 return True
         return False
 
-    def calibrate(self, tensor: torch.Tensor):
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0):
         """Calibration override, should not be invoked."""
+        del tensor, decay
         raise RuntimeError("[NVTORCH-INSPECT ERROR] Calibration with debug is not supported")
 
     def update_quantized(

--- a/transformer_engine/pytorch/__init__.py
+++ b/transformer_engine/pytorch/__init__.py
@@ -55,6 +55,8 @@ from transformer_engine.pytorch.quantization import get_default_recipe
 from transformer_engine.pytorch.quantization import QuantizerRole
 from transformer_engine.pytorch.quantization import QuantizerRequest
 from transformer_engine.pytorch.quantization import DelayedScalingRequest
+from transformer_engine.pytorch.quantization import TEAutocastState
+from transformer_engine.pytorch.quantization import QuantizationCalibrationConfig
 from transformer_engine.pytorch.utils import get_cudnn_version
 from transformer_engine.pytorch.utils import get_device_compute_capability
 from transformer_engine.pytorch.utils import is_bf16_available

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -1121,7 +1121,10 @@ class DotProductAttention(TransformerEngineBaseModule):
         # With quantization off the base class does all that is needed.
         qstate = FP8GlobalStateManager.quantization_state
         if torch.compiler.is_compiling() and not (
-            qstate.fp8_enabled or qstate.fp8_calibration or qstate.fp8_parameters
+            qstate.fp8_enabled
+            or qstate.fp8_calibration
+            or qstate.calibration_config is not None
+            or qstate.fp8_parameters
         ):
             super().init_fp8_metadata(num_gemms=num_gemms)
             return

--- a/transformer_engine/pytorch/attention/fused_mla_q_uproj.py
+++ b/transformer_engine/pytorch/attention/fused_mla_q_uproj.py
@@ -203,6 +203,7 @@ class FusedMLAQUpProjRopeQuant:
 
         from cuda.bindings import driver as cuda
 
+        # pylint: disable-next=c-extension-no-member
         stream = cuda.CUstream(torch.cuda.current_stream(x.device).cuda_stream)
         wrapper = cls._kernel()
 

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -45,6 +45,9 @@ def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
         if name == "dtype":
             value = DType.cast(value)
         object.__setattr__(obj, name, value)
+    # Runtime calibration metadata is intentionally excluded from value semantics,
+    # but rebuilt quantizers still need an initialized state for copy()/quantize().
+    object.__setattr__(obj, "_calibration_state", {})
     # Restore non-value derived state that ``__init__`` would normally build but
     # that cannot live in the value key (e.g. NVFP4's ``rht_matrix`` tensor).
     finalize = getattr(obj, "_rebuild_derived_state", None)

--- a/transformer_engine/pytorch/graph.py
+++ b/transformer_engine/pytorch/graph.py
@@ -20,6 +20,7 @@ from transformer_engine.pytorch.constants import dist_group_type
 from .quantization import (
     autocast,
     FP8GlobalStateManager,
+    QuantizationCalibrationConfig,
     get_default_fp8_recipe,
 )
 from .distributed import get_all_rng_states, graph_safe_rng_available
@@ -1445,6 +1446,7 @@ def make_graphed_callables(
     pre_warmup_hook: Optional[Callable] = None,
     post_warmup_hook: Optional[Callable] = None,
     capture_time_hooks: Optional[List[Optional[Dict[str, Dict]]]] = None,
+    calibration_config: Optional[QuantizationCalibrationConfig] = None,
 ) -> Union[Callable, Tuple[Callable, ...]]:
     """
     Make CUDA graph version of Transformer Engine modules
@@ -1518,10 +1520,10 @@ def make_graphed_callables(
              whether or not to enable low precision quantization (FP8/FP4).
              If tuple, the length must match the number of modules.
     calibrating: bool, default = False
-                 calibration mode allows collecting statistics such as amax and scale
-                 data of quantized tensors even when executing without quantization enabled.
-                 This is useful for saving an inference ready checkpoint while training
-                 using a higher precision.
+                 Enables calibration with the default configuration.
+    calibration_config: QuantizationCalibrationConfig, default = None
+                 Custom configuration for collecting checkpointable quantization scaling
+                 factors. Providing a config also enables calibration.
     recipe: recipe.Recipe, default = None
             recipe used for low precision quantization.
     amax_reduction_group: torch._C._distributed_c10d.ProcessGroup, default = None
@@ -1668,6 +1670,7 @@ def make_graphed_callables(
                 recipe=recipe,
                 amax_reduction_group=amax_reduction_group,
                 _graph=True,
+                calibration_config=calibration_config,
             ):
                 outputs = old_call_funcs[block_cls](self, *args, **kwargs)
             return outputs

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -63,7 +63,7 @@ def _update_scale_buffers(
     for buffer_name, scale in scale_updates.items():
         if scale is None:
             continue
-        if buffer_name.startswith("input"):
+        if activation_scale_decay > 0.0:
             observed_scale = scale.detach().float()
             scale_buffer = scale_buffers.get(buffer_name)
             if scale_buffer is not None and scale_buffer.shape != observed_scale.shape:
@@ -71,10 +71,6 @@ def _update_scale_buffers(
                     "Quantized scaling-factor buffer shape changed from "
                     f"{tuple(scale_buffer.shape)} to {tuple(observed_scale.shape)}"
                 )
-            if activation_scale_decay == 0.0:
-                # If not using scale decay, just buffer the current scaling.
-                scale_buffers[buffer_name] = observed_scale
-                continue
             if scale_buffer is None:
                 # Initialize the rolling activation scaling factor.
                 # Requires CUDA graph warmup step.
@@ -89,8 +85,8 @@ def _update_scale_buffers(
                 out=scale_buffer,
             )
         else:
-            # Keep a reference to the current weight metadata without
-            # allocating or copying a separate buffer.
+            # Without scale history, keep a reference to the current metadata
+            # without allocating or copying a separate buffer.
             # Requires CUDA graph warmup step.
             scale_buffers[buffer_name] = scale.detach()
 

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -6,14 +6,79 @@
 
 import dataclasses
 import queue
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 
 from .. import cpp_extensions as tex
 from ..constants import TE_DType
 from ..export import is_in_onnx_export_mode
+from ..tensor.utils import get_quantization_recipe_name
 from ..utils import get_default_init_method
+
+
+def _get_scale_buffer_info(
+    tensor_name: str,
+    tensor: Any,
+    quantizer: Any,
+) -> Optional[Tuple[str, Optional[torch.Tensor]]]:
+    """Get the calibration buffer name and value for a quantized tensor."""
+    recipe = get_quantization_recipe_name(quantizer)
+    if not recipe:
+        return None
+    if recipe == "fp8_current_scaling":
+        metadata_name = "scale_inv"
+        metadata = getattr(tensor, "_scale_inv", None)
+    else:
+        metadata_name = "amax_rowwise"
+        metadata = getattr(
+            tensor,
+            "_amax_rowwise",
+            getattr(quantizer, "amax", None),
+        )
+    buffer_name = f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
+    return buffer_name, metadata
+
+
+def _update_scale_buffers(
+    scale_buffers: Dict[str, Optional[torch.Tensor]],
+    scale_updates: Dict[str, Optional[torch.Tensor]],
+    activation_scale_decay: float = 0.0,
+) -> None:
+    """Merge observed scaling factors into checkpoint buffers."""
+    for buffer_name, scale in scale_updates.items():
+        if scale is None:
+            continue
+        if buffer_name.startswith("input"):
+            observed_scale = scale.detach().float()
+            scale_buffer = scale_buffers.get(buffer_name)
+            if scale_buffer is not None and scale_buffer.shape != observed_scale.shape:
+                raise RuntimeError(
+                    "Quantized scaling-factor buffer shape changed from "
+                    f"{tuple(scale_buffer.shape)} to {tuple(observed_scale.shape)}"
+                )
+            if activation_scale_decay == 0.0:
+                # If not using scale decay, just buffer the current scaling.
+                scale_buffers[buffer_name] = observed_scale
+                continue
+            if scale_buffer is None:
+                # Initialize the rolling activation scaling factor.
+                # Requires CUDA graph warmup step.
+                scale_buffer = torch.zeros_like(observed_scale)
+                scale_buffers[buffer_name] = scale_buffer
+            # Track a decaying maximum so early-training activation
+            # outliers do not permanently determine the inference scale.
+            scale_buffer.mul_(activation_scale_decay)
+            torch.maximum(
+                scale_buffer,
+                observed_scale,
+                out=scale_buffer,
+            )
+        else:
+            # Keep a reference to the current weight metadata without
+            # allocating or copying a separate buffer.
+            # Requires CUDA graph warmup step.
+            scale_buffers[buffer_name] = scale.detach()
 
 
 def set_quantizer_amax_reduction_group(quantizer, amax_reduction_group) -> None:

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -26,16 +26,30 @@ def _get_scale_buffer_info(
     recipe = get_quantization_recipe_name(quantizer)
     if not recipe:
         return None
-    if recipe == "fp8_current_scaling":
+
+    if recipe == "fp8_delayed_scaling":
+        metadata_name = "amax"
+        metadata = getattr(quantizer, "amax", None)
+    elif recipe == "fp8_current_scaling":
         metadata_name = "scale_inv"
         metadata = getattr(tensor, "_scale_inv", None)
-    else:
+    elif recipe == "nvfp4":
+        metadata_name = "amax"
+        metadata = getattr(tensor, "_amax_rowwise", None)
+    elif recipe == "nvfp4_rowwise":
         metadata_name = "amax_rowwise"
-        metadata = getattr(
-            tensor,
-            "_amax_rowwise",
-            getattr(quantizer, "amax", None),
-        )
+        metadata = getattr(tensor, "_amax_rowwise", None)
+    elif recipe == "mxfp8":
+        # MXFP8 only exposes blockwise E8M0-encoded inverse scales, not a
+        # global FP32 scaling factor suitable for PTQ checkpoint export.
+        return None
+    elif recipe == "fp8_block_scaling":
+        # FP8 block scaling only exposes blockwise inverse scales, not a
+        # global FP32 scaling factor suitable for PTQ checkpoint export.
+        return None
+    else:
+        raise ValueError(f"Unsupported quantization recipe {recipe!r}")
+
     buffer_name = f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
     return buffer_name, metadata
 

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -31,6 +31,17 @@ def _supports_calibration_decay(quantizer_type: type) -> bool:
     )
 
 
+def _is_in_activation_recompute_phase() -> bool:
+    """Whether a forward is running during activation recomputation."""
+    from ..distributed import in_fp8_activation_recompute_phase
+
+    if in_fp8_activation_recompute_phase():
+        return True
+    # Special hidden PyTorch AutoGrad identifier for activation recompute.
+    current_graph_task_id = getattr(torch._C, "_current_graph_task_id", None)
+    return current_graph_task_id is not None and current_graph_task_id() != -1
+
+
 def _resolve_calibration_quantizer(tensor: Any, quantizer: Any) -> Any:
     """Get the quantizer that owns calibration state for a tensor."""
     quantizer = getattr(tensor, "_quantizer", None) or quantizer

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -5,6 +5,8 @@
 """Internal function used by multiple modules."""
 
 import dataclasses
+import functools
+import inspect
 import queue
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -17,13 +19,27 @@ from ..tensor.hybrid_tensor import HybridQuantizer
 from ..utils import get_default_init_method
 
 
+@functools.lru_cache(maxsize=None)
+def _supports_calibration_decay(quantizer_type: type) -> bool:
+    """Whether a quantizer's calibrate override accepts calibration_decay."""
+    try:
+        parameters = inspect.signature(quantizer_type.calibrate).parameters
+    except (TypeError, ValueError):
+        return False
+    return "calibration_decay" in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+
+
 def _resolve_calibration_quantizer(tensor: Any, quantizer: Any) -> Any:
     """Get the quantizer that owns calibration state for a tensor."""
     quantizer = getattr(tensor, "_quantizer", None) or quantizer
     return getattr(quantizer, "parent_quantizer", quantizer)
 
 
-def _get_scale_buffer_info(tensor_name: str, quantizer: Any) -> Dict[str, torch.Tensor]:
+def _get_calibration_metadata_buffers(
+    tensor_name: str, quantizer: Any
+) -> Dict[str, torch.Tensor]:
     """Get checkpoint-buffer aliases from quantizer calibration state."""
     if quantizer is None:
         return {}
@@ -33,7 +49,7 @@ def _get_scale_buffer_info(tensor_name: str, quantizer: Any) -> Dict[str, torch.
     return {
         # Standard naming for PTQ calibration data.
         f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated": value
-        for metadata_name, value in getattr(quantizer, "_calibration_state", {}).items()
+        for metadata_name, value in quantizer._calibration_state.items()
     }
 
 

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -37,9 +37,7 @@ def _resolve_calibration_quantizer(tensor: Any, quantizer: Any) -> Any:
     return getattr(quantizer, "parent_quantizer", quantizer)
 
 
-def _get_calibration_metadata_buffers(
-    tensor_name: str, quantizer: Any
-) -> Dict[str, torch.Tensor]:
+def _get_calibration_metadata_buffers(tensor_name: str, quantizer: Any) -> Dict[str, torch.Tensor]:
     """Get checkpoint-buffer aliases from quantizer calibration state."""
     if quantizer is None:
         return {}

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -14,83 +14,27 @@ from .. import cpp_extensions as tex
 from ..constants import TE_DType
 from ..export import is_in_onnx_export_mode
 from ..tensor.hybrid_tensor import HybridQuantizer
-from ..tensor.utils import get_quantization_recipe_name
 from ..utils import get_default_init_method
 
 
-def _get_scale_buffer_info(
-    tensor_name: str,
-    tensor: Any,
-    quantizer: Any,
-) -> Optional[Tuple[str, Optional[torch.Tensor]]]:
-    """Get the calibration buffer name and value for a quantized tensor."""
-    recipe = get_quantization_recipe_name(quantizer)
+def _resolve_calibration_quantizer(tensor: Any, quantizer: Any) -> Any:
+    """Get the quantizer that owns calibration state for a tensor."""
+    quantizer = getattr(tensor, "_quantizer", None) or quantizer
+    return getattr(quantizer, "parent_quantizer", quantizer)
+
+
+def _get_scale_buffer_info(tensor_name: str, quantizer: Any) -> Dict[str, torch.Tensor]:
+    """Get checkpoint-buffer aliases from quantizer calibration state."""
+    if quantizer is None:
+        return {}
+    recipe = quantizer.get_quantization_recipe_name()
     if not recipe:
-        return None
-
-    if recipe == "fp8_delayed_scaling":
-        metadata_name = "amax"
-        metadata = getattr(quantizer, "amax", None)
-    elif recipe == "fp8_current_scaling":
-        metadata_name = "scale_inv"
-        metadata = getattr(tensor, "_scale_inv", None)
-    elif recipe == "nvfp4":
-        metadata_name = "amax"
-        metadata = getattr(tensor, "_amax_rowwise", None)
-    elif recipe == "nvfp4_rowwise":
-        metadata_name = "amax_rowwise"
-        metadata = getattr(tensor, "_amax_rowwise", None)
-    elif recipe == "mxfp8":
-        # MXFP8 only exposes blockwise E8M0-encoded inverse scales, not a
-        # global FP32 scaling factor suitable for PTQ checkpoint export.
-        return None
-    elif recipe == "fp8_block_scaling":
-        # FP8 block scaling only exposes blockwise inverse scales, not a
-        # global FP32 scaling factor suitable for PTQ checkpoint export.
-        return None
-    else:
-        raise ValueError(f"Unsupported quantization recipe {recipe!r}")
-
-    buffer_name = f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
-    return buffer_name, metadata
-
-
-def _update_scale_buffers(
-    scale_buffers: Dict[str, Optional[torch.Tensor]],
-    scale_updates: Dict[str, Optional[torch.Tensor]],
-    activation_scale_decay: float = 0.0,
-) -> None:
-    """Merge observed scaling factors into checkpoint buffers."""
-    for buffer_name, scale in scale_updates.items():
-        if scale is None or torch.isnan(scale).any():
-            # Un-initialized scale. Ignore it.
-            continue
-        if activation_scale_decay > 0.0:
-            observed_scale = scale.detach().float()
-            scale_buffer = scale_buffers.get(buffer_name)
-            if scale_buffer is not None and scale_buffer.shape != observed_scale.shape:
-                raise RuntimeError(
-                    "Quantized scaling-factor buffer shape changed from "
-                    f"{tuple(scale_buffer.shape)} to {tuple(observed_scale.shape)}"
-                )
-            if scale_buffer is None:
-                # Initialize the rolling activation scaling factor.
-                # Requires CUDA graph warmup step.
-                scale_buffer = torch.zeros_like(observed_scale)
-                scale_buffers[buffer_name] = scale_buffer
-            # Track a decaying maximum so early-training activation
-            # outliers do not permanently determine the inference scale.
-            scale_buffer.mul_(activation_scale_decay)
-            torch.maximum(
-                scale_buffer,
-                observed_scale,
-                out=scale_buffer,
-            )
-        else:
-            # Without scale history, keep a reference to the current metadata
-            # without allocating or copying a separate buffer.
-            # Requires CUDA graph warmup step.
-            scale_buffers[buffer_name] = scale.detach()
+        return {}
+    return {
+        # Standard naming for PTQ calibration data.
+        f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated": value
+        for metadata_name, value in getattr(quantizer, "_calibration_state", {}).items()
+    }
 
 
 def set_quantizer_amax_reduction_group(quantizer, amax_reduction_group) -> None:

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -62,7 +62,8 @@ def _update_scale_buffers(
 ) -> None:
     """Merge observed scaling factors into checkpoint buffers."""
     for buffer_name, scale in scale_updates.items():
-        if scale is None:
+        if scale is None or torch.isnan(scale).any():
+            # Un-initialized scale. Ignore it.
             continue
         if activation_scale_decay > 0.0:
             observed_scale = scale.detach().float()

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -64,7 +64,7 @@ def _update_scale_buffers(
     for buffer_name, scale in scale_updates.items():
         if scale is None:
             continue
-        if buffer_name.startswith("input"):
+        if activation_scale_decay > 0.0:
             observed_scale = scale.detach().float()
             scale_buffer = scale_buffers.get(buffer_name)
             if scale_buffer is not None and scale_buffer.shape != observed_scale.shape:
@@ -72,10 +72,6 @@ def _update_scale_buffers(
                     "Quantized scaling-factor buffer shape changed from "
                     f"{tuple(scale_buffer.shape)} to {tuple(observed_scale.shape)}"
                 )
-            if activation_scale_decay == 0.0:
-                # If not using scale decay, just buffer the current scaling.
-                scale_buffers[buffer_name] = observed_scale
-                continue
             if scale_buffer is None:
                 # Initialize the rolling activation scaling factor.
                 # Requires CUDA graph warmup step.
@@ -90,8 +86,8 @@ def _update_scale_buffers(
                 out=scale_buffer,
             )
         else:
-            # Keep a reference to the current weight metadata without
-            # allocating or copying a separate buffer.
+            # Without scale history, keep a reference to the current metadata
+            # without allocating or copying a separate buffer.
             # Requires CUDA graph warmup step.
             scale_buffers[buffer_name] = scale.detach()
 

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -27,16 +27,30 @@ def _get_scale_buffer_info(
     recipe = get_quantization_recipe_name(quantizer)
     if not recipe:
         return None
-    if recipe == "fp8_current_scaling":
+
+    if recipe == "fp8_delayed_scaling":
+        metadata_name = "amax"
+        metadata = getattr(quantizer, "amax", None)
+    elif recipe == "fp8_current_scaling":
         metadata_name = "scale_inv"
         metadata = getattr(tensor, "_scale_inv", None)
-    else:
+    elif recipe == "nvfp4":
+        metadata_name = "amax"
+        metadata = getattr(tensor, "_amax_rowwise", None)
+    elif recipe == "nvfp4_rowwise":
         metadata_name = "amax_rowwise"
-        metadata = getattr(
-            tensor,
-            "_amax_rowwise",
-            getattr(quantizer, "amax", None),
-        )
+        metadata = getattr(tensor, "_amax_rowwise", None)
+    elif recipe == "mxfp8":
+        # MXFP8 only exposes blockwise E8M0-encoded inverse scales, not a
+        # global FP32 scaling factor suitable for PTQ checkpoint export.
+        return None
+    elif recipe == "fp8_block_scaling":
+        # FP8 block scaling only exposes blockwise inverse scales, not a
+        # global FP32 scaling factor suitable for PTQ checkpoint export.
+        return None
+    else:
+        raise ValueError(f"Unsupported quantization recipe {recipe!r}")
+
     buffer_name = f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
     return buffer_name, metadata
 

--- a/transformer_engine/pytorch/module/_common.py
+++ b/transformer_engine/pytorch/module/_common.py
@@ -6,7 +6,7 @@
 
 import dataclasses
 import queue
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -14,7 +14,72 @@ from .. import cpp_extensions as tex
 from ..constants import TE_DType
 from ..export import is_in_onnx_export_mode
 from ..tensor.hybrid_tensor import HybridQuantizer
+from ..tensor.utils import get_quantization_recipe_name
 from ..utils import get_default_init_method
+
+
+def _get_scale_buffer_info(
+    tensor_name: str,
+    tensor: Any,
+    quantizer: Any,
+) -> Optional[Tuple[str, Optional[torch.Tensor]]]:
+    """Get the calibration buffer name and value for a quantized tensor."""
+    recipe = get_quantization_recipe_name(quantizer)
+    if not recipe:
+        return None
+    if recipe == "fp8_current_scaling":
+        metadata_name = "scale_inv"
+        metadata = getattr(tensor, "_scale_inv", None)
+    else:
+        metadata_name = "amax_rowwise"
+        metadata = getattr(
+            tensor,
+            "_amax_rowwise",
+            getattr(quantizer, "amax", None),
+        )
+    buffer_name = f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"
+    return buffer_name, metadata
+
+
+def _update_scale_buffers(
+    scale_buffers: Dict[str, Optional[torch.Tensor]],
+    scale_updates: Dict[str, Optional[torch.Tensor]],
+    activation_scale_decay: float = 0.0,
+) -> None:
+    """Merge observed scaling factors into checkpoint buffers."""
+    for buffer_name, scale in scale_updates.items():
+        if scale is None:
+            continue
+        if buffer_name.startswith("input"):
+            observed_scale = scale.detach().float()
+            scale_buffer = scale_buffers.get(buffer_name)
+            if scale_buffer is not None and scale_buffer.shape != observed_scale.shape:
+                raise RuntimeError(
+                    "Quantized scaling-factor buffer shape changed from "
+                    f"{tuple(scale_buffer.shape)} to {tuple(observed_scale.shape)}"
+                )
+            if activation_scale_decay == 0.0:
+                # If not using scale decay, just buffer the current scaling.
+                scale_buffers[buffer_name] = observed_scale
+                continue
+            if scale_buffer is None:
+                # Initialize the rolling activation scaling factor.
+                # Requires CUDA graph warmup step.
+                scale_buffer = torch.zeros_like(observed_scale)
+                scale_buffers[buffer_name] = scale_buffer
+            # Track a decaying maximum so early-training activation
+            # outliers do not permanently determine the inference scale.
+            scale_buffer.mul_(activation_scale_decay)
+            torch.maximum(
+                scale_buffer,
+                observed_scale,
+                out=scale_buffer,
+            )
+        else:
+            # Keep a reference to the current weight metadata without
+            # allocating or copying a separate buffer.
+            # Requires CUDA graph warmup step.
+            scale_buffers[buffer_name] = scale.detach()
 
 
 def set_quantizer_amax_reduction_group(quantizer, amax_reduction_group) -> None:

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -4,7 +4,7 @@
 
 """GroupedLinear API"""
 
-from typing import Union, Optional, Callable, Tuple, List
+from typing import Union, Optional, Callable, Tuple, List, Dict
 from itertools import chain
 import os
 import warnings
@@ -31,7 +31,7 @@ from .base import (
     _clear_high_precision_init_val,
     _get_high_precision_init_val,
 )
-from ._common import WeightGradStore
+from ._common import _get_scale_buffer_info, _update_scale_buffers, WeightGradStore
 from ..quantization import FP8GlobalStateManager, QuantizerRole
 from ..utils import (
     divide,
@@ -81,6 +81,29 @@ from ...debug.pytorch.debug_quantization import DebugQuantizer
 from ...debug.pytorch.debug_state import TEDebugState
 
 __all__ = ["GroupedLinear"]
+
+
+def _update_grouped_scale_buffers(
+    scale_buffers: Dict[str, Optional[torch.Tensor]],
+    input_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
+    weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
+    input_quantizer: Optional[Quantizer],
+    weight_quantizer: Optional[Quantizer],
+    activation_scale_decay: float,
+) -> None:
+    """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
+    scale_updates = {}
+    for index, tensor in enumerate(input_tensors):
+        scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizer)
+        if scale_buffer is not None:
+            scale_updates[scale_buffer[0]] = scale_buffer[1]
+    for index, tensor in enumerate(weight_tensors):
+        scale_buffer = _get_scale_buffer_info(
+            f"weight_gemm{index}", tensor, weight_quantizer
+        )
+        if scale_buffer is not None:
+            scale_updates[scale_buffer[0]] = scale_buffer[1]
+    _update_scale_buffers(scale_buffers, scale_updates, activation_scale_decay)
 
 
 class _GroupedLinear(torch.autograd.Function):
@@ -326,6 +349,8 @@ class _GroupedLinear(torch.autograd.Function):
         weight_workspaces: List[Optional[QuantizedTensorStorage]],
         cache_weight: bool,
         skip_fp8_weight_update: Optional[torch.Tensor],
+        scale_buffers: Optional[Dict[str, Optional[torch.Tensor]]],
+        quantized_scaling_factor_buffering_decay: float,
         weights: Tuple[torch.Tensor, ...],
         biases: Tuple[torch.Tensor, ...],
         out: Optional[torch.Tensor] = None,
@@ -413,6 +438,19 @@ class _GroupedLinear(torch.autograd.Function):
             bias=grouped_bias,
             use_split_accumulator=use_split_accumulator,
         )
+
+        if scale_buffers is not None:
+            grouped_inputs = grouped_x.quantized_tensors
+            if grouped_inputs is None:
+                grouped_inputs = grouped_x.split_into_quantized_tensors()
+            _update_grouped_scale_buffers(
+                scale_buffers,
+                grouped_inputs,
+                weights_for_gemm,
+                input_quantizers[0],
+                weight_quantizers[0],
+                quantized_scaling_factor_buffering_decay,
+            )
 
         if is_grad_enabled:
             if weight_requires_grad:
@@ -517,6 +555,8 @@ class _GroupedLinear(torch.autograd.Function):
             skip_fp8_weight_update,
             save_original_input,
             debug,
+            scale_buffers,
+            quantized_scaling_factor_buffering_decay,
         ) = non_tensor_args
         if fp8:
             backward_override = FP8GlobalStateManager.get_fp8_recipe().backward_override
@@ -623,6 +663,10 @@ class _GroupedLinear(torch.autograd.Function):
                 weight_workspaces=weight_workspaces,
                 cache_weight=cache_weight,
                 skip_fp8_weight_update=skip_fp8_weight_update,
+                scale_buffers=scale_buffers,
+                quantized_scaling_factor_buffering_decay=(
+                    quantized_scaling_factor_buffering_decay
+                ),
                 weights=weights,
                 biases=biases,
                 out=out,
@@ -674,6 +718,16 @@ class _GroupedLinear(torch.autograd.Function):
 
         else:
             weights_fp8 = [cast_if_needed(weight, activation_dtype) for weight in weights]
+
+        if scale_buffers is not None:
+            _update_grouped_scale_buffers(
+                scale_buffers,
+                inputmats,
+                weights_fp8,
+                input_quantizers[0],
+                weight_quantizers[0],
+                quantized_scaling_factor_buffering_decay,
+            )
 
         # Initialize biases
         bias_dtype = activation_dtype
@@ -1370,6 +1424,10 @@ class GroupedLinear(TransformerEngineBaseModule):
                        cast tensor. In some scenarios, the input tensor is used by multiple modules,
                        and saving the original input tensor may reduce the memory usage.
                        Cannot work with FP8 DelayedScaling recipe.
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent input and weight quantization
+                       metadata buffers for inference checkpoint export. Buffers store metadata
+                       per grouped GEMM, using inverse scales directly for FP8 current scaling.
     single_grouped_weight : bool, default = False
                        If set to ``True``, grouped weights are stored as a single grouped parameter
                        instead of one parameter per GEMM.
@@ -1415,6 +1473,8 @@ class GroupedLinear(TransformerEngineBaseModule):
         single_grouped_weight: bool = False,
         single_grouped_bias: bool = False,
         name: Optional[str] = None,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1430,6 +1490,10 @@ class GroupedLinear(TransformerEngineBaseModule):
         self.ub_overlap_ag = ub_overlap_ag
         self.ub_name = ub_name
         self.save_original_input = save_original_input
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = (
+            quantized_scaling_factor_buffering_decay
+        )
         single_grouped_weight, single_grouped_bias = resolve_grouped_linear_single_param_flags(
             single_grouped_weight, single_grouped_bias
         )
@@ -1946,6 +2010,13 @@ class GroupedLinear(TransformerEngineBaseModule):
                 if cache_weight
                 else [None] * num_gemms
             )
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
 
             non_tensor_args = (
                 self.apply_bias,
@@ -1969,6 +2040,8 @@ class GroupedLinear(TransformerEngineBaseModule):
                 skip_fp8_weight_update,
                 self.save_original_input,
                 debug,
+                scale_buffers,
+                self.quantized_scaling_factor_buffering_decay,
             )
             out, new_workspaces = linear_fn(
                 *autograd_ctx,
@@ -1980,6 +2053,16 @@ class GroupedLinear(TransformerEngineBaseModule):
                 *weight_tensors,
                 *bias_tensors,
             )
+
+            if scale_buffers is not None:
+                # Assign scaling-factor calibration buffers to the model.
+                # Materializing a new buffer requires a CUDA graph warmup step.
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if cache_weight:
                 for i, ws in enumerate(new_workspaces):

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -92,16 +92,26 @@ def _update_grouped_scale_buffers(
     activation_scale_decay: float,
 ) -> None:
     """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
-    scale_updates = {}
+    activation_scale_updates = {}
     for index, tensor in enumerate(input_tensors):
         scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizer)
         if scale_buffer is not None:
-            scale_updates[scale_buffer[0]] = scale_buffer[1]
+            activation_scale_updates[scale_buffer[0]] = scale_buffer[1]
+    weight_scale_updates = {}
     for index, tensor in enumerate(weight_tensors):
         scale_buffer = _get_scale_buffer_info(f"weight_gemm{index}", tensor, weight_quantizer)
         if scale_buffer is not None:
-            scale_updates[scale_buffer[0]] = scale_buffer[1]
-    _update_scale_buffers(scale_buffers, scale_updates, activation_scale_decay)
+            weight_scale_updates[scale_buffer[0]] = scale_buffer[1]
+    _update_scale_buffers(
+        scale_buffers,
+        activation_scale_updates,
+        activation_scale_decay,
+    )
+    _update_scale_buffers(
+        scale_buffers,
+        weight_scale_updates,
+        activation_scale_decay=0.0,
+    )
 
 
 class _GroupedLinear(torch.autograd.Function):

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -98,9 +98,7 @@ def _update_grouped_scale_buffers(
         if scale_buffer is not None:
             scale_updates[scale_buffer[0]] = scale_buffer[1]
     for index, tensor in enumerate(weight_tensors):
-        scale_buffer = _get_scale_buffer_info(
-            f"weight_gemm{index}", tensor, weight_quantizer
-        )
+        scale_buffer = _get_scale_buffer_info(f"weight_gemm{index}", tensor, weight_quantizer)
         if scale_buffer is not None:
             scale_updates[scale_buffer[0]] = scale_buffer[1]
     _update_scale_buffers(scale_buffers, scale_updates, activation_scale_decay)
@@ -664,9 +662,7 @@ class _GroupedLinear(torch.autograd.Function):
                 cache_weight=cache_weight,
                 skip_fp8_weight_update=skip_fp8_weight_update,
                 scale_buffers=scale_buffers,
-                quantized_scaling_factor_buffering_decay=(
-                    quantized_scaling_factor_buffering_decay
-                ),
+                quantized_scaling_factor_buffering_decay=(quantized_scaling_factor_buffering_decay),
                 weights=weights,
                 biases=biases,
                 out=out,
@@ -1491,9 +1487,7 @@ class GroupedLinear(TransformerEngineBaseModule):
         self.ub_name = ub_name
         self.save_original_input = save_original_input
         self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = (
-            quantized_scaling_factor_buffering_decay
-        )
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
         single_grouped_weight, single_grouped_bias = resolve_grouped_linear_single_param_flags(
             single_grouped_weight, single_grouped_bias
         )

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -166,16 +166,26 @@ def _update_grouped_scale_buffers(
     activation_scale_decay: float,
 ) -> None:
     """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
-    scale_updates = {}
+    activation_scale_updates = {}
     for index, tensor in enumerate(input_tensors):
         scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizer)
         if scale_buffer is not None:
-            scale_updates[scale_buffer[0]] = scale_buffer[1]
+            activation_scale_updates[scale_buffer[0]] = scale_buffer[1]
+    weight_scale_updates = {}
     for index, tensor in enumerate(weight_tensors):
         scale_buffer = _get_scale_buffer_info(f"weight_gemm{index}", tensor, weight_quantizer)
         if scale_buffer is not None:
-            scale_updates[scale_buffer[0]] = scale_buffer[1]
-    _update_scale_buffers(scale_buffers, scale_updates, activation_scale_decay)
+            weight_scale_updates[scale_buffer[0]] = scale_buffer[1]
+    _update_scale_buffers(
+        scale_buffers,
+        activation_scale_updates,
+        activation_scale_decay,
+    )
+    _update_scale_buffers(
+        scale_buffers,
+        weight_scale_updates,
+        activation_scale_decay=0.0,
+    )
 
 
 class _GroupedLinear(torch.autograd.Function):

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -33,6 +33,7 @@ from .base import (
 )
 from ._common import (
     _get_calibration_metadata_buffers,
+    _is_in_activation_recompute_phase,
     _resolve_calibration_quantizer,
     _supports_calibration_decay,
     can_reconstruct_wgrad_input_from_original,
@@ -588,7 +589,7 @@ class _GroupedLinear(torch.autograd.Function):
             use_split_accumulator=use_split_accumulator,
         )
 
-        if calibration_buffers is not None:
+        if calibration_buffers is not None and not _is_in_activation_recompute_phase():
             grouped_inputs = grouped_x.quantized_tensors
             if grouped_inputs is None:
                 grouped_inputs = grouped_x.split_into_quantized_tensors()
@@ -937,7 +938,7 @@ class _GroupedLinear(torch.autograd.Function):
             weights_fp8 = [cast_if_needed(weight, activation_dtype) for weight in weights]
 
         # Calibrate quantizers and buffer their metadata when requested.
-        if calibration_buffers is not None:
+        if calibration_buffers is not None and not _is_in_activation_recompute_phase():
             _calibrate_grouped_tensors(
                 inputmats,
                 weights_fp8,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -172,9 +172,7 @@ def _update_grouped_scale_buffers(
         if scale_buffer is not None:
             scale_updates[scale_buffer[0]] = scale_buffer[1]
     for index, tensor in enumerate(weight_tensors):
-        scale_buffer = _get_scale_buffer_info(
-            f"weight_gemm{index}", tensor, weight_quantizer
-        )
+        scale_buffer = _get_scale_buffer_info(f"weight_gemm{index}", tensor, weight_quantizer)
         if scale_buffer is not None:
             scale_updates[scale_buffer[0]] = scale_buffer[1]
     _update_scale_buffers(scale_buffers, scale_updates, activation_scale_decay)
@@ -855,9 +853,7 @@ class _GroupedLinear(torch.autograd.Function):
                 single_grouped_weight=single_grouped_weight,
                 single_grouped_bias=single_grouped_bias,
                 scale_buffers=scale_buffers,
-                quantized_scaling_factor_buffering_decay=(
-                    quantized_scaling_factor_buffering_decay
-                ),
+                quantized_scaling_factor_buffering_decay=(quantized_scaling_factor_buffering_decay),
                 weights=weights,
                 biases=biases,
                 out=out,
@@ -1742,9 +1738,7 @@ class GroupedLinear(TransformerEngineBaseModule):
             )
         self.use_grouped_tensor = use_grouped_tensor
         self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = (
-            quantized_scaling_factor_buffering_decay
-        )
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
         single_grouped_weight, single_grouped_bias = resolve_grouped_linear_single_param_flags(
             single_grouped_weight, single_grouped_bias
         )

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -168,9 +168,7 @@ def _update_grouped_scale_buffers(
     """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
     activation_scale_updates = {}
     for index, tensor in enumerate(input_tensors):
-        scale_buffer = _get_scale_buffer_info(
-            f"input_gemm{index}", tensor, input_quantizers[index]
-        )
+        scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizers[index])
         if scale_buffer is not None:
             activation_scale_updates[scale_buffer[0]] = scale_buffer[1]
     weight_scale_updates = {}

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -33,7 +33,7 @@ from .base import (
 )
 from ._common import (
     _get_scale_buffer_info,
-    _update_scale_buffers,
+    _resolve_calibration_quantizer,
     can_reconstruct_wgrad_input_from_original,
     WeightGradStore,
 )
@@ -163,31 +163,38 @@ def _update_grouped_scale_buffers(
     weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
     input_quantizers: List[Optional[Quantizer]],
     weight_quantizers: List[Optional[Quantizer]],
-    activation_scale_decay: float,
 ) -> None:
-    """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
+    """Update GroupedLinear PTQ buffers from per-GEMM calibration state."""
     activation_scale_updates = {}
     for index, tensor in enumerate(input_tensors):
-        scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizers[index])
-        if scale_buffer is not None:
-            activation_scale_updates[scale_buffer[0]] = scale_buffer[1]
+        quantizer = _resolve_calibration_quantizer(tensor, input_quantizers[index])
+        activation_scale_updates.update(_get_scale_buffer_info(f"input_gemm{index}", quantizer))
     weight_scale_updates = {}
     for index, tensor in enumerate(weight_tensors):
-        scale_buffer = _get_scale_buffer_info(
-            f"weight_gemm{index}", tensor, weight_quantizers[index]
+        quantizer = _resolve_calibration_quantizer(tensor, weight_quantizers[index])
+        weight_scale_updates.update(
+            _get_scale_buffer_info(f"weight_gemm{index}", quantizer)
         )
-        if scale_buffer is not None:
-            weight_scale_updates[scale_buffer[0]] = scale_buffer[1]
-    _update_scale_buffers(
-        scale_buffers,
-        activation_scale_updates,
-        activation_scale_decay,
-    )
-    _update_scale_buffers(
-        scale_buffers,
-        weight_scale_updates,
-        activation_scale_decay=0.0,
-    )
+    scale_buffers.update(activation_scale_updates)
+    scale_buffers.update(weight_scale_updates)
+
+
+def _calibrate_grouped_tensors(
+    input_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
+    weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
+    input_quantizers: List[Optional[Quantizer]],
+    weight_quantizers: List[Optional[Quantizer]],
+    activation_scale_decay: float,
+) -> None:
+    """Calibrate GroupedLinear input and weight quantizers once per GEMM."""
+    for tensor, quantizer in zip(input_tensors, input_quantizers):
+        quantizer = _resolve_calibration_quantizer(tensor, quantizer)
+        if quantizer is not None:
+            quantizer.calibrate(tensor, decay=activation_scale_decay)
+    for tensor, quantizer in zip(weight_tensors, weight_quantizers):
+        quantizer = _resolve_calibration_quantizer(tensor, quantizer)
+        if quantizer is not None:
+            quantizer.calibrate(tensor)
 
 
 class _GroupedLinear(torch.autograd.Function):
@@ -586,13 +593,19 @@ class _GroupedLinear(torch.autograd.Function):
                     grouped_weights = weights_for_gemm.split_into_quantized_tensors()
             else:
                 grouped_weights = weights_for_gemm
+            _calibrate_grouped_tensors(
+                grouped_inputs,
+                grouped_weights,
+                input_quantizers,
+                weight_quantizers,
+                quantized_scaling_factor_buffering_decay,
+            )
             _update_grouped_scale_buffers(
                 scale_buffers,
                 grouped_inputs,
                 grouped_weights,
                 input_quantizers,
                 weight_quantizers,
-                quantized_scaling_factor_buffering_decay,
             )
 
         if is_grad_enabled:
@@ -919,13 +932,22 @@ class _GroupedLinear(torch.autograd.Function):
             weights_fp8 = [cast_if_needed(weight, activation_dtype) for weight in weights]
 
         if scale_buffers is not None:
+            _calibrate_grouped_tensors(
+                inputmats,
+                weights_fp8,
+                input_quantizers,
+                weight_quantizers,
+                quantized_scaling_factor_buffering_decay,
+            )
+
+        # Buffer scaling metadata only when requested.
+        if scale_buffers is not None:
             _update_grouped_scale_buffers(
                 scale_buffers,
                 inputmats,
                 weights_fp8,
                 input_quantizers,
                 weight_quantizers,
-                quantized_scaling_factor_buffering_decay,
             )
 
         # Initialize biases
@@ -962,11 +984,6 @@ class _GroupedLinear(torch.autograd.Function):
             use_bias=use_bias,
             use_split_accumulator=use_split_accumulator,
         )
-
-        if fp8_calibration:
-            for i in range(num_gemms):
-                input_quantizers[i].calibrate(inputmats[i])
-                weight_quantizers[i].calibrate(weights[i])
 
         if cpu_offloading:
             mark_not_offload(*weights_fp8, *weights)
@@ -1663,10 +1680,6 @@ class GroupedLinear(TransformerEngineBaseModule):
                        and saving the original input tensor may reduce the memory usage.
                        Requires input quantizers that can safely reproduce their results from the
                        original input. Cannot work with FP8 DelayedScaling recipe.
-    buffer_quantized_scaling_factors : bool, default = False
-                       If set to ``True``, maintain nonpersistent input and weight quantization
-                       metadata buffers for inference checkpoint export. Buffers store metadata
-                       per grouped GEMM, using inverse scales directly for FP8 current scaling.
     single_grouped_weight : bool, default = False
                        If set to ``True``, grouped weights are stored as a single grouped parameter
                        instead of one parameter per GEMM.
@@ -1720,8 +1733,6 @@ class GroupedLinear(TransformerEngineBaseModule):
         single_grouped_bias: bool = False,
         name: Optional[str] = None,
         use_grouped_tensor: Optional[bool] = None,
-        buffer_quantized_scaling_factors: bool = False,
-        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1755,8 +1766,6 @@ class GroupedLinear(TransformerEngineBaseModule):
                 f"use_grouped_tensor must be a bool or None, got {type(use_grouped_tensor)}."
             )
         self.use_grouped_tensor = use_grouped_tensor
-        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
         single_grouped_weight, single_grouped_bias = resolve_grouped_linear_single_param_flags(
             single_grouped_weight, single_grouped_bias
         )
@@ -2353,8 +2362,9 @@ class GroupedLinear(TransformerEngineBaseModule):
                     if cache_weight
                     else [None] * num_gemms
                 )
+            calibration_config = FP8GlobalStateManager.get_calibration_config()
             scale_buffers = None
-            if self.buffer_quantized_scaling_factors:
+            if calibration_config is not None:
                 scale_buffers = {
                     name: value
                     for name, value in self._buffers.items()
@@ -2387,7 +2397,11 @@ class GroupedLinear(TransformerEngineBaseModule):
                 use_grouped_bias,
                 self.use_grouped_tensor,
                 scale_buffers,
-                self.quantized_scaling_factor_buffering_decay,
+                (
+                    calibration_config.activation_scale_decay
+                    if calibration_config is not None
+                    else 0.0
+                ),
             )
             out, new_workspaces = linear_fn(
                 *autograd_ctx,

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -32,8 +32,9 @@ from .base import (
     _get_high_precision_init_val,
 )
 from ._common import (
-    _get_scale_buffer_info,
+    _get_calibration_metadata_buffers,
     _resolve_calibration_quantizer,
+    _supports_calibration_decay,
     can_reconstruct_wgrad_input_from_original,
     WeightGradStore,
 )
@@ -157,24 +158,24 @@ def is_module_grouped_tensor_path_supported(
     return False
 
 
-def _update_grouped_scale_buffers(
-    scale_buffers: Dict[str, Optional[torch.Tensor]],
+def _update_grouped_calibration_metadata_buffers(
+    calibration_buffers: Dict[str, Optional[torch.Tensor]],
     input_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
     weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
     input_quantizers: List[Optional[Quantizer]],
     weight_quantizers: List[Optional[Quantizer]],
 ) -> None:
     """Update GroupedLinear PTQ buffers from per-GEMM calibration state."""
-    activation_scale_updates = {}
     for index, tensor in enumerate(input_tensors):
         quantizer = _resolve_calibration_quantizer(tensor, input_quantizers[index])
-        activation_scale_updates.update(_get_scale_buffer_info(f"input_gemm{index}", quantizer))
-    weight_scale_updates = {}
+        calibration_buffers.update(
+            _get_calibration_metadata_buffers(f"input_gemm{index}", quantizer)
+        )
     for index, tensor in enumerate(weight_tensors):
         quantizer = _resolve_calibration_quantizer(tensor, weight_quantizers[index])
-        weight_scale_updates.update(_get_scale_buffer_info(f"weight_gemm{index}", quantizer))
-    scale_buffers.update(activation_scale_updates)
-    scale_buffers.update(weight_scale_updates)
+        calibration_buffers.update(
+            _get_calibration_metadata_buffers(f"weight_gemm{index}", quantizer)
+        )
 
 
 def _calibrate_grouped_tensors(
@@ -182,13 +183,19 @@ def _calibrate_grouped_tensors(
     weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
     input_quantizers: List[Optional[Quantizer]],
     weight_quantizers: List[Optional[Quantizer]],
-    activation_scale_decay: float,
+    transformer_engine_calibration_decay: float,
 ) -> None:
     """Calibrate GroupedLinear input and weight quantizers once per GEMM."""
     for tensor, quantizer in zip(input_tensors, input_quantizers):
         quantizer = _resolve_calibration_quantizer(tensor, quantizer)
         if quantizer is not None:
-            quantizer.calibrate(tensor, decay=activation_scale_decay)
+            if _supports_calibration_decay(type(quantizer)):
+                quantizer.calibrate(
+                    tensor,
+                    calibration_decay=transformer_engine_calibration_decay,
+                )
+            else:
+                quantizer.calibrate(tensor)
     for tensor, quantizer in zip(weight_tensors, weight_quantizers):
         quantizer = _resolve_calibration_quantizer(tensor, quantizer)
         if quantizer is not None:
@@ -471,8 +478,8 @@ class _GroupedLinear(torch.autograd.Function):
         save_original_input: bool,
         single_grouped_weight: bool,
         single_grouped_bias: bool,
-        scale_buffers: Optional[Dict[str, Optional[torch.Tensor]]],
-        quantized_scaling_factor_buffering_decay: float,
+        calibration_buffers: Optional[Dict[str, Optional[torch.Tensor]]],
+        transformer_engine_calibration_decay: float,
         weights: Tuple[torch.Tensor, ...],
         biases: Tuple[torch.Tensor, ...],
         out: Optional[torch.Tensor] = None,
@@ -581,7 +588,7 @@ class _GroupedLinear(torch.autograd.Function):
             use_split_accumulator=use_split_accumulator,
         )
 
-        if scale_buffers is not None:
+        if calibration_buffers is not None:
             grouped_inputs = grouped_x.quantized_tensors
             if grouped_inputs is None:
                 grouped_inputs = grouped_x.split_into_quantized_tensors()
@@ -596,10 +603,10 @@ class _GroupedLinear(torch.autograd.Function):
                 grouped_weights,
                 input_quantizers,
                 weight_quantizers,
-                quantized_scaling_factor_buffering_decay,
+                transformer_engine_calibration_decay,
             )
-            _update_grouped_scale_buffers(
-                scale_buffers,
+            _update_grouped_calibration_metadata_buffers(
+                calibration_buffers,
                 grouped_inputs,
                 grouped_weights,
                 input_quantizers,
@@ -727,8 +734,8 @@ class _GroupedLinear(torch.autograd.Function):
             single_grouped_weight,
             single_grouped_bias,
             use_grouped_tensor,
-            scale_buffers,
-            quantized_scaling_factor_buffering_decay,
+            calibration_buffers,
+            transformer_engine_calibration_decay,
         ) = non_tensor_args
         recipe = FP8GlobalStateManager.get_fp8_recipe() if fp8 else None
         backward_override = recipe.backward_override if recipe is not None else None
@@ -881,8 +888,8 @@ class _GroupedLinear(torch.autograd.Function):
                 save_original_input=save_original_input,
                 single_grouped_weight=single_grouped_weight,
                 single_grouped_bias=single_grouped_bias,
-                scale_buffers=scale_buffers,
-                quantized_scaling_factor_buffering_decay=(quantized_scaling_factor_buffering_decay),
+                calibration_buffers=calibration_buffers,
+                transformer_engine_calibration_decay=transformer_engine_calibration_decay,
                 weights=weights,
                 biases=biases,
                 out=out,
@@ -929,19 +936,17 @@ class _GroupedLinear(torch.autograd.Function):
         else:
             weights_fp8 = [cast_if_needed(weight, activation_dtype) for weight in weights]
 
-        if scale_buffers is not None:
+        # Calibrate quantizers and buffer their metadata when requested.
+        if calibration_buffers is not None:
             _calibrate_grouped_tensors(
                 inputmats,
                 weights_fp8,
                 input_quantizers,
                 weight_quantizers,
-                quantized_scaling_factor_buffering_decay,
+                transformer_engine_calibration_decay,
             )
-
-        # Buffer scaling metadata only when requested.
-        if scale_buffers is not None:
-            _update_grouped_scale_buffers(
-                scale_buffers,
+            _update_grouped_calibration_metadata_buffers(
+                calibration_buffers,
                 inputmats,
                 weights_fp8,
                 input_quantizers,
@@ -2361,9 +2366,9 @@ class GroupedLinear(TransformerEngineBaseModule):
                     else [None] * num_gemms
                 )
             calibration_config = FP8GlobalStateManager.get_calibration_config()
-            scale_buffers = None
+            calibration_buffers = None
             if calibration_config is not None:
-                scale_buffers = {
+                calibration_buffers = {
                     name: value
                     for name, value in self._buffers.items()
                     if name.endswith("_te_ptq_calibrated")
@@ -2394,9 +2399,9 @@ class GroupedLinear(TransformerEngineBaseModule):
                 self.single_grouped_weight,
                 use_grouped_bias,
                 self.use_grouped_tensor,
-                scale_buffers,
+                calibration_buffers,
                 (
-                    calibration_config.activation_scale_decay
+                    calibration_config.transformer_engine_calibration_decay
                     if calibration_config is not None
                     else 0.0
                 ),
@@ -2412,10 +2417,10 @@ class GroupedLinear(TransformerEngineBaseModule):
                 *bias_tensors,
             )
 
-            if scale_buffers is not None:
+            if calibration_buffers is not None:
                 # Assign scaling-factor calibration buffers to the model.
                 # Materializing a new buffer requires a CUDA graph warmup step.
-                for name, value in scale_buffers.items():
+                for name, value in calibration_buffers.items():
                     if value is not None:
                         if name in self._buffers:
                             setattr(self, name, value)

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -161,19 +161,23 @@ def _update_grouped_scale_buffers(
     scale_buffers: Dict[str, Optional[torch.Tensor]],
     input_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
     weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
-    input_quantizer: Optional[Quantizer],
-    weight_quantizer: Optional[Quantizer],
+    input_quantizers: List[Optional[Quantizer]],
+    weight_quantizers: List[Optional[Quantizer]],
     activation_scale_decay: float,
 ) -> None:
     """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
     activation_scale_updates = {}
     for index, tensor in enumerate(input_tensors):
-        scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizer)
+        scale_buffer = _get_scale_buffer_info(
+            f"input_gemm{index}", tensor, input_quantizers[index]
+        )
         if scale_buffer is not None:
             activation_scale_updates[scale_buffer[0]] = scale_buffer[1]
     weight_scale_updates = {}
     for index, tensor in enumerate(weight_tensors):
-        scale_buffer = _get_scale_buffer_info(f"weight_gemm{index}", tensor, weight_quantizer)
+        scale_buffer = _get_scale_buffer_info(
+            f"weight_gemm{index}", tensor, weight_quantizers[index]
+        )
         if scale_buffer is not None:
             weight_scale_updates[scale_buffer[0]] = scale_buffer[1]
     _update_scale_buffers(
@@ -578,12 +582,18 @@ class _GroupedLinear(torch.autograd.Function):
             grouped_inputs = grouped_x.quantized_tensors
             if grouped_inputs is None:
                 grouped_inputs = grouped_x.split_into_quantized_tensors()
+            if isinstance(weights_for_gemm, GroupedTensorStorage):
+                grouped_weights = weights_for_gemm.quantized_tensors
+                if grouped_weights is None:
+                    grouped_weights = weights_for_gemm.split_into_quantized_tensors()
+            else:
+                grouped_weights = weights_for_gemm
             _update_grouped_scale_buffers(
                 scale_buffers,
                 grouped_inputs,
-                weights_for_gemm,
-                input_quantizers[0],
-                weight_quantizers[0],
+                grouped_weights,
+                input_quantizers,
+                weight_quantizers,
                 quantized_scaling_factor_buffering_decay,
             )
 
@@ -915,8 +925,8 @@ class _GroupedLinear(torch.autograd.Function):
                 scale_buffers,
                 inputmats,
                 weights_fp8,
-                input_quantizers[0],
-                weight_quantizers[0],
+                input_quantizers,
+                weight_quantizers,
                 quantized_scaling_factor_buffering_decay,
             )
 

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -4,7 +4,7 @@
 
 """GroupedLinear API"""
 
-from typing import Union, Optional, Callable, Tuple, List
+from typing import Union, Optional, Callable, Tuple, List, Dict
 from itertools import chain
 import os
 import warnings
@@ -31,7 +31,12 @@ from .base import (
     _clear_high_precision_init_val,
     _get_high_precision_init_val,
 )
-from ._common import can_reconstruct_wgrad_input_from_original, WeightGradStore
+from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
+    can_reconstruct_wgrad_input_from_original,
+    WeightGradStore,
+)
 from . import _split_quantization
 from ..quantization import FP8GlobalStateManager, QuantizerRole
 from ..utils import (
@@ -150,6 +155,29 @@ def is_module_grouped_tensor_path_supported(
             and not recipe.row_scaled_activation
         )
     return False
+
+
+def _update_grouped_scale_buffers(
+    scale_buffers: Dict[str, Optional[torch.Tensor]],
+    input_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
+    weight_tensors: List[Union[torch.Tensor, QuantizedTensorStorage]],
+    input_quantizer: Optional[Quantizer],
+    weight_quantizer: Optional[Quantizer],
+    activation_scale_decay: float,
+) -> None:
+    """Update GroupedLinear PTQ calibration buffers with per-GEMM metadata."""
+    scale_updates = {}
+    for index, tensor in enumerate(input_tensors):
+        scale_buffer = _get_scale_buffer_info(f"input_gemm{index}", tensor, input_quantizer)
+        if scale_buffer is not None:
+            scale_updates[scale_buffer[0]] = scale_buffer[1]
+    for index, tensor in enumerate(weight_tensors):
+        scale_buffer = _get_scale_buffer_info(
+            f"weight_gemm{index}", tensor, weight_quantizer
+        )
+        if scale_buffer is not None:
+            scale_updates[scale_buffer[0]] = scale_buffer[1]
+    _update_scale_buffers(scale_buffers, scale_updates, activation_scale_decay)
 
 
 class _GroupedLinear(torch.autograd.Function):
@@ -428,6 +456,8 @@ class _GroupedLinear(torch.autograd.Function):
         save_original_input: bool,
         single_grouped_weight: bool,
         single_grouped_bias: bool,
+        scale_buffers: Optional[Dict[str, Optional[torch.Tensor]]],
+        quantized_scaling_factor_buffering_decay: float,
         weights: Tuple[torch.Tensor, ...],
         biases: Tuple[torch.Tensor, ...],
         out: Optional[torch.Tensor] = None,
@@ -535,6 +565,19 @@ class _GroupedLinear(torch.autograd.Function):
             bias=grouped_bias,
             use_split_accumulator=use_split_accumulator,
         )
+
+        if scale_buffers is not None:
+            grouped_inputs = grouped_x.quantized_tensors
+            if grouped_inputs is None:
+                grouped_inputs = grouped_x.split_into_quantized_tensors()
+            _update_grouped_scale_buffers(
+                scale_buffers,
+                grouped_inputs,
+                weights_for_gemm,
+                input_quantizers[0],
+                weight_quantizers[0],
+                quantized_scaling_factor_buffering_decay,
+            )
 
         if is_grad_enabled:
             input_to_save = grouped_x
@@ -657,6 +700,8 @@ class _GroupedLinear(torch.autograd.Function):
             single_grouped_weight,
             single_grouped_bias,
             use_grouped_tensor,
+            scale_buffers,
+            quantized_scaling_factor_buffering_decay,
         ) = non_tensor_args
         recipe = FP8GlobalStateManager.get_fp8_recipe() if fp8 else None
         backward_override = recipe.backward_override if recipe is not None else None
@@ -809,6 +854,10 @@ class _GroupedLinear(torch.autograd.Function):
                 save_original_input=save_original_input,
                 single_grouped_weight=single_grouped_weight,
                 single_grouped_bias=single_grouped_bias,
+                scale_buffers=scale_buffers,
+                quantized_scaling_factor_buffering_decay=(
+                    quantized_scaling_factor_buffering_decay
+                ),
                 weights=weights,
                 biases=biases,
                 out=out,
@@ -854,6 +903,16 @@ class _GroupedLinear(torch.autograd.Function):
 
         else:
             weights_fp8 = [cast_if_needed(weight, activation_dtype) for weight in weights]
+
+        if scale_buffers is not None:
+            _update_grouped_scale_buffers(
+                scale_buffers,
+                inputmats,
+                weights_fp8,
+                input_quantizers[0],
+                weight_quantizers[0],
+                quantized_scaling_factor_buffering_decay,
+            )
 
         # Initialize biases
         bias_dtype = activation_dtype
@@ -1590,6 +1649,10 @@ class GroupedLinear(TransformerEngineBaseModule):
                        and saving the original input tensor may reduce the memory usage.
                        Requires input quantizers that can safely reproduce their results from the
                        original input. Cannot work with FP8 DelayedScaling recipe.
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent input and weight quantization
+                       metadata buffers for inference checkpoint export. Buffers store metadata
+                       per grouped GEMM, using inverse scales directly for FP8 current scaling.
     single_grouped_weight : bool, default = False
                        If set to ``True``, grouped weights are stored as a single grouped parameter
                        instead of one parameter per GEMM.
@@ -1643,6 +1706,8 @@ class GroupedLinear(TransformerEngineBaseModule):
         single_grouped_bias: bool = False,
         name: Optional[str] = None,
         use_grouped_tensor: Optional[bool] = None,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1676,6 +1741,10 @@ class GroupedLinear(TransformerEngineBaseModule):
                 f"use_grouped_tensor must be a bool or None, got {type(use_grouped_tensor)}."
             )
         self.use_grouped_tensor = use_grouped_tensor
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = (
+            quantized_scaling_factor_buffering_decay
+        )
         single_grouped_weight, single_grouped_bias = resolve_grouped_linear_single_param_flags(
             single_grouped_weight, single_grouped_bias
         )
@@ -2272,6 +2341,13 @@ class GroupedLinear(TransformerEngineBaseModule):
                     if cache_weight
                     else [None] * num_gemms
                 )
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
 
             non_tensor_args = (
                 self.apply_bias,
@@ -2298,6 +2374,8 @@ class GroupedLinear(TransformerEngineBaseModule):
                 self.single_grouped_weight,
                 use_grouped_bias,
                 self.use_grouped_tensor,
+                scale_buffers,
+                self.quantized_scaling_factor_buffering_decay,
             )
             out, new_workspaces = linear_fn(
                 *autograd_ctx,
@@ -2309,6 +2387,16 @@ class GroupedLinear(TransformerEngineBaseModule):
                 *weight_tensors,
                 *bias_tensors,
             )
+
+            if scale_buffers is not None:
+                # Assign scaling-factor calibration buffers to the model.
+                # Materializing a new buffer requires a CUDA graph warmup step.
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if cache_weight:
                 for i, ws in enumerate(new_workspaces):

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -172,9 +172,7 @@ def _update_grouped_scale_buffers(
     weight_scale_updates = {}
     for index, tensor in enumerate(weight_tensors):
         quantizer = _resolve_calibration_quantizer(tensor, weight_quantizers[index])
-        weight_scale_updates.update(
-            _get_scale_buffer_info(f"weight_gemm{index}", quantizer)
-        )
+        weight_scale_updates.update(_get_scale_buffer_info(f"weight_gemm{index}", quantizer))
     scale_buffers.update(activation_scale_updates)
     scale_buffers.update(weight_scale_updates)
 

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -2592,7 +2592,8 @@ class GroupedLinear(TransformerEngineBaseModule):
             [None] * self.num_gemms,
             [None] * self.num_gemms,
         )
-        if self.fp8:
+        # Calibration-only mode needs quantizers to observe non-quantized tensors.
+        if self.fp8 or self.fp8_calibration:
             input_quantizers = [
                 self.quantizers["scaling_fwd"][
                     self._offsets["input"] + i * self._num_fp8_tensors_per_gemm["fwd"]

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -385,14 +385,10 @@ class _LayerNormLinear(torch.autograd.Function):
 
         if scale_buffers is not None:
             scale_updates = {}
-            input_scale_buffer = _get_scale_buffer_info(
-                "input", ln_out_total, input_quantizer
-            )
+            input_scale_buffer = _get_scale_buffer_info("input", ln_out_total, input_quantizer)
             if input_scale_buffer is not None:
                 scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
-            weight_scale_buffer = _get_scale_buffer_info(
-                "weight", weightmat, weight_quantizer
-            )
+            weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
             if weight_scale_buffer is not None:
                 scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
             _update_scale_buffers(
@@ -1630,9 +1626,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                     param.skip_backward_post_hook = True
 
         self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = (
-            quantized_scaling_factor_buffering_decay
-        )
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
 
     def set_meta_tensor(self, fwd: bool, recipe: Recipe) -> None:
         """Init scales and amaxes for fwd | bwd."""

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -384,18 +384,20 @@ class _LayerNormLinear(torch.autograd.Function):
                 weight_quantizer.calibrate(weight)
 
         if scale_buffers is not None:
-            scale_updates = {}
             input_scale_buffer = _get_scale_buffer_info("input", ln_out_total, input_quantizer)
             if input_scale_buffer is not None:
-                scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+                _update_scale_buffers(
+                    scale_buffers,
+                    {input_scale_buffer[0]: input_scale_buffer[1]},
+                    quantized_scaling_factor_buffering_decay,
+                )
             weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
             if weight_scale_buffer is not None:
-                scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
-            _update_scale_buffers(
-                scale_buffers,
-                scale_updates,
-                quantized_scaling_factor_buffering_decay,
-            )
+                _update_scale_buffers(
+                    scale_buffers,
+                    {weight_scale_buffer[0]: weight_scale_buffer[1]},
+                    activation_scale_decay=0.0,
+                )
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -17,7 +17,10 @@ import transformer_engine_torch as tex
 
 from transformer_engine.common.recipe import Recipe
 from transformer_engine.pytorch.torch_version import torch_version
-from transformer_engine.pytorch.tensor.utils import clear_columnwise_cache, is_custom
+from transformer_engine.pytorch.tensor.utils import (
+    clear_columnwise_cache,
+    is_custom,
+)
 from .base import (
     fill_userbuffers_buffer_for_all_gather,
     get_ub,
@@ -66,6 +69,8 @@ from ..constants import FP8BwdTensorIdx, FP8FwdTensorIdx, GemmParallelModes, dis
 from ..jit import no_torch_dynamo
 from ..graph import is_graph_capturing
 from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
     apply_normalization,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -157,6 +162,8 @@ class _LayerNormLinear(torch.autograd.Function):
             symmetric_ar_type,
             debug,
             is_fsdp2,
+            quantized_scaling_factor_buffering_decay,
+            scale_buffers,
         ) = non_tensor_args
         if fp8:
             backward_override = FP8GlobalStateManager.get_fp8_recipe().backward_override
@@ -375,6 +382,24 @@ class _LayerNormLinear(torch.autograd.Function):
                 input_quantizer.calibrate(ln_out_total)
             if weight_quantizer is not None:
                 weight_quantizer.calibrate(weight)
+
+        if scale_buffers is not None:
+            scale_updates = {}
+            input_scale_buffer = _get_scale_buffer_info(
+                "input", ln_out_total, input_quantizer
+            )
+            if input_scale_buffer is not None:
+                scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+            weight_scale_buffer = _get_scale_buffer_info(
+                "weight", weightmat, weight_quantizer
+            )
+            if weight_scale_buffer is not None:
+                scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
+            _update_scale_buffers(
+                scale_buffers,
+                scale_updates,
+                quantized_scaling_factor_buffering_decay,
+            )
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP
@@ -1299,6 +1324,15 @@ class LayerNormLinear(TransformerEngineBaseModule):
                    This can help in latency bound communication situations.
                    Requires PyTorch version 2.7.0 or higher. When set to ``None``, standard all-reduce
                    is used.
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent input and weight quantization
+                       metadata buffers for inference checkpoint export. Per-tensor buffers
+                       store raw global amaxes, except FP8 current scaling buffers, which store
+                       inverse scales directly.
+    quantized_scaling_factor_buffering_decay : float, default = 0.0
+                       Decay applied to buffered activation scaling factors before incorporating
+                       each new observation. Defaults to 0.0, in which case only the most recent
+                       scaling factor is buffered.
     """
 
     def __init__(
@@ -1331,6 +1365,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         name: Optional[str] = None,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1593,6 +1629,11 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 if name in self.weight_names or name in self.bias_names:
                     param.skip_backward_post_hook = True
 
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = (
+            quantized_scaling_factor_buffering_decay
+        )
+
     def set_meta_tensor(self, fwd: bool, recipe: Recipe) -> None:
         """Init scales and amaxes for fwd | bwd."""
         super().set_meta_tensor(fwd, recipe)
@@ -1763,6 +1804,14 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self._fp8_workspaces.get(cache_name) if cache_name is not None else None
             )
 
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
+
             non_tensor_args = (
                 self.eps,
                 is_first_microbatch,
@@ -1803,6 +1852,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.symmetric_ar_type,
                 debug,
                 self.is_fsdp2,
+                self.quantized_scaling_factor_buffering_decay,
+                scale_buffers,
             )
             out, ln_out, new_weight_workspace = fwd_fn(
                 *autograd_ctx,
@@ -1814,6 +1865,14 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 bias_tensor if self.apply_bias and not self.gemm_bias_unfused_add else None,
                 non_tensor_args,
             )
+
+            if scale_buffers is not None:
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if new_weight_workspace is not None and cache_name is not None:
                 if isinstance(new_weight_workspace, torch.Tensor):

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -17,7 +17,10 @@ import transformer_engine_torch as tex
 
 from transformer_engine.common.recipe import Recipe
 from transformer_engine.pytorch.torch_version import torch_version
-from transformer_engine.pytorch.tensor.utils import clear_columnwise_cache, is_custom
+from transformer_engine.pytorch.tensor.utils import (
+    clear_columnwise_cache,
+    is_custom,
+)
 from .base import (
     fill_userbuffers_buffer_for_all_gather,
     get_ub,
@@ -66,6 +69,8 @@ from ..constants import FP8BwdTensorIdx, FP8FwdTensorIdx, GemmParallelModes, dis
 from ..jit import no_torch_dynamo
 from ..graph import is_graph_capturing
 from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
     apply_normalization,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -160,6 +165,8 @@ class _LayerNormLinear(torch.autograd.Function):
             symmetric_ar_type,
             debug,
             is_fsdp2,
+            quantized_scaling_factor_buffering_decay,
+            scale_buffers,
         ) = non_tensor_args
         if fp8:
             backward_override = FP8GlobalStateManager.get_fp8_recipe().backward_override
@@ -382,6 +389,24 @@ class _LayerNormLinear(torch.autograd.Function):
                 input_quantizer.calibrate(ln_out_total)
             if weight_quantizer is not None:
                 weight_quantizer.calibrate(weight)
+
+        if scale_buffers is not None:
+            scale_updates = {}
+            input_scale_buffer = _get_scale_buffer_info(
+                "input", ln_out_total, input_quantizer
+            )
+            if input_scale_buffer is not None:
+                scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+            weight_scale_buffer = _get_scale_buffer_info(
+                "weight", weightmat, weight_quantizer
+            )
+            if weight_scale_buffer is not None:
+                scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
+            _update_scale_buffers(
+                scale_buffers,
+                scale_updates,
+                quantized_scaling_factor_buffering_decay,
+            )
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP
@@ -1301,6 +1326,15 @@ class LayerNormLinear(TransformerEngineBaseModule):
                    This can help in latency bound communication situations.
                    Requires PyTorch version 2.7.0 or higher. When set to ``None``, standard all-reduce
                    is used.
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent input and weight quantization
+                       metadata buffers for inference checkpoint export. Per-tensor buffers
+                       store raw global amaxes, except FP8 current scaling buffers, which store
+                       inverse scales directly.
+    quantized_scaling_factor_buffering_decay : float, default = 0.0
+                       Decay applied to buffered activation scaling factors before incorporating
+                       each new observation. Defaults to 0.0, in which case only the most recent
+                       scaling factor is buffered.
     """
 
     def __init__(
@@ -1333,6 +1367,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         name: Optional[str] = None,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1595,6 +1631,11 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 if name in self.weight_names or name in self.bias_names:
                     param.skip_backward_post_hook = True
 
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = (
+            quantized_scaling_factor_buffering_decay
+        )
+
     def set_meta_tensor(self, fwd: bool, recipe: Recipe) -> None:
         """Init scales and amaxes for fwd | bwd."""
         super().set_meta_tensor(fwd, recipe)
@@ -1765,6 +1806,14 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self._fp8_workspaces.get(cache_name) if cache_name is not None else None
             )
 
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
+
             non_tensor_args = (
                 self.eps,
                 is_first_microbatch,
@@ -1805,6 +1854,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.symmetric_ar_type,
                 debug,
                 self.is_fsdp2,
+                self.quantized_scaling_factor_buffering_decay,
+                scale_buffers,
             )
             out, ln_out, new_weight_workspace = fwd_fn(
                 *autograd_ctx,
@@ -1816,6 +1867,14 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 bias_tensor if self.apply_bias and not self.gemm_bias_unfused_add else None,
                 non_tensor_args,
             )
+
+            if scale_buffers is not None:
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if new_weight_workspace is not None and cache_name is not None:
                 if isinstance(new_weight_workspace, torch.Tensor):

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -391,18 +391,20 @@ class _LayerNormLinear(torch.autograd.Function):
                 weight_quantizer.calibrate(weight)
 
         if scale_buffers is not None:
-            scale_updates = {}
             input_scale_buffer = _get_scale_buffer_info("input", ln_out_total, input_quantizer)
             if input_scale_buffer is not None:
-                scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+                _update_scale_buffers(
+                    scale_buffers,
+                    {input_scale_buffer[0]: input_scale_buffer[1]},
+                    quantized_scaling_factor_buffering_decay,
+                )
             weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
             if weight_scale_buffer is not None:
-                scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
-            _update_scale_buffers(
-                scale_buffers,
-                scale_updates,
-                quantized_scaling_factor_buffering_decay,
-            )
+                _update_scale_buffers(
+                    scale_buffers,
+                    {weight_scale_buffer[0]: weight_scale_buffer[1]},
+                    activation_scale_decay=0.0,
+                )
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -69,8 +69,9 @@ from ..constants import FP8BwdTensorIdx, FP8FwdTensorIdx, GemmParallelModes, dis
 from ..jit import no_torch_dynamo
 from ..graph import is_graph_capturing
 from ._common import (
-    _get_scale_buffer_info,
+    _get_calibration_metadata_buffers,
     _resolve_calibration_quantizer,
+    _supports_calibration_decay,
     apply_normalization,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -165,8 +166,8 @@ class _LayerNormLinear(torch.autograd.Function):
             symmetric_ar_type,
             debug,
             is_fsdp2,
-            quantized_scaling_factor_buffering_decay,
-            scale_buffers,
+            transformer_engine_calibration_decay,
+            calibration_buffers,
         ) = non_tensor_args
         if fp8:
             backward_override = FP8GlobalStateManager.get_fp8_recipe().backward_override
@@ -386,20 +387,24 @@ class _LayerNormLinear(torch.autograd.Function):
         input_calibration_quantizer = _resolve_calibration_quantizer(ln_out_total, input_quantizer)
         weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
-        # Calibrate quantizers if needed.
-        if scale_buffers is not None:
+        # Calibrate quantizers and buffer their metadata when requested.
+        if calibration_buffers is not None:
             if input_calibration_quantizer is not None:
-                input_calibration_quantizer.calibrate(
-                    ln_out_total,
-                    decay=quantized_scaling_factor_buffering_decay,
-                )
+                if _supports_calibration_decay(type(input_calibration_quantizer)):
+                    input_calibration_quantizer.calibrate(
+                        ln_out_total,
+                        calibration_decay=transformer_engine_calibration_decay,
+                    )
+                else:
+                    input_calibration_quantizer.calibrate(ln_out_total)
             if weight_calibration_quantizer is not None:
                 weight_calibration_quantizer.calibrate(weightmat)
-
-        # Buffer scaling metadata only when requested.
-        if scale_buffers is not None:
-            scale_buffers.update(_get_scale_buffer_info("input", input_calibration_quantizer))
-            scale_buffers.update(_get_scale_buffer_info("weight", weight_calibration_quantizer))
+            calibration_buffers.update(
+                _get_calibration_metadata_buffers("input", input_calibration_quantizer)
+            )
+            calibration_buffers.update(
+                _get_calibration_metadata_buffers("weight", weight_calibration_quantizer)
+            )
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP
@@ -1784,9 +1789,9 @@ class LayerNormLinear(TransformerEngineBaseModule):
             )
 
             calibration_config = FP8GlobalStateManager.get_calibration_config()
-            scale_buffers = None
+            calibration_buffers = None
             if calibration_config is not None:
-                scale_buffers = {
+                calibration_buffers = {
                     name: value
                     for name, value in self._buffers.items()
                     if name.endswith("_te_ptq_calibrated")
@@ -1833,11 +1838,11 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 debug,
                 self.is_fsdp2,
                 (
-                    calibration_config.activation_scale_decay
+                    calibration_config.transformer_engine_calibration_decay
                     if calibration_config is not None
                     else 0.0
                 ),
-                scale_buffers,
+                calibration_buffers,
             )
             out, ln_out, new_weight_workspace = fwd_fn(
                 *autograd_ctx,
@@ -1850,8 +1855,8 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 non_tensor_args,
             )
 
-            if scale_buffers is not None:
-                for name, value in scale_buffers.items():
+            if calibration_buffers is not None:
+                for name, value in calibration_buffers.items():
                     if value is not None:
                         if name in self._buffers:
                             setattr(self, name, value)

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -392,14 +392,10 @@ class _LayerNormLinear(torch.autograd.Function):
 
         if scale_buffers is not None:
             scale_updates = {}
-            input_scale_buffer = _get_scale_buffer_info(
-                "input", ln_out_total, input_quantizer
-            )
+            input_scale_buffer = _get_scale_buffer_info("input", ln_out_total, input_quantizer)
             if input_scale_buffer is not None:
                 scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
-            weight_scale_buffer = _get_scale_buffer_info(
-                "weight", weightmat, weight_quantizer
-            )
+            weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
             if weight_scale_buffer is not None:
                 scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
             _update_scale_buffers(
@@ -1632,9 +1628,7 @@ class LayerNormLinear(TransformerEngineBaseModule):
                     param.skip_backward_post_hook = True
 
         self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = (
-            quantized_scaling_factor_buffering_decay
-        )
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
 
     def set_meta_tensor(self, fwd: bool, recipe: Recipe) -> None:
         """Init scales and amaxes for fwd | bwd."""

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -70,7 +70,7 @@ from ..jit import no_torch_dynamo
 from ..graph import is_graph_capturing
 from ._common import (
     _get_scale_buffer_info,
-    _update_scale_buffers,
+    _resolve_calibration_quantizer,
     apply_normalization,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -383,28 +383,31 @@ class _LayerNormLinear(torch.autograd.Function):
             bias_dtype = torch.bfloat16
         bias = cast_if_needed(bias, bias_dtype) if bias is not None else bias
 
-        # Calibrate quantizers if needed
-        if not fp8 and fp8_calibration:
-            if input_quantizer is not None:
-                input_quantizer.calibrate(ln_out_total)
-            if weight_quantizer is not None:
-                weight_quantizer.calibrate(weight)
+        input_calibration_quantizer = _resolve_calibration_quantizer(
+            ln_out_total, input_quantizer
+        )
+        weight_calibration_quantizer = _resolve_calibration_quantizer(
+            weightmat, weight_quantizer
+        )
 
+        # Calibrate quantizers if needed.
         if scale_buffers is not None:
-            input_scale_buffer = _get_scale_buffer_info("input", ln_out_total, input_quantizer)
-            if input_scale_buffer is not None:
-                _update_scale_buffers(
-                    scale_buffers,
-                    {input_scale_buffer[0]: input_scale_buffer[1]},
-                    quantized_scaling_factor_buffering_decay,
+            if input_calibration_quantizer is not None:
+                input_calibration_quantizer.calibrate(
+                    ln_out_total,
+                    decay=quantized_scaling_factor_buffering_decay,
                 )
-            weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
-            if weight_scale_buffer is not None:
-                _update_scale_buffers(
-                    scale_buffers,
-                    {weight_scale_buffer[0]: weight_scale_buffer[1]},
-                    activation_scale_decay=0.0,
-                )
+            if weight_calibration_quantizer is not None:
+                weight_calibration_quantizer.calibrate(weightmat)
+
+        # Buffer scaling metadata only when requested.
+        if scale_buffers is not None:
+            scale_buffers.update(
+                _get_scale_buffer_info("input", input_calibration_quantizer)
+            )
+            scale_buffers.update(
+                _get_scale_buffer_info("weight", weight_calibration_quantizer)
+            )
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP
@@ -1324,15 +1327,6 @@ class LayerNormLinear(TransformerEngineBaseModule):
                    This can help in latency bound communication situations.
                    Requires PyTorch version 2.7.0 or higher. When set to ``None``, standard all-reduce
                    is used.
-    buffer_quantized_scaling_factors : bool, default = False
-                       If set to ``True``, maintain nonpersistent input and weight quantization
-                       metadata buffers for inference checkpoint export. Per-tensor buffers
-                       store raw global amaxes, except FP8 current scaling buffers, which store
-                       inverse scales directly.
-    quantized_scaling_factor_buffering_decay : float, default = 0.0
-                       Decay applied to buffered activation scaling factors before incorporating
-                       each new observation. Defaults to 0.0, in which case only the most recent
-                       scaling factor is buffered.
     """
 
     def __init__(
@@ -1365,8 +1359,6 @@ class LayerNormLinear(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         name: Optional[str] = None,
-        buffer_quantized_scaling_factors: bool = False,
-        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1629,9 +1621,6 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 if name in self.weight_names or name in self.bias_names:
                     param.skip_backward_post_hook = True
 
-        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
-
     def set_meta_tensor(self, fwd: bool, recipe: Recipe) -> None:
         """Init scales and amaxes for fwd | bwd."""
         super().set_meta_tensor(fwd, recipe)
@@ -1802,8 +1791,9 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self._fp8_workspaces.get(cache_name) if cache_name is not None else None
             )
 
+            calibration_config = FP8GlobalStateManager.get_calibration_config()
             scale_buffers = None
-            if self.buffer_quantized_scaling_factors:
+            if calibration_config is not None:
                 scale_buffers = {
                     name: value
                     for name, value in self._buffers.items()
@@ -1850,7 +1840,11 @@ class LayerNormLinear(TransformerEngineBaseModule):
                 self.symmetric_ar_type,
                 debug,
                 self.is_fsdp2,
-                self.quantized_scaling_factor_buffering_decay,
+                (
+                    calibration_config.activation_scale_decay
+                    if calibration_config is not None
+                    else 0.0
+                ),
                 scale_buffers,
             )
             out, ln_out, new_weight_workspace = fwd_fn(

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -70,6 +70,7 @@ from ..jit import no_torch_dynamo
 from ..graph import is_graph_capturing
 from ._common import (
     _get_calibration_metadata_buffers,
+    _is_in_activation_recompute_phase,
     _resolve_calibration_quantizer,
     _supports_calibration_decay,
     apply_normalization,
@@ -130,7 +131,7 @@ class _LayerNormLinear(torch.autograd.Function):
             eps,
             is_first_microbatch,
             fp8,
-            fp8_calibration,
+            _fp8_calibration,
             wgrad_store,
             fuse_wgrad_accumulation,
             input_quantizer,
@@ -388,7 +389,7 @@ class _LayerNormLinear(torch.autograd.Function):
         weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
         # Calibrate quantizers and buffer their metadata when requested.
-        if calibration_buffers is not None:
+        if calibration_buffers is not None and not _is_in_activation_recompute_phase():
             if input_calibration_quantizer is not None:
                 if _supports_calibration_decay(type(input_calibration_quantizer)):
                     input_calibration_quantizer.calibrate(

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -383,12 +383,8 @@ class _LayerNormLinear(torch.autograd.Function):
             bias_dtype = torch.bfloat16
         bias = cast_if_needed(bias, bias_dtype) if bias is not None else bias
 
-        input_calibration_quantizer = _resolve_calibration_quantizer(
-            ln_out_total, input_quantizer
-        )
-        weight_calibration_quantizer = _resolve_calibration_quantizer(
-            weightmat, weight_quantizer
-        )
+        input_calibration_quantizer = _resolve_calibration_quantizer(ln_out_total, input_quantizer)
+        weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
         # Calibrate quantizers if needed.
         if scale_buffers is not None:
@@ -402,12 +398,8 @@ class _LayerNormLinear(torch.autograd.Function):
 
         # Buffer scaling metadata only when requested.
         if scale_buffers is not None:
-            scale_buffers.update(
-                _get_scale_buffer_info("input", input_calibration_quantizer)
-            )
-            scale_buffers.update(
-                _get_scale_buffer_info("weight", weight_calibration_quantizer)
-            )
+            scale_buffers.update(_get_scale_buffer_info("input", input_calibration_quantizer))
+            scale_buffers.update(_get_scale_buffer_info("weight", weight_calibration_quantizer))
 
         # Choose whether to use GEMM kernel with split accumulator
         use_split_accumulator = _2X_ACC_FPROP

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -1884,10 +1884,13 @@ class LayerNormLinear(TransformerEngineBaseModule):
         return out
 
     def _get_quantizers(self, fp8_output, fp8_grad, is_grad_enabled):
-        if not self.fp8:
+        if not self.fp8 and not self.fp8_calibration:
+            # Calibration-only mode needs quantizers to observe non-quantized tensors,
+            # so return None only when neither FP8 nor calibration is active.
             return [None] * 6
 
-        self._warn_missing_output_quantizer_role(fp8_output, fp8_grad)
+        if self.fp8:
+            self._warn_missing_output_quantizer_role(fp8_output, fp8_grad)
 
         grad_input_quantizer = None
         grad_weight_quantizer = None

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -18,7 +18,10 @@ import transformer_engine_torch as tex
 
 from transformer_engine.common.recipe import Recipe
 from transformer_engine.pytorch.torch_version import torch_version
-from transformer_engine.pytorch.tensor.utils import clear_columnwise_cache, is_custom
+from transformer_engine.pytorch.tensor.utils import (
+    clear_columnwise_cache,
+    is_custom,
+)
 from .base import (
     fill_userbuffers_buffer_for_all_gather,
     _ub_communicators,
@@ -74,7 +77,13 @@ from ..tensor.float8_tensor import (
 from ..tensor.mxfp8_tensor import MXFP8Quantizer
 from ..tensor.nvfp4_tensor import NVFP4Quantizer
 from ..tensor.float8_blockwise_tensor import Float8BlockQuantizer
-from ._common import apply_normalization, set_quantizer_amax_reduction_group, WeightGradStore
+from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
+    apply_normalization,
+    set_quantizer_amax_reduction_group,
+    WeightGradStore,
+)
 from ..cpu_offload import (
     is_cpu_offload_enabled,
     start_offload,
@@ -241,6 +250,8 @@ class _LayerNormMLP(torch.autograd.Function):
             checkpoint,
             debug,
             is_fsdp2,
+            quantized_scaling_factor_buffering_decay,
+            scale_buffers,
             recompute_for_bwd,
         ) = non_tensor_args
         if fp8:
@@ -343,6 +354,10 @@ class _LayerNormMLP(torch.autograd.Function):
                 "checkpoint": checkpoint,
                 "debug": debug,
                 "is_fsdp2": is_fsdp2,
+                "quantized_scaling_factor_buffering_decay": (
+                    quantized_scaling_factor_buffering_decay
+                ),
+                "scale_buffers": scale_buffers,
                 "recompute_for_bwd": True,  # set this to true for recomputation phase
             }
         # Make sure input dimensions are compatible
@@ -557,6 +572,16 @@ class _LayerNormMLP(torch.autograd.Function):
             if fc1_weight_quantizer is not None:
                 fc1_weight_quantizer.calibrate(fc1_weight)
 
+        fc1_input_scale_buffer = None
+        fc1_weight_scale_buffer = None
+        if scale_buffers is not None:
+            fc1_input_scale_buffer = _get_scale_buffer_info(
+                "fc1_input", ln_out_total, fc1_input_quantizer
+            )
+            fc1_weight_scale_buffer = _get_scale_buffer_info(
+                "fc1_weight", fc1_weight_final, fc1_weight_quantizer
+            )
+
         # ------------------------------------------------------
         # FC1 GEMM
         # ------------------------------------------------------
@@ -670,6 +695,28 @@ class _LayerNormMLP(torch.autograd.Function):
 
                 if fc2_weight_quantizer is not None:
                     fc2_weight_quantizer.calibrate(fc2_weight)
+
+            if scale_buffers is not None:
+                scale_updates = {}
+                if fc1_input_scale_buffer is not None:
+                    scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
+                if fc1_weight_scale_buffer is not None:
+                    scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
+                fc2_input_scale_buffer = _get_scale_buffer_info(
+                    "fc2_input", act_out, fc2_input_quantizer
+                )
+                if fc2_input_scale_buffer is not None:
+                    scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
+                fc2_weight_scale_buffer = _get_scale_buffer_info(
+                    "fc2_weight", fc2_weight_final, fc2_weight_quantizer
+                )
+                if fc2_weight_scale_buffer is not None:
+                    scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
+                _update_scale_buffers(
+                    scale_buffers,
+                    scale_updates,
+                    quantized_scaling_factor_buffering_decay,
+                )
 
             # Configure Userbuffers reduce-scatter if needed
             ub_obj_fc2out = None
@@ -1939,6 +1986,15 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 whether to use selective activation checkpointing, where activations are not saved for bwd,
                 and instead are recomputed (skipping fc2, as it is not needed for backward). Trades compute
                 for memory. default is false, in which activations are saved in fwd. not supported for onnx forward
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent activation and weight quantization
+                       metadata buffers for both internal linear layers for inference checkpoint
+                       export. Per-tensor buffers store raw global amaxes, except FP8 current
+                       scaling buffers, which store inverse scales directly.
+    quantized_scaling_factor_buffering_decay : float, default = 0.0
+                       Decay applied to buffered activation scaling factors before incorporating
+                       each new observation. Defaults to 0.0, in which case only the most recent
+                       scaling factor is buffered.
     """
 
     def __init__(
@@ -1975,6 +2031,8 @@ class LayerNormMLP(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         checkpoint: bool = False,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1996,6 +2054,10 @@ class LayerNormMLP(TransformerEngineBaseModule):
         self.zero_centered_gamma = zero_centered_gamma
         self.symmetric_ar_type = symmetric_ar_type
         self.checkpoint = checkpoint
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = (
+            quantized_scaling_factor_buffering_decay
+        )
 
         # GEMM-GELU fusion is currently only supported with split GEMM-AG overlap
         self.gemm_gelu_fusion = (
@@ -2376,6 +2438,14 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self._fp8_workspaces.get(cache_name_fc2) if cache_name_fc2 is not None else None
             )
 
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
+
             non_tensor_args = (
                 self.eps,
                 is_first_microbatch,
@@ -2426,6 +2496,8 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self.checkpoint,
                 debug,
                 self.is_fsdp2,
+                self.quantized_scaling_factor_buffering_decay,
+                scale_buffers,
             )
             out, ln_out, new_fc1_ws, new_fc2_ws = fwd_fn(
                 *autograd_ctx,
@@ -2440,6 +2512,14 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 fc2_bias if self.apply_bias and not self.gemm_bias_unfused_add else None,
                 non_tensor_args,
             )
+
+            if scale_buffers is not None:
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if new_fc1_ws is not None and cache_name_fc1 is not None:
                 if isinstance(new_fc1_ws, torch.Tensor):

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -700,27 +700,19 @@ class _LayerNormMLP(torch.autograd.Function):
                 activation_scale_updates = {}
                 weight_scale_updates = {}
                 if fc1_input_scale_buffer is not None:
-                    activation_scale_updates[fc1_input_scale_buffer[0]] = (
-                        fc1_input_scale_buffer[1]
-                    )
+                    activation_scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
                 if fc1_weight_scale_buffer is not None:
-                    weight_scale_updates[fc1_weight_scale_buffer[0]] = (
-                        fc1_weight_scale_buffer[1]
-                    )
+                    weight_scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
                 fc2_input_scale_buffer = _get_scale_buffer_info(
                     "fc2_input", act_out, fc2_input_quantizer
                 )
                 if fc2_input_scale_buffer is not None:
-                    activation_scale_updates[fc2_input_scale_buffer[0]] = (
-                        fc2_input_scale_buffer[1]
-                    )
+                    activation_scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
                 fc2_weight_scale_buffer = _get_scale_buffer_info(
                     "fc2_weight", fc2_weight_final, fc2_weight_quantizer
                 )
                 if fc2_weight_scale_buffer is not None:
-                    weight_scale_updates[fc2_weight_scale_buffer[0]] = (
-                        fc2_weight_scale_buffer[1]
-                    )
+                    weight_scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
                 _update_scale_buffers(
                     scale_buffers,
                     activation_scale_updates,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -2055,9 +2055,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
         self.symmetric_ar_type = symmetric_ar_type
         self.checkpoint = checkpoint
         self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = (
-            quantized_scaling_factor_buffering_decay
-        )
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
 
         # GEMM-GELU fusion is currently only supported with split GEMM-AG overlap
         self.gemm_gelu_fusion = (

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -697,25 +697,39 @@ class _LayerNormMLP(torch.autograd.Function):
                     fc2_weight_quantizer.calibrate(fc2_weight)
 
             if scale_buffers is not None:
-                scale_updates = {}
+                activation_scale_updates = {}
+                weight_scale_updates = {}
                 if fc1_input_scale_buffer is not None:
-                    scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
+                    activation_scale_updates[fc1_input_scale_buffer[0]] = (
+                        fc1_input_scale_buffer[1]
+                    )
                 if fc1_weight_scale_buffer is not None:
-                    scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
+                    weight_scale_updates[fc1_weight_scale_buffer[0]] = (
+                        fc1_weight_scale_buffer[1]
+                    )
                 fc2_input_scale_buffer = _get_scale_buffer_info(
                     "fc2_input", act_out, fc2_input_quantizer
                 )
                 if fc2_input_scale_buffer is not None:
-                    scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
+                    activation_scale_updates[fc2_input_scale_buffer[0]] = (
+                        fc2_input_scale_buffer[1]
+                    )
                 fc2_weight_scale_buffer = _get_scale_buffer_info(
                     "fc2_weight", fc2_weight_final, fc2_weight_quantizer
                 )
                 if fc2_weight_scale_buffer is not None:
-                    scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
+                    weight_scale_updates[fc2_weight_scale_buffer[0]] = (
+                        fc2_weight_scale_buffer[1]
+                    )
                 _update_scale_buffers(
                     scale_buffers,
-                    scale_updates,
+                    activation_scale_updates,
                     quantized_scaling_factor_buffering_decay,
+                )
+                _update_scale_buffers(
+                    scale_buffers,
+                    weight_scale_updates,
+                    activation_scale_decay=0.0,
                 )
 
             # Configure Userbuffers reduce-scatter if needed

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -700,25 +700,39 @@ class _LayerNormMLP(torch.autograd.Function):
                     fc2_weight_quantizer.calibrate(fc2_weight)
 
             if scale_buffers is not None:
-                scale_updates = {}
+                activation_scale_updates = {}
+                weight_scale_updates = {}
                 if fc1_input_scale_buffer is not None:
-                    scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
+                    activation_scale_updates[fc1_input_scale_buffer[0]] = (
+                        fc1_input_scale_buffer[1]
+                    )
                 if fc1_weight_scale_buffer is not None:
-                    scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
+                    weight_scale_updates[fc1_weight_scale_buffer[0]] = (
+                        fc1_weight_scale_buffer[1]
+                    )
                 fc2_input_scale_buffer = _get_scale_buffer_info(
                     "fc2_input", act_out, fc2_input_quantizer
                 )
                 if fc2_input_scale_buffer is not None:
-                    scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
+                    activation_scale_updates[fc2_input_scale_buffer[0]] = (
+                        fc2_input_scale_buffer[1]
+                    )
                 fc2_weight_scale_buffer = _get_scale_buffer_info(
                     "fc2_weight", fc2_weight_final, fc2_weight_quantizer
                 )
                 if fc2_weight_scale_buffer is not None:
-                    scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
+                    weight_scale_updates[fc2_weight_scale_buffer[0]] = (
+                        fc2_weight_scale_buffer[1]
+                    )
                 _update_scale_buffers(
                     scale_buffers,
-                    scale_updates,
+                    activation_scale_updates,
                     quantized_scaling_factor_buffering_decay,
+                )
+                _update_scale_buffers(
+                    scale_buffers,
+                    weight_scale_updates,
+                    activation_scale_decay=0.0,
                 )
 
             # Configure Userbuffers reduce-scatter if needed

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -77,7 +77,7 @@ from ..tensor.hybrid_tensor import HybridQuantizer
 from ..tensor.identity_tensor import IdentityQuantizer
 from ._common import (
     _get_scale_buffer_info,
-    _update_scale_buffers,
+    _resolve_calibration_quantizer,
     apply_normalization,
     set_quantizer_amax_reduction_group,
     set_quantizer_usage_for_wgrad_all_gather,
@@ -568,21 +568,32 @@ class _LayerNormMLP(torch.autograd.Function):
         if fc2_bias is not None:
             fc2_bias = cast_if_needed(fc2_bias, bias_dtype)
 
-        # Calibrate quantizers if needed
-        if not fp8 and fp8_calibration:
-            if fc1_input_quantizer is not None:
-                fc1_input_quantizer.calibrate(ln_out_total)
-            if fc1_weight_quantizer is not None:
-                fc1_weight_quantizer.calibrate(fc1_weight)
+        fc1_input_calibration_quantizer = _resolve_calibration_quantizer(
+            ln_out_total, fc1_input_quantizer
+        )
+        fc1_weight_calibration_quantizer = _resolve_calibration_quantizer(
+            fc1_weight_final, fc1_weight_quantizer
+        )
 
-        fc1_input_scale_buffer = None
-        fc1_weight_scale_buffer = None
+        # Calibrate FC1 quantizers if needed.
+        should_calibrate = scale_buffers is not None
+        if should_calibrate:
+            if fc1_input_calibration_quantizer is not None:
+                fc1_input_calibration_quantizer.calibrate(
+                    ln_out_total,
+                    decay=quantized_scaling_factor_buffering_decay,
+                )
+            if fc1_weight_calibration_quantizer is not None:
+                fc1_weight_calibration_quantizer.calibrate(fc1_weight_final)
+
+        fc1_input_scale_buffer = {}
+        fc1_weight_scale_buffer = {}
         if scale_buffers is not None:
             fc1_input_scale_buffer = _get_scale_buffer_info(
-                "fc1_input", ln_out_total, fc1_input_quantizer
+                "fc1_input", fc1_input_calibration_quantizer
             )
             fc1_weight_scale_buffer = _get_scale_buffer_info(
-                "fc1_weight", fc1_weight_final, fc1_weight_quantizer
+                "fc1_weight", fc1_weight_calibration_quantizer
             )
 
         # ------------------------------------------------------
@@ -675,9 +686,14 @@ class _LayerNormMLP(torch.autograd.Function):
                 else:
                     act_out = activation_func(fc1_out, fc2_input_quantizer, **act_params)
 
-        if not fp8 and fp8_calibration:
-            if fc2_input_quantizer is not None:
-                fc2_input_quantizer.calibrate(act_out)
+        fc2_input_calibration_quantizer = _resolve_calibration_quantizer(
+            act_out, fc2_input_quantizer
+        )
+        if should_calibrate and fc2_input_calibration_quantizer is not None:
+            fc2_input_calibration_quantizer.calibrate(
+                act_out,
+                decay=quantized_scaling_factor_buffering_decay,
+            )
 
         # we want to skip fc2 computation if we are checkpointing and recomputing,
         # otherwise we compute fc2
@@ -694,38 +710,27 @@ class _LayerNormMLP(torch.autograd.Function):
             ):  # we can safely get rid of these if this is the case
                 clear_tensor_data(fc1_out)
 
-            if not fp8 and fp8_calibration:
-
-                if fc2_weight_quantizer is not None:
-                    fc2_weight_quantizer.calibrate(fc2_weight)
+            fc2_weight_calibration_quantizer = _resolve_calibration_quantizer(
+                fc2_weight_final, fc2_weight_quantizer
+            )
+            if should_calibrate and fc2_weight_calibration_quantizer is not None:
+                fc2_weight_calibration_quantizer.calibrate(fc2_weight_final)
 
             if scale_buffers is not None:
                 activation_scale_updates = {}
                 weight_scale_updates = {}
-                if fc1_input_scale_buffer is not None:
-                    activation_scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
-                if fc1_weight_scale_buffer is not None:
-                    weight_scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
+                activation_scale_updates.update(fc1_input_scale_buffer)
+                weight_scale_updates.update(fc1_weight_scale_buffer)
                 fc2_input_scale_buffer = _get_scale_buffer_info(
-                    "fc2_input", act_out, fc2_input_quantizer
+                    "fc2_input", fc2_input_calibration_quantizer
                 )
-                if fc2_input_scale_buffer is not None:
-                    activation_scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
+                activation_scale_updates.update(fc2_input_scale_buffer)
                 fc2_weight_scale_buffer = _get_scale_buffer_info(
-                    "fc2_weight", fc2_weight_final, fc2_weight_quantizer
+                    "fc2_weight", fc2_weight_calibration_quantizer
                 )
-                if fc2_weight_scale_buffer is not None:
-                    weight_scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
-                _update_scale_buffers(
-                    scale_buffers,
-                    activation_scale_updates,
-                    quantized_scaling_factor_buffering_decay,
-                )
-                _update_scale_buffers(
-                    scale_buffers,
-                    weight_scale_updates,
-                    activation_scale_decay=0.0,
-                )
+                weight_scale_updates.update(fc2_weight_scale_buffer)
+                scale_buffers.update(activation_scale_updates)
+                scale_buffers.update(weight_scale_updates)
 
             # Configure Userbuffers reduce-scatter if needed
             ub_obj_fc2out = None
@@ -1993,15 +1998,6 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 whether to use selective activation checkpointing, where activations are not saved for bwd,
                 and instead are recomputed (skipping fc2, as it is not needed for backward). Trades compute
                 for memory. default is false, in which activations are saved in fwd. not supported for onnx forward
-    buffer_quantized_scaling_factors : bool, default = False
-                       If set to ``True``, maintain nonpersistent activation and weight quantization
-                       metadata buffers for both internal linear layers for inference checkpoint
-                       export. Per-tensor buffers store raw global amaxes, except FP8 current
-                       scaling buffers, which store inverse scales directly.
-    quantized_scaling_factor_buffering_decay : float, default = 0.0
-                       Decay applied to buffered activation scaling factors before incorporating
-                       each new observation. Defaults to 0.0, in which case only the most recent
-                       scaling factor is buffered.
     """
 
     def __init__(
@@ -2038,8 +2034,6 @@ class LayerNormMLP(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         checkpoint: bool = False,
-        buffer_quantized_scaling_factors: bool = False,
-        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -2061,9 +2055,6 @@ class LayerNormMLP(TransformerEngineBaseModule):
         self.zero_centered_gamma = zero_centered_gamma
         self.symmetric_ar_type = symmetric_ar_type
         self.checkpoint = checkpoint
-        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
-
         # GEMM-GELU fusion is currently only supported with split GEMM-AG overlap
         self.gemm_gelu_fusion = (
             bool(int(os.getenv("NVTE_GEMM_GELU_FUSION", "0")))
@@ -2443,8 +2434,9 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self._fp8_workspaces.get(cache_name_fc2) if cache_name_fc2 is not None else None
             )
 
+            calibration_config = FP8GlobalStateManager.get_calibration_config()
             scale_buffers = None
-            if self.buffer_quantized_scaling_factors:
+            if calibration_config is not None:
                 scale_buffers = {
                     name: value
                     for name, value in self._buffers.items()
@@ -2501,7 +2493,11 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self.checkpoint,
                 debug,
                 self.is_fsdp2,
-                self.quantized_scaling_factor_buffering_decay,
+                (
+                    calibration_config.activation_scale_decay
+                    if calibration_config is not None
+                    else 0.0
+                ),
                 scale_buffers,
             )
             out, ln_out, new_fc1_ws, new_fc2_ws = fwd_fn(

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -18,7 +18,10 @@ import transformer_engine_torch as tex
 
 from transformer_engine.common.recipe import Recipe
 from transformer_engine.pytorch.torch_version import torch_version
-from transformer_engine.pytorch.tensor.utils import clear_columnwise_cache, is_custom
+from transformer_engine.pytorch.tensor.utils import (
+    clear_columnwise_cache,
+    is_custom,
+)
 from .base import (
     fill_userbuffers_buffer_for_all_gather,
     _ub_communicators,
@@ -73,6 +76,8 @@ from ..tensor.float8_blockwise_tensor import Float8BlockQuantizer
 from ..tensor.hybrid_tensor import HybridQuantizer
 from ..tensor.identity_tensor import IdentityQuantizer
 from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
     apply_normalization,
     set_quantizer_amax_reduction_group,
     set_quantizer_usage_for_wgrad_all_gather,
@@ -244,6 +249,8 @@ class _LayerNormMLP(torch.autograd.Function):
             checkpoint,
             debug,
             is_fsdp2,
+            quantized_scaling_factor_buffering_decay,
+            scale_buffers,
             recompute_for_bwd,
         ) = non_tensor_args
         if fp8:
@@ -346,6 +353,10 @@ class _LayerNormMLP(torch.autograd.Function):
                 "checkpoint": checkpoint,
                 "debug": debug,
                 "is_fsdp2": is_fsdp2,
+                "quantized_scaling_factor_buffering_decay": (
+                    quantized_scaling_factor_buffering_decay
+                ),
+                "scale_buffers": scale_buffers,
                 "recompute_for_bwd": True,  # set this to true for recomputation phase
             }
         # Make sure input dimensions are compatible
@@ -564,6 +575,16 @@ class _LayerNormMLP(torch.autograd.Function):
             if fc1_weight_quantizer is not None:
                 fc1_weight_quantizer.calibrate(fc1_weight)
 
+        fc1_input_scale_buffer = None
+        fc1_weight_scale_buffer = None
+        if scale_buffers is not None:
+            fc1_input_scale_buffer = _get_scale_buffer_info(
+                "fc1_input", ln_out_total, fc1_input_quantizer
+            )
+            fc1_weight_scale_buffer = _get_scale_buffer_info(
+                "fc1_weight", fc1_weight_final, fc1_weight_quantizer
+            )
+
         # ------------------------------------------------------
         # FC1 GEMM
         # ------------------------------------------------------
@@ -677,6 +698,28 @@ class _LayerNormMLP(torch.autograd.Function):
 
                 if fc2_weight_quantizer is not None:
                     fc2_weight_quantizer.calibrate(fc2_weight)
+
+            if scale_buffers is not None:
+                scale_updates = {}
+                if fc1_input_scale_buffer is not None:
+                    scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
+                if fc1_weight_scale_buffer is not None:
+                    scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
+                fc2_input_scale_buffer = _get_scale_buffer_info(
+                    "fc2_input", act_out, fc2_input_quantizer
+                )
+                if fc2_input_scale_buffer is not None:
+                    scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
+                fc2_weight_scale_buffer = _get_scale_buffer_info(
+                    "fc2_weight", fc2_weight_final, fc2_weight_quantizer
+                )
+                if fc2_weight_scale_buffer is not None:
+                    scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
+                _update_scale_buffers(
+                    scale_buffers,
+                    scale_updates,
+                    quantized_scaling_factor_buffering_decay,
+                )
 
             # Configure Userbuffers reduce-scatter if needed
             ub_obj_fc2out = None
@@ -1944,6 +1987,15 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 whether to use selective activation checkpointing, where activations are not saved for bwd,
                 and instead are recomputed (skipping fc2, as it is not needed for backward). Trades compute
                 for memory. default is false, in which activations are saved in fwd. not supported for onnx forward
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent activation and weight quantization
+                       metadata buffers for both internal linear layers for inference checkpoint
+                       export. Per-tensor buffers store raw global amaxes, except FP8 current
+                       scaling buffers, which store inverse scales directly.
+    quantized_scaling_factor_buffering_decay : float, default = 0.0
+                       Decay applied to buffered activation scaling factors before incorporating
+                       each new observation. Defaults to 0.0, in which case only the most recent
+                       scaling factor is buffered.
     """
 
     def __init__(
@@ -1980,6 +2032,8 @@ class LayerNormMLP(TransformerEngineBaseModule):
         delay_wgrad_compute: bool = False,
         symmetric_ar_type: Optional[str] = None,
         checkpoint: bool = False,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -2001,6 +2055,10 @@ class LayerNormMLP(TransformerEngineBaseModule):
         self.zero_centered_gamma = zero_centered_gamma
         self.symmetric_ar_type = symmetric_ar_type
         self.checkpoint = checkpoint
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = (
+            quantized_scaling_factor_buffering_decay
+        )
 
         # GEMM-GELU fusion is currently only supported with split GEMM-AG overlap
         self.gemm_gelu_fusion = (
@@ -2381,6 +2439,14 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self._fp8_workspaces.get(cache_name_fc2) if cache_name_fc2 is not None else None
             )
 
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
+
             non_tensor_args = (
                 self.eps,
                 is_first_microbatch,
@@ -2431,6 +2497,8 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 self.checkpoint,
                 debug,
                 self.is_fsdp2,
+                self.quantized_scaling_factor_buffering_decay,
+                scale_buffers,
             )
             out, ln_out, new_fc1_ws, new_fc2_ws = fwd_fn(
                 *autograd_ctx,
@@ -2445,6 +2513,14 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 fc2_bias if self.apply_bias and not self.gemm_bias_unfused_add else None,
                 non_tensor_args,
             )
+
+            if scale_buffers is not None:
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if new_fc1_ws is not None and cache_name_fc1 is not None:
                 if isinstance(new_fc1_ws, torch.Tensor):

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -76,8 +76,9 @@ from ..tensor.float8_blockwise_tensor import Float8BlockQuantizer
 from ..tensor.hybrid_tensor import HybridQuantizer
 from ..tensor.identity_tensor import IdentityQuantizer
 from ._common import (
-    _get_scale_buffer_info,
+    _get_calibration_metadata_buffers,
     _resolve_calibration_quantizer,
+    _supports_calibration_decay,
     apply_normalization,
     set_quantizer_amax_reduction_group,
     set_quantizer_usage_for_wgrad_all_gather,
@@ -249,8 +250,8 @@ class _LayerNormMLP(torch.autograd.Function):
             checkpoint,
             debug,
             is_fsdp2,
-            quantized_scaling_factor_buffering_decay,
-            scale_buffers,
+            transformer_engine_calibration_decay,
+            calibration_buffers,
             recompute_for_bwd,
         ) = non_tensor_args
         if fp8:
@@ -353,10 +354,8 @@ class _LayerNormMLP(torch.autograd.Function):
                 "checkpoint": checkpoint,
                 "debug": debug,
                 "is_fsdp2": is_fsdp2,
-                "quantized_scaling_factor_buffering_decay": (
-                    quantized_scaling_factor_buffering_decay
-                ),
-                "scale_buffers": scale_buffers,
+                "transformer_engine_calibration_decay": transformer_engine_calibration_decay,
+                "calibration_buffers": calibration_buffers,
                 "recompute_for_bwd": True,  # set this to true for recomputation phase
             }
         # Make sure input dimensions are compatible
@@ -575,24 +574,26 @@ class _LayerNormMLP(torch.autograd.Function):
             fc1_weight_final, fc1_weight_quantizer
         )
 
-        # Calibrate FC1 quantizers if needed.
-        should_calibrate = scale_buffers is not None
+        fc1_input_calibration_buffers = {}
+        fc1_weight_calibration_buffers = {}
+
+        # Calibrate FC1 quantizers and collect their metadata when requested.
+        should_calibrate = calibration_buffers is not None
         if should_calibrate:
             if fc1_input_calibration_quantizer is not None:
-                fc1_input_calibration_quantizer.calibrate(
-                    ln_out_total,
-                    decay=quantized_scaling_factor_buffering_decay,
-                )
+                if _supports_calibration_decay(type(fc1_input_calibration_quantizer)):
+                    fc1_input_calibration_quantizer.calibrate(
+                        ln_out_total,
+                        calibration_decay=transformer_engine_calibration_decay,
+                    )
+                else:
+                    fc1_input_calibration_quantizer.calibrate(ln_out_total)
             if fc1_weight_calibration_quantizer is not None:
                 fc1_weight_calibration_quantizer.calibrate(fc1_weight_final)
-
-        fc1_input_scale_buffer = {}
-        fc1_weight_scale_buffer = {}
-        if scale_buffers is not None:
-            fc1_input_scale_buffer = _get_scale_buffer_info(
+            fc1_input_calibration_buffers = _get_calibration_metadata_buffers(
                 "fc1_input", fc1_input_calibration_quantizer
             )
-            fc1_weight_scale_buffer = _get_scale_buffer_info(
+            fc1_weight_calibration_buffers = _get_calibration_metadata_buffers(
                 "fc1_weight", fc1_weight_calibration_quantizer
             )
 
@@ -690,10 +691,13 @@ class _LayerNormMLP(torch.autograd.Function):
             act_out, fc2_input_quantizer
         )
         if should_calibrate and fc2_input_calibration_quantizer is not None:
-            fc2_input_calibration_quantizer.calibrate(
-                act_out,
-                decay=quantized_scaling_factor_buffering_decay,
-            )
+            if _supports_calibration_decay(type(fc2_input_calibration_quantizer)):
+                fc2_input_calibration_quantizer.calibrate(
+                    act_out,
+                    calibration_decay=transformer_engine_calibration_decay,
+                )
+            else:
+                fc2_input_calibration_quantizer.calibrate(act_out)
 
         # we want to skip fc2 computation if we are checkpointing and recomputing,
         # otherwise we compute fc2
@@ -713,24 +717,21 @@ class _LayerNormMLP(torch.autograd.Function):
             fc2_weight_calibration_quantizer = _resolve_calibration_quantizer(
                 fc2_weight_final, fc2_weight_quantizer
             )
-            if should_calibrate and fc2_weight_calibration_quantizer is not None:
-                fc2_weight_calibration_quantizer.calibrate(fc2_weight_final)
-
-            if scale_buffers is not None:
-                activation_scale_updates = {}
-                weight_scale_updates = {}
-                activation_scale_updates.update(fc1_input_scale_buffer)
-                weight_scale_updates.update(fc1_weight_scale_buffer)
-                fc2_input_scale_buffer = _get_scale_buffer_info(
-                    "fc2_input", fc2_input_calibration_quantizer
+            if should_calibrate:
+                if fc2_weight_calibration_quantizer is not None:
+                    fc2_weight_calibration_quantizer.calibrate(fc2_weight_final)
+                calibration_buffers.update(fc1_input_calibration_buffers)
+                calibration_buffers.update(fc1_weight_calibration_buffers)
+                calibration_buffers.update(
+                    _get_calibration_metadata_buffers(
+                        "fc2_input", fc2_input_calibration_quantizer
+                    )
                 )
-                activation_scale_updates.update(fc2_input_scale_buffer)
-                fc2_weight_scale_buffer = _get_scale_buffer_info(
-                    "fc2_weight", fc2_weight_calibration_quantizer
+                calibration_buffers.update(
+                    _get_calibration_metadata_buffers(
+                        "fc2_weight", fc2_weight_calibration_quantizer
+                    )
                 )
-                weight_scale_updates.update(fc2_weight_scale_buffer)
-                scale_buffers.update(activation_scale_updates)
-                scale_buffers.update(weight_scale_updates)
 
             # Configure Userbuffers reduce-scatter if needed
             ub_obj_fc2out = None
@@ -2435,9 +2436,9 @@ class LayerNormMLP(TransformerEngineBaseModule):
             )
 
             calibration_config = FP8GlobalStateManager.get_calibration_config()
-            scale_buffers = None
+            calibration_buffers = None
             if calibration_config is not None:
-                scale_buffers = {
+                calibration_buffers = {
                     name: value
                     for name, value in self._buffers.items()
                     if name.endswith("_te_ptq_calibrated")
@@ -2494,11 +2495,11 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 debug,
                 self.is_fsdp2,
                 (
-                    calibration_config.activation_scale_decay
+                    calibration_config.transformer_engine_calibration_decay
                     if calibration_config is not None
                     else 0.0
                 ),
-                scale_buffers,
+                calibration_buffers,
             )
             out, ln_out, new_fc1_ws, new_fc2_ws = fwd_fn(
                 *autograd_ctx,
@@ -2514,8 +2515,8 @@ class LayerNormMLP(TransformerEngineBaseModule):
                 non_tensor_args,
             )
 
-            if scale_buffers is not None:
-                for name, value in scale_buffers.items():
+            if calibration_buffers is not None:
+                for name, value in calibration_buffers.items():
                     if value is not None:
                         if name in self._buffers:
                             setattr(self, name, value)

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -2056,9 +2056,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
         self.symmetric_ar_type = symmetric_ar_type
         self.checkpoint = checkpoint
         self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = (
-            quantized_scaling_factor_buffering_decay
-        )
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
 
         # GEMM-GELU fusion is currently only supported with split GEMM-AG overlap
         self.gemm_gelu_fusion = (

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -703,27 +703,19 @@ class _LayerNormMLP(torch.autograd.Function):
                 activation_scale_updates = {}
                 weight_scale_updates = {}
                 if fc1_input_scale_buffer is not None:
-                    activation_scale_updates[fc1_input_scale_buffer[0]] = (
-                        fc1_input_scale_buffer[1]
-                    )
+                    activation_scale_updates[fc1_input_scale_buffer[0]] = fc1_input_scale_buffer[1]
                 if fc1_weight_scale_buffer is not None:
-                    weight_scale_updates[fc1_weight_scale_buffer[0]] = (
-                        fc1_weight_scale_buffer[1]
-                    )
+                    weight_scale_updates[fc1_weight_scale_buffer[0]] = fc1_weight_scale_buffer[1]
                 fc2_input_scale_buffer = _get_scale_buffer_info(
                     "fc2_input", act_out, fc2_input_quantizer
                 )
                 if fc2_input_scale_buffer is not None:
-                    activation_scale_updates[fc2_input_scale_buffer[0]] = (
-                        fc2_input_scale_buffer[1]
-                    )
+                    activation_scale_updates[fc2_input_scale_buffer[0]] = fc2_input_scale_buffer[1]
                 fc2_weight_scale_buffer = _get_scale_buffer_info(
                     "fc2_weight", fc2_weight_final, fc2_weight_quantizer
                 )
                 if fc2_weight_scale_buffer is not None:
-                    weight_scale_updates[fc2_weight_scale_buffer[0]] = (
-                        fc2_weight_scale_buffer[1]
-                    )
+                    weight_scale_updates[fc2_weight_scale_buffer[0]] = fc2_weight_scale_buffer[1]
                 _update_scale_buffers(
                     scale_buffers,
                     activation_scale_updates,

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -77,6 +77,7 @@ from ..tensor.hybrid_tensor import HybridQuantizer
 from ..tensor.identity_tensor import IdentityQuantizer
 from ._common import (
     _get_calibration_metadata_buffers,
+    _is_in_activation_recompute_phase,
     _resolve_calibration_quantizer,
     _supports_calibration_decay,
     apply_normalization,
@@ -578,7 +579,11 @@ class _LayerNormMLP(torch.autograd.Function):
         fc1_weight_calibration_buffers = {}
 
         # Calibrate FC1 quantizers and collect their metadata when requested.
-        should_calibrate = calibration_buffers is not None
+        should_calibrate = (
+            calibration_buffers is not None
+            and not _is_in_activation_recompute_phase()
+            and not is_recomputation
+        )
         if should_calibrate:
             if fc1_input_calibration_quantizer is not None:
                 if _supports_calibration_decay(type(fc1_input_calibration_quantizer)):

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -723,9 +723,7 @@ class _LayerNormMLP(torch.autograd.Function):
                 calibration_buffers.update(fc1_input_calibration_buffers)
                 calibration_buffers.update(fc1_weight_calibration_buffers)
                 calibration_buffers.update(
-                    _get_calibration_metadata_buffers(
-                        "fc2_input", fc2_input_calibration_quantizer
-                    )
+                    _get_calibration_metadata_buffers("fc2_input", fc2_input_calibration_quantizer)
                 )
                 calibration_buffers.update(
                     _get_calibration_metadata_buffers(

--- a/transformer_engine/pytorch/module/layernorm_mlp.py
+++ b/transformer_engine/pytorch/module/layernorm_mlp.py
@@ -2566,6 +2566,7 @@ class LayerNormMLP(TransformerEngineBaseModule):
             fc2_grad_output_quantizer,
         ) = [None] * 10
         fc1_weight_quantizer, fc2_weight_quantizer = self._get_weight_quantizers()
+        # Calibration-only mode needs quantizers to observe non-quantized tensors.
         if self.fp8 or self.fp8_calibration:
             fc1_input_quantizer = self.quantizers["scaling_fwd"][FP8FwdTensorIdx.GEMM1_INPUT]
             fc1_input_quantizer.internal = True

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -30,7 +30,13 @@ from .base import (
     _2X_ACC_DGRAD,
     _2X_ACC_WGRAD,
 )
-from ._common import noop_cat, set_quantizer_amax_reduction_group, WeightGradStore
+from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
+    noop_cat,
+    set_quantizer_amax_reduction_group,
+    WeightGradStore,
+)
 from ..quantization import FP8GlobalStateManager, QuantizerRole
 from ..utils import (
     cast_if_needed,
@@ -76,7 +82,10 @@ from ..quantized_tensor import (
 )
 from ..tensor.float8_tensor import Float8CurrentScalingQuantizer, Float8Quantizer
 from ..tensor.mxfp8_tensor import MXFP8Quantizer
-from ..tensor.utils import clear_columnwise_cache, is_custom
+from ..tensor.utils import (
+    clear_columnwise_cache,
+    is_custom,
+)
 from ..export import is_in_onnx_export_mode, assert_warmed_up
 from ..cpu_offload import (
     is_cpu_offload_enabled,
@@ -159,6 +168,10 @@ class LinearFwdArgs:
     # --- Weight-grad scheduling ---
     fuse_wgrad_accumulation: bool
     wgrad_store: Optional[Any]
+
+    # Inference Scaling Factor Calibration Buffering
+    scale_buffers: Optional[Dict[str, Optional[torch.Tensor]]]
+    quantized_scaling_factor_buffering_decay: float
 
     # --- Misc ---
     cpu_offloading: bool
@@ -266,8 +279,8 @@ def _linear_forward_impl(
 
     Returns ``(out, new_weight_workspace, tensors_to_save_from_forward, None,
     ctx_attrs)``. ``new_weight_workspace`` is the freshly produced FP8 weight
-    workspace (returned alongside ``out`` so the caller can refresh its
-    cache). The last three are ``None`` when gradients are disabled.
+    workspace returned alongside ``out`` so the caller can refresh its cache.
+    Scaling-factor checkpoint buffers are updated through ``args.scale_buffers``.
     """
 
     weight = args.weight
@@ -479,6 +492,25 @@ def _linear_forward_impl(
             input_quantizer.calibrate(inputmat_total)
         if weight_quantizer is not None:
             weight_quantizer.calibrate(weight)
+
+    # Capture scaling metadata while it is still available.
+    if args.scale_buffers is not None:
+        scale_updates = {}
+        input_scale_buffer = _get_scale_buffer_info(
+            "input", inputmat_total, input_quantizer
+        )
+        if input_scale_buffer is not None:
+            scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+        weight_scale_buffer = _get_scale_buffer_info(
+            "weight", weightmat, weight_quantizer
+        )
+        if weight_scale_buffer is not None:
+            scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
+        _update_scale_buffers(
+            args.scale_buffers,
+            scale_updates,
+            args.quantized_scaling_factor_buffering_decay,
+        )
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP
@@ -1532,6 +1564,18 @@ class Linear(TransformerEngineBaseModule):
                        cast tensor. In some scenarios, the input tensor is used by multiple modules,
                        and saving the original input tensor may reduce the memory usage.
                        Cannot work with FP8 DelayedScaling recipe.
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent input and weight quantization
+                       metadata buffers for inference checkpoint export. Per-tensor buffers
+                       store raw global amaxes, except FP8 current scaling buffers, which store
+                       inverse scales directly.
+                       Each buffer is materialized only when its tensor uses a quantizer with a
+                       per-tensor scaling factor. Used to propagate scaling factors from training
+                       into inference.
+    quantized_scaling_factor_buffering_decay : float, default = 0.0
+                       Decay applied to buffered activation scaling factors before incorporating
+                       each new observation. Defaults to 0.0, in which case only the most recent
+                       scaling factor is buffered.
     """
 
     def __init__(
@@ -1561,6 +1605,8 @@ class Linear(TransformerEngineBaseModule):
         symmetric_ar_type: Optional[str] = None,
         save_original_input: bool = False,
         name: Optional[str] = None,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -1788,6 +1834,9 @@ class Linear(TransformerEngineBaseModule):
                 if name in self.weight_names or name in self.bias_names:
                     param.skip_backward_post_hook = True
 
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
+
     def get_quantizer_roles(
         self,
         *,
@@ -1972,6 +2021,13 @@ class Linear(TransformerEngineBaseModule):
                 bias_tensor if (self.apply_bias and not self.gemm_bias_unfused_add) else None
             )
             wgrad_store = self.wgrad_store if self.wgrad_store.delay_wgrad_compute() else None
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
             fwd_args = LinearFwdArgs(
                 # tensors
                 weight=weight_tensor,
@@ -2028,6 +2084,11 @@ class Linear(TransformerEngineBaseModule):
                 # weight-grad scheduling
                 fuse_wgrad_accumulation=self.fuse_wgrad_accumulation,
                 wgrad_store=wgrad_store,
+                # Inference Scaling Factor Calibration Buffering
+                scale_buffers=scale_buffers,
+                quantized_scaling_factor_buffering_decay=(
+                    self.quantized_scaling_factor_buffering_decay
+                ),
                 # misc
                 cpu_offloading=is_cpu_offload_enabled(),
                 is_grad_enabled=is_grad_enabled,
@@ -2039,6 +2100,16 @@ class Linear(TransformerEngineBaseModule):
                 linear_bias_tensor,
                 fwd_args,
             )
+
+            if scale_buffers is not None:
+                # Assign the scaling factor calibration buffers to model.
+                # Requires CUDA graph warmup step.
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if new_weight_workspace is not None and cache_name is not None:
                 if isinstance(new_weight_workspace, torch.Tensor):

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -496,14 +496,10 @@ def _linear_forward_impl(
     # Capture scaling metadata while it is still available.
     if args.scale_buffers is not None:
         scale_updates = {}
-        input_scale_buffer = _get_scale_buffer_info(
-            "input", inputmat_total, input_quantizer
-        )
+        input_scale_buffer = _get_scale_buffer_info("input", inputmat_total, input_quantizer)
         if input_scale_buffer is not None:
             scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
-        weight_scale_buffer = _get_scale_buffer_info(
-            "weight", weightmat, weight_quantizer
-        )
+        weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
         if weight_scale_buffer is not None:
             scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
         _update_scale_buffers(

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -495,18 +495,20 @@ def _linear_forward_impl(
 
     # Capture scaling metadata while it is still available.
     if args.scale_buffers is not None:
-        scale_updates = {}
         input_scale_buffer = _get_scale_buffer_info("input", inputmat_total, input_quantizer)
         if input_scale_buffer is not None:
-            scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+            _update_scale_buffers(
+                args.scale_buffers,
+                {input_scale_buffer[0]: input_scale_buffer[1]},
+                args.quantized_scaling_factor_buffering_decay,
+            )
         weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
         if weight_scale_buffer is not None:
-            scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
-        _update_scale_buffers(
-            args.scale_buffers,
-            scale_updates,
-            args.quantized_scaling_factor_buffering_decay,
-        )
+            _update_scale_buffers(
+                args.scale_buffers,
+                {weight_scale_buffer[0]: weight_scale_buffer[1]},
+                activation_scale_decay=0.0,
+            )
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -32,6 +32,8 @@ from .base import (
     _2X_ACC_WGRAD,
 )
 from ._common import (
+    _get_scale_buffer_info,
+    _update_scale_buffers,
     can_reconstruct_wgrad_input_from_original,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -93,7 +95,10 @@ from ..dynamo import (
 )
 from ..tensor.float8_tensor import Float8CurrentScalingQuantizer, Float8Quantizer
 from ..tensor.mxfp8_tensor import MXFP8Quantizer
-from ..tensor.utils import clear_columnwise_cache, is_custom
+from ..tensor.utils import (
+    clear_columnwise_cache,
+    is_custom,
+)
 from ..export import is_in_onnx_export_mode, assert_warmed_up
 from ..cpu_offload import (
     is_cpu_offload_enabled,
@@ -175,6 +180,10 @@ class LinearFwdArgs:
     # --- Weight-grad scheduling ---
     fuse_wgrad_accumulation: bool
     wgrad_store: Optional[Any]
+
+    # Inference Scaling Factor Calibration Buffering
+    scale_buffers: Optional[Dict[str, Optional[torch.Tensor]]]
+    quantized_scaling_factor_buffering_decay: float
 
     # --- Misc ---
     cpu_offloading: bool
@@ -370,6 +379,7 @@ def _linear_forward_impl(
     ctx_attrs)``. ``new_weight_workspace`` is the freshly produced FP8 weight
     workspace (returned alongside ``out`` so the caller can refresh its
     cache). The last two are ``None`` when gradients are disabled.
+    Scaling-factor checkpoint buffers are updated through ``args.scale_buffers``.
     """
 
     weight = args.weight
@@ -604,6 +614,25 @@ def _linear_forward_impl(
             input_quantizer.calibrate(inputmat_total)
         if weight_quantizer is not None:
             weight_quantizer.calibrate(weight)
+
+    # Capture scaling metadata while it is still available.
+    if args.scale_buffers is not None:
+        scale_updates = {}
+        input_scale_buffer = _get_scale_buffer_info(
+            "input", inputmat_total, input_quantizer
+        )
+        if input_scale_buffer is not None:
+            scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+        weight_scale_buffer = _get_scale_buffer_info(
+            "weight", weightmat, weight_quantizer
+        )
+        if weight_scale_buffer is not None:
+            scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
+        _update_scale_buffers(
+            args.scale_buffers,
+            scale_updates,
+            args.quantized_scaling_factor_buffering_decay,
+        )
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP
@@ -1990,6 +2019,18 @@ class Linear(TransformerEngineBaseModule):
                        and saving the original input tensor may reduce the memory usage.
                        Requires an input quantizer that can safely reproduce its result from the
                        original input. Cannot work with FP8 DelayedScaling recipe.
+    buffer_quantized_scaling_factors : bool, default = False
+                       If set to ``True``, maintain nonpersistent input and weight quantization
+                       metadata buffers for inference checkpoint export. Per-tensor buffers
+                       store raw global amaxes, except FP8 current scaling buffers, which store
+                       inverse scales directly.
+                       Each buffer is materialized only when its tensor uses a quantizer with a
+                       per-tensor scaling factor. Used to propagate scaling factors from training
+                       into inference.
+    quantized_scaling_factor_buffering_decay : float, default = 0.0
+                       Decay applied to buffered activation scaling factors before incorporating
+                       each new observation. Defaults to 0.0, in which case only the most recent
+                       scaling factor is buffered.
     """
 
     def __init__(
@@ -2019,6 +2060,8 @@ class Linear(TransformerEngineBaseModule):
         symmetric_ar_type: Optional[str] = None,
         save_original_input: bool = False,
         name: Optional[str] = None,
+        buffer_quantized_scaling_factors: bool = False,
+        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -2245,6 +2288,9 @@ class Linear(TransformerEngineBaseModule):
             for name, param in self.named_parameters():
                 if name in self.weight_names or name in self.bias_names:
                     param.skip_backward_post_hook = True
+
+        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
+        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
 
     def get_quantizer_roles(
         self,
@@ -2475,7 +2521,13 @@ class Linear(TransformerEngineBaseModule):
                 bias_tensor if (self.apply_bias and not self.gemm_bias_unfused_add) else None
             )
             wgrad_store = self.wgrad_store if self.wgrad_store.delay_wgrad_compute() else None
-
+            scale_buffers = None
+            if self.buffer_quantized_scaling_factors:
+                scale_buffers = {
+                    name: value
+                    for name, value in self._buffers.items()
+                    if name.endswith("_te_ptq_calibrated")
+                }
             fwd_args = LinearFwdArgs(
                 # tensors
                 weight=weight_tensor,
@@ -2532,6 +2584,11 @@ class Linear(TransformerEngineBaseModule):
                 # weight-grad scheduling
                 fuse_wgrad_accumulation=self.fuse_wgrad_accumulation,
                 wgrad_store=wgrad_store,
+                # Inference Scaling Factor Calibration Buffering
+                scale_buffers=scale_buffers,
+                quantized_scaling_factor_buffering_decay=(
+                    self.quantized_scaling_factor_buffering_decay
+                ),
                 # misc
                 cpu_offloading=is_cpu_offload_enabled(),
                 is_grad_enabled=is_grad_enabled,
@@ -2554,6 +2611,16 @@ class Linear(TransformerEngineBaseModule):
                 out, new_weight_workspace = _linear_eager(
                     weight_tensor, inp, linear_bias_tensor, fwd_args, is_grad_enabled
                 )
+
+            if scale_buffers is not None:
+                # Assign the scaling factor calibration buffers to model.
+                # Requires CUDA graph warmup step.
+                for name, value in scale_buffers.items():
+                    if value is not None:
+                        if name in self._buffers:
+                            setattr(self, name, value)
+                        else:
+                            self.register_buffer(name, value, persistent=False)
 
             if new_weight_workspace is not None and cache_name is not None:
                 if isinstance(new_weight_workspace, torch.Tensor):

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -33,7 +33,7 @@ from .base import (
 )
 from ._common import (
     _get_scale_buffer_info,
-    _update_scale_buffers,
+    _resolve_calibration_quantizer,
     can_reconstruct_wgrad_input_from_original,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -608,29 +608,29 @@ def _linear_forward_impl(
         bias_dtype = torch.bfloat16
     bias = cast_if_needed(bias, bias_dtype) if bias is not None else bias
 
-    # Calibrate quantizers if needed
-    if not fp8 and args.fp8_calibration:
-        if input_quantizer is not None:
-            input_quantizer.calibrate(inputmat_total)
-        if weight_quantizer is not None:
-            weight_quantizer.calibrate(weight)
+    input_calibration_quantizer = _resolve_calibration_quantizer(
+        inputmat_total, input_quantizer
+    )
+    weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
-    # Capture scaling metadata while it is still available.
+    # Calibrate quantizers if needed.
     if args.scale_buffers is not None:
-        input_scale_buffer = _get_scale_buffer_info("input", inputmat_total, input_quantizer)
-        if input_scale_buffer is not None:
-            _update_scale_buffers(
-                args.scale_buffers,
-                {input_scale_buffer[0]: input_scale_buffer[1]},
-                args.quantized_scaling_factor_buffering_decay,
+        if input_calibration_quantizer is not None:
+            input_calibration_quantizer.calibrate(
+                inputmat_total,
+                decay=args.quantized_scaling_factor_buffering_decay,
             )
-        weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
-        if weight_scale_buffer is not None:
-            _update_scale_buffers(
-                args.scale_buffers,
-                {weight_scale_buffer[0]: weight_scale_buffer[1]},
-                activation_scale_decay=0.0,
-            )
+        if weight_calibration_quantizer is not None:
+            weight_calibration_quantizer.calibrate(weightmat)
+
+    # Buffer scaling metadata only when requested.
+    if args.scale_buffers is not None:
+        args.scale_buffers.update(
+            _get_scale_buffer_info("input", input_calibration_quantizer)
+        )
+        args.scale_buffers.update(
+            _get_scale_buffer_info("weight", weight_calibration_quantizer)
+        )
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP
@@ -2017,18 +2017,6 @@ class Linear(TransformerEngineBaseModule):
                        and saving the original input tensor may reduce the memory usage.
                        Requires an input quantizer that can safely reproduce its result from the
                        original input. Cannot work with FP8 DelayedScaling recipe.
-    buffer_quantized_scaling_factors : bool, default = False
-                       If set to ``True``, maintain nonpersistent input and weight quantization
-                       metadata buffers for inference checkpoint export. Per-tensor buffers
-                       store raw global amaxes, except FP8 current scaling buffers, which store
-                       inverse scales directly.
-                       Each buffer is materialized only when its tensor uses a quantizer with a
-                       per-tensor scaling factor. Used to propagate scaling factors from training
-                       into inference.
-    quantized_scaling_factor_buffering_decay : float, default = 0.0
-                       Decay applied to buffered activation scaling factors before incorporating
-                       each new observation. Defaults to 0.0, in which case only the most recent
-                       scaling factor is buffered.
     """
 
     def __init__(
@@ -2058,8 +2046,6 @@ class Linear(TransformerEngineBaseModule):
         symmetric_ar_type: Optional[str] = None,
         save_original_input: bool = False,
         name: Optional[str] = None,
-        buffer_quantized_scaling_factors: bool = False,
-        quantized_scaling_factor_buffering_decay: float = 0.0,
     ) -> None:
         super().__init__(name)
 
@@ -2286,9 +2272,6 @@ class Linear(TransformerEngineBaseModule):
             for name, param in self.named_parameters():
                 if name in self.weight_names or name in self.bias_names:
                     param.skip_backward_post_hook = True
-
-        self.buffer_quantized_scaling_factors = buffer_quantized_scaling_factors
-        self.quantized_scaling_factor_buffering_decay = quantized_scaling_factor_buffering_decay
 
     def get_quantizer_roles(
         self,
@@ -2519,8 +2502,9 @@ class Linear(TransformerEngineBaseModule):
                 bias_tensor if (self.apply_bias and not self.gemm_bias_unfused_add) else None
             )
             wgrad_store = self.wgrad_store if self.wgrad_store.delay_wgrad_compute() else None
+            calibration_config = FP8GlobalStateManager.get_calibration_config()
             scale_buffers = None
-            if self.buffer_quantized_scaling_factors:
+            if calibration_config is not None:
                 scale_buffers = {
                     name: value
                     for name, value in self._buffers.items()
@@ -2585,7 +2569,9 @@ class Linear(TransformerEngineBaseModule):
                 # Inference Scaling Factor Calibration Buffering
                 scale_buffers=scale_buffers,
                 quantized_scaling_factor_buffering_decay=(
-                    self.quantized_scaling_factor_buffering_decay
+                    calibration_config.activation_scale_decay
+                    if calibration_config is not None
+                    else 0.0
                 ),
                 # misc
                 cpu_offloading=is_cpu_offload_enabled(),
@@ -2708,7 +2694,7 @@ class Linear(TransformerEngineBaseModule):
         prepare_forward. Quantizer checks stay in compile_unsupported_reason."""
         if debug:
             return "debug instrumentation (nvidia-dlfw-inspect)"
-        if self.buffer_quantized_scaling_factors:
+        if FP8GlobalStateManager.get_calibration_config() is not None:
             return "quantized scaling-factor buffering"
         weight_tensor, bias_tensor = self._get_weight_and_bias_tensors()
         if is_distributed_weight(weight_tensor):

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -2708,6 +2708,8 @@ class Linear(TransformerEngineBaseModule):
         prepare_forward. Quantizer checks stay in compile_unsupported_reason."""
         if debug:
             return "debug instrumentation (nvidia-dlfw-inspect)"
+        if self.buffer_quantized_scaling_factors:
+            return "quantized scaling-factor buffering"
         weight_tensor, bias_tensor = self._get_weight_and_bias_tensors()
         if is_distributed_weight(weight_tensor):
             return "a DistributedWeight (custom weight parallelism, e.g. GTP)"

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -32,8 +32,9 @@ from .base import (
     _2X_ACC_WGRAD,
 )
 from ._common import (
-    _get_scale_buffer_info,
+    _get_calibration_metadata_buffers,
     _resolve_calibration_quantizer,
+    _supports_calibration_decay,
     can_reconstruct_wgrad_input_from_original,
     noop_cat,
     set_quantizer_amax_reduction_group,
@@ -181,9 +182,9 @@ class LinearFwdArgs:
     fuse_wgrad_accumulation: bool
     wgrad_store: Optional[Any]
 
-    # Inference Scaling Factor Calibration Buffering
-    scale_buffers: Optional[Dict[str, Optional[torch.Tensor]]]
-    quantized_scaling_factor_buffering_decay: float
+    # Transformer Engine calibration metadata buffering
+    calibration_buffers: Optional[Dict[str, Optional[torch.Tensor]]]
+    transformer_engine_calibration_decay: float
 
     # --- Misc ---
     cpu_offloading: bool
@@ -379,7 +380,7 @@ def _linear_forward_impl(
     ctx_attrs)``. ``new_weight_workspace`` is the freshly produced FP8 weight
     workspace (returned alongside ``out`` so the caller can refresh its
     cache). The last two are ``None`` when gradients are disabled.
-    Scaling-factor checkpoint buffers are updated through ``args.scale_buffers``.
+    Calibration metadata buffers are updated through ``args.calibration_buffers``.
     """
 
     weight = args.weight
@@ -611,20 +612,24 @@ def _linear_forward_impl(
     input_calibration_quantizer = _resolve_calibration_quantizer(inputmat_total, input_quantizer)
     weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
-    # Calibrate quantizers if needed.
-    if args.scale_buffers is not None:
+    # Calibrate quantizers and buffer their metadata when requested.
+    if args.calibration_buffers is not None:
         if input_calibration_quantizer is not None:
-            input_calibration_quantizer.calibrate(
-                inputmat_total,
-                decay=args.quantized_scaling_factor_buffering_decay,
-            )
+            if _supports_calibration_decay(type(input_calibration_quantizer)):
+                input_calibration_quantizer.calibrate(
+                    inputmat_total,
+                    calibration_decay=args.transformer_engine_calibration_decay,
+                )
+            else:
+                input_calibration_quantizer.calibrate(inputmat_total)
         if weight_calibration_quantizer is not None:
             weight_calibration_quantizer.calibrate(weightmat)
-
-    # Buffer scaling metadata only when requested.
-    if args.scale_buffers is not None:
-        args.scale_buffers.update(_get_scale_buffer_info("input", input_calibration_quantizer))
-        args.scale_buffers.update(_get_scale_buffer_info("weight", weight_calibration_quantizer))
+        args.calibration_buffers.update(
+            _get_calibration_metadata_buffers("input", input_calibration_quantizer)
+        )
+        args.calibration_buffers.update(
+            _get_calibration_metadata_buffers("weight", weight_calibration_quantizer)
+        )
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP
@@ -2497,9 +2502,9 @@ class Linear(TransformerEngineBaseModule):
             )
             wgrad_store = self.wgrad_store if self.wgrad_store.delay_wgrad_compute() else None
             calibration_config = FP8GlobalStateManager.get_calibration_config()
-            scale_buffers = None
+            calibration_buffers = None
             if calibration_config is not None:
-                scale_buffers = {
+                calibration_buffers = {
                     name: value
                     for name, value in self._buffers.items()
                     if name.endswith("_te_ptq_calibrated")
@@ -2560,10 +2565,10 @@ class Linear(TransformerEngineBaseModule):
                 # weight-grad scheduling
                 fuse_wgrad_accumulation=self.fuse_wgrad_accumulation,
                 wgrad_store=wgrad_store,
-                # Inference Scaling Factor Calibration Buffering
-                scale_buffers=scale_buffers,
-                quantized_scaling_factor_buffering_decay=(
-                    calibration_config.activation_scale_decay
+                # Buffering TE calibration metadata, e.g. scaling factors.
+                calibration_buffers=calibration_buffers,
+                transformer_engine_calibration_decay=(
+                    calibration_config.transformer_engine_calibration_decay
                     if calibration_config is not None
                     else 0.0
                 ),
@@ -2590,10 +2595,10 @@ class Linear(TransformerEngineBaseModule):
                     weight_tensor, inp, linear_bias_tensor, fwd_args, is_grad_enabled
                 )
 
-            if scale_buffers is not None:
-                # Assign the scaling factor calibration buffers to model.
+            if calibration_buffers is not None:
+                # Assign Transformer Engine calibration metadata buffers to the model.
                 # Requires CUDA graph warmup step.
-                for name, value in scale_buffers.items():
+                for name, value in calibration_buffers.items():
                     if value is not None:
                         if name in self._buffers:
                             setattr(self, name, value)
@@ -2689,7 +2694,7 @@ class Linear(TransformerEngineBaseModule):
         if debug:
             return "debug instrumentation (nvidia-dlfw-inspect)"
         if FP8GlobalStateManager.get_calibration_config() is not None:
-            return "quantized scaling-factor buffering"
+            return "Transformer Engine calibration metadata buffering"
         weight_tensor, bias_tensor = self._get_weight_and_bias_tensors()
         if is_distributed_weight(weight_tensor):
             return "a DistributedWeight (custom weight parallelism, e.g. GTP)"

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -608,9 +608,7 @@ def _linear_forward_impl(
         bias_dtype = torch.bfloat16
     bias = cast_if_needed(bias, bias_dtype) if bias is not None else bias
 
-    input_calibration_quantizer = _resolve_calibration_quantizer(
-        inputmat_total, input_quantizer
-    )
+    input_calibration_quantizer = _resolve_calibration_quantizer(inputmat_total, input_quantizer)
     weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
     # Calibrate quantizers if needed.
@@ -625,12 +623,8 @@ def _linear_forward_impl(
 
     # Buffer scaling metadata only when requested.
     if args.scale_buffers is not None:
-        args.scale_buffers.update(
-            _get_scale_buffer_info("input", input_calibration_quantizer)
-        )
-        args.scale_buffers.update(
-            _get_scale_buffer_info("weight", weight_calibration_quantizer)
-        )
+        args.scale_buffers.update(_get_scale_buffer_info("input", input_calibration_quantizer))
+        args.scale_buffers.update(_get_scale_buffer_info("weight", weight_calibration_quantizer))
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -617,18 +617,20 @@ def _linear_forward_impl(
 
     # Capture scaling metadata while it is still available.
     if args.scale_buffers is not None:
-        scale_updates = {}
         input_scale_buffer = _get_scale_buffer_info("input", inputmat_total, input_quantizer)
         if input_scale_buffer is not None:
-            scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
+            _update_scale_buffers(
+                args.scale_buffers,
+                {input_scale_buffer[0]: input_scale_buffer[1]},
+                args.quantized_scaling_factor_buffering_decay,
+            )
         weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
         if weight_scale_buffer is not None:
-            scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
-        _update_scale_buffers(
-            args.scale_buffers,
-            scale_updates,
-            args.quantized_scaling_factor_buffering_decay,
-        )
+            _update_scale_buffers(
+                args.scale_buffers,
+                {weight_scale_buffer[0]: weight_scale_buffer[1]},
+                activation_scale_decay=0.0,
+            )
 
     # Choose whether to use GEMM kernel with split accumulator
     use_split_accumulator = _2X_ACC_FPROP

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -618,14 +618,10 @@ def _linear_forward_impl(
     # Capture scaling metadata while it is still available.
     if args.scale_buffers is not None:
         scale_updates = {}
-        input_scale_buffer = _get_scale_buffer_info(
-            "input", inputmat_total, input_quantizer
-        )
+        input_scale_buffer = _get_scale_buffer_info("input", inputmat_total, input_quantizer)
         if input_scale_buffer is not None:
             scale_updates[input_scale_buffer[0]] = input_scale_buffer[1]
-        weight_scale_buffer = _get_scale_buffer_info(
-            "weight", weightmat, weight_quantizer
-        )
+        weight_scale_buffer = _get_scale_buffer_info("weight", weightmat, weight_quantizer)
         if weight_scale_buffer is not None:
             scale_updates[weight_scale_buffer[0]] = weight_scale_buffer[1]
         _update_scale_buffers(

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -33,6 +33,7 @@ from .base import (
 )
 from ._common import (
     _get_calibration_metadata_buffers,
+    _is_in_activation_recompute_phase,
     _resolve_calibration_quantizer,
     _supports_calibration_decay,
     can_reconstruct_wgrad_input_from_original,
@@ -613,7 +614,7 @@ def _linear_forward_impl(
     weight_calibration_quantizer = _resolve_calibration_quantizer(weightmat, weight_quantizer)
 
     # Calibrate quantizers and buffer their metadata when requested.
-    if args.calibration_buffers is not None:
+    if args.calibration_buffers is not None and not _is_in_activation_recompute_phase():
         if input_calibration_quantizer is not None:
             if _supports_calibration_decay(type(input_calibration_quantizer)):
                 input_calibration_quantizer.calibrate(

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -2621,10 +2621,13 @@ class Linear(TransformerEngineBaseModule):
         return out
 
     def _get_quantizers(self, fp8_output, fp8_grad, is_grad_enabled):
-        if not self.fp8:
+        if not self.fp8 and not self.fp8_calibration:
+            # Calibration-only mode needs quantizers to observe non-quantized tensors,
+            # so return None only when neither FP8 nor calibration is active.
             return [None] * 6
 
-        self._warn_missing_output_quantizer_role(fp8_output, fp8_grad)
+        if self.fp8:
+            self._warn_missing_output_quantizer_role(fp8_output, fp8_grad)
 
         grad_input_quantizer = None
         grad_weight_quantizer = None

--- a/transformer_engine/pytorch/quantization.py
+++ b/transformer_engine/pytorch/quantization.py
@@ -385,6 +385,37 @@ def is_nvfp4_available(return_reason: bool = False) -> Union[bool, Tuple[bool, s
     return check_nvfp4_support()[0]
 
 
+@dataclass(frozen=True, slots=True)
+class QuantizationCalibrationConfig:
+    """Configuration for collecting checkpointable quantization scaling factors.
+
+    Parameters
+    ----------
+    activation_scale_decay : float, default = 0.0
+        Decay applied to buffered activation scaling factors before incorporating
+        each new observation. With zero decay, only the latest value is retained.
+    """
+
+    activation_scale_decay: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.activation_scale_decay < 0.0:
+            raise ValueError("activation_scale_decay must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class TEAutocastState:
+    """Snapshot of process-global quantization autocast state."""
+
+    fp8_enabled: bool
+    fp8_calibration: bool
+    calibration_config: Optional[QuantizationCalibrationConfig]
+    fp8_recipe: Optional[Recipe]
+    fp8_distributed_group: Optional[dist_group_type]
+    is_first_fp8_module: bool
+    fp8_graph_capturing: bool
+
+
 @dataclass(slots=True)
 class FP8GlobalState:
     """Mutable process-global FP8 state stored on an instance.
@@ -410,6 +441,7 @@ class FP8GlobalState:
         default_factory=dict
     )
     skip_fp8_weight_update_tensor: Optional[torch.Tensor] = None
+    calibration_config: Optional[QuantizationCalibrationConfig] = None
 
 
 class FP8GlobalStateManager:
@@ -571,8 +603,21 @@ class FP8GlobalStateManager:
 
     @classmethod
     def is_fp8_calibration(cls) -> bool:
-        """Is FP8 calibration"""
+        """Whether quantization calibration is enabled."""
         return cls.quantization_state.fp8_calibration
+
+    @classmethod
+    def get_calibration_config(cls) -> Optional[QuantizationCalibrationConfig]:
+        """Get the active quantization calibration configuration."""
+        qstate = cls.quantization_state
+        if not qstate.fp8_calibration:
+            # User-declined calibration using the legacy fp8_calibration config.
+            return None
+        if qstate.calibration_config is not None:
+            # User-provided calibration config.
+            return qstate.calibration_config
+        # Default (fp8_calibration=True) config.
+        return QuantizationCalibrationConfig()
 
     @classmethod
     def with_fp8_parameters(cls) -> bool:
@@ -616,30 +661,30 @@ class FP8GlobalStateManager:
         return cls.quantization_state.fp8_distributed_group
 
     @classmethod
-    def get_autocast_state(cls) -> tuple:
+    def get_autocast_state(cls) -> TEAutocastState:
         """Snapshot the autocast-related fields of the quantization state."""
         qstate = cls.quantization_state
-        return (
-            qstate.fp8_enabled,
-            qstate.fp8_calibration,
-            qstate.fp8_recipe,
-            qstate.fp8_distributed_group,
-            qstate.is_first_fp8_module,
-            qstate.fp8_graph_capturing,
+        return TEAutocastState(
+            fp8_enabled=qstate.fp8_enabled,
+            fp8_calibration=qstate.fp8_calibration,
+            calibration_config=qstate.calibration_config,
+            fp8_recipe=qstate.fp8_recipe,
+            fp8_distributed_group=qstate.fp8_distributed_group,
+            is_first_fp8_module=qstate.is_first_fp8_module,
+            fp8_graph_capturing=qstate.fp8_graph_capturing,
         )
 
     @classmethod
-    def set_autocast_state(cls, state: tuple) -> None:
+    def set_autocast_state(cls, state: TEAutocastState) -> None:
         """Restore a previously saved autocast state snapshot."""
         qstate = cls.quantization_state
-        (
-            qstate.fp8_enabled,
-            qstate.fp8_calibration,
-            qstate.fp8_recipe,
-            qstate.fp8_distributed_group,
-            qstate.is_first_fp8_module,
-            qstate.fp8_graph_capturing,
-        ) = state
+        qstate.fp8_enabled = state.fp8_enabled
+        qstate.fp8_calibration = state.fp8_calibration
+        qstate.calibration_config = state.calibration_config
+        qstate.fp8_recipe = state.fp8_recipe
+        qstate.fp8_distributed_group = state.fp8_distributed_group
+        qstate.is_first_fp8_module = state.is_first_fp8_module
+        qstate.fp8_graph_capturing = state.fp8_graph_capturing
 
     @staticmethod
     def reduce_tensor_across_group_op_max(tensor: torch.Tensor, group: dist_group_type) -> None:
@@ -734,8 +779,12 @@ class FP8GlobalStateManager:
         fp8_recipe: Optional[Recipe] = None,
         fp8_group: Optional[dist_group_type] = None,
         _graph: bool = False,
+        calibration_config: Optional[QuantizationCalibrationConfig] = None,
     ) -> None:
         """Set state and tracking variables for entry into FP8 region."""
+
+        if calibrating and calibration_config is None:
+            calibration_config = QuantizationCalibrationConfig()
 
         fp8_recipe = get_default_fp8_recipe() if fp8_recipe is None else fp8_recipe
         autocast_key = cls.get_unique_autocast_key(fp8_recipe, fp8_group)
@@ -746,7 +795,8 @@ class FP8GlobalStateManager:
         )
 
         qstate.fp8_enabled = enabled
-        qstate.fp8_calibration = calibrating
+        qstate.fp8_calibration = calibration_config is not None
+        qstate.calibration_config = calibration_config
         qstate.fp8_recipe = fp8_recipe
         qstate.fp8_distributed_group = fp8_group
         qstate.fp8_graph_capturing = _graph
@@ -944,6 +994,7 @@ def fp8_autocast(
     fp8_recipe: Optional[Recipe] = None,
     fp8_group: Optional[dist_group_type] = None,
     _graph: bool = False,
+    calibration_config: Optional[QuantizationCalibrationConfig] = None,
 ) -> "autocast":
     """
     .. warning::
@@ -966,6 +1017,7 @@ def fp8_autocast(
         recipe=fp8_recipe,
         amax_reduction_group=fp8_group,
         _graph=_graph,
+        calibration_config=calibration_config,
     )
 
 
@@ -997,10 +1049,12 @@ class autocast:
     enabled : bool, default = True
              whether or not to enable low precision quantization (FP8/FP4).
     calibrating : bool, default = False
-                 calibration mode allows collecting statistics such as amax and scale
-                 data of quantized tensors even when executing without quantization enabled.
-                 This is useful for saving an inference ready checkpoint while training
-                 using a higher precision.
+                 Enables calibration with the default configuration. Calibration
+                 collects and buffers quantized scaling factors even when executing
+                 without quantization enabled.
+    calibration_config : QuantizationCalibrationConfig, default = None
+                  Custom configuration for collecting checkpointable quantization scaling
+                  factors. Providing a config also enables calibration.
     recipe : recipe.Recipe, default = None
             recipe used for low precision quantization.
     amax_reduction_group : torch._C._distributed_c10d.ProcessGroup, default = None
@@ -1012,7 +1066,7 @@ class autocast:
     # to avoid overheads.
     __slots__ = (
         "_enabled",
-        "_calibrating",
+        "_calibration_config",
         "_recipe",
         "_amax_reduction_group",
         "_graph",
@@ -1026,9 +1080,14 @@ class autocast:
         recipe: Optional["Recipe"] = None,
         amax_reduction_group: Optional["dist_group_type"] = None,
         _graph: bool = False,
+        calibration_config: Optional[QuantizationCalibrationConfig] = None,
     ) -> None:
         self._enabled = enabled
-        self._calibrating = calibrating
+        self._calibration_config = (
+            QuantizationCalibrationConfig()
+            if calibrating and calibration_config is None
+            else calibration_config
+        )
         self._recipe = recipe
         self._amax_reduction_group = amax_reduction_group
         self._graph = _graph
@@ -1046,7 +1105,8 @@ class autocast:
         self._fp8_state = FP8GlobalStateManager.get_autocast_state()
         FP8GlobalStateManager.autocast_enter(
             enabled=self._enabled,
-            calibrating=self._calibrating,
+            calibrating=False,
+            calibration_config=self._calibration_config,
             fp8_recipe=self._recipe,
             fp8_group=self._amax_reduction_group,
             _graph=self._graph,

--- a/transformer_engine/pytorch/quantization.py
+++ b/transformer_engine/pytorch/quantization.py
@@ -391,16 +391,16 @@ class QuantizationCalibrationConfig:
 
     Parameters
     ----------
-    activation_scale_decay : float, default = 0.0
+    transformer_engine_calibration_decay : float, default = 0.0
         Decay applied to buffered activation scaling factors before incorporating
         each new observation. With zero decay, only the latest value is retained.
     """
 
-    activation_scale_decay: float = 0.0
+    transformer_engine_calibration_decay: float = 0.0
 
     def __post_init__(self) -> None:
-        if self.activation_scale_decay < 0.0:
-            raise ValueError("activation_scale_decay must be non-negative")
+        if self.transformer_engine_calibration_decay < 0.0:
+            raise ValueError("transformer_engine_calibration_decay must be non-negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -1050,7 +1050,7 @@ class autocast:
              whether or not to enable low precision quantization (FP8/FP4).
     calibrating : bool, default = False
                  Enables calibration with the default configuration. Calibration
-                 collects and buffers quantized scaling factors even when executing
+                 collects and buffers Transformer Engine calibration metadata even when executing
                  without quantization enabled.
     calibration_config : QuantizationCalibrationConfig, default = None
                   Custom configuration for collecting checkpointable quantization scaling

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -571,7 +571,6 @@ class Quantizer(abc.ABC):
         ``calibration_decay`` decays the historical maximum before incorporating
         the current observation. A value of zero retains only the current metadata.
         """
-        pass
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -404,6 +404,7 @@ class Quantizer(abc.ABC):
         self.columnwise_usage = columnwise
         self.internal = False
         self.optimize_for_gemm = False
+        self._calibration_state: Dict[str, torch.Tensor] = {}
 
     def __repr__(self):
         return (
@@ -564,13 +565,60 @@ class Quantizer(abc.ABC):
             "nontensor_kwargs": meta["nontensor_kwargs"],
         }
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
-        """Calibrate quantizer state
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+        """Observe a tensor and update persistent calibration state."""
+        pass
 
-        Updates quantization state as if quantizing a tensor, but
-        without actually performing the quantization.
+    def get_quantization_recipe_name(self) -> str:
+        """Get the stable name of the quantization recipe."""
+        return ""
 
-        """
+    def _update_calibration_value(
+        self,
+        metadata_name: str,
+        observed_value: Optional[torch.Tensor],
+        *,
+        decay: float,
+    ) -> None:
+        """Merge an observation into quantizer-owned calibration state."""
+        if observed_value is None or torch.isnan(observed_value).any():
+            # Un-initialized scale. Ignore it.
+            return
+        observed_value = observed_value.detach()
+        calibration_state = getattr(self, "_calibration_state", None)
+        if calibration_state is None:
+            calibration_state = {}
+            self._calibration_state = calibration_state
+        calibration_value = calibration_state.get(metadata_name)
+        if decay > 0.0:
+            if calibration_value is not None and calibration_value.shape != observed_value.shape:
+                raise RuntimeError(
+                    "Quantizer calibration value shape changed from "
+                    f"{tuple(calibration_value.shape)} to {tuple(observed_value.shape)}"
+                )
+            if calibration_value is None:
+                # Initialize the rolling activation scaling factor.
+                # Requires CUDA graph warmup step.
+                calibration_value = torch.zeros_like(observed_value)
+                calibration_state[metadata_name] = calibration_value
+            # Track a decaying maximum so early-training activation
+            # outliers do not permanently determine the inference scale.
+            calibration_value.mul_(decay)
+            torch.maximum(calibration_value, observed_value, out=calibration_value)
+        else:
+            # Without scale history, keep a reference to the current metadata
+            # without allocating or copying a separate buffer.
+            # Requires CUDA graph warmup step, and only access this value
+            # at an appropriate time (e.g. checkpointing) if captured by CG.
+            calibration_state[metadata_name] = observed_value
+
+    def _share_calibration_state_with(self, quantizer: "Quantizer") -> None:
+        """Make a shallow quantizer copy share persistent calibration state."""
+        calibration_state = getattr(self, "_calibration_state", None)
+        if calibration_state is None:
+            calibration_state = {}
+            self._calibration_state = calibration_state
+        quantizer._calibration_state = calibration_state
 
     def set_usage(
         self, *, rowwise: Optional[bool] = None, columnwise: Optional[bool] = None

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -565,8 +565,12 @@ class Quantizer(abc.ABC):
             "nontensor_kwargs": meta["nontensor_kwargs"],
         }
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
-        """Observe a tensor and update persistent calibration state."""
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
+        """Observe a tensor and update persistent calibration state.
+
+        ``calibration_decay`` decays the historical maximum before incorporating
+        the current observation. A value of zero retains only the current metadata.
+        """
         pass
 
     def get_quantization_recipe_name(self) -> str:
@@ -578,19 +582,16 @@ class Quantizer(abc.ABC):
         metadata_name: str,
         observed_value: Optional[torch.Tensor],
         *,
-        decay: float,
+        calibration_decay: float,
     ) -> None:
         """Merge an observation into quantizer-owned calibration state."""
         if observed_value is None or torch.isnan(observed_value).any():
             # Un-initialized scale. Ignore it.
             return
         observed_value = observed_value.detach()
-        calibration_state = getattr(self, "_calibration_state", None)
-        if calibration_state is None:
-            calibration_state = {}
-            self._calibration_state = calibration_state
+        calibration_state = self._calibration_state
         calibration_value = calibration_state.get(metadata_name)
-        if decay > 0.0:
+        if calibration_decay > 0.0:
             if calibration_value is not None and calibration_value.shape != observed_value.shape:
                 raise RuntimeError(
                     "Quantizer calibration value shape changed from "
@@ -603,7 +604,7 @@ class Quantizer(abc.ABC):
                 calibration_state[metadata_name] = calibration_value
             # Track a decaying maximum so early-training activation
             # outliers do not permanently determine the inference scale.
-            calibration_value.mul_(decay)
+            calibration_value.mul_(calibration_decay)
             torch.maximum(calibration_value, observed_value, out=calibration_value)
         else:
             # Without scale history, keep a reference to the current metadata
@@ -614,11 +615,7 @@ class Quantizer(abc.ABC):
 
     def _share_calibration_state_with(self, quantizer: "Quantizer") -> None:
         """Make a shallow quantizer copy share persistent calibration state."""
-        calibration_state = getattr(self, "_calibration_state", None)
-        if calibration_state is None:
-            calibration_state = {}
-            self._calibration_state = calibration_state
-        quantizer._calibration_state = calibration_state
+        quantizer._calibration_state = self._calibration_state
 
     def set_usage(
         self, *, rowwise: Optional[bool] = None, columnwise: Optional[bool] = None

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -243,10 +243,18 @@ class Float8BlockQuantizer(Quantizer):
             return False
         return True
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
         # NOTE: This interface is specific to requirements like delayed scaling
         # where state from an estimator influences distribution parameters.
+        # NOTE(@cspades): Currently, PTQ calibration requirements don't need
+        # non-global / blockwise scaling factors, which are usually computed
+        # on-the-fly during inference. Implement this interface for future
+        # applications of blockwise scaling factor calibration.
         pass
+
+    def get_quantization_recipe_name(self) -> str:
+        """Get the stable name of the quantization recipe."""
+        return "fp8_block_scaling"
 
     def _get_compatible_recipe(self) -> Union[type[Recipe], None]:
         return Float8BlockScaling

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -244,12 +244,10 @@ class Float8BlockQuantizer(Quantizer):
         return True
 
     def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
-        # NOTE: This interface is specific to requirements like delayed scaling
-        # where state from an estimator influences distribution parameters.
         # NOTE(@cspades): Currently, PTQ calibration requirements don't need
         # non-global / blockwise scaling factors, which are usually computed
         # on-the-fly during inference. Implement this interface for future
-        # applications of blockwise scaling factor calibration.
+        # applications of blockwise FP8 calibration.
         pass
 
     def get_quantization_recipe_name(self) -> str:

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -244,11 +244,11 @@ class Float8BlockQuantizer(Quantizer):
         return True
 
     def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
+        """Float8BlockQuantizer does not yet support calibration."""
         # NOTE(@cspades): Currently, PTQ calibration requirements don't need
         # non-global / blockwise scaling factors, which are usually computed
         # on-the-fly during inference. Implement this interface for future
         # applications of blockwise FP8 calibration.
-        pass
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -243,7 +243,7 @@ class Float8BlockQuantizer(Quantizer):
             return False
         return True
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
         # NOTE: This interface is specific to requirements like delayed scaling
         # where state from an estimator influences distribution parameters.
         # NOTE(@cspades): Currently, PTQ calibration requirements don't need

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -136,9 +136,7 @@ class Float8Quantizer(Quantizer):
             amin, amax = tensor.aminmax()
             observed_amax = torch.max(-amin, amax).reshape(1)
             self.amax.copy_(observed_amax)
-        self._update_calibration_value(
-            "amax", observed_amax, calibration_decay=calibration_decay
-        )
+        self._update_calibration_value("amax", observed_amax, calibration_decay=calibration_decay)
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""
@@ -359,9 +357,7 @@ class Float8CurrentScalingQuantizer(Quantizer):
                 scale = torch.ldexp(torch.ones_like(scale), exponent - 1)
             scale.masked_fill_(torch.isinf(amax) | (amax == 0), 1.0)
             scale_inv = torch.reciprocal(scale)
-        self._update_calibration_value(
-            "scale_inv", scale_inv, calibration_decay=calibration_decay
-        )
+        self._update_calibration_value("scale_inv", scale_inv, calibration_decay=calibration_decay)
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -125,8 +125,9 @@ class Float8Quantizer(Quantizer):
         """Quantize tensor implementation"""
         return tex.quantize(tensor, self)
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
         if isinstance(tensor, (QuantizedTensor, QuantizedTensorStorage)):
+            # Retrieve the quantization metadata from quantized storage.
             observed_amax = self.amax
         else:
             # If quantized amax metadata does not yet exist or calibrate() is called directly,
@@ -135,7 +136,9 @@ class Float8Quantizer(Quantizer):
             amin, amax = tensor.aminmax()
             observed_amax = torch.max(-amin, amax).reshape(1)
             self.amax.copy_(observed_amax)
-        self._update_calibration_value("amax", observed_amax, decay=decay)
+        self._update_calibration_value(
+            "amax", observed_amax, calibration_decay=calibration_decay
+        )
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""
@@ -329,13 +332,14 @@ class Float8CurrentScalingQuantizer(Quantizer):
         """Quantize tensor implementation"""
         return tex.quantize(tensor, self)
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
-        """Compute and calibrate (decaying amax) quantization metadata."""
-        scale_inv = getattr(tensor, "_scale_inv", None)
-        if scale_inv is None:
-            # If the scale_inv does not yet exist or calibrate() is called directly,
-            # then recompute the absmax / scale without quantization. This path is
-            # not performant and SHOULD NOT be called within training or inference.
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
+        """Compute and calibrate quantization metadata."""
+        if isinstance(tensor, (QuantizedTensor, QuantizedTensorStorage)):
+            # Retrieve the quantization metadata from quantized storage.
+            scale_inv = tensor._scale_inv
+        else:
+            # Direct calibration of a non-quantized tensor must reconstruct the metadata.
+            # This path is not performant and SHOULD NOT be called within training or inference.
             amin, amax = tensor.aminmax()
             amax = torch.maximum(-amin, amax).float().reshape(1)
             if self.with_amax_reduction and torch.distributed.is_initialized():
@@ -355,7 +359,9 @@ class Float8CurrentScalingQuantizer(Quantizer):
                 scale = torch.ldexp(torch.ones_like(scale), exponent - 1)
             scale.masked_fill_(torch.isinf(amax) | (amax == 0), 1.0)
             scale_inv = torch.reciprocal(scale)
-        self._update_calibration_value("scale_inv", scale_inv, decay=decay)
+        self._update_calibration_value(
+            "scale_inv", scale_inv, calibration_decay=calibration_decay
+        )
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -17,14 +17,14 @@ from transformer_engine.common.recipe import (
 )
 from ..utils import canonicalize_process_group, devices_match, is_non_tn_fp8_gemm_supported
 from .storage.float8_tensor_storage import Float8TensorStorage, _FromFloat8Func
-from ..quantized_tensor import QuantizedTensor, Quantizer
+from ..quantized_tensor import QuantizedTensor, QuantizedTensorStorage, Quantizer
 from ..dynamo import register_value_opaque_quantizer
 from ._quantization_helpers import (
     _IdentityFunc,
     _resolve_view_shape,
     safe_quantized_repr,
 )
-from ..constants import dist_group_type, DType
+from ..constants import dist_group_type, DType, TE_DType_To_Torch
 
 aten = torch.ops.aten
 
@@ -93,6 +93,7 @@ class Float8Quantizer(Quantizer):
             columnwise=self.columnwise_usage,
         )
         quantizer.internal = self.internal
+        self._share_calibration_state_with(quantizer)
 
         return quantizer
 
@@ -124,9 +125,21 @@ class Float8Quantizer(Quantizer):
         """Quantize tensor implementation"""
         return tex.quantize(tensor, self)
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
-        amin, amax = tensor.aminmax()
-        self.amax.copy_(torch.max(-amin, amax))
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+        if isinstance(tensor, (QuantizedTensor, QuantizedTensorStorage)):
+            observed_amax = self.amax
+        else:
+            # If quantized amax metadata does not yet exist or calibrate() is called directly,
+            # then recompute the absmax without quantization. This path is
+            # not performant and SHOULD NOT be called within training or inference.
+            amin, amax = tensor.aminmax()
+            observed_amax = torch.max(-amin, amax).reshape(1)
+            self.amax.copy_(observed_amax)
+        self._update_calibration_value("amax", observed_amax, decay=decay)
+
+    def get_quantization_recipe_name(self) -> str:
+        """Get the stable name of the quantization recipe."""
+        return "fp8_delayed_scaling"
 
     def get_columnwise_shape(self, rowwise_data_shape: Iterable[int]) -> Tuple[int, ...]:
         """Calculate the shape of the columnwise data for Float8 1D blockwise quantization."""
@@ -276,6 +289,7 @@ class Float8CurrentScalingQuantizer(Quantizer):
         )
         quantizer.internal = self.internal
         quantizer.optimize_for_gemm = self.optimize_for_gemm
+        self._share_calibration_state_with(quantizer)
 
         return quantizer
 
@@ -315,9 +329,37 @@ class Float8CurrentScalingQuantizer(Quantizer):
         """Quantize tensor implementation"""
         return tex.quantize(tensor, self)
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
-        # current scaling don't need to calibrate
-        return
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+        """Compute and calibrate (decaying amax) quantization metadata."""
+        scale_inv = getattr(tensor, "_scale_inv", None)
+        if scale_inv is None:
+            # If the scale_inv does not yet exist or calibrate() is called directly,
+            # then recompute the absmax / scale without quantization. This path is
+            # not performant and SHOULD NOT be called within training or inference.
+            amin, amax = tensor.aminmax()
+            amax = torch.maximum(-amin, amax).float().reshape(1)
+            if self.with_amax_reduction and torch.distributed.is_initialized():
+                torch.distributed.all_reduce(
+                    amax,
+                    op=torch.distributed.ReduceOp.MAX,
+                    group=self._canonicalized_amax_reduction_group(),
+                )
+            if self.amax_epsilon > 0.0:
+                amax.clamp_min_(self.amax_epsilon)
+            fp8_max = torch.finfo(TE_DType_To_Torch[self.dtype]).max
+            scale = fp8_max / amax
+            finite_scale = torch.finfo(tensor.dtype).max
+            scale.nan_to_num_(nan=float("nan"), posinf=finite_scale, neginf=finite_scale)
+            if self.force_pow_2_scales:
+                _, exponent = torch.frexp(scale)
+                scale = torch.ldexp(torch.ones_like(scale), exponent - 1)
+            scale.masked_fill_(torch.isinf(amax) | (amax == 0), 1.0)
+            scale_inv = torch.reciprocal(scale)
+        self._update_calibration_value("scale_inv", scale_inv, decay=decay)
+
+    def get_quantization_recipe_name(self) -> str:
+        """Get the stable name of the quantization recipe."""
+        return "fp8_current_scaling"
 
     def create_tensor_from_data(
         self,

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -134,7 +134,7 @@ class Float8Quantizer(Quantizer):
             # then recompute the absmax without quantization. This path is
             # not performant and SHOULD NOT be called within training or inference.
             amin, amax = tensor.aminmax()
-            observed_amax = torch.max(-amin, amax).reshape(1)
+            observed_amax = torch.max(-amin, amax).float().reshape(1)
             self.amax.copy_(observed_amax)
         self._update_calibration_value("amax", observed_amax, calibration_decay=calibration_decay)
 

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -131,8 +131,8 @@ class Float8Quantizer(Quantizer):
             observed_amax = self.amax
         else:
             # If quantized amax metadata does not yet exist or calibrate() is called directly,
-            # then recompute the absmax without quantization. This path is
-            # not performant and SHOULD NOT be called within training or inference.
+            # then recompute the absmax without quantization.
+            # This path is NOT performant and should only be used for non-quantized Tensor calibration.
             amin, amax = tensor.aminmax()
             observed_amax = torch.max(-amin, amax).float().reshape(1)
             self.amax.copy_(observed_amax)
@@ -337,7 +337,7 @@ class Float8CurrentScalingQuantizer(Quantizer):
             scale_inv = tensor._scale_inv
         else:
             # Direct calibration of a non-quantized tensor must reconstruct the metadata.
-            # This path is not performant and SHOULD NOT be called within training or inference.
+            # This path is NOT performant and should only be used for non-quantized Tensor calibration.
             amin, amax = tensor.aminmax()
             amax = torch.maximum(-amin, amax).float().reshape(1)
             if self.with_amax_reduction and torch.distributed.is_initialized():

--- a/transformer_engine/pytorch/tensor/hybrid_tensor.py
+++ b/transformer_engine/pytorch/tensor/hybrid_tensor.py
@@ -159,7 +159,6 @@ class HybridQuantizer(Quantizer):
 
     def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
         """HybridQuantizer calibrate() has not yet been implemented."""
-        pass
 
     @property
     def with_amax_reduction(self) -> bool:

--- a/transformer_engine/pytorch/tensor/hybrid_tensor.py
+++ b/transformer_engine/pytorch/tensor/hybrid_tensor.py
@@ -157,6 +157,10 @@ class HybridQuantizer(Quantizer):
         quantizer.optimize_for_gemm = self.optimize_for_gemm
         return quantizer
 
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
+        """Reject calibration until child metadata ownership is supported."""
+        raise NotImplementedError("Calibration is not yet supported for HybridQuantizer")
+
     @property
     def with_amax_reduction(self) -> bool:
         """Whether either sub-quantizer has cross-rank amax reduction enabled."""

--- a/transformer_engine/pytorch/tensor/hybrid_tensor.py
+++ b/transformer_engine/pytorch/tensor/hybrid_tensor.py
@@ -158,8 +158,8 @@ class HybridQuantizer(Quantizer):
         return quantizer
 
     def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
-        """Reject calibration until child metadata ownership is supported."""
-        raise NotImplementedError("Calibration is not yet supported for HybridQuantizer")
+        """HybridQuantizer calibrate() has not yet been implemented."""
+        pass
 
     @property
     def with_amax_reduction(self) -> bool:

--- a/transformer_engine/pytorch/tensor/identity_tensor.py
+++ b/transformer_engine/pytorch/tensor/identity_tensor.py
@@ -162,9 +162,9 @@ class IdentityQuantizer(Quantizer):
         dst._dtype = data.dtype
         return dst
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
         # No state to calibrate.
-        return
+        pass
 
     def _get_compatible_recipe(self):
         # Only reachable via CustomRecipe (qfactory returns IdentityQuantizer).

--- a/transformer_engine/pytorch/tensor/identity_tensor.py
+++ b/transformer_engine/pytorch/tensor/identity_tensor.py
@@ -163,8 +163,7 @@ class IdentityQuantizer(Quantizer):
         return dst
 
     def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
-        # No state to calibrate.
-        pass
+        """No-op since identity quantization has no calibration state."""
 
     def _get_compatible_recipe(self):
         # Only reachable via CustomRecipe (qfactory returns IdentityQuantizer).

--- a/transformer_engine/pytorch/tensor/identity_tensor.py
+++ b/transformer_engine/pytorch/tensor/identity_tensor.py
@@ -162,7 +162,7 @@ class IdentityQuantizer(Quantizer):
         dst._dtype = data.dtype
         return dst
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
         # No state to calibrate.
         pass
 

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -138,7 +138,6 @@ class MXFP8Quantizer(Quantizer):
         # non-global / blockwise scaling factors, which are usually computed
         # on-the-fly during inference. Implement this interface for future
         # applications of MXFP8 calibration.
-        pass
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -132,7 +132,7 @@ class MXFP8Quantizer(Quantizer):
             return False
         return True
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
         """Calibrate an MXFP8 tensor."""
         # NOTE(@cspades): Currently, PTQ calibration requirements don't need
         # non-global / blockwise scaling factors, which are usually computed

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -132,9 +132,17 @@ class MXFP8Quantizer(Quantizer):
             return False
         return True
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
-        # TODO(ksivamani): No calibration needed for mxfp8?
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+        """Calibrate an MXFP8 tensor."""
+        # NOTE(@cspades): Currently, PTQ calibration requirements don't need
+        # non-global / blockwise scaling factors, which are usually computed
+        # on-the-fly during inference. Implement this interface for future
+        # applications of MXFP8 calibration.
         pass
+
+    def get_quantization_recipe_name(self) -> str:
+        """Get the stable name of the quantization recipe."""
+        return "mxfp8"
 
     def get_scale_shape(
         self,

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -22,7 +22,7 @@ from ..utils import (
 )
 
 from .storage.nvfp4_tensor_storage import NVFP4TensorStorage, _FromNVFP4Func
-from ..quantized_tensor import QuantizedTensor, Quantizer
+from ..quantized_tensor import QuantizedTensor, QuantizedTensorStorage, Quantizer
 from ..dynamo import register_value_opaque_quantizer
 from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 
@@ -340,13 +340,14 @@ class NVFP4Quantizer(Quantizer):
         shape[-1] = shape[-1] // 2
         return tuple(shape)
 
-    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+    def calibrate(self, tensor: torch.Tensor, *, calibration_decay: float = 0.0) -> None:
         metadata_name = "amax_rowwise" if self.row_scaled_nvfp4 else "amax"
-        observed_amax = getattr(tensor, "_amax_rowwise", None)
-        if observed_amax is None:
-            # If quantized amax metadata does not yet exist or calibrate() is called directly,
-            # then recompute the absmax without quantization. This path is
-            # not performant and SHOULD NOT be called within training or inference.
+        if isinstance(tensor, (QuantizedTensor, QuantizedTensorStorage)):
+            # Retrieve the quantization metadata from quantized storage.
+            observed_amax = tensor._amax_rowwise
+        else:
+            # Direct calibration of a non-quantized tensor must reconstruct the metadata.
+            # This path is not performant and SHOULD NOT be called within training or inference.
             calibration_input = tensor
             if self.with_rht and self.with_post_rht_amax:
                 original_shape = calibration_input.shape
@@ -364,7 +365,11 @@ class NVFP4Quantizer(Quantizer):
                     op=torch.distributed.ReduceOp.MAX,
                     group=self._canonicalized_amax_reduction_group(),
                 )
-        self._update_calibration_value(metadata_name, observed_amax, decay=decay)
+        self._update_calibration_value(
+            metadata_name,
+            observed_amax,
+            calibration_decay=calibration_decay,
+        )
 
     def get_quantization_recipe_name(self) -> str:
         """Get the stable name of the quantization recipe."""

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -247,6 +247,7 @@ class NVFP4Quantizer(Quantizer):
         )
         quantizer.internal = self.internal
         quantizer.optimize_for_gemm = self.optimize_for_gemm
+        self._share_calibration_state_with(quantizer)
 
         return quantizer
 
@@ -339,8 +340,35 @@ class NVFP4Quantizer(Quantizer):
         shape[-1] = shape[-1] // 2
         return tuple(shape)
 
-    def calibrate(self, tensor: torch.Tensor) -> None:
-        pass  # Calibration is no-op
+    def calibrate(self, tensor: torch.Tensor, *, decay: float = 0.0) -> None:
+        metadata_name = "amax_rowwise" if self.row_scaled_nvfp4 else "amax"
+        observed_amax = getattr(tensor, "_amax_rowwise", None)
+        if observed_amax is None:
+            # If quantized amax metadata does not yet exist or calibrate() is called directly,
+            # then recompute the absmax without quantization. This path is
+            # not performant and SHOULD NOT be called within training or inference.
+            calibration_input = tensor
+            if self.with_rht and self.with_post_rht_amax:
+                original_shape = calibration_input.shape
+                calibration_input = (
+                    calibration_input.reshape(-1, 16).to(torch.bfloat16) @ self.rht_matrix
+                ).reshape(original_shape)
+            if self.row_scaled_nvfp4:
+                amin, amax = calibration_input.aminmax(dim=-1)
+            else:
+                amin, amax = calibration_input.aminmax()
+            observed_amax = torch.maximum(-amin, amax).reshape(-1).float()
+            if self.with_amax_reduction and torch.distributed.is_initialized():
+                torch.distributed.all_reduce(
+                    observed_amax,
+                    op=torch.distributed.ReduceOp.MAX,
+                    group=self._canonicalized_amax_reduction_group(),
+                )
+        self._update_calibration_value(metadata_name, observed_amax, decay=decay)
+
+    def get_quantization_recipe_name(self) -> str:
+        """Get the stable name of the quantization recipe."""
+        return "nvfp4_rowwise" if self.row_scaled_nvfp4 else "nvfp4"
 
     def _canonicalized_amax_reduction_group(self) -> dist_group_type:
         """Get process group for amax reduction"""

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -348,16 +348,10 @@ class NVFP4Quantizer(Quantizer):
         else:
             # Direct calibration of a non-quantized tensor must reconstruct the metadata.
             # This path is not performant and SHOULD NOT be called within training or inference.
-            calibration_input = tensor
-            if self.with_rht and self.with_post_rht_amax:
-                original_shape = calibration_input.shape
-                calibration_input = (
-                    calibration_input.reshape(-1, 16).to(torch.bfloat16) @ self.rht_matrix
-                ).reshape(original_shape)
             if self.row_scaled_nvfp4:
-                amin, amax = calibration_input.aminmax(dim=-1)
+                amin, amax = tensor.aminmax(dim=-1)
             else:
-                amin, amax = calibration_input.aminmax()
+                amin, amax = tensor.aminmax()
             observed_amax = torch.maximum(-amin, amax).reshape(-1).float()
             if self.with_amax_reduction and torch.distributed.is_initialized():
                 torch.distributed.all_reduce(

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -347,7 +347,7 @@ class NVFP4Quantizer(Quantizer):
             observed_amax = tensor._amax_rowwise
         else:
             # Direct calibration of a non-quantized tensor must reconstruct the metadata.
-            # This path is not performant and SHOULD NOT be called within training or inference.
+            # This path is NOT performant and should only be used for non-quantized Tensor calibration.
             if self.row_scaled_nvfp4:
                 amin, amax = tensor.aminmax(dim=-1)
             else:

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -24,6 +24,26 @@ from ..utils import is_non_tn_fp8_gemm_supported
 from ..constants import NVFP4_BLOCK_SCALING_SIZE, DType
 
 
+def get_quantization_recipe_name(quantizer: Optional[Quantizer]) -> str:
+    """Get a stable recipe name from a quantizer."""
+    quantizer = getattr(quantizer, "parent_quantizer", quantizer)
+    if quantizer is None:
+        return ""
+    if isinstance(quantizer, Float8Quantizer):
+        return "fp8_delayed_scaling"
+    if isinstance(quantizer, Float8CurrentScalingQuantizer):
+        return "fp8_current_scaling"
+    if isinstance(quantizer, MXFP8Quantizer):
+        return "mxfp8"
+    if isinstance(quantizer, Float8BlockQuantizer):
+        return "fp8_block_scaling"
+    if isinstance(quantizer, NVFP4Quantizer):
+        if quantizer.row_scaled_nvfp4:
+            return "nvfp4_rowwise"
+        return "nvfp4"
+    raise ValueError(f"Unsupported quantizer type: {type(quantizer)}")
+
+
 def replace_raw_data(tensor: QuantizedTensor, new_raw_data: torch.Tensor):
     r"""Change a quantized tensor's data buffer while preserving values
 

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -41,7 +41,9 @@ def get_quantization_recipe_name(quantizer: Optional[Quantizer]) -> str:
         if quantizer.row_scaled_nvfp4:
             return "nvfp4_rowwise"
         return "nvfp4"
-    raise ValueError(f"Unsupported quantizer type: {type(quantizer)}")
+    # Custom recipes may provide arbitrary Quantizer implementations without a
+    # stable recipe name or globally checkpointable scaling metadata.
+    return ""
 
 
 def replace_raw_data(tensor: QuantizedTensor, new_raw_data: torch.Tensor):

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -27,6 +27,26 @@ from ..utils import is_non_tn_fp8_gemm_supported
 from ..constants import NVFP4_BLOCK_SCALING_SIZE, DType
 
 
+def get_quantization_recipe_name(quantizer: Optional[Quantizer]) -> str:
+    """Get a stable recipe name from a quantizer."""
+    quantizer = getattr(quantizer, "parent_quantizer", quantizer)
+    if quantizer is None:
+        return ""
+    if isinstance(quantizer, Float8Quantizer):
+        return "fp8_delayed_scaling"
+    if isinstance(quantizer, Float8CurrentScalingQuantizer):
+        return "fp8_current_scaling"
+    if isinstance(quantizer, MXFP8Quantizer):
+        return "mxfp8"
+    if isinstance(quantizer, Float8BlockQuantizer):
+        return "fp8_block_scaling"
+    if isinstance(quantizer, NVFP4Quantizer):
+        if quantizer.row_scaled_nvfp4:
+            return "nvfp4_rowwise"
+        return "nvfp4"
+    raise ValueError(f"Unsupported quantizer type: {type(quantizer)}")
+
+
 def replace_raw_data(tensor: QuantizedTensor, new_raw_data: torch.Tensor):
     r"""Change a quantized tensor's data buffer while preserving values
 

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -44,7 +44,9 @@ def get_quantization_recipe_name(quantizer: Optional[Quantizer]) -> str:
         if quantizer.row_scaled_nvfp4:
             return "nvfp4_rowwise"
         return "nvfp4"
-    raise ValueError(f"Unsupported quantizer type: {type(quantizer)}")
+    # Custom recipes may provide arbitrary Quantizer implementations without a
+    # stable recipe name or globally checkpointable scaling metadata.
+    return ""
 
 
 def replace_raw_data(tensor: QuantizedTensor, new_raw_data: torch.Tensor):

--- a/transformer_engine/pytorch/tensor/utils.py
+++ b/transformer_engine/pytorch/tensor/utils.py
@@ -32,21 +32,7 @@ def get_quantization_recipe_name(quantizer: Optional[Quantizer]) -> str:
     quantizer = getattr(quantizer, "parent_quantizer", quantizer)
     if quantizer is None:
         return ""
-    if isinstance(quantizer, Float8Quantizer):
-        return "fp8_delayed_scaling"
-    if isinstance(quantizer, Float8CurrentScalingQuantizer):
-        return "fp8_current_scaling"
-    if isinstance(quantizer, MXFP8Quantizer):
-        return "mxfp8"
-    if isinstance(quantizer, Float8BlockQuantizer):
-        return "fp8_block_scaling"
-    if isinstance(quantizer, NVFP4Quantizer):
-        if quantizer.row_scaled_nvfp4:
-            return "nvfp4_rowwise"
-        return "nvfp4"
-    # Custom recipes may provide arbitrary Quantizer implementations without a
-    # stable recipe name or globally checkpointable scaling metadata.
-    return ""
+    return quantizer.get_quantization_recipe_name()
 
 
 def replace_raw_data(tensor: QuantizedTensor, new_raw_data: torch.Tensor):


### PR DESCRIPTION
# Description

<table>
  <tr>
    <td align="center" width="25%"><b>agieval</b><br/><img src="https://github.com/user-attachments/assets/90910fb9-4973-42f5-9b5a-54ff050fe9d0" width="380" alt="agieval" /></td>
    <td align="center" width="25%"><b>arc_challenge</b><br/><img src="https://github.com/user-attachments/assets/d704a7dc-ffa5-45af-852e-423f5bf4e626" width="380" alt="arc_challenge" /></td>
    <td align="center" width="25%"><b>arc_easy</b><br/><img src="https://github.com/user-attachments/assets/43900535-116f-466c-ad02-b55931073034" width="380" alt="arc_easy" /></td>
    <td align="center" width="25%"><b>gsm8k</b><br/><img src="https://github.com/user-attachments/assets/4e15609a-c274-495b-88e4-e8ae5c348143" width="380" alt="gsm8k" /></td>
  </tr>
  <tr>
    <td align="center" width="25%"><b>humaneval</b><br/><img src="https://github.com/user-attachments/assets/9dd42da9-8308-4fd8-b8e7-31d8d639f950" width="380" alt="humaneval" /></td>
    <td align="center" width="25%"><b>lambada_standard</b><br/><img src="https://github.com/user-attachments/assets/232a1665-e5e9-43c6-aeed-29657fff5b75" width="380" alt="lambada_standard" /></td>
    <td align="center" width="25%"><b>mmlu</b><br/><img src="https://github.com/user-attachments/assets/a301a998-b81c-4694-a960-969da4f5981a" width="380" alt="mmlu" /></td>
    <td align="center" width="25%"><b>winogrande</b><br/><img src="https://github.com/user-attachments/assets/f047e56e-3c25-4cbc-aaca-41e9d1ed5d08" width="380" alt="winogrande" /></td>
  </tr>
</table>

Source: https://github.com/NVIDIA/Megatron-LM/issues/5660#issuecomment-5581231117

See issue for context: https://github.com/NVIDIA/Megatron-LM/issues/5660
Related to: https://github.com/NVIDIA/Megatron-LM/pull/6183

- Extended the `Quantizer.calibrate()` API to support decayed calibration and model buffering.
  - The public API `autocast(calibrating: bool, calibration_config: QuantizationCalibrationConfig)` (both arguments, kept the older one for legacy / backwards compatibility with decay defaulting to 0) turns on the feature, and by default it is deactivated.
  - `calibrate` will first look for calibration metadata according to the quantization recipe, but if that doesn't exist yet it will just take the non-quantized `Tensor` argument and compute its quantization metadata, _**since this is the original behavior of `calibrate`**_.
    - It is super un-performant to recompute the quantization metadata, usually it is fused into a TE kernel. So during training and inference, this path where we cannot find the quantization metadata should never be run.
  - `calibrate` now has implementations for all of the recipes that use FP32 global scaling factors, and the decayed calibration update is implemented in the base class `Quantizer._update_calibration_value`. It'll also buffer them automatically, which is a change in behavior but the extra buffering feature isn't a big deal for performance/memory (and frankly what's the point of storing calibration data natively in TE if we never export it), refer to my results below!
- To enable users to mine PTQ calibration data from their pre-training datasets, buffer scaling factors for quantized activations and weights for checkpointing in Megatron and inference in vLLM, Tensor-RT, ModelOpt, etc.
  - This is an exported common state artifact, it can be saved but (should) not (be) loaded, and will not appear in the model state dict. No risk of surprise overwriting of weight scaling factors, for instance.
  - Buffer names are linked to TE modules and are named pretty comprehensively: `f"{tensor_name}_tensor_{metadata_name}_{recipe}_te_ptq_calibrated"`
- `QuantizationCalibrationConfig` only has a single argument at the moment but in the future could hypothetically have way more, it's just that now we only buffer FP32 global scaling factors so it's simply just `activation_scale_decay`.
  - `activation_scale_decay` controls the decay of past max-accumulated activation scaling factors when your model or dataset is in-flight during training. Intends to capture steady-state maxima.
    - `New AbsMax = Max(Old AbsMax * Decay, Observed AbsMax)`
    - Setting it to 0 implies only taking the most recent scaling factor, while setting it to 1 implies taking an absmax over the entire history of your model and/or dataset.
    - You can do quite a lot of hacky customization on the MCore side, i.e. setting LR=0 means you're basically just calibrating on your calibration dataset with a frozen model.
  - Tiny performance loss to compute the accumulated max, but almost unnoticeable for both dense and MoE (GroupedLinear).
  - Tiny memory overhead to store the accumulated activation scaling factors. Since it's just 4 bytes per activation (FP32 global scale), it's not a lot at all.
    - Weights do not need to be accumulated, so the weight buffer points to the literal row-wise scaling factor in the quantized tensor storage and doesn't take any memory. (Set row-wise usage to True, on the user to do it.)
  - We do not save blockwise scaling factors (or `CustomRecipe` and `HybridQuantizer`, which will error out), those are usually computed during inference or using more advanced calibration techniques.
    - We do store the row-wise NVFP4 scaling factors, but in MCore I just max-reduce it to a scalar as well.
- `TEAutocastState` is another new data-class that may concern you since it changes the API of `get_autocast_state` and `set_autocast_state` which are public interfaces for the global quant state.
  - That being said, currently Megatron-LM and other NeMo repositories are not directly using this, and it gets really messy with checkpointing if I have to reset `QuantizationCalibrationConfig` so I think now's a good time to stop returning `tuple`s...

## Testing

- Really basic unit tests, tell me if you want to see more.
- Performance is only affected when decay is activated, and memory is only increased when buffering activations.
```
# Main / No scaling factor checkpointing.

[2026-07-27 13:24:57.339692] iteration       16/15258789 | consumed samples:         2048 | elapsed time per iteration (ms): 6282.9 | throughput per GPU (TFLOP/s/GPU): 2147.5 | learning rate: 7.864316E-08 | global batch size:   128 | lm loss: 1.207198E+01 | loss scale: 1.0 | grad norm: 20.134 | number of skipped iterations:   0 |number of nan iterations:   0 |

[Rank 0] (after 2 iterations) memory (MB) | allocated: 69607.20 | max allocated: 99633.89 | reserved: 72394.00| max reserved: 100310.00

# Scaling factor & absmax checkpointing. (--buffer-transformer-engine-calibration-metadata)

[2026-07-27 13:45:56.610449] iteration       16/15258789 | consumed samples:         2048 | elapsed time per iteration (ms): 6282.0 | throughput per GPU (TFLOP/s/GPU): 2147.8 | learning rate: 7.864316E-08 | global batch size:   128 | lm loss: 1.207239E+01 | loss scale: 1.0 | grad norm: 20.133 | number of skipped iterations:   0 | number of nan iterations:   0 |

[Rank 0] (after 2 iterations) memory (MB) | allocated: 69607.26 | max allocated: 99633.94 | reserved: 72394.00 | max reserved: 100310.00

# Decaying Activation Scaling Factors & Absmax (--transformer-engine-calibration-decay 0.99)

[2026-07-27 13:51:03.183943] iteration       16/15258789 | consumed samples:         2048 | elapsed time per iteration (ms): 6486.2 | throughput per GPU (TFLOP/s/GPU): 2080.2 | learning rate: 7.864316E-08 | global batch size:   128 | lm loss: 1.207229E+01 | loss scale: 1.0 | grad norm: 20.133 | number of skipped iterations:   0 |number of nan iterations:   0 |

[Rank 0] (after 2 iterations) memory (MB) | allocated: 69607.32 | max allocated: 99634.00 | reserved: 72396.00| max reserved: 100310.00
```
For future reference, I also considered buffering MXFP8 / NVFP4 / FP8-Blockwise factors, but there is a memory and massive performance hit, and generally inference computes these dynamically:
```
# Decaying Activation Scaling Factors + Blockwise Activation Scales (i.e. `_rowwise_scale_inv`)
# (Just FYI why we don't want to export blockwise scales, they significantly affect perf and memory, and aren't really necessary for calibration.)

[2026-07-27 13:57:09.949572] iteration       16/15258789 | consumed samples:         2048 | elapsed time per iteration (ms): 6857.8 | throughput per GPU (TFLOP/s/GPU): 1967.5 | learning rate: 7.864316E-08 | global batch size:   128 | lm loss: 1.207223E+01 | loss scale: 1.0 | grad norm: 20.134 | number of skipped iterations:   0 |number of nan iterations:   0 |

[Rank 0] (after 2 iterations) memory (MB) | allocated: 71158.36 | max allocated: 101184.57 | reserved: 74394.00 | max reserved: 101934.00 
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
