### PR TITLE
Fix typo in contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Coding Guidelines
 -----------------
 
 * We follow `Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html>`_. When no
-  rules can be found, follow the already occuring conventions. If there is no precedence in our
+  rules can be found, follow the already occurring conventions. If there is no precedence in our
   codebase we are open to discussion.
 * Prior to your contribution, please make sure that the code passes the linter check. We do both C++
   and Python linting. To invoke the check, please use


### PR DESCRIPTION
# Description

Correct `occuring` to `occurring` in the contribution guidelines. This is a documentation-only spelling fix and does not change the contribution process.

## Type of change

- [x] Documentation change

## Changes

- Fix the spelling of `occurring` in the coding guidelines.

# Checklist

- [x] I have read and followed the contributing guidelines.
- [x] The functionality is complete.
- [x] My changes generate no new warnings.
- [x] Verified the old phrase is absent and the corrected phrase appears once.
- [x] `git diff --check` passes.