### PR TITLE
[JAX] Add NLTK pin <3.10.1 in encoder requirements

### DIFF
--- a/examples/jax/encoder/requirements.txt
+++ b/examples/jax/encoder/requirements.txt
@@ -1,4 +1,4 @@
 datasets<4.0.0
 flax>=0.7.1
-nltk>=3.8.2
+nltk>=3.8.2,<3.10.1
 optax


### PR DESCRIPTION
Follow up to #3306, nvbug 6553963