### PR TITLE
[JAX][Core] TE EP handle_mem pointer relocation incorrect result fix

### DIFF
--- a/tests/cpp_distributed/test_ep.cu
+++ b/tests/cpp_distributed/test_ep.cu
@@ -542,6 +542,127 @@ TYPED_TEST(EPDispatchBwdTest, DispatchBwdCheck) {
   NVTE_CHECK_CUDA(cudaStreamDestroy(stream));
 }
 
+// A scan carry may preserve the bytes of handle_mem while assigning them a new
+// device address. Backward must rebuild NCCL's host handle from those bytes,
+// including the native top-k index dtype and routing state.
+TYPED_TEST(EPDispatchBwdTest, RelocatedHandleMem) {
+  using Tok = TypeParam;
+  EP_PULL_FIXTURE();
+  // The rest of this suite uses int64 routing. Reset the process-wide fallback
+  // config before and after this int32 regression so it is independent of test
+  // order while preserving the existing coverage.
+  ep_reinitialize(/*zero_copy=*/0);
+  EPBuffers<Tok> buf;
+  buf.alloc(num_tokens_, top_k_, hidden_dim_, num_local_experts_,
+            ep_size_, max_tokens_per_rank_);
+  this->template upload_inputs<Tok>(buf);
+  EPTensors<Tok> t(buf, num_tokens_, top_k_, hidden_dim_, num_local_experts_);
+
+  const auto h_topk_idx_int64 = routing_balanced(
+      g_process_id, num_tokens_, top_k_, num_experts_, num_local_experts_);
+  const std::vector<int32_t> h_topk_idx(h_topk_idx_int64.begin(), h_topk_idx_int64.end());
+  DevBuf<int32_t> topk_idx;
+  topk_idx.alloc(h_topk_idx.size());
+  NVTE_CHECK_CUDA(cudaMemcpy(topk_idx.get(), h_topk_idx.data(),
+                             h_topk_idx.size() * sizeof(int32_t), cudaMemcpyHostToDevice));
+  TensorWrapper topk_idx_tensor(
+      topk_idx.get(), std::vector<size_t>{static_cast<size_t>(num_tokens_),
+                                          static_cast<size_t>(top_k_)}, DType::kInt32);
+
+  std::vector<float> h_topk_weights(num_tokens_ * top_k_);
+  for (int tok = 0; tok < num_tokens_; ++tok) {
+    for (int k = 0; k < top_k_; ++k) {
+      h_topk_weights[tok * top_k_ + k] = static_cast<float>(
+          (g_process_id * num_tokens_ + tok) * top_k_ + k + 1);
+    }
+  }
+  NVTE_CHECK_CUDA(cudaMemcpy(buf.topk_weights.get(), h_topk_weights.data(),
+                             h_topk_weights.size() * sizeof(float), cudaMemcpyHostToDevice));
+
+  DevBuf<uint8_t> relocated_handle_mem;
+  relocated_handle_mem.alloc(buf.handle_mem_size);
+  ASSERT_NE(relocated_handle_mem.get(), buf.handle_mem.get());
+  TensorWrapper relocated_handle(
+      relocated_handle_mem.get(), std::vector<size_t>{buf.handle_mem_size}, DType::kByte);
+
+  cudaStream_t stream;
+  NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
+
+  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), topk_idx_tensor.data(),
+                                  t.recv_tokens_per_expert.data(), nullptr,
+                                  &t.layer_cfg_, stream));
+  ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), topk_idx_tensor.data(),
+                                   t.tokens.data(), NVTECommWindow{}, t.topk_weights.data(),
+                                   NVTECommWindow{}, t.recv_tokens.data(), NVTECommWindow{},
+                                   t.recv_topk_weights.data(), NVTECommWindow{}, stream));
+  ASSERT_NO_THROW(nvte_ep_combine(t.handle_mem.data(), t.recv_tokens.data(), NVTECommWindow{},
+                                  t.result.data(), stream));
+
+  std::vector<Tok> h_grad(num_tokens_ * hidden_dim_, tok_from_float<Tok>(0.1f));
+  NVTE_CHECK_CUDA(cudaMemcpyAsync(buf.grad_result.get(), h_grad.data(),
+                                  h_grad.size() * sizeof(Tok), cudaMemcpyHostToDevice, stream));
+  NVTE_CHECK_CUDA(cudaMemsetAsync(buf.grad_expert.get(), 0, buf.grad_expert.bytes(), stream));
+  NVTE_CHECK_CUDA(cudaMemsetAsync(buf.g_recv_topk_weights.get(), 0,
+                                  buf.g_recv_topk_weights.bytes(), stream));
+  NVTE_CHECK_CUDA(cudaMemsetAsync(buf.grad_topk_weights.get(), 0,
+                                  buf.grad_topk_weights.bytes(), stream));
+
+  NVTE_CHECK_CUDA(cudaMemcpyAsync(relocated_handle_mem.get(), buf.handle_mem.get(),
+                                  buf.handle_mem_size, cudaMemcpyDeviceToDevice, stream));
+  NVTE_CHECK_CUDA(cudaMemcpyAsync(buf.g_recv_topk_weights.get(),
+                                  buf.recv_topk_weights.get(),
+                                  buf.g_recv_topk_weights.bytes(),
+                                  cudaMemcpyDeviceToDevice, stream));
+  ASSERT_NO_THROW(nvte_ep_combine_bwd(relocated_handle.data(), t.grad_result.data(),
+                                      NVTECommWindow{}, t.grad_expert.data(), NVTECommWindow{},
+                                      stream));
+  ASSERT_NO_THROW(nvte_ep_dispatch_bwd(relocated_handle.data(), t.grad_expert.data(),
+                                       NVTECommWindow{}, t.g_recv_topk_weights.data(),
+                                       NVTECommWindow{}, t.grad_tokens.data(),
+                                       t.grad_topk_weights.data(), stream));
+  NVTE_CHECK_CUDA(cudaStreamSynchronize(stream));
+
+  std::vector<Tok> h_grad_tokens(num_tokens_ * hidden_dim_);
+  NVTE_CHECK_CUDA(cudaMemcpy(h_grad_tokens.data(), buf.grad_tokens.get(),
+                             h_grad_tokens.size() * sizeof(Tok), cudaMemcpyDeviceToHost));
+  const float expected =
+      static_cast<float>(top_k_) * tok_to_float(tok_from_float<Tok>(0.1f));
+  for (int tok = 0; tok < num_tokens_; ++tok) {
+    for (int hidden = 0; hidden < hidden_dim_; ++hidden) {
+      EXPECT_NEAR(tok_to_float(h_grad_tokens[tok * hidden_dim_ + hidden]), expected,
+                  bf16_tol(expected))
+          << "relocated handle_mem token " << tok << " hidden " << hidden;
+    }
+  }
+
+  std::vector<float> h_grad_topk_weights(num_tokens_ * top_k_);
+  NVTE_CHECK_CUDA(cudaMemcpy(h_grad_topk_weights.data(), buf.grad_topk_weights.get(),
+                             h_grad_topk_weights.size() * sizeof(float),
+                             cudaMemcpyDeviceToHost));
+  int topk_weight_errors = 0;
+  for (int tok = 0; tok < num_tokens_; ++tok) {
+    for (int k = 0; k < top_k_; ++k) {
+      const float got = h_grad_topk_weights[tok * top_k_ + k];
+      const float expected_weight = h_topk_weights[tok * top_k_ + k];
+      if (std::fabs(got - expected_weight) > 1e-5f) {
+        if (topk_weight_errors < 8) {
+          ADD_FAILURE() << "relocated handle_mem top-k gradient token " << tok
+                        << " k " << k << ": got " << got
+                        << ", expected " << expected_weight;
+        }
+        ++topk_weight_errors;
+      }
+    }
+  }
+  EXPECT_EQ(topk_weight_errors, 0);
+
+  if (g_process_id == 0 && topk_weight_errors == 0)
+    printf("  RelocatedHandleMem: passed (int32 routing restored after memcpy)\n");
+
+  NVTE_CHECK_CUDA(cudaStreamDestroy(stream));
+  ep_reinitialize(/*zero_copy=*/0);
+}
+
 // =============================================================================
 // EPDispatchBwdGradWeightsTest: round-trip per-(t, k) weights.
 // =============================================================================

