### PR TITLE
[PyTorch] Decline fused grouped MLP when the backward format is not E4M3

### DIFF
--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -899,6 +899,36 @@ class TestGroupedLinearOp:
 class TestGroupedMLPFusedOp:
     """Tests for grouped MLP fused op"""
 
+    def test_fusion_declined_for_e5m2_grad_output(self, monkeypatch) -> None:
+        """MXFP8 with Format.HYBRID must fall back to the unfused ops.
+
+        The fused backward reinterprets the grad output's storage as E4M3, so an
+        E5M2 backward format would be misread rather than converted.
+        """
+        from transformer_engine.common.recipe import Format, MXFP8BlockScaling
+
+        fused_op_cls = grouped_mlp_module.GroupedMLP_CuTeGEMMGLU
+        monkeypatch.setattr(fused_op_cls, "is_supported", classmethod(lambda cls: True))
+
+        # Never matches the fusion pattern, so the window scan leaves it alone. That keeps
+        # this test on the dispatch logic and off the kernels, which need SM100.
+        ops = [object(), object(), object()]
+
+        # Declined before the window is scanned, so the original list comes straight back.
+        hybrid = MXFP8BlockScaling(fp8_format=Format.HYBRID)
+        assert (
+            grouped_mlp_module.fuse_grouped_mlp_ops(ops, recipe=hybrid, fused_op_cls=fused_op_cls)
+            is ops
+        )
+
+        # E4M3 gets past the guard and is rebuilt by the scan.
+        e4m3 = MXFP8BlockScaling(fp8_format=Format.E4M3)
+        rebuilt = grouped_mlp_module.fuse_grouped_mlp_ops(
+            ops, recipe=e4m3, fused_op_cls=fused_op_cls
+        )
+        assert rebuilt is not ops
+        assert rebuilt == ops
+
     @pytest.mark.parametrize("bias", (False, True))
     @pytest.mark.parametrize("quantization", _grouped_mlp_quantization_list)
     @pytest.mark.parametrize("single_grouped_weight", (False, True))

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -899,36 +899,37 @@ class TestGroupedLinearOp:
 class TestGroupedMLPFusedOp:
     """Tests for grouped MLP fused op"""
 
-    def test_fusion_declined_for_e5m2_grad_output(self, monkeypatch) -> None:
-        """MXFP8 with Format.HYBRID must fall back to the unfused ops.
-
-        The fused backward reinterprets the grad output's storage as E4M3, so an
-        E5M2 backward format would be misread rather than converted. The check is
-        MXFP8-only, since fp8_format says nothing about NVFP4 gradients.
-        """
+    def test_fusion_requires_supported_grad_output_format(self, monkeypatch) -> None:
+        """Fuse E4M3 MXFP8 and NVFP4, but decline MXFP8 with an E5M2 backward."""
         from transformer_engine.common.recipe import Format, MXFP8BlockScaling, NVFP4BlockScaling
 
         fused_op_cls = grouped_mlp_module.GroupedMLP_CuTeGEMMGLU
         monkeypatch.setattr(fused_op_cls, "is_supported", classmethod(lambda cls: True))
 
-        # Never matches the fusion pattern, so the window scan leaves it alone. That keeps
-        # this test on the dispatch logic and off the kernels, which need SM100.
-        ops = [object(), object(), object()]
+        fc1 = te.ops.GroupedLinear(1, 64, 128, bias=False, device="cuda")
+        activation = te.ops.ScaledSwiGLU(glu_interleave_size=32)
+        fc2 = te.ops.GroupedLinear(1, 64, 64, bias=False, device="cuda")
+        ops = [fc1, activation, fc2]
 
-        # Declined before the window is scanned, so the original list comes straight back.
+        def fuse(recipe):
+            return grouped_mlp_module.fuse_grouped_mlp_ops(
+                ops,
+                recipe=recipe,
+                fused_op_cls=fused_op_cls,
+            )
+
+        def assert_fused(recipe):
+            fused_ops = fuse(recipe)
+            assert len(fused_ops) == 1
+            fused_op = fused_ops[0]
+            assert isinstance(fused_op, fused_op_cls)
+            assert list(fused_op.basic_ops) == ops
+
         hybrid = MXFP8BlockScaling(fp8_format=Format.HYBRID)
