### PR TITLE
fix: simplify redundant softmax version condition

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -471,8 +471,7 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
         // pre-9.13.1: vanilla
         // 9.13.1+: vanilla, off-by-one, learnable
         (cudnn_runtime_version >= 91301 ||
-         (cudnn_runtime_version < 91301 &&
-          softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX)) &&
+         softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX) &&
         // max_logit
         // pre-9.21: no (the composite softmax node rejects the Stats + Max output combination)
         // 9.21+: yes (Stats + Max via the unified softmax node)


### PR DESCRIPTION
This PR simplifies a redundant softmax version condition in `transformer_engine/common/fused_attn/fused_attn.cpp`.

## Changes
- `transformer_engine/common/fused_attn/fused_attn.cpp`: remove the redundant `cudnn_runtime_version < 91301` conjunct.

## Details

The original guard:
```cpp
cudnn_runtime_version >= 91301 ||
(cudnn_runtime_version < 91301 && softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX)
```
is logically equivalent to:
```cpp
cudnn_runtime_version >= 91301 ||
softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX
```

```diff
-        (cudnn_runtime_version >= 91301 ||
-         (cudnn_runtime_version < 91301 &&
-          softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX)) &&
+        (cudnn_runtime_version >= 91301 ||
+         softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX) &&
```

## Tests
- Covered by existing fused-attention tests that exercise different cudnn versions and softmax types.

## Contributor guidelines
- Signed-off-by: Andrew White <andrewwhitecdw@users.noreply.github.com>