### PR TITLE
Support quantized tensor subclasses across Python and C++

### DIFF
--- a/tests/pytorch/test_hybrid_quantization.py
+++ b/tests/pytorch/test_hybrid_quantization.py
@@ -1738,6 +1738,25 @@ class TestHybridTorchDispatch:
         assert isinstance(detached, HybridQuantizedTensor)
         assert not detached.requires_grad
 
+    def test_detach_preserves_subclass(self, hybrid_tensor):
+        """HybridQuantizedTensor detach preserves its runtime subclass."""
+
+        class DerivedHybridQuantizedTensor(HybridQuantizedTensor):
+            pass
+
+        hybrid_tensor.__class__ = DerivedHybridQuantizedTensor
+        source_data = hybrid_tensor.get_data_tensors()
+
+        detached = hybrid_tensor.detach()
+
+        assert type(detached) is DerivedHybridQuantizedTensor
+        for detached_data, source_data_tensor in zip(detached.get_data_tensors(), source_data):
+            assert detached_data is source_data_tensor
+        assert not detached.requires_grad
+
+        parameter = torch.nn.Parameter(hybrid_tensor)
+        assert type(parameter) is DerivedHybridQuantizedTensor
+
     def test_repr(self, hybrid_tensor):
         r = repr(hybrid_tensor)
         assert "HybridQuantizedTensor" in r

--- a/tests/pytorch/test_identity_quantizer.py
+++ b/tests/pytorch/test_identity_quantizer.py
@@ -249,7 +249,9 @@ class TestIdentityQuantizerUnit:
         detached = tensor.detach()
 
         assert type(detached) is DerivedIdentityTensor
-        assert detached._hp_data is tensor._hp_data
+        assert detached._hp_data.data_ptr() == tensor._hp_data.data_ptr()
+        assert detached._hp_data.stride() == tensor._hp_data.stride()
+        assert detached._hp_data.storage_offset() == tensor._hp_data.storage_offset()
         assert not detached.requires_grad
 
         parameter = torch.nn.Parameter(tensor)

--- a/tests/pytorch/test_identity_quantizer.py
+++ b/tests/pytorch/test_identity_quantizer.py
@@ -237,6 +237,24 @@ class TestIdentityQuantizerUnit:
         out = IdentityQuantizer()(x)
         assert isinstance(out, IdentityTensor)
 
+    def test_detach_preserves_subclass(self):
+        """IdentityTensor detach preserves its runtime subclass."""
+
+        class DerivedIdentityTensor(IdentityTensor):
+            pass
+
+        tensor = IdentityQuantizer()(torch.randn(8, 16, device="cuda", dtype=torch.bfloat16))
+        tensor.__class__ = DerivedIdentityTensor
+
+        detached = tensor.detach()
+
+        assert type(detached) is DerivedIdentityTensor
+        assert detached._hp_data is tensor._hp_data
+        assert not detached.requires_grad
+
+        parameter = torch.nn.Parameter(tensor)
+        assert type(parameter) is DerivedIdentityTensor
+
     def test_internal_returns_storage(self):
         x = torch.randn(8, 16, device="cuda", dtype=torch.bfloat16)
         q = IdentityQuantizer()

--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -563,6 +563,49 @@ class TestQuantizedTensor:
         torch.manual_seed(seed)
         torch.cuda.manual_seed(seed)
 
