### PR TITLE
fix: typo and unnecessary f-string in BRCM skip message

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -476,12 +476,12 @@ class FusedAttnRunner:
         if self.attn_mask_type.is_bottom_right():
             if self.max_seqlen_q > self.max_seqlen_kv:
                 pytest.skip(
-                    f"BRCM requires cross attn type pattern, i.e.max_seqlen_kv >= max_seqlen_q"
+                    "BRCM requires cross attn type pattern, i.e.max_seqlen_kv >= max_seqlen_q"
                 )
             if self.attn_bias_type is not AttnBiasType.NO_BIAS:
-                pytest.skip(f"cuDNN does not support pre or post scale bias for BRCM")
+                pytest.skip("cuDNN does not support pre or post scale bias for BRCM")
             if self.dropout_prob != 0.0:
-                pytest.skip(f"cuDNN does not support non-zero dropoouts for BRCM")
+                pytest.skip("cuDNN does not support non-zero dropouts for BRCM")
 
         if self.qkv_layout.is_qkvpacked():
             if self.max_seqlen_q != self.max_seqlen_kv:


### PR DESCRIPTION
This PR fixes a typo in `tests/jax/test_fused_attn.py`: typo and unnecessary f-string in BRCM skip message.

## Changes
- `tests/jax/test_fused_attn.py`: typo and unnecessary f-string in BRCM skip message.

## Details
```diff
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -1,1 +1,1 @@
-                pytest.skip(f"cuDNN does not support non-zero dropoouts for BRCM")
+                pytest.skip("cuDNN does not support non-zero dropouts for BRCM")
```

## Tests

> Let me know if you want tests added for this fix or not.