### PR TITLE
[PyTorch] Make the Triton mask-map permute respect num_out_tokens

### DIFF
--- a/tests/pytorch/test_permutation.py
+++ b/tests/pytorch/test_permutation.py
@@ -1739,6 +1739,43 @@ def test_permutation_mask_map(
     )
 
 
+@pytest.mark.parametrize("torch_dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_permutation_mask_map_capacity_drop(torch_dtype):
+    """num_out_tokens smaller than routing_map.sum(): over-capacity entries must be
+    dropped (as the CUDA index-map path does), not written past the output buffer."""
+    num_tokens, num_expert, hidden_size = 64, 8, 128
+    torch.manual_seed(1234)
+
+    routing_map = (torch.rand(num_tokens, num_expert) > 0.5).bool().cuda()
+    total_routed = int(routing_map.sum())
+    capacity = total_routed - 17
+    assert capacity > 0
+
+    inp = torch.randn((num_tokens, hidden_size)).cuda().to(torch_dtype)
+
+    out, row_id_map = te_permute(inp, routing_map, num_out_tokens=capacity, map_type="mask")
+
+    # reference: expert-major order of routed (expert, token) pairs, first
+    # `capacity` destination rows kept
+    token_idx = torch.nonzero(routing_map.T.contiguous(), as_tuple=False)[:, 1]
+    ref = inp[token_idx[:capacity]]
+    assert out.shape[0] == capacity
+    torch.testing.assert_close(out.float(), ref.float(), atol=0, rtol=0)
+
+    # the row map must mark exactly the over-capacity entries as dropped
+    n_routed = row_id_map[:, 2 * num_expert]
+    assert int(n_routed.sum()) == capacity
+
+    # unpermute consumes the same map: each token gets the sum of its kept copies
+    unperm = te_unpermute(out, row_id_map, restore_shape=inp.shape, map_type="mask")
+    kept_flat = torch.zeros(num_expert * num_tokens, dtype=torch.bool, device=inp.device)
+    routed_flat_idx = torch.nonzero(routing_map.T.contiguous().flatten(), as_tuple=False)[:, 0]
+    kept_flat[routed_flat_idx[:capacity]] = True
+    kept_map = kept_flat.view(num_expert, num_tokens).T.contiguous()
+    ref_unperm = (inp.float().unsqueeze(1) * kept_map.unsqueeze(-1).float()).sum(1)
+    torch.testing.assert_close(unperm.float(), ref_unperm, atol=1e-2, rtol=1e-2)
+
+
 @pytest.mark.parametrize("te_dtype", _te_dtypes)
 @pytest.mark.parametrize("num_out_tokens", [None])
 @pytest.mark.parametrize(

--- a/transformer_engine/common/triton/permutation.py
+++ b/transformer_engine/common/triton/permutation.py
@@ -131,6 +131,7 @@ def _row_id_map_pass_2_kernel(
     workspace_ptr,
     # sizes
     num_tokens,
+    num_out_tokens,
     # strides
     stride_row_id_map_token,
     stride_row_id_map_expert,
@@ -155,6 +156,9 @@ def _row_id_map_pass_2_kernel(
         -1,
         row_id_within_token_block + tl.sum(n_tokens_per_chunk) - 1,
     )
+    # capacity limit: destinations at or past num_out_tokens are dropped, matching
+    # the `idx >= num_out_tokens` branch of moe_permute_row_map in permutation.cu
+    row_id = tl.where(row_id >= num_out_tokens, -1, row_id)
     tl.store(
         row_id_map_ptr + pid_m * stride_row_id_map_expert + offset * stride_row_id_map_token,
         row_id,

--- a/transformer_engine/jax/triton_extensions/permutation.py
+++ b/transformer_engine/jax/triton_extensions/permutation.py
@@ -251,6 +251,9 @@ class RowIdMapPass2Primitive(BasePrimitive):
             input_output_aliases={0: 0, 1: 1},
             constexprs={
                 "num_tokens": num_tokens,
+                # the JAX path sizes its buffers from num_out_tokens up front, so
+                # disable the kernel's capacity drop here (no entry can reach INT32_MAX)
+                "num_out_tokens": 2**31 - 1,
                 "stride_row_id_map_token": row_id_stride_token,
                 "stride_row_id_map_expert": row_id_stride_expert,
                 "WORKSPACE_LOAD_WIDTH": workspace_load_width,

--- a/transformer_engine/pytorch/permutation.py
+++ b/transformer_engine/pytorch/permutation.py
@@ -318,7 +318,9 @@ def moe_permute_mask_map_forward(
     num_tokens, hidden_size = inp.size()
     num_experts = routing_map.size(1)
 
-    row_id_map = triton_permutation.make_row_id_map(routing_map, num_tokens, num_experts)
+    row_id_map = triton_permutation.make_row_id_map(
+        routing_map, num_tokens, num_experts, num_out_tokens
+    )
 
     # FP8 handling
     fp8 = isinstance(inp, QuantizedTensor)

--- a/transformer_engine/pytorch/triton/permutation.py
+++ b/transformer_engine/pytorch/triton/permutation.py
@@ -25,6 +25,7 @@ def make_row_id_map(
     routing_map: torch.Tensor,
     num_tokens: int,
     num_experts: int,
+    num_out_tokens: int,
 ):
     """
     Prepare the row_id_map for the permutation.
@@ -39,6 +40,9 @@ def make_row_id_map(
         Number of tokens in the input tensor.
     num_experts : int
         Number of experts in the input tensor.
+    num_out_tokens : int
+        Number of rows in the permuted output. Routing-map entries whose destination row falls at
+        or past this limit are dropped (marked -1), like the CUDA index-map path does.
 
     Returns
     -------
@@ -94,6 +98,7 @@ def make_row_id_map(
         row_id_map,
         workspace_tensor,
         num_tokens,
+        num_out_tokens,
         row_id_map.stride(0),
         row_id_map.stride(1),
         triton.next_power_of_2(num_experts * triton.cdiv(num_tokens, block_size)),


### PR DESCRIPTION
# Description

Fixes #3346.

The Triton mask-map path of `moe_permute` sizes its output at exactly `num_out_tokens` rows, but `_permute_kernel` receives `num_out_tokens` marked unused and the row-id map assigns destination rows as an unbounded cumsum — so a routing map with more routed entries than `num_out_tokens` writes the excess rows past the end of the allocation (48 invalid global writes under compute-sanitizer in the linked issue's repro, ending in an unspecified launch failure; 0 errors after this change). The CUDA index-map path behind the same public API implements the capacity limit by marking over-capacity entries `-1` in its row map (`moe_permute_row_map`'s `idx >= num_out_tokens` branch).

This PR gives the Triton path the same semantics at the same place:

- `_row_id_map_pass_2_kernel` takes `num_out_tokens` and marks destinations at or past it as `-1` — pass 3 then excludes them from `n_routed`, and every consumer of the map (permute, unpermute, and their backwards) already skips dropped entries via the existing `-1` handling. No compute kernel changes.
- The PyTorch `make_row_id_map` and its caller thread `num_out_tokens` through.
- The JAX lowering passes an explicit no-drop sentinel (`2**31 - 1`), keeping JAX behavior unchanged; wiring `token_dispatch`'s `num_out_tokens` into it can follow separately if desired.
- New `test_permutation_mask_map_capacity_drop` (fp32/fp16/bf16): capacity 17 below `routing_map.sum()`, checking the kept rows against an expert-major reference permutation, the row map's `n_routed` accounting, and the unpermute of the dropped map. All three fail without the fix and pass with it; the rest of the mask-map suite is unchanged — 151 passed / 113 skipped / 16 failed, with the same 16 failing ids, both with and without the change (those 16 are FP8 `DelayedScaling` cases that already fail at this commit in my prebuilt-wheel setup, on an NVRTC/CUDA-header version mismatch that has nothing to do with permutation).

# Checklist

- [x] The documentation is up to date with these changes (docstring of `make_row_id_map`).
- [x] The tests are up to date with these changes.

## Environment

- Base commit: 07e281f2 (main); prebuilt transformer-engine-cu12 2.17.0 + source checkout for Python/Triton
- NVIDIA L40S (sm_89), driver CUDA 12.4
- torch 2.13.0+cu126, triton 3.7.1, Python 3.12