-        assert (
-            grouped_mlp_module.fuse_grouped_mlp_ops(ops, recipe=hybrid, fused_op_cls=fused_op_cls)
-            is ops
-        )
+        assert fuse(hybrid) is ops
 
-        # E4M3 gets past the guard and is rebuilt by the scan.
         e4m3 = MXFP8BlockScaling(fp8_format=Format.E4M3)
-        rebuilt = grouped_mlp_module.fuse_grouped_mlp_ops(
-            ops, recipe=e4m3, fused_op_cls=fused_op_cls
-        )
-        assert rebuilt is not ops
-        assert rebuilt == ops
+        assert_fused(e4m3)
 
         # NVFP4 quantizes gradients to FP4, so the FP8 format must not gate it. Forcing the
         # lookup to E5M2 is what an NVFP4 recipe would hit if the check were not MXFP8-only.
@@ -936,11 +937,7 @@ class TestGroupedMLPFusedOp:
             grouped_mlp_module, "get_fp8_torch_dtype", lambda *_, **__: torch.float8_e5m2
         )
         nvfp4 = NVFP4BlockScaling(disable_rht=False)
-        rebuilt = grouped_mlp_module.fuse_grouped_mlp_ops(
-            ops, recipe=nvfp4, fused_op_cls=fused_op_cls
-        )
-        assert rebuilt is not ops
-        assert rebuilt == ops
+        assert_fused(nvfp4)
 
     @pytest.mark.parametrize("bias", (False, True))
     @pytest.mark.parametrize("quantization", _grouped_mlp_quantization_list)

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -903,9 +903,10 @@ class TestGroupedMLPFusedOp:
         """MXFP8 with Format.HYBRID must fall back to the unfused ops.
 
         The fused backward reinterprets the grad output's storage as E4M3, so an
-        E5M2 backward format would be misread rather than converted.
+        E5M2 backward format would be misread rather than converted. The check is
+        MXFP8-only, since fp8_format says nothing about NVFP4 gradients.
         """
-        from transformer_engine.common.recipe import Format, MXFP8BlockScaling
+        from transformer_engine.common.recipe import Format, MXFP8BlockScaling, NVFP4BlockScaling
 
         fused_op_cls = grouped_mlp_module.GroupedMLP_CuTeGEMMGLU
         monkeypatch.setattr(fused_op_cls, "is_supported", classmethod(lambda cls: True))
@@ -925,6 +926,18 @@ class TestGroupedMLPFusedOp:
         e4m3 = MXFP8BlockScaling(fp8_format=Format.E4M3)
         rebuilt = grouped_mlp_module.fuse_grouped_mlp_ops(
             ops, recipe=e4m3, fused_op_cls=fused_op_cls
+        )
+        assert rebuilt is not ops
+        assert rebuilt == ops
+
+        # NVFP4 quantizes gradients to FP4, so the FP8 format must not gate it. Forcing the
+        # lookup to E5M2 is what an NVFP4 recipe would hit if the check were not MXFP8-only.
+        monkeypatch.setattr(
+            grouped_mlp_module, "get_fp8_torch_dtype", lambda *_, **__: torch.float8_e5m2
+        )
+        nvfp4 = NVFP4BlockScaling(disable_rht=False)
+        rebuilt = grouped_mlp_module.fuse_grouped_mlp_ops(
+            ops, recipe=nvfp4, fused_op_cls=fused_op_cls
         )
         assert rebuilt is not ops
         assert rebuilt == ops

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -16,7 +16,7 @@ import torch
 from packaging.version import Version as PkgVersion
 
 import transformer_engine_torch as tex
