### PR TITLE
[JAX] SBHD reorder skip uses original shape instead of swapped tensor

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -835,7 +835,7 @@ class TestReorderCausalLoadBalancing:
             seq_dim = 0
 
         if reorder_strategy == ReorderStrategy.Striped:
-            seq_lens = shape[seq_dim]
+            seq_lens = tensor.shape[seq_dim]
             if seq_lens < (cp_size * stripe_size):
                 pytest.skip(f"{seq_lens=} must be larger than {cp_size*stripe_size=}")
 


### PR DESCRIPTION
This PR fixes the SBHD Striped skip logic in `tests/jax/test_distributed_fused_attn.py` so it reads the sequence length from the swapped tensor shape rather than the original shape.

## Changes
- `tests/jax/test_distributed_fused_attn.py`: use `tensor.shape[seq_dim]` instead of `shape[seq_dim]` after the SBHD axis swap.

## Details

When `qkv_format == QKVFormat.SBHD`, the test swaps axes 0 and 1 so `seq_dim` becomes 0. The old skip guard read `shape[seq_dim]`, which is the original (unswapped) batch size for SBHD, causing incorrect skips. The fix reads `tensor.shape[seq_dim]`, which reflects the swapped sequence length.

```diff
-            seq_lens = shape[seq_dim]
+            seq_lens = tensor.shape[seq_dim]
```

## Tests
- Covered by the existing parametrized `TestReorderCausalLoadBalancing.test` cases that exercise SBHD inputs.

## Contributor guidelines
- Signed-off-by: Andrew White <andrewwhitecdw@users.noreply.github.com>