+    @pytest.mark.parametrize(
+        "quantization",
+        [
+            pytest.param(
+                "fp8",
+                marks=pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8),
+            ),
+            pytest.param(
+                "fp8_blockwise",
+                marks=pytest.mark.skipif(
+                    not fp8_block_scaling_available,
+                    reason=reason_for_no_fp8_block_scaling,
+                ),
+            ),
+            pytest.param(
+                "mxfp8",
+                marks=pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8),
+            ),
+            pytest.param(
+                "nvfp4",
+                marks=pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4),
+            ),
+        ],
+    )
+    def test_detach_preserves_subclass(self, quantization: str) -> None:
+        """Detaching a quantized tensor preserves its runtime subclass."""
+        quantizer = make_quantizer(quantization)
+        tensor = quantizer(torch.randn(128, 128, dtype=torch.bfloat16, device="cuda"))
+        derived_type = type(f"Derived{type(tensor).__name__}", (type(tensor),), {})
+        tensor.__class__ = derived_type
+
+        detached = tensor.detach()
+
+        assert type(detached) is derived_type
+        for detached_data, source_data in zip(
+            detached.get_data_tensors(), tensor.get_data_tensors()
+        ):
+            assert detached_data is source_data
+        assert not detached.requires_grad
+
+        parameter = torch.nn.Parameter(tensor)
+        assert type(parameter) is derived_type
+
     @pytest.mark.parametrize("op", ("clone", "view", "reshape", "contiguous"))
     @pytest.mark.parametrize("quantization", _quantization_list)
     def test_identity_op(

--- a/tests/pytorch/test_quantized_tensor.py
+++ b/tests/pytorch/test_quantized_tensor.py
@@ -606,6 +606,43 @@ class TestQuantizedTensor:
         parameter = torch.nn.Parameter(tensor)
         assert type(parameter) is derived_type
 
+    @pytest.mark.parametrize(
+        "quantization",
+        [
+            pytest.param(
+                "fp8",
+                marks=pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8),
+            ),
+            pytest.param(
+                "fp8_blockwise",
+                marks=pytest.mark.skipif(
+                    not fp8_block_scaling_available,
+                    reason=reason_for_no_fp8_block_scaling,
+                ),
+            ),
+            pytest.param(
+                "mxfp8",
+                marks=pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8),
+            ),
+            pytest.param(
+                "nvfp4",
+                marks=pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4),
+            ),
+        ],
+    )
+    def test_update_quantized_supports_subclass(self, quantization: str) -> None:
+        """Quantizers update derived quantized tensor wrappers in-place."""
+        quantizer = make_quantizer(quantization)
+        source = torch.randn(128, 128, dtype=torch.bfloat16, device="cuda")
+        tensor = quantizer(source)
+        derived_type = type(f"Derived{type(tensor).__name__}", (type(tensor),), {})
+        tensor.__class__ = derived_type
+
+        quantizer.update_quantized(torch.zeros_like(source), tensor)
+
+        assert type(tensor) is derived_type
+        torch.testing.assert_close(tensor.dequantize(), torch.zeros_like(source))
+
     @pytest.mark.parametrize("op", ("clone", "view", "reshape", "contiguous"))
     @pytest.mark.parametrize("quantization", _quantization_list)
     def test_identity_op(

--- a/transformer_engine/pytorch/csrc/pybind.h
+++ b/transformer_engine/pytorch/csrc/pybind.h
@@ -57,13 +57,15 @@ inline bool IsFloat8CurrentScalingQuantizers(PyObject *obj) {
 }
 
 inline bool IsFloat8Tensor(PyObject *obj) {
-  return Py_TYPE(obj) == Float8TensorPythonClass || Py_TYPE(obj) == Float8TensorStoragePythonClass;
+  return PyObject_TypeCheck(obj, Float8TensorPythonClass) ||
+         PyObject_TypeCheck(obj, Float8TensorStoragePythonClass);
 }
 
 inline bool IsMXFP8Quantizers(PyObject *obj) { return Py_TYPE(obj) == MXFP8QuantizerClass; }
 
 inline bool IsMXFP8Tensor(PyObject *obj) {
-  return Py_TYPE(obj) == MXFP8TensorPythonClass || Py_TYPE(obj) == MXFP8TensorStoragePythonClass;
+  return PyObject_TypeCheck(obj, MXFP8TensorPythonClass) ||
+         PyObject_TypeCheck(obj, MXFP8TensorStoragePythonClass);
 }
 
 inline bool IsFloat8BlockwiseQuantizers(PyObject *obj) {
@@ -73,12 +75,13 @@ inline bool IsFloat8BlockwiseQuantizers(PyObject *obj) {
 inline bool IsNVFP4Quantizers(PyObject *obj) { return Py_TYPE(obj) == NVFP4QuantizerClass; }
 
 inline bool IsFloat8BlockwiseQTensor(PyObject *obj) {
-  return Py_TYPE(obj) == Float8BlockwiseQTensorPythonClass ||
-         Py_TYPE(obj) == Float8BlockwiseQTensorStoragePythonClass;
+  return PyObject_TypeCheck(obj, Float8BlockwiseQTensorPythonClass) ||
+         PyObject_TypeCheck(obj, Float8BlockwiseQTensorStoragePythonClass);
 }
 
 inline bool IsNVFP4Tensor(PyObject *obj) {
-  return Py_TYPE(obj) == NVFP4TensorPythonClass || Py_TYPE(obj) == NVFP4TensorStoragePythonClass;
+  return PyObject_TypeCheck(obj, NVFP4TensorPythonClass) ||
+         PyObject_TypeCheck(obj, NVFP4TensorStoragePythonClass);
 }
 
 TensorWrapper NVTETensorFromFloat8Tensor(py::handle tensor, Quantizer *quantizer);

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -797,13 +797,10 @@ class QuantizedTensor(torch.Tensor):
     def detach(self) -> QuantizedTensor:
         """Create new quantized tensor with same data
 
-        Output tensor must be detached from the current autograd
-        graph and have the same runtime type as ``self``.
+        Output tensor must be detached from the current autograd graph.
 
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} class does not implement detach function"
-        )
+        return type(self).make_like(self)
 
     def clear(self):
         """Deallocate this tensor's memory. Typically not needed and must be used carefully"""

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -798,7 +798,7 @@ class QuantizedTensor(torch.Tensor):
         """Create new quantized tensor with same data
 
         Output tensor must be detached from the current autograd
-        graph.
+        graph and have the same runtime type as ``self``.
 
         """
         raise NotImplementedError(

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -362,7 +362,7 @@ class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):
 
     def detach(self) -> Float8BlockwiseQTensor:
         # pylint: disable=missing-function-docstring
-        return Float8BlockwiseQTensor.make_like(self)
+        return self.__class__.make_like(self)
 
     def clone(self) -> Float8BlockwiseQTensor:
         # pylint: disable=missing-function-docstring

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -360,10 +360,6 @@ class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):
             return _FromFloat8BlockwiseFunc.apply(self, dequant_dtype)
         return _FromFloat8BlockwiseFunc.forward(None, self, dequant_dtype)
 
-    def detach(self) -> Float8BlockwiseQTensor:
-        # pylint: disable=missing-function-docstring
-        return self.__class__.make_like(self)
-
     def clone(self) -> Float8BlockwiseQTensor:
         # pylint: disable=missing-function-docstring
         rowwise_data = None

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -521,7 +521,7 @@ class Float8Tensor(Float8TensorStorage, QuantizedTensor):
 
     def detach(self) -> Float8Tensor:
         # pylint: disable=missing-function-docstring
-        return Float8Tensor.make_like(self)
+        return self.__class__.make_like(self)
 
     def clone(self) -> Float8Tensor:
         # pylint: disable=missing-function-docstring

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -519,10 +519,6 @@ class Float8Tensor(Float8TensorStorage, QuantizedTensor):
             return self.quantize_(tensor.dequantize(), noop_flag=noop_flag)
         return super().quantize_(tensor, noop_flag=noop_flag)
 
-    def detach(self) -> Float8Tensor:
-        # pylint: disable=missing-function-docstring
-        return self.__class__.make_like(self)
-
     def clone(self) -> Float8Tensor:
         # pylint: disable=missing-function-docstring
         # ``_data`` may be None for columnwise-only sub-storages of a

--- a/transformer_engine/pytorch/tensor/hybrid_tensor.py
+++ b/transformer_engine/pytorch/tensor/hybrid_tensor.py
@@ -469,7 +469,7 @@ class HybridQuantizedTensor(HybridQuantizedTensorStorage, QuantizedTensor):
                     "HybridQuantizedTensor.detach() does not support storage-only "
                     f"columnwise sub-storage {col_cls.__name__}"
                 )
-        return HybridQuantizedTensor(
+        return self.__class__(
             shape=self.shape,
             dtype=self.dtype,
             rowwise_storage=row,

--- a/transformer_engine/pytorch/tensor/identity_tensor.py
+++ b/transformer_engine/pytorch/tensor/identity_tensor.py
@@ -266,7 +266,7 @@ class IdentityTensor(IdentityTensorStorage, QuantizedTensor):
         self, data: torch.Tensor, *, requires_grad: Optional[bool] = None
     ) -> "IdentityTensor":
         requires_grad = self.requires_grad if requires_grad is None else requires_grad
-        return IdentityTensor(
+        return self.__class__(
             shape=data.shape,
             dtype=self.dtype,
             hp_data=data,

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -321,10 +321,6 @@ class MXFP8Tensor(MXFP8TensorStorage, QuantizedTensor):
             return self.quantize_(tensor.dequantize())
         return super().quantize_(tensor, noop_flag=noop_flag)
 
-    def detach(self) -> MXFP8Tensor:
-        # pylint: disable=missing-function-docstring
-        return self.__class__.make_like(self)
-
     def clone(self) -> MXFP8Tensor:
         # pylint: disable=missing-function-docstring
         # _rowwise_data may be None for columnwise-only sub-storages (hybrid quantization)

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -323,8 +323,7 @@ class MXFP8Tensor(MXFP8TensorStorage, QuantizedTensor):
 
     def detach(self) -> MXFP8Tensor:
         # pylint: disable=missing-function-docstring
-        # TODO(ksivamani): Fix the detach bug
-        return MXFP8Tensor.make_like(self)
+        return self.__class__.make_like(self)
 
     def clone(self) -> MXFP8Tensor:
         # pylint: disable=missing-function-docstring

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -530,8 +530,7 @@ class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
 
     def detach(self) -> NVFP4Tensor:
         # pylint: disable=missing-function-docstring
-        # TODO(ksivamani): Fix the detach bug
-        return NVFP4Tensor.make_like(self)
+        return self.__class__.make_like(self)
 
     def clone(self) -> NVFP4Tensor:
         # pylint: disable=missing-function-docstring

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -528,10 +528,6 @@ class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
         self._get_quantizer().update_quantized(tensor, self, noop_flag=noop_flag)
         return self
 
-    def detach(self) -> NVFP4Tensor:
-        # pylint: disable=missing-function-docstring
-        return self.__class__.make_like(self)
-
     def clone(self) -> NVFP4Tensor:
         # pylint: disable=missing-function-docstring
         assert self._rowwise_data is not None


### PR DESCRIPTION
# Description

Transformer Engine quantized tensors can be subclassed, but two boundaries assumed an exact concrete wrapper class:

1. Concrete `detach()` implementations reconstructed the base TE class, dropping the tensor's runtime subclass. PyTorch then rejected the result when rewrapping it as a `torch.nn.Parameter`, because `Parameter` requires `detach()` to preserve the exact runtime type.
2. The PyTorch C++ bindings used exact `Py_TYPE` comparisons for quantized tensor outputs. As a result, operations such as `MXFP8Quantizer.update_quantized(src, dst)` rejected a valid `MXFP8Tensor` subclass even though Python `isinstance(dst, MXFP8Tensor)` was true.

Megatron Core GTP exposes both cases because it represents native quantized parameters with dynamic subclasses such as `GTP_MXFP8Tensor`. The newer module application path in #3153 made the latent detach mismatch visible. The downstream integration is NVIDIA/Megatron-LM#6546.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Define runtime-type preservation as part of the `QuantizedTensor.detach()` contract.
- Construct detached tensors through the runtime class for `Float8Tensor`, `Float8BlockwiseQTensor`, `MXFP8Tensor`, `NVFP4Tensor`, `IdentityTensor`, and `HybridQuantizedTensor`.
- Use CPython subtype checks for the Float8, blockwise Float8, MXFP8, and NVFP4 tensor/storage wrapper families in the C++ bindings. Quantizer objects retain their existing exact-type checks.
- Add tests that verify exact subclass preservation, aliased quantized storage, detached autograd state, successful `torch.nn.Parameter` construction, and `update_quantized` into dynamic subclasses.

## Validation

Built and tested on GB300 from TE commit `bf64b4e8b2985ce7ff394b7f3cb240e764b24a3a`:

- 10/10 quantized subclass regression cases passed, covering detach and C++ `update_quantized` across Float8, blockwise Float8, MXFP8, NVFP4, Identity, and Hybrid wrappers.
- 3/3 existing module `_apply` attribute-preservation tests passed.
- 135/135 MXFP8 2D tests passed.
- Transformer Engine Python and C++ lint passed.
- Clean Megatron Core focused suite passed 10/10 with the downstream detach/update workarounds absent.
- Two-node real-data 1D and 2D MXFP8 proxy runs each completed 10 training iterations plus validation with GTP and native MXFP8 parameter gather.
- The same two-node 1D and 2D runs also passed with `NVTE_CUTEDSL_FUSED_GROUPED_MLP=1` after installing the official final cuDNN-frontend 1.27.0 package:
  - [1D W&B run](https://wandb.ai/nvidia/dingqingy-8-17/runs/yiz9iak8)
  - [2D W&B run](https://wandb.ai/nvidia/dingqingy-8-17/runs/b8ix9ar0)

The cuDNN-frontend package replacement addresses a separate pre-release package mismatch around optional `prob_tensor`; it is not part of this PR.

# Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