--- a/tests/jax/test_te_ep_moe.py
+++ b/tests/jax/test_te_ep_moe.py
@@ -503,6 +503,100 @@ def _make_inputs(key):
     return jax.random.normal(key, (BATCH, SEQ, HIDDEN), dtype=DTYPE)
 
 
+def _make_scan_params(mesh, num_layers):
+    """Create distinct MoE parameters whose leading axis is scanned."""
+    gate_key, wi_0_key, wi_1_key, wo_key = jax.random.split(jax.random.PRNGKey(101), 4)
+
+    with _ctx(mesh):
+
+        @jax.jit
+        def initialize():
+            params = {
+                "gate_kernel": jax.random.normal(
+                    gate_key, (num_layers, HIDDEN, NUM_EXPERTS), dtype=DTYPE
+                )
+                / np.sqrt(HIDDEN),
+                "wi_0": jax.random.normal(
+                    wi_0_key,
+                    (num_layers, NUM_EXPERTS, HIDDEN, INTER),
+                    dtype=DTYPE,
+                )
+                / np.sqrt(HIDDEN),
+                "wi_1": jax.random.normal(
+                    wi_1_key,
+                    (num_layers, NUM_EXPERTS, HIDDEN, INTER),
+                    dtype=DTYPE,
+                )
+                / np.sqrt(HIDDEN),
+                "wo": jax.random.normal(
+                    wo_key,
+                    (num_layers, NUM_EXPERTS, INTER, HIDDEN),
+                    dtype=DTYPE,
+                )
+                / np.sqrt(INTER),
+            }
+            shardings = {
+                "gate_kernel": P(None, FSDP_AXIS, EP_AXIS),
+                "wi_0": P(None, EP_AXIS, FSDP_AXIS, None),
+                "wi_1": P(None, EP_AXIS, FSDP_AXIS, None),
+                "wo": P(None, EP_AXIS, None, FSDP_AXIS),
+            }
+            return {
+                name: jax.lax.with_sharding_constraint(value, NamedSharding(mesh, shardings[name]))
+                for name, value in params.items()
+            }
+
+        params = initialize()
+        jax.block_until_ready(params)
+    return params
+
+
+def _scan_moe_layer(params, x):
+    """One residual TE-EP layer used by both scan and unrolled controls."""
+    branch, _aux, _total_recv_tokens = moe(
+        x,
+        params["gate_kernel"],
+        params["wi_0"],
+        params["wi_1"],
+        params["wo"],
+        num_experts=NUM_EXPERTS,
+        num_experts_per_tok=TOPK,
+        score_function="softmax",
+        ep_axis=EP_AXIS,
+        data_parallelism_axes=(FSDP_AXIS,),
+        input_axes=("batch", None, None),
+        gate_kernel_axes=("embed", "exp"),
+        wi_kernel_axes=("exp", "embed", "mlp"),
+        wo_kernel_axes=("exp", "mlp", "embed"),
+        dtype=DTYPE,
+    )
+    return x + branch
+
+
+def _run_scan_layers(params, x, *, scan_layers):
+    """Execute identical layer parameters with lax.scan or Python unrolling."""
+    if scan_layers:
+
+        def body(carry, layer_params):
+            return _scan_moe_layer(layer_params, carry), None
+
+        return jax.lax.scan(body, x, params)[0]
+
+    value = x
+    for layer in range(params["gate_kernel"].shape[0]):
+        layer_params = jax.tree_util.tree_map(lambda p: p[layer], params)
+        value = _scan_moe_layer(layer_params, value)
+    return value
+
+
+def _scan_value_and_grad(params, x, *, scan_layers):
+    def loss_fn(layer_params, inputs):
+        output = _run_scan_layers(layer_params, inputs, scan_layers=scan_layers)
+        return jnp.mean(output.astype(jnp.float32) ** 2), output
+
+    return jax.value_and_grad(loss_fn, argnums=(0, 1), has_aux=True)(params, x)
+
+
 # -----------------------------------------------------------------------------
 # Tests
 # -----------------------------------------------------------------------------
