### PR TITLE
fix: add missing NVTE_BHSD to qkv format to_string

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -79,6 +79,8 @@ std::string to_string(NVTE_QKV_Format format) {
       return "NVTE_SBHD";
     case NVTE_BSHD:
       return "NVTE_BSHD";
+    case NVTE_BHSD:
+      return "NVTE_BHSD";
     case NVTE_THD:
       return "NVTE_THD";
     case NVTE_BSHD_2SBHD:


### PR DESCRIPTION
This PR addresses the following issue in `transformer_engine/common/fused_attn/fused_attn.cpp`: add missing NVTE_BHSD to qkv format to_string.

## Changes
- `transformer_engine/common/fused_attn/fused_attn.cpp`: add missing NVTE_BHSD to qkv format to_string.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/test_qkv_format_to_string.cpp`