### PR TITLE
[PyTorch] Fix deferred initialization in fusible ops

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -649,6 +649,254 @@ class TestFuser:
             assert x.grad.dtype == model_dtype
             assert op.weight.grad.dtype == model_dtype
 
+    _deferred_init_op_types = (
+        "basic_linear",
+        "bias",
+        "layer_norm",
+        "rmsnorm",
+        "grouped_linear",
+        "grouped_linear_single_param",
+        "linear",
+        "sequential",
+    )
+
+    @staticmethod
+    def _make_deferred_init_op(
+        op_type: str,
+        *,
+        size: int,
+        num_groups: int,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> torch.nn.Module:
+        """Construct an op for the deferred initialization tests"""
+        kwargs = {"device": device, "dtype": dtype}
+        if op_type == "basic_linear":
+            return te_ops.BasicLinear(size, size, **kwargs)
+        if op_type == "bias":
+            return te_ops.Bias(size, **kwargs)
+        if op_type == "layer_norm":
+            return te_ops.LayerNorm(size, **kwargs)
+        if op_type == "rmsnorm":
+            return te_ops.RMSNorm(size, **kwargs)
+        if op_type == "grouped_linear":
+            return te_ops.GroupedLinear(num_groups, size, size, bias=True, **kwargs)
+        if op_type == "grouped_linear_single_param":
+            return te_ops.GroupedLinear(
+                num_groups,
+                size,
+                size,
+                bias=True,
+                single_grouped_weight=True,
+                single_grouped_bias=True,
+                **kwargs,
+            )
+        if op_type == "linear":
+            return te_ops.Linear(size, size, bias=True, **kwargs)
+        if op_type == "sequential":
+            return te_ops.Sequential(
+                te_ops.LayerNorm(size, **kwargs),
+                te_ops.Linear(size, size, bias=True, **kwargs),
+            )
+        raise ValueError(f"Unsupported op type ({op_type})")
+
+    @staticmethod
+    def _check_materialized_params(
+        op: torch.nn.Module,
+        device: torch.device | str,
+        *,
+        expect_grads: bool = True,
+    ) -> dict[str, torch.nn.Parameter]:
+        """Check that an op's params are on the device, and return them"""
+        params = dict(op.named_parameters())
+        assert params
+        for name, param in params.items():
+            assert param.device.type == device, f"{name} was not materialized on {device}"
+            if expect_grads:
+                assert param.grad is not None, f"{name} did not get a grad"
+                assert param.grad.device.type == device, f"{name} got a grad on {param.grad.device}"
+
+        # Fused ops must not alias stale params
+        for module in op.modules():
+            if isinstance(module, te_ops.Linear):
+                assert module.weight is module.basic_ops[module._linear_idx].weight
+                assert module.bias is module.basic_ops[module._bias_idx].bias
+        return params
+
+    @pytest.mark.parametrize("op_type", _deferred_init_op_types)
+    @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("input_requires_grad", (False, True))
+    def test_deferred_param_init(
+        self,
+        monkeypatch,
+        *,
+        op_type: str,
+        size: int = 32,
+        num_groups: int = 2,
+        dtype: torch.dtype,
+        input_requires_grad: bool,
+        device: torch.device = "cuda",
+    ) -> None:
+        """Test ops constructed on the meta device
+
+        Ops replace their params when materializing them on the first
+        forward pass. See
+        https://github.com/NVIDIA/TransformerEngine/issues/3322.
+
+        """
+        if op_type == "grouped_linear_single_param":
+            # Materializing params also changes how many there are
+            monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
+
+        # Construct operation on meta device
+        op_kwargs = {"size": size, "num_groups": num_groups, "dtype": dtype}
+        op = self._make_deferred_init_op(op_type, device="meta", **op_kwargs)
+        for param in op.parameters():
+            assert param.device.type == "meta"
+
+        # Forward and backward pass
+        in_shape = (size, size)
+        extra_inputs = []
+        if op_type.startswith("grouped_linear"):
+            in_shape = (size * num_groups, size)
+            extra_inputs.append(torch.tensor([size] * num_groups, dtype=torch.int, device=device))
+        x = torch.randn(in_shape, dtype=dtype, device=device, requires_grad=input_requires_grad)
+        y = op(x, *extra_inputs)
+        dy = torch.randn_like(y)
+        y.backward(dy)
+
+        # Check that params have been materialized
+        params = self._check_materialized_params(op, device)
+        if input_requires_grad:
+            assert x.grad is not None and x.grad.device.type == device
+        else:
+            assert x.grad is None
+
+        # Check against an op that was constructed on the device
+        ref_op = self._make_deferred_init_op(op_type, device=device, **op_kwargs)
+        ref_params = dict(ref_op.named_parameters())
+        assert ref_params.keys() == params.keys()
+        with torch.no_grad():
+            for name, ref_param in ref_params.items():
+                ref_param.copy_(params[name])
+        x_ref = x.clone().detach().requires_grad_(input_requires_grad)
+        y_ref = ref_op(x_ref, *extra_inputs)
+        y_ref.backward(dy)
+        tols = dtype_tols(dtype)
+        assert_close(y, y_ref, **tols)
+        if input_requires_grad:
+            assert_close_grads(x, x_ref, **tols)
+        for name, ref_param in ref_params.items():
+            assert_close(params[name].grad, ref_param.grad, **tols)
+
+    @pytest.mark.parametrize("op_type", _deferred_init_op_types)
+    def test_deferred_param_init_explicit(
+        self,
+        monkeypatch,
+        *,
+        op_type: str,
+        size: int = 32,
+        num_groups: int = 2,
+        dtype: torch.dtype = torch.bfloat16,
+        device: torch.device = "cuda",
+    ) -> None:
+        """Test ops materialized with reset_parameters before the first forward pass"""
+        if op_type == "grouped_linear_single_param":
+            monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
+
+        # Construct operation on meta device and materialize it
+        op = self._make_deferred_init_op(
+            op_type, size=size, num_groups=num_groups, dtype=dtype, device="meta"
+        )
+        with torch.no_grad():
+            op.reset_parameters()
+        self._check_materialized_params(op, device, expect_grads=False)
+
+        # Forward and backward pass
+        in_shape = (size, size)
+        extra_inputs = []
+        if op_type.startswith("grouped_linear"):
+            in_shape = (size * num_groups, size)
+            extra_inputs.append(torch.tensor([size] * num_groups, dtype=torch.int, device=device))
+        x = torch.randn(in_shape, dtype=dtype, device=device, requires_grad=True)
+        y = op(x, *extra_inputs)
+        y.backward(torch.randn_like(y))
+        self._check_materialized_params(op, device)
+        assert x.grad is not None and x.grad.device.type == device
+
+    @pytest.mark.parametrize("op_type", ("linear", "grouped_linear"))
+    @pytest.mark.parametrize("quantization", _quantization_list)
+    @pytest.mark.parametrize("quantized_weight", (False, True))
+    def test_deferred_param_init_quantized(
+        self,
+        *,
+        op_type: str,
+        size: int = 128,
+        num_groups: int = 2,
+        dtype: torch.dtype = torch.bfloat16,
+        device: torch.device = "cuda",
+        quantization: Optional[str],
+        quantized_weight: bool,
+    ) -> None:
+        """Test quantized op constructed on the meta device"""
+
+        # Skip invalid configurations
+        in_shape = (size, size)
+        extra_inputs = []
+        if op_type == "grouped_linear":
+            in_shape = (size * num_groups, size)
+            extra_inputs.append(torch.tensor([size] * num_groups, dtype=torch.int, device=device))
+        if quantization is None:
+            pytest.skip("Quantization scheme is not specified")
+        maybe_skip_quantization(quantization, dims=in_shape, device=device, dtype=dtype)
+
+        # Construct operation on meta device
+        recipe = make_recipe(quantization)
+        with te.quantized_model_init(enabled=quantized_weight, recipe=recipe):
+            op = self._make_deferred_init_op(
+                op_type, size=size, num_groups=num_groups, dtype=dtype, device="meta"
+            )
+
+        # Forward and backward pass
+        x = torch.randn(in_shape, dtype=dtype, device=device, requires_grad=True)
+        with te.autocast(recipe=recipe):
+            y = op(x, *extra_inputs)
+        y.backward(torch.randn_like(y))
+
+        # Check that params have been materialized
+        params = self._check_materialized_params(op, device)
+        if quantized_weight:
+            weights = [param for name, param in params.items() if "weight" in name]
+            assert weights
+            for weight in weights:
+                assert isinstance(weight, QuantizedTensor)
+        assert x.grad is not None and x.grad.device.type == device
+
+    def test_param_replaced_after_first_forward(
+        self,
+        *,
+        size: int = 32,
+        dtype: torch.dtype = torch.float32,
+        device: torch.device = "cuda",
+    ) -> None:
+        """Test replacing an op's params after the fuser has cached them"""
+
+        # Forward and backward pass to populate the fuser's param cache
+        model = te_ops.Sequential(te_ops.BasicLinear(size, size, device=device, dtype=dtype))
+        x = torch.randn((size, size), dtype=dtype, device=device, requires_grad=True)
+        y = model(x)
+        y.backward(torch.randn_like(y))
+
+        # Replace the param and check that grads follow it
+        weight = torch.nn.Parameter(torch.randn((size, size), dtype=dtype, device=device))
+        model[0].register_parameter("weight", weight)
+        y = model(x)
+        dy = torch.randn_like(y)
+        y.backward(dy)
+        assert weight.grad is not None
+        assert_close(y, x @ weight.t(), **dtype_tols(dtype))
+        assert_close(weight.grad, dy.t() @ x, **dtype_tols(dtype))
+
 
 class TestBasicOps:
     """Tests for individual operations"""

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -330,9 +330,12 @@ class OperationFuser:
         ops: list[FusibleOperation],
     ) -> None:
 
