### PR TITLE
[PyTorch] Restore FlashAttention 2 head dim support on sm103

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/utils.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/utils.py
@@ -913,19 +913,11 @@ def get_attention_backend(
     if (  # pylint: disable=too-many-boolean-expressions
         use_flash_attention_2
         and FlashAttentionUtils.is_installed
-        and (
-            fa2_padded_head_dim > 256
-            or fa2_padded_head_dim % 8 != 0
-            or (
-                fa2_padded_head_dim > 192
-                and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (12, 0))
-            )
-        )
+        and (fa2_padded_head_dim > 256 or fa2_padded_head_dim % 8 != 0)
     ):
         logger.debug(
             "Disabling FlashAttention 2 due to unsupported head_dim_qk and head_dim_v. "
-            "Supported after padding: padded head_dim %%8 = 0, padded head_dim <= 256 "
-            "(>192 requires sm80/90/100+). "
+            "Supported after padding: padded head_dim %%8 = 0, padded head_dim <= 256. "
             "Found: head_dim_qk = %s, head_dim_v = %s, padded head_dim = %s, on sm%s.",
             head_dim_qk,
             head_dim_v,


### PR DESCRIPTION
# Description

Restore the FlashAttention 2 head-dimension behavior from #2836. #2629 preserved the new padded Q/V head-dimension handling but accidentally reintroduced the exact compute-capability allowlist that #2836 removed.

On B300 (sm103), that allowlist rejects a padded head dimension of 256 and falls back to quadratic unfused attention.

<img width="2340" height="1098" alt="image" src="https://github.com/user-attachments/assets/89d6864c-7347-4713-bce9-ec81fde76820" />

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Preserve the padded Q/V head-dimension validation introduced by #2629.
- Remove the stale architecture allowlist for FlashAttention 2 head dimensions above 192.
- Update the backend-selection diagnostic to match.

## Testing

### Status quo

- Layout: one 8xB300 node with four B300s assigned to the Megatron trainer (`TP=4`) and four to rollout inference. Qwen3.6-27B used BF16 THD attention, head dim 256, Transformer Engine 2.11.0, and FlashAttention 2.8.3.
- Our production workload requested FlashAttention, but TE's exact compute-capability allowlist omitted B300 (`sm103`) and silently selected `UnfusedDotProductAttention` instead.
- XID 1043331 replayed an unsliced 65,332-token datum with a 65,536-token microbatch budget. The quadratic unfused softmax tried to allocate 202.75 GiB and raised `torch.OutOfMemoryError` during forward.

### After the fix

- Used the same image, package versions, TP4 trainer layout, model, BF16 THD configuration, head dim, 65,536-token budget, and exact 65,332-token datum. Only this selector gate was patched.
- The full 64k training update completed without OOM: `forward_backward` took 413.2s, the Adam optimizer step took 9.6s, and grad norm was finite at 1776.48. This validates FlashAttention 2 and 64k context on the four-B300 trainer configuration.
- Python compilation and diff checks pass.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes