### PR TITLE
fix: allgather striped window_size (5,0) id says (8,0)

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -485,7 +485,7 @@ class TestDistributedContextParallelSelfAttn:
         "window_size",
         [
             pytest.param((-1, -1), id="window_size(-1, -1)"),
-            pytest.param((5, 0), id="window_size(8, 0)"),
+            pytest.param((5, 0), id="window_size(5, 0)"),
         ],
     )
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR addresses the following issue in `tests/jax/test_distributed_fused_attn.py`: allgather striped window_size (5,0) id says (8,0).

## Changes
- `tests/jax/test_distributed_fused_attn.py`: allgather striped window_size (5,0) id says (8,0).

## Details
```diff
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -1,7 +1,7 @@
-    @pytest.mark.parametrize(
-        "window_size",
-        [
-            pytest.param((-1, -1), id="window_size(-1, -1)"),
-            pytest.param((5, 0), id="window_size(8, 0)"),
-        ],
-    )
+    @pytest.mark.parametrize(
+        "window_size",
+        [
+            pytest.param((-1, -1), id="window_size(-1, -1)"),
+            pytest.param((5, 0), id="window_size(5, 0)"),
+        ],
+    )
```

## Tests

> Let me know if you want tests added for this fix or not.