+        # Ops before flattening out fused ops
+        self._ops: list[FusibleOperation] = list(ops)
+
         # Get list of basic operations
         basic_ops = []
-        for op in ops:
+        for op in self._ops:
             if op.is_fused_op:
                 basic_ops.extend(op.basic_ops)
             else:
@@ -354,7 +357,14 @@ class OperationFuser:
         self.backward_override = None
         self._last_amax_history_len = 0
 
-        # Flatten list of parameters
+        # Cached params, populated on the first forward pass (version -1 never matches)
+        self._basic_op_params: list[list[torch.nn.Parameter]]
+        self._basic_op_num_params: list[int]
+        self._flat_basic_op_params: list[torch.nn.Parameter]
+        self._param_version: int = -1
+
+    def _cache_parameters(self) -> None:
+        """Cache the basic ops' params, which is too expensive to redo every forward"""
         self._basic_op_params = [list(op.parameters()) for op in self._basic_ops]
         self._basic_op_num_params = list(map(len, self._basic_op_params))
         self._flat_basic_op_params = sum(self._basic_op_params, [])
@@ -423,6 +433,23 @@ class OperationFuser:
     ):
         """Attempt to fuse operations if neccesary"""
 
+        # Initialize ops before the first forward pass
+        # Note: Reset recipe state first since params may be quantized,
+        # and initialize top-down so fused ops can sync aliased params.
+        is_first_forward = self.recipe_type is None
+        if is_first_forward:
+            for op in self._basic_ops:
+                op.reset_recipe_state(recipe=recipe)
+            for op in self._ops:
+                op.pre_first_fuser_forward()
+
+        # Refresh the param cache if any op has replaced its params
+        param_version = sum(op.param_version for op in self._basic_ops)
+        params_changed = param_version != self._param_version
+        if params_changed:
+            self._cache_parameters()
+            self._param_version = param_version
+
         # Determine which basic ops require backward
         if not is_grad_enabled:
             first_op_requiring_backward = self._num_basic_ops
