### PR TITLE
fix: comment typo 'mas' -> 'mask' in two TODOs

### DIFF
--- a/tests/jax/test_fused_attn.py
+++ b/tests/jax/test_fused_attn.py
@@ -957,7 +957,7 @@ class FusedAttnRunner:
 
         customcall_args = [
             # Put test data onto each GPU for distributed.
-            # TODO(mgoldfarb-nvidia): We will need to add reordering for bias, mas and
+            # TODO(mgoldfarb-nvidia): We will need to add reordering for bias, mask and
             # THD params once we support those features on CP.
             jax.device_put(self.cp_reorder_fn(self.q), self.qkvo_sharding),
             jax.device_put(self.cp_reorder_fn(self.k), self.qkvo_sharding),
@@ -1089,7 +1089,7 @@ class FusedAttnRunner:
             self.dropout_rng,
         ]
         customcall_args = [
-            # TODO(mgoldfarb-nvidia): We will need to add reordering for bias, mas and
+            # TODO(mgoldfarb-nvidia): We will need to add reordering for bias, mask and
             # THD params once we support those features on CP.
             jax.device_put(self.cp_reorder_fn(self.q), self.qkvo_sharding),
             jax.device_put(self.cp_reorder_fn(self.k), self.qkvo_sharding),


### PR DESCRIPTION
This PR fixes a comment typo in `tests/jax/test_fused_attn.py` where "mas" should be "mask" in two TODO lines.

## Changes
- `tests/jax/test_fused_attn.py`: correct `bias, mas and` to `bias, mask and` in two TODO comments.

## Tests
- No runtime behavior change; comment-only fix.

## Contributor guidelines
- Signed-off-by: Andrew White <andrewwhitecdw@users.noreply.github.com>