### PR TITLE
fix: make_mask uses deprecated jnp.bool instead of jnp.bool_

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -222,7 +222,7 @@ def make_mask(
             segment_pos_q,
             segment_pos_kv,
             window_size,
-            dtype=jnp.bool,
+            dtype=jnp.bool_,
             segment_ids_q=segment_ids_q,
             segment_ids_kv=segment_ids_kv,
         )


### PR DESCRIPTION
This PR fixes a deprecated JAX API use in `tests/jax/test_fused_attn.py`.

## Changes
- `tests/jax/test_fused_attn.py`: `make_mask` passes `dtype=jnp.bool` to `make_swa_mask` for the bottom-right sliding-window branch; `jnp.bool` is a deprecated alias (removed in newer JAX releases as a trap) and `jnp.bool_` is the correct spelling of the boolean dtype.

## Details
The call site now uses `jnp.bool_`, matching the rest of the suite, so the JAX fused-attention tests keep importing and running on current JAX versions. `make_mask` itself is defined only inside this test script, so there is no production code path affected.

## Testing
Covered by the existing JAX fused-attention test suite; no dedicated regression test added since the function under fix lives in this test file only (per review feedback).