@@ -679,6 +773,42 @@ class TestTeEpMoeBackward:
             rtol=GRAD_FFN_RTOL,
             err_msg=f"d_x parity breach [config={config}]",
         )
+
+    def test_scan_layers_match_unrolled(self, mesh):
+        """Relocated scan residuals must preserve int32 EP routing in backward."""
+        params = _make_scan_params(mesh, num_layers=4)
+        x = _make_inputs(jax.random.PRNGKey(102))
+
+        with _ctx(mesh):
+            x_sh = _shard_inputs(x, mesh)
+            unrolled = jax.jit(partial(_scan_value_and_grad, scan_layers=False))(params, x_sh)
+            jax.block_until_ready(unrolled)
+            scanned = jax.jit(partial(_scan_value_and_grad, scan_layers=True))(params, x_sh)
+            jax.block_until_ready(scanned)
+
+        (unrolled_loss, unrolled_output), (unrolled_grads, unrolled_grad_x) = unrolled
+        (scanned_loss, scanned_output), (scanned_grads, scanned_grad_x) = scanned
+
+        np.testing.assert_allclose(
+            np.asarray(jax.device_get(scanned_loss), dtype=np.float32),
+            np.asarray(jax.device_get(unrolled_loss), dtype=np.float32),
+            atol=TE_TO_TE_ATOL,
+            rtol=TE_TO_TE_RTOL,
+            err_msg="scan_layers=True loss differs from scan_layers=False",
+        )
+        comparisons = {
+            "output": (scanned_output, unrolled_output),
+            "d_x": (scanned_grad_x, unrolled_grad_x),
+            **{f"d_{name}": (scanned_grads[name], unrolled_grads[name]) for name in scanned_grads},
+        }
+        for name, (actual, expected) in comparisons.items():
+            np.testing.assert_allclose(
+                _to_global_numpy(actual, mesh).astype(np.float32),
+                _to_global_numpy(expected, mesh).astype(np.float32),
+                atol=TE_TO_TE_ATOL,
+                rtol=TE_TO_TE_RTOL,
+                err_msg=f"scan_layers=True {name} differs from scan_layers=False",
+            )
 
 
 class TestTeEpMoeAuxLoss:

