### PR TITLE
fix: reorder test uses original shape after swapping SBHD axes

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -835,7 +835,7 @@ class TestReorderCausalLoadBalancing:
             seq_dim = 0
 
         if reorder_strategy == ReorderStrategy.Striped:
-            seq_lens = shape[seq_dim]
+            seq_lens = tensor.shape[seq_dim]
             if seq_lens < (cp_size * stripe_size):
                 pytest.skip(f"{seq_lens=} must be larger than {cp_size*stripe_size=}")
 


### PR DESCRIPTION
This PR addresses the following issue in `tests/jax/test_distributed_fused_attn.py`: reorder test uses original shape after swapping SBHD axes.

## Changes
- `tests/jax/test_distributed_fused_attn.py`: reorder test uses original shape after swapping SBHD axes.

## Details
```diff
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -1,4 +1,4 @@
-        if reorder_strategy == ReorderStrategy.Striped:
-            seq_lens = shape[seq_dim]
-            if seq_lens < (cp_size * stripe_size):
-                pytest.skip(f"{seq_lens=} must be larger than {cp_size*stripe_size=}")
+        if reorder_strategy == ReorderStrategy.Striped:
+            seq_lens = tensor.shape[seq_dim]
+            if seq_lens < (cp_size * stripe_size):
+                pytest.skip(f"{seq_lens=} must be larger than {cp_size*stripe_size=}")
```

## Tests
- `tests/jax/test_distributed_fused_attn.py`