### PR TITLE
[PyTorch] Share MXFP8 data tensor between rowwise and columnwise for 2D quantization

### DIFF
--- a/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
@@ -53,7 +53,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
                           const __grid_constant__ CUtensorMap tensor_map_output_colwise,
                           e8m0_t *const scales_rowwise, e8m0_t *const scales_colwise,
                           const float *noop, float *const dbias_workspace, float *const amax_ptr,
-                          const size_t rows, const size_t cols, const size_t scale_stride_rowwise,
+                          const bool skip_colwise_data_write, const size_t rows,
+                          const size_t cols, const size_t scale_stride_rowwise,
                           const size_t scale_stride_colwise) {
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
   constexpr bool COMPUTE_ACTIVATIONS = IS_DACT || IS_ACT;
@@ -509,9 +510,11 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
             global_offset_Y, reinterpret_cast<uint64_t *>(&out_rowwise_data_sh[buff_offset]));
       }
       if constexpr (COLWISE_SCALING) {
-        ptx::cp_async_bulk_tensor_2d_shared_to_global(
-            reinterpret_cast<const uint64_t *>(&tensor_map_output_colwise), global_offset_X,
-            global_offset_Y, reinterpret_cast<uint64_t *>(&out_colwise_data_sh[buff_offset]));
+        if (!skip_colwise_data_write) {
+          ptx::cp_async_bulk_tensor_2d_shared_to_global(
+              reinterpret_cast<const uint64_t *>(&tensor_map_output_colwise), global_offset_X,
+              global_offset_Y, reinterpret_cast<uint64_t *>(&out_colwise_data_sh[buff_offset]));
+        }
       }
 
       // Create a "bulk async-group" out of the previous bulk copy operation.
@@ -872,7 +875,7 @@ void quantize(const Tensor &input, const Tensor *act_input, const Tensor *noop, 
                     kernel<<<grid, block_size, dshmem_size, stream>>>(
                         tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
                         tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
-                        workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise,
+                        workspace_ptr, amax_ptr, false, rows, cols, scale_stride_rowwise,
                         scale_stride_colwise);
                   });
                   break;
@@ -889,7 +892,7 @@ void quantize(const Tensor &input, const Tensor *act_input, const Tensor *noop, 
                     kernel<<<grid, block_size, dshmem_size, stream>>>(
                         tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
                         tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
-                        workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise,
+                        workspace_ptr, amax_ptr, false, rows, cols, scale_stride_rowwise,
                         scale_stride_colwise);
                   });
                   break;
@@ -906,8 +909,9 @@ void quantize(const Tensor &input, const Tensor *act_input, const Tensor *noop, 
                     kernel<<<grid, block_size, dshmem_size, stream>>>(
                         tensor_map_input, tensor_map_act_input, tensor_map_output_rowwise,
                         tensor_map_output_colwise, scales_rowwise_ptr, scales_colwise_ptr, noop_ptr,
-                        workspace_ptr, amax_ptr, rows, cols, scale_stride_rowwise,
-                        scale_stride_colwise);
+                        workspace_ptr, amax_ptr,
+                        use_2d_quantization && output->data == output->columnwise_data, rows, cols,
+                        scale_stride_rowwise, scale_stride_colwise);
                   });
                   break;
                 }

--- a/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
@@ -53,9 +53,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
                           const __grid_constant__ CUtensorMap tensor_map_output_colwise,
                           e8m0_t *const scales_rowwise, e8m0_t *const scales_colwise,
                           const float *noop, float *const dbias_workspace, float *const amax_ptr,
-                          const bool skip_colwise_data_write, const size_t rows,
-                          const size_t cols, const size_t scale_stride_rowwise,
-                          const size_t scale_stride_colwise) {
+                          const bool skip_colwise_data_write, const size_t rows, const size_t cols,
+                          const size_t scale_stride_rowwise, const size_t scale_stride_colwise) {
 #if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
   constexpr bool COMPUTE_ACTIVATIONS = IS_DACT || IS_ACT;
   constexpr bool NO_ACTIVATIONS = !COMPUTE_ACTIVATIONS;

--- a/transformer_engine/pytorch/csrc/quantizer.cpp
+++ b/transformer_engine/pytorch/csrc/quantizer.cpp
@@ -1531,8 +1531,13 @@ std::pair<TensorWrapper, py::object> MXFP8Quantizer::create_tensor(
   if (columnwise_usage) {
     const std::vector<int64_t> scale_inv_shape_int64(columnwise_scale_inv_shape.begin(),
                                                      columnwise_scale_inv_shape.end());
-    columnwise_data_tensor = at::empty(shape_int64, uint8_tensor_opts);
     columnwise_scale_inv_tensor = at::empty(scale_inv_shape_int64, uint8_tensor_opts);
+    if (with_2d_quantization && rowwise_usage) {
+      // 2D quantization: rowwise and columnwise data are identical, share the buffer
+      columnwise_data_tensor = rowwise_data_tensor;
+    } else {
+      columnwise_data_tensor = at::empty(shape_int64, uint8_tensor_opts);
+    }
   }
 
   // Convert tensors to Python

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -87,7 +87,9 @@ class MXFP8Quantizer(Quantizer):
                 torch.uint8,
             )
         if self.columnwise_usage:
-            specs["_columnwise_data"] = (shape, torch.uint8)
+            # 2D quantization: data is identical, reuse rowwise_data instead of allocating a copy
+            if not (self.with_2d_quantization and self.rowwise_usage):
+                specs["_columnwise_data"] = (shape, torch.uint8)
             specs["_columnwise_scale_inv"] = (
                 tuple(self.get_scale_shape(shape, columnwise=True)),
                 torch.uint8,
@@ -263,6 +265,15 @@ class MXFP8Tensor(MXFP8TensorStorage, QuantizedTensor):
         with_gemm_swizzled_scales: bool,
         **kwargs,
     ):
+        # 2D quantization: columnwise data is identical to rowwise, alias it
+        if (
+            columnwise_data is None
+            and rowwise_data is not None
+            and quantizer is not None
+            and getattr(quantizer, "with_2d_quantization", False)
+            and getattr(quantizer, "columnwise_usage", False)
+        ):
+            columnwise_data = rowwise_data
         return super().__new__(
             cls,
             rowwise_data,


### PR DESCRIPTION
## Summary

For 2D MXFP8 quantization, the rowwise and columnwise FP8 data tensors are byte-identical since they originate from the same 32x32 block scales. Currently, two separate `[M, K]` uint8 buffers are allocated and written with identical data.

This PR shares a single data buffer between the two representations, halving the FP8 weight memory footprint for 2D-quantized weights.

## Changes

- **C++ quantizer** (`quantizer.cpp`): When `with_2d_quantization && rowwise_usage && columnwise_usage`, reuse `rowwise_data_tensor` as `columnwise_data_tensor` instead of allocating a separate buffer.
- **Python `inner_tensor_specs`** (`mxfp8_tensor.py`): Skip `_columnwise_data` allocation when 2D and rowwise is already enabled.
- **`MXFP8Tensor.__new__`** (`mxfp8_tensor.py`): When `columnwise_data` is None and 2D quantization is active, alias it to `rowwise_data`.

No GEMM or kernel changes are needed: cuBLAS already selects the appropriate pointer via the `transA` flag and handles the transpose internally.

## Related

- Follow-up to #2634 (Add 2d quant for mxfp8)