-from ...constants import MXFP8_BLOCK_SCALING_SIZE, NVFP4_BLOCK_SCALING_SIZE, TE_DType
+from ...constants import DType, MXFP8_BLOCK_SCALING_SIZE, NVFP4_BLOCK_SCALING_SIZE, TE_DType
 from ...cpu_offload import is_cpu_offload_enabled, mark_activation_offload, start_offload
 from ...cpp_extensions import general_gemm, general_grouped_gemm_for_grouped_tensor
 from ...distributed_weight import (
@@ -26,7 +26,7 @@ from ...distributed_weight import (
     finalize_weight_grads,
 )
 from ...module.base import _2X_ACC_WGRAD
-from ...quantization import Recipe
+from ...quantization import Recipe, get_fp8_torch_dtype
 from ...tensor import NVFP4Quantizer, NVFP4Tensor, NVFP4TensorStorage, Quantizer
 from ...tensor.grouped_tensor import GroupedTensor
 from ...tensor.mxfp8_tensor import MXFP8Quantizer, MXFP8Tensor
@@ -816,6 +816,11 @@ def fuse_grouped_mlp_ops(
         return ops
     # NVFP4 fused grouped MLP uses graph-safe grouped quantize, which currently requires RHT.
     if recipe.nvfp4() and recipe.disable_rht:
+        return ops
+    # The fused backward reinterprets the grad output's storage as E4M3, so a recipe with an
+    # E5M2 backward format would have its gradients misread rather than converted. NVFP4 pins
+    # fp8_format to E4M3, so in practice this declines MXFP8 with Format.HYBRID.
+    if get_fp8_torch_dtype(recipe, fprop_tensor=False) != torch.float8_e4m3fn:
         return ops
     if activation_op_types is None:
         activation_op_types = (ScaledSwiGLU, ScaledClampedQGeGLU)
@@ -1923,6 +1928,13 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
             or isinstance(fc1_weight_param, NVFP4Tensor)
             or isinstance(fc2_weight_param, NVFP4Tensor)
         )
+        if not use_nvfp4 and fc2_grad_output_quantizer.dtype != DType.kFloat8E4M3:
+            # The pack below reinterprets the grad output's storage as E4M3 rather than
+            # converting it, so anything else would be read as the wrong format.
+            raise RuntimeError(
+                "Fused grouped MLP backward requires an E4M3 grad output, but the recipe "
+                f"produced {fc2_grad_output_quantizer.dtype}."
+            )
         data_dtype = torch.float4_e2m1fn_x2 if use_nvfp4 else torch.float8_e4m3fn
         scale_view_dtype = torch.float8_e4m3fn if use_nvfp4 else torch.float8_e8m0fnu
         sf_vec_size = NVFP4_BLOCK_SCALING_SIZE if use_nvfp4 else MXFP8_BLOCK_SCALING_SIZE

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -817,10 +817,11 @@ def fuse_grouped_mlp_ops(
     # NVFP4 fused grouped MLP uses graph-safe grouped quantize, which currently requires RHT.
     if recipe.nvfp4() and recipe.disable_rht:
         return ops
-    # The fused backward reinterprets the grad output's storage as E4M3, so a recipe with an
-    # E5M2 backward format would have its gradients misread rather than converted. NVFP4 pins
-    # fp8_format to E4M3, so in practice this declines MXFP8 with Format.HYBRID.
-    if get_fp8_torch_dtype(recipe, fprop_tensor=False) != torch.float8_e4m3fn:
+    # The fused MXFP8 backward reinterprets the grad output's storage as E4M3, so an E5M2
+    # backward format would have its gradients misread rather than converted. This declines
+    # MXFP8 with Format.HYBRID. fp8_format does not describe NVFP4 gradients, so NVFP4 is
+    # excluded from the check rather than relying on its value.
+    if recipe.mxfp8() and get_fp8_torch_dtype(recipe, fprop_tensor=False) != torch.float8_e4m3fn:
         return ops
     if activation_op_types is None:
         activation_op_types = (ScaledSwiGLU, ScaledClampedQGeGLU)


### PR DESCRIPTION
# Description

`GroupedMLP_CuTeGEMMGLU` packs the incoming activation gradient by reinterpreting its storage as E4M3, conditioned only on NVFP4 and never on the FP8 format. Under `MXFP8BlockScaling(fp8_format=Format.HYBRID)` the backward quantizers emit E5M2, so those bytes are read as the wrong format rather than converted and every gradient out of the fusion is wrong. The forward pass is unaffected.

This declines the fusion when the recipe's backward format is not E4M3, next to the existing RHT check, and raises rather than reinterpreting if such a gradient still reaches the kernel path. NVFP4 pins `fp8_format` to E4M3, so it is unaffected.

Fixes #3342

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Decline the fusion in `fuse_grouped_mlp_ops()` when `get_fp8_torch_dtype(recipe, fprop_tensor=False)` is not E4M3.
- Raise in the fused backward if a non-E4M3 grad output reaches the pack.
- Add `test_fusion_declined_for_e5m2_grad_output`.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