--- a/transformer_engine/common/ep/ep_backend.cpp
+++ b/transformer_engine/common/ep/ep_backend.cpp
@@ -159,6 +159,7 @@ void EPBackend::shutdown() {
   inst.lru_.clear();
   inst.index_.clear();
   inst.fallback_layer_cfg_.reset();
+  inst.fallback_num_tokens_.reset();
   // ncclEpGroupDestroy reads from ep_comm_; destroy group while comm is still alive.
   if (inst.ep_group_ != nullptr) {
     ncclEpGroupDestroy(inst.ep_group_);
@@ -196,6 +197,7 @@ EPBackend::~EPBackend() {
   lru_.clear();
   index_.clear();
   fallback_layer_cfg_.reset();
+  fallback_num_tokens_.reset();
   ep_group_ = nullptr;
   ep_comm_ = nullptr;
   initialized_ = false;
@@ -272,6 +274,10 @@ ncclEpHandle_t EPBackend::prepare_handle_locked(void* handle_mem, NVTEEpLayerCon
                "EP prepare alignment=", layer_cfg.dispatch_output_per_expert_alignment,
                " disagrees with process-wide cached alignment=",
                fallback_layer_cfg_->dispatch_output_per_expert_alignment);
+    NVTE_CHECK(fallback_layer_cfg_->topk_dtype == layer_cfg.topk_dtype,
+               "EP prepare topk_dtype=", static_cast<int>(layer_cfg.topk_dtype),
+               " disagrees with process-wide cached topk_dtype=",
+               static_cast<int>(fallback_layer_cfg_->topk_dtype));
   } else {
     fallback_layer_cfg_ = layer_cfg;
   }
@@ -281,14 +287,10 @@ ncclEpHandle_t EPBackend::prepare_handle_locked(void* handle_mem, NVTEEpLayerCon
     lru_.splice(lru_.begin(), lru_, it->second);
     return it->second->handle;
   }
-  ncclEpHandleConfig_t hcfg = NCCL_EP_HANDLE_CONFIG_INIT;
-  hcfg.dispatch_output_per_expert_alignment = layer_cfg.dispatch_output_per_expert_alignment;
-  size_t hm_size = 0;
-  NVTE_CHECK_NCCL(ncclEpHandleMemSize(ep_group_, NCCL_EP_LAYOUT_EXPERT_MAJOR, &hcfg, &hm_size,
-                                      layer_cfg.top_k));
-  ncclEpHandle_t h = open_handle(handle_mem, hm_size, layer_cfg.top_k,
+  const HandleMemLayout layout = handle_mem_layout_locked(layer_cfg);
+  ncclEpHandle_t h = open_handle(handle_mem, layout.nccl_bytes, layer_cfg.top_k,
                                  layer_cfg.dispatch_output_per_expert_alignment);
-  lru_.push_front(HandleEntry{handle_mem, h, layer_cfg, hm_size});
+  lru_.push_front(HandleEntry{handle_mem, h, layer_cfg, layout.total_bytes});
   index_.emplace(handle_mem, lru_.begin());
   while (lru_.size() > cache_cap_locked()) {
     HandleEntry& victim = lru_.back();
@@ -299,7 +301,7 @@ ncclEpHandle_t EPBackend::prepare_handle_locked(void* handle_mem, NVTEEpLayerCon
   return h;
 }
 
-ncclEpHandle_t EPBackend::lookup_handle_locked(void* handle_mem) {
+ncclEpHandle_t EPBackend::lookup_handle_locked(void* handle_mem, cudaStream_t stream) {
   auto it = index_.find(handle_mem);
   if (it != index_.end()) {
     lru_.splice(lru_.begin(), lru_, it->second);
@@ -312,23 +314,50 @@ ncclEpHandle_t EPBackend::lookup_handle_locked(void* handle_mem) {
   const uintptr_t hm_addr = reinterpret_cast<uintptr_t>(handle_mem);
   NVTE_CHECK(fallback_layer_cfg_.has_value(), "ep op on handle_mem=0x", hm_addr,
              " with no cached entry and no prior nvte_ep_prepare; call prepare first.");
-  return prepare_handle_locked(handle_mem, *fallback_layer_cfg_);
+  NVTE_CHECK(fallback_num_tokens_.has_value(), "missing cached EP routing token count");
+  ncclEpHandle_t handle = prepare_handle_locked(handle_mem, *fallback_layer_cfg_);
+  restore_handle_locked(handle, handle_mem, *fallback_layer_cfg_, *fallback_num_tokens_, stream);
+  return handle;
 }
 
 // ---------------------------------------------------------------------------
 // Per-step operations
 // ---------------------------------------------------------------------------
 
+EPBackend::HandleMemLayout EPBackend::handle_mem_layout_locked(NVTEEpLayerConfig layer_cfg) {
+  ncclEpHandleConfig_t hcfg = NCCL_EP_HANDLE_CONFIG_INIT;
+  hcfg.dispatch_output_per_expert_alignment = layer_cfg.dispatch_output_per_expert_alignment;
+  size_t nccl_bytes = 0;
+  NVTE_CHECK_NCCL(ncclEpHandleMemSize(ep_group_, NCCL_EP_LAYOUT_EXPERT_MAJOR, &hcfg, &nccl_bytes,
+                                      layer_cfg.top_k));
+  constexpr size_t kRoutingAlignment = alignof(int64_t);
+  const size_t snapshot_offset = (nccl_bytes + kRoutingAlignment - 1) & ~(kRoutingAlignment - 1);
+  const size_t max_indices =
+      static_cast<size_t>(group_config_.max_tokens_per_rank) * static_cast<size_t>(layer_cfg.top_k);
+  NVTE_CHECK(max_indices <= (SIZE_MAX - snapshot_offset) / sizeof(int64_t),
+             "EP routing snapshot size overflow");
+  return HandleMemLayout{nccl_bytes, snapshot_offset,
+                         snapshot_offset + max_indices * sizeof(int64_t)};
+}
+
+void EPBackend::restore_handle_locked(ncclEpHandle_t handle, void* handle_mem,
+                                      NVTEEpLayerConfig layer_cfg, size_t num_tokens,
+                                      cudaStream_t stream) {
+  const HandleMemLayout layout = handle_mem_layout_locked(layer_cfg);
+  size_t topk_shape[2] = {num_tokens, static_cast<size_t>(layer_cfg.top_k)};
+  ncclEpTensor_t topk_idx = NCCL_EP_TENSOR_INIT;
+  topk_idx.ndim = 2;
+  topk_idx.datatype = te_dtype_to_nccl_dtype(layer_cfg.topk_dtype);
+  topk_idx.data = static_cast<char*>(handle_mem) + layout.routing_snapshot_offset;
+  topk_idx.sizes = topk_shape;
+  NVTE_CHECK_NCCL(ncclEpUpdateHandle(handle, &topk_idx, nullptr, stream));
+}
+
 size_t EPBackend::handle_mem_size(NVTEEpLayerConfig layer_cfg) {
   NVTE_CHECK(layer_cfg.top_k > 0, "top_k must be > 0, got ", layer_cfg.top_k);
   std::lock_guard<std::mutex> lock(mutex_);
   NVTE_CHECK(initialized_, "EPBackend not initialized");
-  ncclEpHandleConfig_t hcfg = NCCL_EP_HANDLE_CONFIG_INIT;
-  hcfg.dispatch_output_per_expert_alignment = layer_cfg.dispatch_output_per_expert_alignment;
-  size_t hm_size = 0;
-  NVTE_CHECK_NCCL(ncclEpHandleMemSize(ep_group_, NCCL_EP_LAYOUT_EXPERT_MAJOR, &hcfg, &hm_size,
-                                      layer_cfg.top_k));
-  return hm_size;
+  return handle_mem_layout_locked(layer_cfg).total_bytes;
 }
 
 void EPBackend::prepare(void* handle_mem, const NVTETensor topk_idx,
@@ -337,6 +366,19 @@ void EPBackend::prepare(void* handle_mem, const NVTETensor topk_idx,
   NVTE_CHECK(handle_mem != nullptr, "handle_mem must not be null");
   NVTE_CHECK(layer_cfg.top_k > 0, "top_k must be > 0, got ", layer_cfg.top_k);
   NVTE_CHECK(nvte_tensor_shape(topk_idx).ndim == 2, "topk_idx must be 2D [T, top_k]");
+
+  const NVTEDType topk_dtype = nvte_tensor_type(topk_idx);
+  NVTE_CHECK(topk_dtype == kNVTEInt32 || topk_dtype == kNVTEInt64,
+             "topk_idx must be int32 or int64, got ", static_cast<int>(topk_dtype));
+  if (layer_cfg.topk_dtype != kNVTEByte) {
+    NVTE_CHECK(layer_cfg.topk_dtype == topk_dtype,
+               "layer_cfg.topk_dtype=", static_cast<int>(layer_cfg.topk_dtype),
+               " disagrees with topk_idx dtype=", static_cast<int>(topk_dtype));
+  }
+  layer_cfg.topk_dtype = topk_dtype;
+  const size_t num_tokens = nvte_tensor_shape(topk_idx).data[0];
+  NVTE_CHECK(num_tokens <= static_cast<size_t>(group_config_.max_tokens_per_rank),
+             "topk_idx token count exceeds max_tokens_per_rank");
 
   NVTEShape topk_idx_shape;
   ncclEpTensor_t nccl_topk_idx = make_nccl_ep_tensor(topk_idx, topk_idx_shape);
@@ -362,8 +404,20 @@ void EPBackend::prepare(void* handle_mem, const NVTETensor topk_idx,
 
   std::lock_guard<std::mutex> lock(mutex_);
   NVTE_CHECK(initialized_, "EPBackend not initialized");
+  if (fallback_num_tokens_.has_value()) {
+    NVTE_CHECK(*fallback_num_tokens_ == num_tokens, "EP prepare num_tokens=", num_tokens,
+               " disagrees with process-wide cached num_tokens=", *fallback_num_tokens_);
+  } else {
+    fallback_num_tokens_ = num_tokens;
+  }
   ncclEpHandle_t h = prepare_handle_locked(handle_mem, layer_cfg);
   NVTE_CHECK_NCCL(ncclEpUpdateHandle(h, &nccl_topk_idx, &layout_info, stream));
+  const HandleMemLayout handle_layout = handle_mem_layout_locked(layer_cfg);
+  const size_t snapshot_bytes = num_tokens * static_cast<size_t>(layer_cfg.top_k) *
+                                typeToSize(static_cast<DType>(topk_dtype));
+  NVTE_CHECK_CUDA(cudaMemcpyAsync(
+      static_cast<char*>(handle_mem) + handle_layout.routing_snapshot_offset,
+      nvte_tensor_data(topk_idx), snapshot_bytes, cudaMemcpyDeviceToDevice, stream));
 }
 
 void EPBackend::dispatch(void* handle_mem, const NVTETensor topk_idx, const NVTETensor tokens,
@@ -425,7 +479,7 @@ void EPBackend::dispatch(void* handle_mem, const NVTETensor topk_idx, const NVTE
 
   std::lock_guard<std::mutex> lock(mutex_);
   NVTE_CHECK(initialized_, "EPBackend not initialized");
-  ncclEpHandle_t h = lookup_handle_locked(handle_mem);
+  ncclEpHandle_t h = lookup_handle_locked(handle_mem, stream);
   NVTE_CHECK_NCCL(ncclEpDispatch(h, &in_struct, &out_struct,
                                  /*layout_info=*/nullptr, &dispatch_cfg, stream));
 }
@@ -449,7 +503,7 @@ void EPBackend::combine(void* handle_mem, const NVTETensor expert_out,
 
   std::lock_guard<std::mutex> lock(mutex_);
   NVTE_CHECK(initialized_, "EPBackend not initialized");
-  ncclEpHandle_t h = lookup_handle_locked(handle_mem);
+  ncclEpHandle_t h = lookup_handle_locked(handle_mem, stream);
   NVTE_CHECK_NCCL(ncclEpCombine(h, &in_struct, &out_struct, /*config=*/nullptr, stream));
 }
 
@@ -487,7 +541,7 @@ void EPBackend::dispatch_bwd(void* handle_mem, const NVTETensor grad,
 
   std::lock_guard<std::mutex> lock(mutex_);
   NVTE_CHECK(initialized_, "EPBackend not initialized");
-  ncclEpHandle_t h = lookup_handle_locked(handle_mem);
+  ncclEpHandle_t h = lookup_handle_locked(handle_mem, stream);
   NVTE_CHECK_NCCL(ncclEpCombine(h, &in_struct, &out_struct, &cfg, stream));
 }
 

--- a/transformer_engine/common/ep/ep_backend.h
+++ b/transformer_engine/common/ep/ep_backend.h
@@ -87,6 +87,12 @@ class EPBackend {
   ncclEpHandle_t open_handle(void* handle_mem, size_t handle_mem_size, int num_topk,
                              size_t dispatch_output_per_expert_alignment);
 
+  struct HandleMemLayout {
+    size_t nccl_bytes;
+    size_t routing_snapshot_offset;
+    size_t total_bytes;
+  };
+
   // LRU cache: most-recently-used at the front of lru_, evict from the back.
   struct HandleEntry {
     void* handle_mem;
@@ -104,10 +110,14 @@ class EPBackend {
   std::unordered_map<void*, std::list<HandleEntry>::iterator> index_;
   size_t handle_cache_cap_{0};  // set lazily from NVTE_EP_HANDLE_CACHE_SIZE
   std::optional<NVTEEpLayerConfig> fallback_layer_cfg_;
+  std::optional<size_t> fallback_num_tokens_;
 
   // Caller must hold mutex_.
   ncclEpHandle_t prepare_handle_locked(void* handle_mem, NVTEEpLayerConfig layer_cfg);
-  ncclEpHandle_t lookup_handle_locked(void* handle_mem);
+  ncclEpHandle_t lookup_handle_locked(void* handle_mem, cudaStream_t stream);
+  HandleMemLayout handle_mem_layout_locked(NVTEEpLayerConfig layer_cfg);
+  void restore_handle_locked(ncclEpHandle_t handle, void* handle_mem, NVTEEpLayerConfig layer_cfg,
+                             size_t num_tokens, cudaStream_t stream);
   size_t cache_cap_locked();
 };
 

--- a/transformer_engine/common/include/transformer_engine/ep.h
+++ b/transformer_engine/common/include/transformer_engine/ep.h
@@ -81,6 +81,9 @@ typedef struct {
    *  When > 1, each expert's slab in recv_tokens is zero-padded up to a
    *  multiple of this for downstream per-expert GEMM alignment. */
   size_t dispatch_output_per_expert_alignment;
+  /*! Dtype of topk_idx (kNVTEInt32 or kNVTEInt64). kNVTEByte means
+   *  unspecified and is filled from topk_idx by nvte_ep_prepare. */
+  NVTEDType topk_dtype;
 } NVTEEpLayerConfig;
 
 /* Zero-init a config with struct_size set to the current layout:


### PR DESCRIPTION
# Description

Added new C++ and JAX tests to reproduce an issue where if a handle_mem was relocated, it would have a cache miss since the pointer doesn't match. This is okay, but the creation of a new handle was slightly incorrect. The topk_dtype was never set via `ncclEpUpdateHandle`, so the backward pass was reading data with an incorrect dtype and therefore produced incorrect results.

If you run these C++ and JAX tests without the corresponding core fixes in this PR, both will fail with mismatching results. With these fixes, the tests pass.

The core piece of the fix is here:
```
  ncclEpTensor_t topk_idx = NCCL_EP_TENSOR_INIT;
  topk_idx.ndim = 2;
  topk_idx.datatype = te_dtype_to_nccl_dtype(layer_cfg.topk_dtype);
  topk_idx.data = static_cast<char*>(handle_mem) + layout.routing_snapshot_offset;
  topk_idx.sizes = topk_shape;
  NVTE_CHECK_NCCL(ncclEpUpdateHandle(handle, &topk_idx, nullptr, stream));
```
When a handle_mem pointer has a cache miss, it is recreated as before but with the additional metadata for topk dtype.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- C++ tests to reproduce this issue by manually relocating the handle_mem buffer
- JAX tests to reproduce this issue with jax.lax.scan (which triggers a relocation)
- Store topk dtype metadata so it can be used correctly when a new handle is needed on cache miss

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
