### PR TITLE
Pin nltk to work around breaking change in tests

### DIFF
--- a/qa/L0_jax_unittest/test.sh
+++ b/qa/L0_jax_unittest/test.sh
@@ -21,7 +21,7 @@ FAILED_CASES=""
 
 export NVTE_JAX_TEST_TIMING=1
 
-pip3 install "nltk>=3.8.2" || error_exit "Failed to install nltk"
+pip3 install "nltk>=3.8.2,<3.10.1" || error_exit "Failed to install nltk"
 pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 
 : ${TE_PATH:=/opt/transformerengine}

--- a/qa/L2_jax_unittest/test.sh
+++ b/qa/L2_jax_unittest/test.sh
@@ -21,7 +21,7 @@ FAILED_CASES=""
 
 export NVTE_JAX_TEST_TIMING=1
 
-pip3 install "nltk>=3.8.2" || error_exit "Failed to install nltk"
+pip3 install "nltk>=3.8.2,<3.10.1" || error_exit "Failed to install nltk"
 pip3 install pytest==8.2.1 || error_exit "Failed to install pytest"
 
 : ${TE_PATH:=/opt/transformerengine}


### PR DESCRIPTION
# Description

JAX nightly tests are failing because TE tests install an unpinned dependency (nltk), which pushed [a breaking change on Saturday](https://github.com/nltk/nltk/issues/3730). This limits the dependency to 3.10.0 or earlier. The change can be reverted after [an upstream fix PR is merged.](https://github.com/nltk/nltk/pull/3732)

This was not caught in the TE nightly tests because these create the test container in a slightly different way. Because TE tests set `--container-workdir=/opt/transformerengine/qa/L0_jax_distributed_unittest`, the nltk bug happens to not be hit.

Eventually we probably want to start pinning these test dependencies to remove this class of bug. Pinning to a specific checksum would make the root cause much more obvious.

See nvbug 6553963

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix new nltk version breaking JAX nightly tests

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
