### PR TITLE
fix: add missing NVTE_BHSD_BHSD_BHSD to layout to_string

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -68,6 +68,8 @@ std::string to_string(NVTE_QKV_Layout layout) {
       return "NVTE_Paged_KV_THD_BSHD_BSHD";
     case NVTE_Paged_KV_THD_SBHD_SBHD:
       return "NVTE_Paged_KV_THD_SBHD_SBHD";
+    case NVTE_BHSD_BHSD_BHSD:
+      return "NVTE_BHSD_BHSD_BHSD";
     default:
       return "UNKNOWN_QKV_LAYOUT(" + std::to_string(static_cast<int>(layout)) + ")";
   }
@@ -89,6 +91,8 @@ std::string to_string(NVTE_QKV_Format format) {
       return "NVTE_THD_2BSHD";
     case NVTE_THD_2SBHD:
       return "NVTE_THD_2SBHD";
+    case NVTE_BHSD:
+      return "NVTE_BHSD";
     default:
       return "UNKNOWN_QKV_FORMAT(" + std::to_string(static_cast<int>(format)) + ")";
   }


### PR DESCRIPTION
This PR addresses the following issue in `transformer_engine/common/fused_attn/fused_attn.cpp`: add missing NVTE_BHSD_BHSD_BHSD to layout to_string.

## Changes
- `transformer_engine/common/fused_attn/fused_attn.cpp`: add missing NVTE_BHSD_BHSD_BHSD to layout to_string.

## Details
```diff
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -1,27 +1,31 @@
-    case NVTE_Paged_KV_THD_SBHD_SBHD:
-      return "NVTE_Paged_KV_THD_SBHD_SBHD";
-    default:
-      return "UNKNOWN_QKV_LAYOUT(" + std::to_string(static_cast<int>(layout)) + ")";
-  }
-}
-
-std::string to_string(NVTE_QKV_Format format) {
-  switch (format) {
-    case NVTE_SBHD:
-      return "NVTE_SBHD";
-    case NVTE_BSHD:
-      return "NVTE_BSHD";
-    case NVTE_THD:
-      return "NVTE_THD";
-    case NVTE_BSHD_2SBHD:
-      return "NVTE_BSHD_2SBHD";
-    case NVTE_SBHD_2BSHD:
-      return "NVTE_SBHD_2BSHD";
-    case NVTE_THD_2BSHD:
-      return "NVTE_THD_2BSHD";
-    case NVTE_THD_2SBHD:
-      return "NVTE_THD_2SBHD";
-    default:
-      return "UNKNOWN_QKV_FORMAT(" + std::to_string(static_cast<int>(format)) + ")";
-  }
-}
+    case NVTE_Paged_KV_THD_SBHD_SBHD:
+      return "NVTE_Paged_KV_THD_SBHD_SBHD";
+    case NVTE_BHSD_BHSD_BHSD:
+      return "NVTE_BHSD_BHSD_BHSD";
+    default:
+      return "UNKNOWN_QKV_LAYOUT(" + std::to_string(static_cast<int>(layout)) + ")";
+  }
+}
+
+std::string to_string(NVTE_QKV_Format format) {
+  switch (format) {
+    case NVTE_SBHD:
+      return "NVTE_SBHD";
+    case NVTE_BSHD:
+      return "NVTE_BSHD";
+    case NVTE_THD:
+      return "NVTE_THD";
+    case NVTE_BSHD_2SBHD:
+      return "NVTE_BSHD_2SBHD";
+    case NVTE_SBHD_2BSHD:
+      return "NVTE_SBHD_2BSHD";
+    case NVTE_THD_2BSHD:
+      return "NVTE_THD_2BSHD";
+    case NVTE_THD_2SBHD:
+      return "NVTE_THD_2SBHD";
+    case NVTE_BHSD:
+      return "NVTE_BHSD";
+    default:
+      return "UNKNOWN_QKV_FORMAT(" + std::to_string(static_cast<int>(format)) + ")";
+  }
+}
```

## Tests
- `tests/cpp/test_fused_attn.cpp`

```diff
--- a/tests/cpp/test_fused_attn.cpp
+++ b/tests/cpp/test_fused_attn.cpp
@@ -0,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "transformer_engine/fused_attn.h"
+
+namespace transformer_engine {
+namespace test {
+
+TEST(FusedAttnUtils, QkvLayoutToStringBhsd) {
+  EXPECT_EQ(to_string(NVTE_BHSD_BHSD_BHSD), "NVTE_BHSD_BHSD_BHSD");
+}
+
+TEST(FusedAttnUtils, QkvFormatToStringBhsd) {
+  EXPECT_EQ(to_string(NVTE_BHSD), "NVTE_BHSD");
+}
+
+}  // namespace test
+}  // namespace transformer_engine
```