### PR TITLE
[PyTorch] Regression test + docs for THD CP tail-padding mislabeling (pad_between_seqs)

### DIFF
--- a/tests/pytorch/attention/run_cp_thd_tail_padding.py
+++ b/tests/pytorch/attention/run_cp_thd_tail_padding.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Regression test for THD + context-parallel (p2p) tail padding.
+
+GitHub issue: https://github.com/NVIDIA/TransformerEngine/issues/3331
+
+A single packed sequence whose REAL length is not divisible by 2*cp_size is
+tail-padded to a multiple of 2*cp_size (the common case for packed THD
+training). The pad_between_seqs=False CP path approximates per-ring-step
+seqlens as cu_seqlens // cp_size, which mislabels chunk-boundary rows in
+this case, producing (a) nondeterministic forward outputs (uninitialized
+softmax-LSE aux rows merged into a real row's scale factor), (b) silently
+wrong attention (real keys dropped from every query's attention, real query
+rows receiving exact-zero output), and (c) nondeterministic gradients on all
+CP ranks.
+
+This test pins the exact-path semantics — reached via explicit
+pad_between_seqs=True, or via auto-detect with padded cu_seqlens supplied as
+tensors distinct from their unpadded counterparts — along two axes:
+
+  1. determinism: forward and fwd+bwd outputs are bitwise-stable across
+     iterations on identical inputs;
+  2. correctness: the reassembled CP output and gradients match the no-CP
+     reference on all real (non-padding) rows within bf16 tolerance.
+
+Launch: torchrun --standalone --nproc-per-node={2,4} run_cp_thd_tail_padding.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Backend selection must be pinned before transformer_engine is imported: the
+# defect lives in the FusedAttention (cuDNN) CP path.
+os.environ["NVTE_FLASH_ATTN"] = "0"
+os.environ.setdefault("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+
+import torch
+import torch.distributed as dist
+
+import transformer_engine.pytorch as te
+
+SEQ_REAL = 698  # real tokens; 698 % (2*cp) != 0 for cp in {2, 4} -> tail padding
+HEADS_Q = 8
+HEADS_KV = 1
+HEAD_DIM = 128
+SEED = 16
+FWD_ITERS = 25  # forward determinism iterations
+BWD_ITERS = 10  # fwd+bwd determinism iterations
+# bf16 CP-vs-reference rounding tolerance. The defect produces mean |delta|
+# 0.04 / max 0.36 plus exact-zero real rows — an order of magnitude outside
+# this band, so the check cannot pass under the bug by luck.
+ATOL = 2.5e-2
+RTOL = 2.5e-2
+
+
+def shard_indices(cp: int, rank: int, chunk: int) -> torch.Tensor:
+    """Load-balanced CP shard: chunks [rank, 2*cp-1-rank] of the padded buffer."""
+    return torch.cat(
+        [
+            torch.arange(rank * chunk, (rank + 1) * chunk),
+            torch.arange((2 * cp - 1 - rank) * chunk, (2 * cp - rank) * chunk),
+        ]
+    )
+
+
+def make_attn(dev: torch.device, with_cp: bool) -> te.DotProductAttention:
+    attn = te.DotProductAttention(
+        num_attention_heads=HEADS_Q,
+        kv_channels=HEAD_DIM,
+        num_gqa_groups=HEADS_KV,
+        attention_dropout=0.0,
+        attn_mask_type="padding_causal",
+        qkv_format="thd",
+        softmax_scale=None,
+    ).to(dev)
+    if with_cp:
+        cp_group = dist.new_group(ranks=list(range(dist.get_world_size())), backend="nccl")
+        attn.set_context_parallel_group(
+            cp_group,
+            list(range(dist.get_world_size())),
+            torch.cuda.Stream(device=dev),
+            cp_comm_type="p2p",
+        )
+    return attn
+
+
+def run_fwd(attn, q, k, v, cu, cu_padded, t_total, pad_mode):
+    kwargs = dict(
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+        cu_seqlens_q_padded=cu_padded,
+        cu_seqlens_kv_padded=cu_padded,
+        max_seqlen_q=t_total,
+        max_seqlen_kv=t_total,
+    )
+    # "explicit" pins the exact per-rank path; "auto" exercises the auto-detect
+    # (distinct padded/unpadded tensor objects must select pad_between_seqs=True).
+    if pad_mode == "explicit":
+        kwargs["pad_between_seqs"] = True
+    return attn(q, k, v, **kwargs)
+
+
+def check_close(name, actual, expected, failures):
+    diff = (actual.float() - expected.float()).abs()
+    tol = ATOL + RTOL * expected.float().abs()
+    bad = diff > tol
+    if bad.any():
+        failures.append(
+            f"{name}: {int(bad.sum())}/{bad.numel()} elems exceed tolerance, "
+            f"max|delta|={diff.max().item():.4f}"
+        )
+
+
+def main() -> int:
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    cp = dist.get_world_size()
+    torch.cuda.set_device(rank)
+    dev = torch.device("cuda", rank)
+
+    assert SEQ_REAL % (2 * cp) != 0, "test requires real length not divisible by 2*cp"
+    chunk = -(-SEQ_REAL // (2 * cp))  # ceil division
+    t_total = 2 * cp * chunk  # padded total; SEQ_REAL < t_total (tail padding)
+
+    idx = shard_indices(cp, rank, chunk)
+    real_mask = idx < SEQ_REAL
+    local_real = torch.nonzero(real_mask).flatten()  # real rows in the local shard
+    global_real = idx[real_mask]  # their positions in the full padded buffer
+
+    cu = torch.tensor([0, SEQ_REAL], dtype=torch.int32, device=dev)
+    cu_padded = torch.tensor([0, t_total], dtype=torch.int32, device=dev)
+
+    # Identical full-buffer inputs on every rank (CPU generator is device-independent).
+    g = torch.Generator(device="cpu").manual_seed(SEED)
+    q_full = torch.randn(t_total, HEADS_Q, HEAD_DIM, generator=g).bfloat16()
+    k_full = torch.randn(t_total, HEADS_KV, HEAD_DIM, generator=g).bfloat16()
+    v_full = torch.randn(t_total, HEADS_KV, HEAD_DIM, generator=g).bfloat16()
+    dout_full = torch.randn(t_total, HEADS_Q * HEAD_DIM, generator=g).bfloat16()
+
+    q_loc, k_loc, v_loc = (x[idx].to(dev) for x in (q_full, k_full, v_full))
+    dout_loc = dout_full[idx].to(dev)
+
+    # No-CP reference: full padded buffer, exact path, computed identically per rank.
+    attn_ref = make_attn(dev, with_cp=False)
+    qr, kr, vr = (x.to(dev).requires_grad_(True) for x in (q_full, k_full, v_full))
+    out_ref = attn_ref(
+        qr,
+        kr,
+        vr,
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+        cu_seqlens_q_padded=cu_padded,
+        cu_seqlens_kv_padded=cu_padded,
+        max_seqlen_q=t_total,
+        max_seqlen_kv=t_total,
+        pad_between_seqs=True,
+    )
+    out_ref.backward(dout_full.to(dev))
+
+    failures = []
+    for pad_mode in ["explicit", "auto"]:
+        attn = make_attn(dev, with_cp=True)
+
+        # Arm 1: forward determinism — bitwise-stable across iterations.
+        with torch.inference_mode():
+            outs = [
+                run_fwd(attn, q_loc, k_loc, v_loc, cu, cu_padded, t_total, pad_mode).clone()
+                for _ in range(FWD_ITERS)
+            ]
+        n_mismatch = sum(not torch.equal(outs[0], o) for o in outs[1:])
+        if n_mismatch:
+            failures.append(
+                f"{pad_mode}: forward nondeterministic "
+                f"({n_mismatch}/{FWD_ITERS - 1} iterations differ bitwise)"
+            )
+
+        # Arm 2: fwd+bwd determinism — outputs and gradients bitwise-stable.
+        iter_results = []
+        for _ in range(BWD_ITERS):
+            qg, kg, vg = (x.clone().requires_grad_(True) for x in (q_loc, k_loc, v_loc))
+            out = run_fwd(attn, qg, kg, vg, cu, cu_padded, t_total, pad_mode)
+            out.backward(dout_loc)
+            iter_results.append(
+                (out.detach().clone(), qg.grad.clone(), kg.grad.clone(), vg.grad.clone())
+            )
+        base = iter_results[0]
+        n_mismatch = sum(
+            not all(torch.equal(b, r) for b, r in zip(base, res)) for res in iter_results[1:]
+        )
+        if n_mismatch:
+            failures.append(
+                f"{pad_mode}: fwd+bwd nondeterministic "
+                f"({n_mismatch}/{BWD_ITERS - 1} iterations differ bitwise)"
+            )
+
+        # Arm 3: correctness vs the no-CP reference on real rows.
+        out_cp, dq_cp, dk_cp, dv_cp = base
+        check_close(f"{pad_mode} out", out_cp[local_real], out_ref.detach()[global_real], failures)
+        check_close(f"{pad_mode} dq", dq_cp[local_real], qr.grad[global_real], failures)
+        check_close(f"{pad_mode} dk", dk_cp[local_real], kr.grad[global_real], failures)
+        check_close(f"{pad_mode} dv", dv_cp[local_real], vr.grad[global_real], failures)
+
+    gathered = [None] * cp
+    dist.all_gather_object(gathered, failures)
+    if rank == 0:
+        all_failures = [f"rank {r}: {f}" for r, fs in enumerate(gathered) for f in fs]
+        if all_failures:
+            print("FAIL (issue #3331 regression):", flush=True)
+            for f in all_failures:
+                print(f"  {f}", flush=True)
+        else:
+            print(
+                f"PASS: THD+CP(p2p) tail padding deterministic and correct "
+                f"(cp={cp}, real={SEQ_REAL}, padded={t_total}, modes=explicit,auto)",
+                flush=True,
+            )
+    dist.destroy_process_group()
+    return 1 if any(any(fs) for fs in gathered) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/pytorch/attention/run_cp_thd_tail_padding.py
+++ b/tests/pytorch/attention/run_cp_thd_tail_padding.py
@@ -144,22 +144,22 @@ def main() -> int:
     q_loc, k_loc, v_loc = (x[idx].to(dev) for x in (q_full, k_full, v_full))
     dout_loc = dout_full[idx].to(dev)
 
-    # No-CP reference: full padded buffer, exact path, computed identically per rank.
+    # No-CP reference on the UNPADDED buffer (ground truth for the real tokens):
+    # no padding anywhere, so no pad_between_seqs involvement at all. Real token i
+    # occupies row i in both the padded and unpadded layouts, so global_real indexes
+    # the reference directly.
     attn_ref = make_attn(dev, with_cp=False)
-    qr, kr, vr = (x.to(dev).requires_grad_(True) for x in (q_full, k_full, v_full))
+    qr, kr, vr = (x[:SEQ_REAL].to(dev).requires_grad_(True) for x in (q_full, k_full, v_full))
     out_ref = attn_ref(
         qr,
         kr,
         vr,
         cu_seqlens_q=cu,
         cu_seqlens_kv=cu,
-        cu_seqlens_q_padded=cu_padded,
-        cu_seqlens_kv_padded=cu_padded,
-        max_seqlen_q=t_total,
-        max_seqlen_kv=t_total,
-        pad_between_seqs=True,
+        max_seqlen_q=SEQ_REAL,
+        max_seqlen_kv=SEQ_REAL,
     )
-    out_ref.backward(dout_full.to(dev))
+    out_ref.backward(dout_full[:SEQ_REAL].to(dev))
 
     failures = []
     for pad_mode in ["explicit", "auto"]:

--- a/tests/pytorch/attention/run_cp_thd_tail_padding.py
+++ b/tests/pytorch/attention/run_cp_thd_tail_padding.py
@@ -214,7 +214,7 @@ def main() -> int:
                 print(f"  {f}", flush=True)
         else:
             print(
-                f"PASS: THD+CP(p2p) tail padding deterministic and correct "
+                "PASS: THD+CP(p2p) tail padding deterministic and correct "
                 f"(cp={cp}, real={SEQ_REAL}, padded={t_total}, modes=explicit,auto)",
                 flush=True,
             )

--- a/tests/pytorch/attention/test_cp_thd_tail_padding.py
+++ b/tests/pytorch/attention/test_cp_thd_tail_padding.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+import os
+import pathlib
+import sys
+
+import pytest
+import torch
+
+from transformer_engine.pytorch import get_device_compute_capability
+
+_current_file = pathlib.Path(__file__).resolve()
+sys.path.append(str(_current_file.parent.parent))
+from utils import run_distributed
+
+
+@pytest.mark.skipif(
+    get_device_compute_capability() < (9, 0), reason="THD format requires sm90+."
+)
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_cp_thd_tail_padding(world_size):
+    """THD + CP(p2p) with tail padding: deterministic and matches no-CP reference.
+
+    Regression test for https://github.com/NVIDIA/TransformerEngine/issues/3331 —
+    the pad_between_seqs auto-detect must route tail-padded THD batches to the
+    exact per-rank path under context parallelism.
+    """
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs!")
+
+    run_distributed(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            f"--nproc-per-node={world_size}",
+            "--standalone",
+            str(_current_file.parent / "run_cp_thd_tail_padding.py"),
+        ],
+        env={
+            **os.environ,
+            "NVTE_FLASH_ATTN": "0",
+            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
+        },
+        timeout=600,
+    )

--- a/tests/pytorch/attention/test_cp_thd_tail_padding.py
+++ b/tests/pytorch/attention/test_cp_thd_tail_padding.py
@@ -16,9 +16,7 @@ sys.path.append(str(_current_file.parent.parent))
 from utils import run_distributed
 
 
-@pytest.mark.skipif(
-    get_device_compute_capability() < (9, 0), reason="THD format requires sm90+."
-)
+@pytest.mark.skipif(get_device_compute_capability() < (9, 0), reason="THD format requires sm90+.")
 @pytest.mark.parametrize("world_size", [2, 4])
 def test_cp_thd_tail_padding(world_size):
     """THD + CP(p2p) with tail padding: deterministic and matches no-CP reference.

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -1549,6 +1549,16 @@ class DotProductAttention(TransformerEngineBaseModule):
         pad_between_seqs: Optional[bool], default = None
             If ``None``, inferred from qkv_format, cu_seqlens and cu_seqlens_padded.
             If ``True``, there are padding tokens between individual sequences in a packed batch.
+            With context parallelism, this must be ``True`` whenever the packed batch
+            contains ANY padding — including tail padding after the last sequence
+            (e.g. a sequence whose real length is not a multiple of 2*cp_size). The
+            ``False`` CP path assumes padding-free uniform chunking and silently
+            mislabels boundary rows otherwise (see
+            https://github.com/NVIDIA/TransformerEngine/issues/3331). The ``None``
+            auto-detect returns ``True`` only when padded cu_seqlens are supplied as
+            tensors distinct from their unpadded counterparts; callers with
+            tail-only padding who pass the same tensor for both must set this flag
+            explicitly.
         fp8_output: Optional[bool], default = False
             Whether to enforce output to be in FP8 or not.
         num_splits: Optional[int], default = 1
@@ -1954,6 +1964,15 @@ class DotProductAttention(TransformerEngineBaseModule):
             # If padded cu_seqlens are the *same object* as the unpadded ones, no real
             # inter-sequence padding exists (only THD tail padding) -- treat as False so
             # FlashAttention v2/v4 remain eligible.
+            # NOTE: under context parallelism, tail padding is NOT benign on the
+            # pad_between_seqs=False path, which approximates per-step seqlens as
+            # cu_seqlens // cp_size and mislabels chunk-boundary rows whenever a
+            # sequence's real length is not divisible by 2*cp_size (nondeterministic
+            # boundary-row outputs, silently dropped real keys/queries; see
+            # https://github.com/NVIDIA/TransformerEngine/issues/3331). THD+CP callers
+            # with tail-padded sequences must pass pad_between_seqs=True explicitly
+            # (or supply padded cu_seqlens as tensors distinct from the unpadded
+            # ones) so the exact per-rank path is taken.
             if pad_between_seqs is None:
                 if qkv_format == "thd":
                     if (


### PR DESCRIPTION
# Description

Regression test + documentation for the THD + context-parallel tail-padding defect reported in #3331.

In short: with `qkv_format="thd"` + CP `p2p`, a sequence whose real length is not divisible by `2*cp_size` (tail-padded — the common case for packed THD training) is mishandled whenever the `pad_between_seqs=False` fast path is taken, because that path approximates per-ring-step seqlens as `cu_seqlens // cp_size` and thereby mislabels chunk-boundary rows. Consequences (proven at element level in #3331): nondeterministic forward rows, silently wrong attention (real keys dropped, real query rows exact-zero), nondeterministic gradients on all CP ranks.

`main` routes callers that pass *distinct* padded/unpadded cu_seqlens tensors to the exact path (incidental effect of the #2898 auto-detect rewrite), but nothing pins that behavior, and the docstring/comment still describe tail padding as a safe `False` signal — which is incorrect under CP.

Refs #3331 (this PR is the regression test + docs; the deeper routing question — e.g. whether THD+CP should always take the exact per-rank path, and LSE aux hardening as defense in depth — is left for discussion on the issue, per the asks there).

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue) — regression coverage for a released bug

## Changes

- **`tests/pytorch/attention/run_cp_thd_tail_padding.py`** (new): distributed runner. Single packed sequence, real length 698 (not divisible by `2*cp` for cp∈{2,4}), tail-padded; FusedAttention backend, `padding_causal`, THD, CP `p2p`. Three arms per pad mode (`pad_between_seqs=True` explicit, and auto-detect with distinct padded tensors): (1) forward bitwise determinism over 25 iterations, (2) fwd+bwd bitwise determinism over 10 iterations, (3) correctness of out/dq/dk/dv vs an unpadded no-CP reference on all real rows.
- **`tests/pytorch/attention/test_cp_thd_tail_padding.py`** (new): pytest wrapper launching the runner at world sizes 2 and 4 via `run_distributed`.
- **`dot_product_attention.py`**: docstring for `pad_between_seqs` and the auto-detect comment now state that tail padding is *not* benign under CP, and that tail-padded THD+CP callers must pass `pad_between_seqs=True` explicitly or supply distinct padded cu_seqlens tensors.

# Validation (H100×4, torch 2.11.0+cu128, cuDNN 9.25.0.15)

| run | TE 2.17.1 (affected release) | TE main (this branch) |
|---|---|---|
| CP4 | **FAIL** — auto arm: forward nondeterministic 24/24 iters; fwd+bwd nondeterministic; out/dq/dk/dv vs reference max \|Δ\| up to 1.41 | **PASS** (both modes) |
| CP2 | **FAIL** — auto arm: deterministic mis-attention vs reference, max \|Δ\| up to 0.95 | **PASS** (both modes) |

The explicit `pad_between_seqs=True` arm passes on 2.17.1 as well, confirming the documented workaround.

One environment note: TE 2.17.1's THD backward fails wholesale with cuDNN 9.19.0 (the version torch 2.11.0+cu128 pins) — `CUDNN_STATUS_BAD_PARAM` at `fused_attn_f16_arbitrary_seqlen.cu:934` (reshape attribute), independent of this defect and reproducible on a plain no-CP THD backward; cuDNN 9.25.0.15 resolves it. May be worth a minimum-cuDNN note for the THD backward path.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes — new test validated on H100×4 (see table); it exercises a path no existing test covers (existing THD CP tests pad every sequence, so internal boundaries always move and the auto-detect never sees the tail-only case)