@@ -437,7 +464,8 @@ class OperationFuser:
                     break
 
         # Early exit if fusion parameters haven't changed
-        need_reset = False
+        # Note: Replaced params may change which fusions apply.
+        need_reset = is_first_forward or params_changed
         recipe_type = type(recipe)
         backward_override = recipe.backward_override if recipe is not None else None
         fusion_params = (recipe_type, first_op_requiring_backward, backward_override)
@@ -458,14 +486,10 @@ class OperationFuser:
         if not need_reset:
             return
 
-        # Reset recipe state
-        for op in self._basic_ops:
-            op.reset_recipe_state(recipe=recipe)
-
-        # Check if this is the first iteration
-        if self.recipe_type is None:
+        # Reset recipe state, unless already done above on the first forward
+        if not is_first_forward:
             for op in self._basic_ops:
-                op.pre_first_fuser_forward()
+                op.reset_recipe_state(recipe=recipe)
 
         # Apply joint forward-backward fusions first
         joint_ops = OperationFuser._apply_fusions(

--- a/transformer_engine/pytorch/ops/linear.py
+++ b/transformer_engine/pytorch/ops/linear.py
@@ -166,6 +166,29 @@ class Linear(FusedOperation):
         elif name == "bias" and self._bias_idx is not None:
             self.basic_ops[self._bias_idx].bias = param
 
+    def _sync_parameters(self) -> None:
+        """Match this op's registered params to its basic ops
+
+        Only re-registers changed params since this runs on every
+        forward pass for a standalone op.
+
+        """
+        weight = self.basic_ops[self._linear_idx].weight
+        if weight is not self._parameters["weight"]:
+            self.register_parameter("weight", weight)
+        if self._bias_idx is not None:
+            bias = self.basic_ops[self._bias_idx].bias
+            if bias is not self._parameters["bias"]:
+                self.register_parameter("bias", bias)
+
+    def pre_first_fuser_forward(self) -> None:
+        super().pre_first_fuser_forward()
+        self._sync_parameters()
+
+    def reset_parameters(self) -> None:
+        super().reset_parameters()
+        self._sync_parameters()
+
     def state_dict(self, *, prefix: str = "", **kwargs) -> dict[str, Any]:
         """Save state"""
         state_dict = super().state_dict(prefix=prefix, **kwargs)

--- a/transformer_engine/pytorch/ops/op.py
+++ b/transformer_engine/pytorch/ops/op.py
@@ -183,6 +183,8 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
     num_extra_inputs: int = 0
     # Number of extra tensor outputs
     num_extra_outputs: int = 0
+    # Number of param registrations
+    _param_version: int = 0
 
     def __init__(self) -> None:
         super().__init__()
@@ -194,6 +196,16 @@ class BasicOperation(FusibleOperation, metaclass=abc.ABCMeta):
     @property
     def is_fused_op(self) -> bool:
         return False
+
+    @property
+    def param_version(self) -> int:
+        """Counter for param registrations, so the fuser can detect replaced params"""
+        return self._param_version
+
+    def register_parameter(self, name: str, param: Optional[torch.nn.Parameter]) -> None:
+        """Add a parameter to the operation"""
+        super().register_parameter(name, param)
+        self._param_version += 1
 
     def num_quantizers(
         self,
@@ -758,6 +770,12 @@ class FusedOperation(FusibleOperation):
     def pre_fuser_forward(self, *, requires_grad: bool) -> None:
         for op in self.basic_ops:
             op.pre_fuser_forward(requires_grad=requires_grad)
+
+    def reset_parameters(self) -> None:
+        """Initialize parameters, materializing them if needed"""
+        for op in self.basic_ops:
+            if hasattr(op, "reset_parameters"):
+                op.reset_parameters()
 
     def forward(
         self,

--- a/transformer_engine/pytorch/ops/sequential.py
+++ b/transformer_engine/pytorch/ops/sequential.py
@@ -142,6 +142,12 @@ class Sequential(torch.nn.Module):
         out.extend(modules)
         return out
 
+    def reset_parameters(self) -> None:
+        """Initialize parameters, materializing them if needed"""
+        for module in self._modules.values():
+            if hasattr(module, "reset_parameters"):
+                module.reset_parameters()
+
     @classmethod
     def _make_module_groups(
         cls,


### PR DESCRIPTION
# Description

Ops replace their params when materializing them on the first fuser forward pass, which invalidated the fuser's cached params and ops.Linear's parameter aliases. Backward then failed with a meta-vs-cuda device mismatch.

This PR makes basic ops version their parameter registrations, and the fuser treats version change as a cache invalidation. `te.ops.FusedOperation` and `te.Sequential` also now have a `reset_parameters()` method to explicitly materialize parameters the same way it's done for standard `torch.nn.Modules` and TE custom modules.

New tests added for deferred initialization with the affected ops.

Fixes #3322

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
