### PR TITLE
Fix FlashAttention local version validation

### DIFF
--- a/tests/pytorch/attention/test_attention.py
+++ b/tests/pytorch/attention/test_attention.py
@@ -8,6 +8,7 @@ import pathlib
 import copy
 from typing import Any, Dict, Tuple, Union
 
+from packaging.version import Version as PkgVersion
 import pytest
 import torch
 
@@ -29,6 +30,7 @@ from transformer_engine.pytorch.attention.dot_product_attention import (
 )
 from transformer_engine.pytorch.attention.dot_product_attention.utils import (
     FlashAttentionUtils,
+    _get_supported_versions,
     check_set_window_size,
 )
 from transformer_engine.pytorch.attention import RotaryPositionEmbedding
@@ -92,6 +94,39 @@ reset_rng_states()
 def reset_global_fp8_state():
     yield
     FP8GlobalStateManager.reset()
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    (
+        ("2.1.0", False),
+        ("2.1.1", True),
+        ("2.8.3", True),
+        ("2.8.3+local_version", True),
+        ("2.8.3.post1", True),
+        ("2.8.4", False),
+        ("2.8.4+local_version", False),
+        ("2.9.0", False),
+    ),
+)
+def test_flash_attention_version_support(version, expected):
+    """Test the supported Flash Attention v2 version range."""
+    assert (
+        FlashAttentionUtils.is_version_supported(
+            PkgVersion(version), FlashAttentionUtils.version_required
+        )
+        is expected
+    )
+
+
+def test_flash_attention_supported_version_message():
+    """Test that the supported version range describes an exclusive upper bound."""
+    assert (
+        _get_supported_versions(
+            FlashAttentionUtils.version_required, FlashAttentionUtils.max_version
+        )
+        == ">= 2.1.1, < 2.8.4"
+    )
 
 
 # Define F16 data types to test

--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -95,14 +95,14 @@ _flash_attn_varlen_fwd = None
 _flash_attn_varlen_bwd = None
 # Try to import Flash Attention v2
 try:
-    fa_utils.version = PkgVersion(PkgVersion(get_pkg_version("flash-attn")).public)
+    fa_utils.version = PkgVersion(get_pkg_version("flash-attn"))
 except PackageNotFoundError:
     pass  # only print warning if use_flash_attention_2 = True in get_attention_backend
 else:
     if torch.cuda.is_available() and get_device_compute_capability() >= (10, 0):
-        if fa_utils.version_required_blackwell <= fa_utils.version <= fa_utils.max_version:
+        if fa_utils.is_version_supported(fa_utils.version, fa_utils.version_required_blackwell):
             fa_utils.is_installed = True
-    elif fa_utils.version_required <= fa_utils.version <= fa_utils.max_version:
+    elif fa_utils.is_version_supported(fa_utils.version, fa_utils.version_required):
         fa_utils.is_installed = True
 
     if fa_utils.is_installed:
@@ -814,8 +814,8 @@ class FlashAttention(torch.nn.Module):
                 fa_utils.version >= fa_utils.version_required
             ), f"FlashAttention minimum version {fa_utils.version_required} is required."
             assert (
-                fa_utils.version <= fa_utils.max_version
-            ), f"FlashAttention maximum version {fa_utils.max_version} is supported."
+                fa_utils.version < fa_utils.max_version
+            ), f"FlashAttention versions before {fa_utils.max_version} are supported."
 
         self.softmax_scale = softmax_scale
         self.attention_dropout_ctx = attention_dropout_ctx

--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -105,7 +105,7 @@ def _get_supported_versions(version_min, version_max):
     """
     Calculate version info based on min and max numbers
     """
-    return ">= " + str(version_min) + ", " + "<= " + str(version_max)
+    return ">= " + str(version_min) + ", " + "< " + str(version_max)
 
 
 def maybe_contiguous(tensor: torch.Tensor) -> torch.Tensor:
@@ -122,7 +122,7 @@ class FlashAttentionUtils:
     version = PkgVersion("0")
     version_required = PkgVersion("2.1.1")
     version_required_blackwell = PkgVersion("2.7.3")
-    max_version = PkgVersion("2.8.3")
+    max_version = PkgVersion("2.8.4")
     v2_plus = False
     v2_1_plus = False
     v2_3_plus = False
@@ -154,6 +154,11 @@ pip install flash-attn-4==4.0.0b11 nvidia-cutlass-dsl[cu13]"""
     # Set by backends.py if FA4 is installed; calls flash_attn.cute.interface._validate_head_dims
     # which raises AssertionError for unsupported (head_dim, head_dim_v) combinations.
     v4_validate_head_dims: Callable = None
+
+    @staticmethod
+    def is_version_supported(version: PkgVersion, minimum_version: PkgVersion) -> bool:
+        """Check whether a Flash Attention v2 version is supported."""
+        return minimum_version <= version < FlashAttentionUtils.max_version
 
     @staticmethod
     def set_flash_attention_version():


### PR DESCRIPTION
# Description

Use half-open interval for FA version checks

Fixes #3334

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- change FA version check logic to use half-open interval
- tests for version check logic

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
