### PR TITLE
[JAX] Move ffi type definition before ffi target definitions

### DIFF
--- a/transformer_engine/jax/cpp_extensions/base.py
+++ b/transformer_engine/jax/cpp_extensions/base.py
@@ -263,10 +263,8 @@ def register_primitive(cls, outer_only=False):
     cls.outer_primitive = outer_p
 
 
-for _name, _value in transformer_engine_jax.registrations().items():
-    ffi.register_ffi_target(_name, _value, platform="CUDA")
-
 # Register EpInstanceState (no-op when TE is built without NCCL EP).
+# Custom types must be registered before any FFI handler that references them.
 if hasattr(transformer_engine_jax, "get_ep_instance_state_type_id"):
     ffi.register_ffi_type(
         "EpInstanceState",
@@ -276,6 +274,10 @@ if hasattr(transformer_engine_jax, "get_ep_instance_state_type_id"):
         },
         platform="CUDA",
     )
+
+
+for _name, _value in transformer_engine_jax.registrations().items():
+    ffi.register_ffi_target(_name, _value, platform="CUDA")
 
 
 def manage_primitives(enable_names=None, disable_names=None, disable_all_first=False):


### PR DESCRIPTION
# Description

Fixes issue that has occurred on most recent versions of nightly JAX/XLA
```
jax.errors.JaxRuntimeError: FAILED_PRECONDITION: Types used by FFI handlers must be registered before the handler registration
```

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Fix registration order

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
