### PR TITLE
[PyTorch] Advance FusedAdam step counter for empty param groups

### DIFF
--- a/tests/pytorch/test_fused_optimizer.py
+++ b/tests/pytorch/test_fused_optimizer.py
@@ -166,6 +166,31 @@ class TestFusedAdam(TestFusedOptimizer):
 
             torch.testing.assert_close(ref_param, tst_param)
 
+    @pytest.mark.parametrize("capturable", [False, True])
+    def test_empty_param_group_advances_step(self, capturable):
+        # An empty param group must advance its step counter like a populated one.
+        # The same group can be empty on one data-parallel rank and populated on
+        # another, and "step" is part of the checkpoint, so a group that stops
+        # counting makes a resumed run apply a stale bias correction.
+        param = torch.nn.Parameter(torch.rand(4, dtype=torch.float, device="cuda"))
+        tst_optim = self.fused_optim(
+            [{"params": [param]}, {"params": []}], capturable=capturable, **self.options
+        )
+
+        num_steps = 3
+        for _ in range(num_steps):
+            param.grad = torch.rand_like(param)
+            tst_optim.step()
+
+        populated_step, empty_step = (int(g["step"]) for g in tst_optim.param_groups)
+        assert populated_step == num_steps
+        assert empty_step == populated_step
+
+        # The counter is checkpointed through the param groups, so the empty group
+        # has to round trip with the same value as the populated one.
+        checkpoint = tst_optim.state_dict()
+        assert int(checkpoint["param_groups"][1]["step"]) == num_steps
+
     def test_empty_param_at_end_of_group(self):
         tensors = [
             torch.ones(4, dtype=torch.float, device="cuda"),

--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -557,12 +557,11 @@ class FusedAdam(torch.optim.Optimizer):
             loss = closure()
 
         for group in self.param_groups:
-            if len(group["params"]) == 0:
-                continue
-            device = group["params"][0].device
-            bias_correction = 1 if group["bias_correction"] else 0
-            beta1, beta2 = group["betas"]
-
+            # Advance the step counter before skipping empty groups. A param group can be
+            # empty on some data-parallel ranks and populated on others, so incrementing
+            # only for populated groups desynchronizes "step" across the ranks that share
+            # an optimizer state shard. A rank then resumes from a checkpoint written by a
+            # rank where the group was empty and applies a stale bias correction.
             # assume same step across group now to simplify things
             # per parameter step can be easily support by making it tensor, or pass list into kernel
             if "step" in group:
@@ -570,9 +569,24 @@ class FusedAdam(torch.optim.Optimizer):
                     1 if not self.capturable else (self._dummy_overflow_buf != 1).to(torch.int)
                 )
             else:
-                group["step"] = (
-                    1 if not self.capturable else torch.tensor([1], dtype=torch.int, device=device)
+                # Empty groups have no parameter to take the device from, so fall back to
+                # the device of the optimizer's own scratch buffer.
+                step_device = (
+                    group["params"][0].device
+                    if len(group["params"]) > 0
+                    else self._dummy_overflow_buf.device
                 )
+                group["step"] = (
+                    1
+                    if not self.capturable
+                    else torch.tensor([1], dtype=torch.int, device=step_device)
+                )
+
+            if len(group["params"]) == 0:
+                continue
+            device = group["params"][0].device
+            bias_correction = 1 if group["bias_correction"] else 0
+            beta1, beta2 = group["betas"]
 
             # create lists for multi-tensor apply
             p_main_of_fp8_model = []


### PR DESCRIPTION
Fixes #1986

## Root cause

`FusedAdam.step()` opens its param-group loop with an early skip for groups that hold no parameters:

```python
for group in self.param_groups:
    if len(group["params"]) == 0:
        continue
    device = group["params"][0].device
    ...
    if "step" in group:
        group["step"] += ...
    else:
        group["step"] = ...
```

The step counter is updated after that skip, so an empty group never gets one. That is harmless for a group that is empty everywhere, but a group is often empty on only some data-parallel ranks. A `no_weight_decay` group holding just RMSNorm parameters is the usual case, and with pipeline or expert parallelism the ranks that own none of those parameters see an empty group while their peers do not.

`step` lives in `param_groups`, so `state_dict()` serializes it and it goes into the checkpoint. The ranks where the group was empty write `step = null` while the ranks where it was populated write the true iteration count, which is exactly what the counter table in the issue shows for a `PP=2, EP=4, DP=8` run at iteration 2640. On resume, a rank that loads its optimizer shard from a rank where the group was empty picks up the stale value, and `bias_correction` computes `1 - beta1 ** step` from a step that has nothing to do with how far training actually got.

## Fix

Move the counter update above the empty-group skip so every group advances on every rank, then skip the kernel work for empty groups as before. This is the change suggested in the issue.

One detail the issue does not cover: with `capturable=True` the first update creates `group["step"]` as a device tensor and takes the device from `group["params"][0]`, which an empty group does not have. The new code falls back to the device of `self._dummy_overflow_buf`, the optimizer's own scratch buffer, which is allocated on CUDA in `__init__`. Nothing else in the loop moved, so populated groups execute exactly the same sequence as before.

## Verification

I do not have a GPU, so I could not run the TE test suite. Two things I did do.

The control flow itself is checked with a standalone CPU script that reproduces the loop head, before and after, on a real `torch.optim.Optimizer` so that `param_groups` and `state_dict()` behave as they do in TE. The kernel launch plays no part in the defect and is omitted:

```python
import torch


class LoopHead(torch.optim.Optimizer):
    def __init__(self, params, fixed):
        super().__init__(params, {"lr": 1e-3})
        self.fixed = fixed

    def step(self):
        for group in self.param_groups:
            if self.fixed:
                # post-fix ordering
                if "step" in group:
                    group["step"] += 1
                else:
                    group["step"] = 1
                if len(group["params"]) == 0:
                    continue
            else:
                # ordering on main
                if len(group["params"]) == 0:
                    continue
                if "step" in group:
                    group["step"] += 1
                else:
                    group["step"] = 1


def run(fixed, num_steps=3):
    populated = torch.nn.Parameter(torch.zeros(4))
    optim = LoopHead([{"params": [populated]}, {"params": []}], fixed=fixed)
    for _ in range(num_steps):
        optim.step()
    return (
        [g.get("step") for g in optim.param_groups],
        [g.get("step") for g in optim.state_dict()["param_groups"]],
    )


for label, fixed in (("main", False), ("fixed", True)):
    print(label, run(fixed))
```

Output:

```
main  ([3, None], [3, None])
fixed ([3, 3], [3, 3])
```

The `None` in the checkpoint on `main` is the `null` step reported in the issue.

The regression test in this PR is the GPU version of the same property. `test_empty_param_group_advances_step` builds a `FusedAdam` over one populated group and one empty group, steps three times, and asserts that both groups report the same step in `param_groups` and in `state_dict()`. It is parametrized over `capturable` so the tensor-valued counter and the new device fallback are both exercised. On `main` the test fails at the first assertion on the empty group with a `KeyError` for `step`.

The changed files were formatted with the repository's pinned `black` 24.4.2 and the pre-commit arguments, and both are unchanged by it.
