### PR TITLE
fix: remove unused `import time`

### DIFF
--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -9,7 +9,6 @@ import signal
 import subprocess
 import sys
 import threading
-import time
 import pathlib
 import logging
 import copy


### PR DESCRIPTION
This PR addresses the following issue in `tests/pytorch/attention/test_attention_with_cp.py`: remove unused `import time`.

## Changes
- `tests/pytorch/attention/test_attention_with_cp.py`: remove unused `import time`.

## Details
```diff
--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -1,12 +1,11 @@
-import json
-import os
-import select
-import signal
-import subprocess
-import sys
-import threading
-import time
-import pathlib
-import logging
-import copy
-from collections import deque
+import json
+import os
+import select
+import signal
+import subprocess
+import sys
+import threading
+import pathlib
+import logging
+import copy
+from collections import deque
```

## Tests

> Let me know if you want tests added for this fix or not.