### PR TITLE
[Common][PyTorch] Add QB router histogram paths

### DIFF
--- a/tests/pytorch/test_fused_router.py
+++ b/tests/pytorch/test_fused_router.py
@@ -772,8 +772,7 @@ def test_qb_topk_plus_one_tie_and_bin_clamping(histogram_mode):
     torch.testing.assert_close(probs, reference["probs"])
     torch.testing.assert_close(routing_map, reference["routing_map"])
     torch.testing.assert_close(raw_scores, reference["raw_scores"])
-    if histogram_mode == QBHistogramMode.TWO_KERNEL:
-        torch.testing.assert_close(cutoff, reference["cutoff"])
+    torch.testing.assert_close(cutoff, reference["cutoff"])
     torch.testing.assert_close(histogram, reference["histogram"])
     assert histogram[:, 0].sum() > 0
     assert histogram[:, -1].sum() > 0

--- a/tests/pytorch/test_fused_router.py
+++ b/tests/pytorch/test_fused_router.py
@@ -4,11 +4,13 @@
 import torch
 from typing import Optional
 from transformer_engine.pytorch.router import (
+    QBHistogramMode,
     RoutingMapFormat,
     fused_topk_with_score_function,
     fused_compute_score_for_moe_aux_loss,
     fused_moe_aux_loss,
 )
+import transformer_engine_torch as tex
 import pytest
 from copy import deepcopy
 
@@ -128,6 +130,63 @@ def topk_score_function_pytorch(
     topk_map = torch.zeros_like(logits).int().scatter(1, top_indices, 1).bool()
 
     return topk_masked_gates, topk_map
+
+
+def qb_topk_score_function_pytorch(
+    logits: torch.Tensor,
+    topk: int,
+    expert_bias: torch.Tensor,
+    bin_bounds: torch.Tensor,
+    num_bins: int,
+    histogram: Optional[torch.Tensor] = None,
+):
+    """Pure-PyTorch reference for Kimi K3 QB routing and histogram accumulation."""
+    original_shape = logits.shape
+    num_experts = original_shape[-1]
+    raw_scores = torch.sigmoid(logits.float()).reshape(-1, num_experts)
+    biased_scores = raw_scores + expert_bias
+    topk_plus_one_scores, topk_plus_one_indices = torch.topk(biased_scores, k=topk + 1, dim=-1)
+    cutoff = topk_plus_one_scores.min(dim=-1).values
+    cutoff_candidates = topk_plus_one_indices.masked_fill(
+        topk_plus_one_scores != cutoff.unsqueeze(1), -1
+    )
+    dropped_expert = cutoff_candidates.max(dim=-1).values
+    topk_indices = topk_plus_one_indices[
+        topk_plus_one_indices != dropped_expert.unsqueeze(1)
+    ].reshape(-1, topk)
+
+    selected_raw_scores = torch.gather(raw_scores, 1, topk_indices)
+    if topk > 1:
+        selected_probs = selected_raw_scores / (
+            selected_raw_scores.sum(dim=-1, keepdim=True) + 1e-20
+        )
+    else:
+        selected_probs = selected_raw_scores
+    probs = torch.zeros_like(raw_scores).scatter(1, topk_indices, selected_probs)
+    routing_map = torch.zeros_like(raw_scores, dtype=torch.bool).scatter(1, topk_indices, True)
+
+    lower, upper = bin_bounds[0], bin_bounds[1]
+    required_bias = cutoff.unsqueeze(1) - raw_scores
+    bin_scale = num_bins / (upper - lower)
+    bin_indices = torch.floor((required_bias - lower) * bin_scale).to(torch.int64)
+    bin_indices.clamp_(0, num_bins - 1)
+    expert_offsets = torch.arange(num_experts, device=logits.device, dtype=torch.int64) * num_bins
+    flat_indices = (bin_indices + expert_offsets).reshape(-1)
+    counts = torch.bincount(flat_indices, minlength=num_experts * num_bins)
+    counts = counts.reshape(num_experts, num_bins).to(torch.int32)
+    if histogram is None:
+        histogram = torch.zeros_like(counts)
+    histogram.add_(counts)
+
+    return {
+        "probs": probs.reshape(original_shape).to(logits.dtype),
+        "routing_map": routing_map.reshape(original_shape),
+        "topk_indices": topk_indices.reshape(*original_shape[:-1], topk),
+        "raw_scores": raw_scores.reshape(original_shape),
+        "cutoff": cutoff.reshape(original_shape[:-1]),
+        "bin_indices": bin_indices.reshape(original_shape),
+        "histogram": histogram,
+    }
 
 
 # Pytorch-based compute routing scores for aux loss
@@ -353,6 +412,204 @@ def test_topk_sqrtsoftplus(
         topk_output_mode="dense" if topk_index_dtype is not None else "sparse",
         topk_index_dtype=topk_index_dtype or torch.int16,
     )
+
+
+@pytest.mark.parametrize("histogram_mode", ["two_kernel", "fused_atomic"])
+@pytest.mark.parametrize("topk", [8, 16])
+@pytest.mark.parametrize(
+    "routing_output_mode",
+    ["bytemap", "bitmap_u8", "dense_int16", "dense_int32", "dense_int64"],
+)
+def test_qb_topk_histogram(histogram_mode, topk, routing_output_mode):
+    num_tokens = 257
+    num_experts = 896
+    num_bins = 1000
+    logits = torch.randn(
+        num_tokens, num_experts, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    expert_bias = torch.linspace(-0.2, 0.2, num_experts, device="cuda", dtype=torch.float32)
+    bin_bounds = torch.stack((expert_bias.min() - 1.0, expert_bias.max() + 1.0))
+    reference_histogram = torch.zeros(num_experts, num_bins, device="cuda", dtype=torch.int32)
+    reference = qb_topk_score_function_pytorch(
+        logits,
+        topk,
+        expert_bias,
+        bin_bounds,
+        num_bins,
+        reference_histogram,
+    )
+
+    fused_logits = logits.detach().clone().requires_grad_(True)
+    fused_histogram = torch.zeros_like(reference_histogram)
+    dense_dtype = {
+        "dense_int16": torch.int16,
+        "dense_int32": torch.int32,
+        "dense_int64": torch.int64,
+    }.get(routing_output_mode)
+    topk_indices = (
+        torch.empty(num_tokens, topk, device="cuda", dtype=dense_dtype)
+        if dense_dtype is not None
+        else None
+    )
+    routing_map_format = (
+        RoutingMapFormat.BITMAP_U8
+        if routing_output_mode == "bitmap_u8"
+        else RoutingMapFormat.BYTEMAP
+    )
+    fused_probs, fused_routing_output = fused_topk_with_score_function(
+        logits=fused_logits,
+        topk=topk,
+        use_pre_softmax=False,
+        num_groups=None,
+        group_topk=None,
+        scaling_factor=None,
+        score_function="sigmoid",
+        expert_bias=expert_bias,
+        routing_map_format=routing_map_format,
+        topk_indices=topk_indices,
+        qb_histogram=fused_histogram,
+        qb_bin_bounds=bin_bounds,
+        qb_histogram_mode=histogram_mode,
+    )
+    torch.testing.assert_close(fused_probs, reference["probs"])
+    if dense_dtype is not None:
+        fused_routing_map = topk_indices_to_routing_map(fused_routing_output, num_experts)
+        torch.testing.assert_close(fused_routing_map, reference["routing_map"])
+    elif routing_output_mode == "bitmap_u8":
+        torch.testing.assert_close(
+            fused_routing_output,
+            _bytemap_to_bitmap_u8(reference["routing_map"]),
+        )
+    else:
+        torch.testing.assert_close(fused_routing_output, reference["routing_map"])
+    torch.testing.assert_close(fused_histogram, reference["histogram"])
+
+    grad = torch.randn_like(fused_probs)
+    reference["probs"].backward(grad)
+    fused_probs.backward(grad)
+    torch.testing.assert_close(fused_logits.grad, logits.grad, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("histogram_mode", ["two_kernel", "fused_atomic"])
+def test_qb_histogram_accumulates_microbatches(histogram_mode):
+    num_experts = 64
+    topk = 8
+    num_bins = 1000
+    expert_bias = torch.linspace(-0.1, 0.1, num_experts, device="cuda", dtype=torch.float32)
+    bin_bounds = torch.stack((expert_bias.min() - 1.0, expert_bias.max() + 1.0))
+    reference_histogram = torch.zeros(num_experts, num_bins, device="cuda", dtype=torch.int32)
+    fused_histogram = torch.zeros_like(reference_histogram)
+
+    for num_tokens in (127, 193):
+        logits = torch.randn(num_tokens, num_experts, device="cuda", dtype=torch.float32)
+        qb_topk_score_function_pytorch(
+            logits,
+            topk,
+            expert_bias,
+            bin_bounds,
+            num_bins,
+            reference_histogram,
+        )
+        fused_topk_with_score_function(
+            logits=logits,
+            topk=topk,
+            use_pre_softmax=False,
+            num_groups=None,
+            group_topk=None,
+            scaling_factor=None,
+            score_function="sigmoid",
+            expert_bias=expert_bias,
+            qb_histogram=fused_histogram,
+            qb_bin_bounds=bin_bounds,
+            qb_histogram_mode=histogram_mode,
+        )
+
+    torch.testing.assert_close(fused_histogram, reference_histogram)
+
+
+def test_qb_topk_argument_validation():
+    logits = torch.randn(16, 32, device="cuda", dtype=torch.float32)
+    expert_bias = torch.zeros(32, device="cuda", dtype=torch.float32)
+    histogram = torch.zeros(32, 1000, device="cuda", dtype=torch.int32)
+    bin_bounds = torch.tensor([-1.0, 1.0], device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="provided together"):
+        fused_topk_with_score_function(
+            logits,
+            4,
+            False,
+            None,
+            None,
+            None,
+            "sigmoid",
+            expert_bias,
+            qb_histogram=histogram,
+        )
+    with pytest.raises(ValueError, match="only supports"):
+        fused_topk_with_score_function(
+            logits,
+            4,
+            False,
+            None,
+            None,
+            None,
+            "softmax",
+            expert_bias,
+            qb_histogram=histogram,
+            qb_bin_bounds=bin_bounds,
+            qb_histogram_mode="two_kernel",
+        )
+
+
+@pytest.mark.parametrize(
+    "histogram_mode",
+    [QBHistogramMode.TWO_KERNEL, QBHistogramMode.FUSED_ATOMIC],
+)
+def test_qb_topk_plus_one_tie_and_bin_clamping(histogram_mode):
+    logits = torch.tensor(
+        [
+            [3.0, 3.0, 3.0, -1.0, -2.0, -3.0, -4.0, -5.0],
+            [5.0, 4.0, 3.0, 2.0, -2.0, -3.0, -4.0, -5.0],
+        ],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    _, num_experts = logits.shape
+    topk = 2
+    num_bins = 8
+    expert_bias = torch.zeros(num_experts, device="cuda", dtype=torch.float32)
+    bin_bounds = torch.tensor([-0.05, 0.05], device="cuda", dtype=torch.float32)
+    reference = qb_topk_score_function_pytorch(
+        logits,
+        topk,
+        expert_bias,
+        bin_bounds,
+        num_bins,
+    )
+    histogram = torch.zeros(num_experts, num_bins, device="cuda", dtype=torch.int32)
+
+    probs, routing_map, raw_scores, cutoff, histogram = tex.fused_topk_with_score_function_qb_fwd(
+        logits,
+        topk,
+        None,
+        expert_bias,
+        int(RoutingMapFormat.BYTEMAP),
+        None,
+        histogram,
+        bin_bounds,
+        histogram_mode,
+    )
+
+    torch.testing.assert_close(probs, reference["probs"])
+    torch.testing.assert_close(routing_map, reference["routing_map"])
+    torch.testing.assert_close(raw_scores, reference["raw_scores"])
+    if histogram_mode == QBHistogramMode.TWO_KERNEL:
+        torch.testing.assert_close(cutoff, reference["cutoff"])
+    torch.testing.assert_close(histogram, reference["histogram"])
+    assert histogram[:, 0].sum() > 0
+    assert histogram[:, -1].sum() > 0
+    # The first token has exactly Top-(k+1) equal scores. The deterministic
+    # compaction rule drops the largest expert ID at the cutoff.
+    assert routing_map[0, :3].tolist() == [True, True, False]
 
 
 @pytest.mark.parametrize("dtype", [torch.float32])
@@ -736,11 +993,29 @@ def profile_topk_softmax(
     group_topk = 4
     scaling_factor = 1.2
     test_topk_sigmoid(
-        torch.float32, num_tokens, num_experts, topk, group_topk, scaling_factor, enable_bias
+        torch.float32,
+        num_tokens,
+        num_experts,
+        topk,
+        group_topk,
+        scaling_factor,
+        enable_bias,
     )
     test_topk_softmax(
-        torch.float32, num_tokens, num_experts, topk, use_pre_softmax, group_topk, scaling_factor
+        torch.float32,
+        num_tokens,
+        num_experts,
+        topk,
+        use_pre_softmax,
+        group_topk,
+        scaling_factor,
     )
     test_topk_sqrtsoftplus(
-        torch.float32, num_tokens, num_experts, topk, group_topk, scaling_factor, enable_bias
+        torch.float32,
+        num_tokens,
+        num_experts,
+        topk,
+        group_topk,
+        scaling_factor,
+        enable_bias,
     )

--- a/tests/pytorch/test_fused_router.py
+++ b/tests/pytorch/test_fused_router.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
+import os
+import subprocess
+import sys
+
 import torch
 from typing import Optional
 from transformer_engine.pytorch.router import (
@@ -558,6 +562,82 @@ def test_qb_topk_argument_validation():
             qb_bin_bounds=bin_bounds,
             qb_histogram_mode="two_kernel",
         )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires at least two CUDA devices")
+@pytest.mark.parametrize("histogram_mode", ["two_kernel", "fused_atomic"])
+def test_qb_topk_uses_logits_device(histogram_mode):
+    current_device = torch.cuda.current_device()
+    logits_device = (current_device + 1) % torch.cuda.device_count()
+    device = torch.device("cuda", logits_device)
+    num_tokens, num_experts, topk, num_bins = 17, 32, 4, 64
+    logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    expert_bias = torch.zeros(num_experts, device=device, dtype=torch.float32)
+    histogram = torch.zeros(num_experts, num_bins, device=device, dtype=torch.int32)
+    bin_bounds = torch.tensor([-1.0, 1.0], device=device, dtype=torch.float32)
+
+    probs, routing_map = fused_topk_with_score_function(
+        logits,
+        topk,
+        False,
+        None,
+        None,
+        None,
+        "sigmoid",
+        expert_bias,
+        qb_histogram=histogram,
+        qb_bin_bounds=bin_bounds,
+        qb_histogram_mode=histogram_mode,
+    )
+    torch.cuda.synchronize(logits_device)
+
+    assert probs.device == device
+    assert routing_map.device == device
+    assert histogram.sum().item() == num_tokens * num_experts
+    assert torch.cuda.current_device() == current_device
+
+
+@pytest.mark.parametrize("histogram_mode", ["two_kernel", "fused_atomic"])
+@pytest.mark.parametrize("invalid_bounds", ["equal", "reversed", "nonfinite"])
+def test_qb_topk_rejects_invalid_bin_bounds(histogram_mode, invalid_bounds):
+    script = f"""
+import torch
+from transformer_engine.pytorch.router import fused_topk_with_score_function
+
+logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
+histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
+bounds = {{
+    "equal": [1.0, 1.0],
+    "reversed": [1.0, -1.0],
+    "nonfinite": [float("nan"), 1.0],
+}}[{invalid_bounds!r}]
+bin_bounds = torch.tensor(bounds, device="cuda", dtype=torch.float32)
+fused_topk_with_score_function(
+    logits,
+    4,
+    False,
+    None,
+    None,
+    None,
+    "sigmoid",
+    expert_bias,
+    qb_histogram=histogram,
+    qb_bin_bounds=bin_bounds,
+    qb_histogram_mode={histogram_mode!r},
+)
+torch.cuda.synchronize()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "CUDA error" in output, output
 
 
 @pytest.mark.parametrize(

--- a/tests/pytorch/test_fused_router.py
+++ b/tests/pytorch/test_fused_router.py
@@ -656,10 +656,18 @@ def test_qb_topk_revalidates_updated_bin_bounds():
         )
 
 
-def test_qb_raw_binding_rejects_invalid_bin_bounds_recoverably():
+@pytest.mark.parametrize(
+    "histogram_mode",
+    [QBHistogramMode.TWO_KERNEL, QBHistogramMode.FUSED_ATOMIC],
+)
+@pytest.mark.parametrize("use_dense_indices", [False, True])
+def test_qb_raw_binding_rejects_invalid_bin_bounds_recoverably(histogram_mode, use_dense_indices):
     logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
     expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
     histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
+    topk_indices = (
+        torch.empty(8, 4, device="cuda", dtype=torch.int32) if use_dense_indices else None
+    )
     invalid_bounds = torch.tensor([1.0, 1.0], device="cuda", dtype=torch.float32)
     with pytest.raises(RuntimeError, match="finite with lower < upper"):
         tex.fused_topk_with_score_function_qb_fwd(
@@ -668,10 +676,10 @@ def test_qb_raw_binding_rejects_invalid_bin_bounds_recoverably():
             None,
             expert_bias,
             int(RoutingMapFormat.BYTEMAP),
-            None,
+            topk_indices,
             histogram,
             invalid_bounds,
-            QBHistogramMode.FUSED_ATOMIC,
+            histogram_mode,
         )
 
     # The validation error must not poison the CUDA context.
@@ -682,10 +690,10 @@ def test_qb_raw_binding_rejects_invalid_bin_bounds_recoverably():
         None,
         expert_bias,
         int(RoutingMapFormat.BYTEMAP),
-        None,
+        topk_indices,
         histogram,
         valid_bounds,
-        QBHistogramMode.FUSED_ATOMIC,
+        histogram_mode,
     )
     torch.cuda.synchronize()
 

--- a/tests/pytorch/test_fused_router.py
+++ b/tests/pytorch/test_fused_router.py
@@ -1,10 +1,6 @@
 # Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See LICENSE for license information.
-import os
-import subprocess
-import sys
-
 import torch
 from typing import Optional
 from transformer_engine.pytorch.router import (
@@ -600,44 +596,130 @@ def test_qb_topk_uses_logits_device(histogram_mode):
 @pytest.mark.parametrize("histogram_mode", ["two_kernel", "fused_atomic"])
 @pytest.mark.parametrize("invalid_bounds", ["equal", "reversed", "nonfinite"])
 def test_qb_topk_rejects_invalid_bin_bounds(histogram_mode, invalid_bounds):
-    script = f"""
-import torch
-from transformer_engine.pytorch.router import fused_topk_with_score_function
+    logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+    expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
+    histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
+    bounds = {
+        "equal": [1.0, 1.0],
+        "reversed": [1.0, -1.0],
+        "nonfinite": [float("nan"), 1.0],
+    }[invalid_bounds]
+    bin_bounds = torch.tensor(bounds, device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="finite with lower < upper"):
+        fused_topk_with_score_function(
+            logits,
+            4,
+            False,
+            None,
+            None,
+            None,
+            "sigmoid",
+            expert_bias,
+            qb_histogram=histogram,
+            qb_bin_bounds=bin_bounds,
+            qb_histogram_mode=histogram_mode,
+        )
 
-logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
-expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
-histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
-bounds = {{
-    "equal": [1.0, 1.0],
-    "reversed": [1.0, -1.0],
-    "nonfinite": [float("nan"), 1.0],
-}}[{invalid_bounds!r}]
-bin_bounds = torch.tensor(bounds, device="cuda", dtype=torch.float32)
-fused_topk_with_score_function(
-    logits,
-    4,
-    False,
-    None,
-    None,
-    None,
-    "sigmoid",
-    expert_bias,
-    qb_histogram=histogram,
-    qb_bin_bounds=bin_bounds,
-    qb_histogram_mode={histogram_mode!r},
-)
-torch.cuda.synchronize()
-"""
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        env=os.environ.copy(),
-        capture_output=True,
-        text=True,
-        check=False,
+
+def test_qb_topk_revalidates_updated_bin_bounds():
+    logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+    expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
+    histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
+    bin_bounds = torch.tensor([-1.0, 1.0], device="cuda", dtype=torch.float32)
+    fused_topk_with_score_function(
+        logits,
+        4,
+        False,
+        None,
+        None,
+        None,
+        "sigmoid",
+        expert_bias,
+        qb_histogram=histogram,
+        qb_bin_bounds=bin_bounds,
+        qb_histogram_mode="fused_atomic",
     )
-    output = result.stdout + result.stderr
-    assert result.returncode != 0, output
-    assert "CUDA error" in output, output
+    bin_bounds.fill_(0.0)
+    with pytest.raises(ValueError, match="finite with lower < upper"):
+        fused_topk_with_score_function(
+            logits,
+            4,
+            False,
+            None,
+            None,
+            None,
+            "sigmoid",
+            expert_bias,
+            qb_histogram=histogram,
+            qb_bin_bounds=bin_bounds,
+            qb_histogram_mode="fused_atomic",
+        )
+
+
+def test_qb_raw_binding_rejects_invalid_bin_bounds_recoverably():
+    logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+    expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
+    histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
+    invalid_bounds = torch.tensor([1.0, 1.0], device="cuda", dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="finite with lower < upper"):
+        tex.fused_topk_with_score_function_qb_fwd(
+            logits,
+            4,
+            None,
+            expert_bias,
+            int(RoutingMapFormat.BYTEMAP),
+            None,
+            histogram,
+            invalid_bounds,
+            QBHistogramMode.FUSED_ATOMIC,
+        )
+
+    # The validation error must not poison the CUDA context.
+    valid_bounds = torch.tensor([-1.0, 1.0], device="cuda", dtype=torch.float32)
+    tex.fused_topk_with_score_function_qb_fwd(
+        logits,
+        4,
+        None,
+        expert_bias,
+        int(RoutingMapFormat.BYTEMAP),
+        None,
+        histogram,
+        valid_bounds,
+        QBHistogramMode.FUSED_ATOMIC,
+    )
+    torch.cuda.synchronize()
+
+
+@pytest.mark.parametrize("histogram_mode", ["two_kernel", "fused_atomic"])
+def test_qb_topk_cuda_graph_uses_prevalidated_bounds(histogram_mode):
+    logits = torch.randn(8, 16, device="cuda", dtype=torch.float32)
+    expert_bias = torch.zeros(16, device="cuda", dtype=torch.float32)
+    histogram = torch.zeros(16, 32, device="cuda", dtype=torch.int32)
+    bin_bounds = torch.tensor([-1.0, 1.0], device="cuda", dtype=torch.float32)
+
+    def run_router():
+        return fused_topk_with_score_function(
+            logits,
+            4,
+            False,
+            None,
+            None,
+            None,
+            "sigmoid",
+            expert_bias,
+            qb_histogram=histogram,
+            qb_bin_bounds=bin_bounds,
+            qb_histogram_mode=histogram_mode,
+        )
+
+    run_router()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        probs, routing_map = run_router()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.isfinite(probs).all()
+    assert routing_map.sum().item() == logits.shape[0] * 4
 
 
 @pytest.mark.parametrize(

--- a/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
+++ b/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
@@ -250,11 +250,12 @@ __global__ void fused_topk_forward_simple_kernel(
 
     const CompType cutoff =
         extract_qb_cutoff_and_compact<QbMode>(topk_indices, topk_scores, topk, lane_id);
-    if constexpr (QbMode == QBMode::TwoKernel) {
+    if constexpr (kUseQB) {
       if (lane_id == 0) {
         qb_cutoff[token_offset_cur_warp] = cutoff;
       }
-    } else if constexpr (QbMode == QBMode::FusedAtomic) {
+    }
+    if constexpr (QbMode == QBMode::FusedAtomic) {
       accumulate_qb_histogram_epilogue<QbMode>(intermediate_output + pos_offset, cutoff,
                                                num_experts, lane_id, qb_bin_bounds, qb_num_bins,
                                                qb_histogram);
@@ -568,11 +569,12 @@ __global__ void fused_topk_with_score_function_forward_kernel(
 
     const CompType cutoff =
         extract_qb_cutoff_and_compact<QbMode>(topk_indices, topk_scores, topk, lane_id);
-    if constexpr (QbMode == QBMode::TwoKernel) {
+    if constexpr (kUseQB) {
       if (lane_id == 0) {
         qb_cutoff[token_offset_cur_warp] = cutoff;
       }
-    } else if constexpr (QbMode == QBMode::FusedAtomic) {
+    }
+    if constexpr (QbMode == QBMode::FusedAtomic) {
       accumulate_qb_histogram_epilogue<QbMode>(intermediate_output + pos_offset, cutoff,
                                                num_experts, lane_id, qb_bin_bounds, qb_num_bins,
                                                qb_histogram);

--- a/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
+++ b/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
@@ -39,6 +39,16 @@ __device__ inline QBBinParams load_qb_bin_params(const CompType *bin_bounds, int
   return {lower, static_cast<CompType>(num_bins) / (upper - lower)};
 }
 
+void validate_qb_bin_bounds(const Tensor bin_bounds, cudaStream_t stream) {
+  float bounds[2];
+  NVTE_CHECK_CUDA(cudaMemcpyAsync(bounds, bin_bounds.data.dptr, sizeof(bounds),
+                                  cudaMemcpyDeviceToHost, stream));
+  NVTE_CHECK_CUDA(cudaStreamSynchronize(stream));
+  NVTE_CHECK(std::isfinite(bounds[0]) && std::isfinite(bounds[1]) && bounds[0] < bounds[1],
+             "QB bin_bounds values must be finite with lower < upper, got [", bounds[0], ", ",
+             bounds[1], "]");
+}
+
 template <QBMode Mode>
 __device__ inline CompType extract_qb_cutoff_and_compact(int *topk_indices, CompType *topk_scores,
                                                          int topk, int lane_id) {
@@ -913,7 +923,7 @@ __global__ void qb_histogram_accumulate_kernel(const CompType *raw_scores, const
 }
 
 void qb_histogram_accumulate(const Tensor raw_scores, const Tensor cutoff, const Tensor bin_bounds,
-                             Tensor histogram, cudaStream_t stream) {
+                             Tensor histogram, bool validate_bin_bounds, cudaStream_t stream) {
   NVTE_CHECK(raw_scores.data.dtype == DType::kFloat32, "QB raw_scores must have FP32 dtype");
   NVTE_CHECK(cutoff.data.dtype == DType::kFloat32, "QB cutoff must have FP32 dtype");
   NVTE_CHECK(bin_bounds.data.dtype == DType::kFloat32, "QB bin_bounds must have FP32 dtype");
@@ -930,6 +940,9 @@ void qb_histogram_accumulate(const Tensor raw_scores, const Tensor cutoff, const
              "QB histogram must have shape [num_experts, num_bins]");
   const int num_bins = static_cast<int>(histogram.data.shape[1]);
   NVTE_CHECK(num_bins > 0, "QB num_bins must be positive");
+  if (validate_bin_bounds) {
+    validate_qb_bin_bounds(bin_bounds, stream);
+  }
 
   const int token_partitions = std::min(4, std::max(1, (num_tokens + 1023) / 1024));
   const dim3 grid((num_experts + kQBExpertsPerBlock - 1) / kQBExpertsPerBlock, token_partitions);
@@ -1123,7 +1136,8 @@ void fused_topk_with_score_function_forward_qb(
     const Tensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
     const Tensor expert_bias, Tensor probs, Tensor routing_map,
     NVTERoutingMapFormat routing_map_format, Tensor intermediate_output, Tensor cutoff,
-    Tensor histogram, Tensor bin_bounds, NVTEQBHistogramMode histogram_mode, cudaStream_t stream) {
+    Tensor histogram, Tensor bin_bounds, NVTEQBHistogramMode histogram_mode,
+    bool validate_bin_bounds, cudaStream_t stream) {
   check_routing_map_format(routing_map_format);
   const int num_bins =
       check_qb_forward_tensors(logits, num_tokens, num_experts, topk, expert_bias, probs,
@@ -1132,6 +1146,9 @@ void fused_topk_with_score_function_forward_qb(
       expected_routing_map_shape(num_tokens, num_experts, routing_map_format);
   NVTE_CHECK(routing_map.data.shape == routing_map_shape,
              "QB routing_map shape does not match routing_map_format");
+  if (validate_bin_bounds) {
+    validate_qb_bin_bounds(bin_bounds, stream);
+  }
 
 #define QB_ROUTER_FORWARD_LAUNCH(RoutingMapFormatVal, QbModeVal)                                   \
   TE_ROUTER_PROBS_TYPE_SWITCH_ALL(                                                                 \
@@ -1170,7 +1187,7 @@ void fused_topk_with_score_function_forward_qb_with_indices(
     const Tensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
     const Tensor expert_bias, Tensor probs, Tensor topk_indices, Tensor intermediate_output,
     Tensor cutoff, Tensor histogram, Tensor bin_bounds, NVTEQBHistogramMode histogram_mode,
-    cudaStream_t stream) {
+    bool validate_bin_bounds, cudaStream_t stream) {
   const int num_bins =
       check_qb_forward_tensors(logits, num_tokens, num_experts, topk, expert_bias, probs,
                                intermediate_output, cutoff, histogram, bin_bounds);
@@ -1178,6 +1195,9 @@ void fused_topk_with_score_function_forward_qb_with_indices(
                                           static_cast<size_t>(topk)};
   NVTE_CHECK(topk_indices.data.shape == indices_shape,
              "QB topk_indices must have shape [num_tokens, topk]");
+  if (validate_bin_bounds) {
+    validate_qb_bin_bounds(bin_bounds, stream);
+  }
 
 #define QB_ROUTER_FORWARD_WITH_INDICES_LAUNCH(DataType, IndexType, QbModeVal)                     \
   fused_topk_with_score_function_forward_with_indices_kernel_launcher<DataType, float, IndexType, \
@@ -1751,7 +1771,24 @@ void nvte_fused_topk_with_score_function_forward_qb_v2(
       *convertNVTETensorCheck(routing_map), routing_map_format,
       *convertNVTETensorCheck(intermediate_output), *convertNVTETensorCheck(cutoff),
       *convertNVTETensorCheck(histogram), *convertNVTETensorCheck(bin_bounds), histogram_mode,
-      stream);
+      /*validate_bin_bounds=*/true, stream);
+}
+
+void nvte_fused_topk_with_score_function_forward_qb_v2_unchecked(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor routing_map,
+    NVTERoutingMapFormat routing_map_format, NVTETensor intermediate_output, NVTETensor cutoff,
+    NVTETensor histogram, NVTETensor bin_bounds, NVTEQBHistogramMode histogram_mode,
+    cudaStream_t stream) {
+  NVTE_API_CALL(nvte_fused_topk_with_score_function_forward_qb_v2_unchecked);
+  using namespace transformer_engine;
+  fused_router::fused_topk_with_score_function_forward_qb(
+      *convertNVTETensorCheck(logits), num_tokens, num_experts, topk, scaling_factor,
+      *convertNVTETensorCheck(expert_bias), *convertNVTETensorCheck(probs),
+      *convertNVTETensorCheck(routing_map), routing_map_format,
+      *convertNVTETensorCheck(intermediate_output), *convertNVTETensorCheck(cutoff),
+      *convertNVTETensorCheck(histogram), *convertNVTETensorCheck(bin_bounds), histogram_mode,
+      /*validate_bin_bounds=*/false, stream);
 }
 
 void nvte_fused_topk_with_score_function_forward_qb_with_indices(
@@ -1766,7 +1803,22 @@ void nvte_fused_topk_with_score_function_forward_qb_with_indices(
       *convertNVTETensorCheck(expert_bias), *convertNVTETensorCheck(probs),
       *convertNVTETensorCheck(topk_indices), *convertNVTETensorCheck(intermediate_output),
       *convertNVTETensorCheck(cutoff), *convertNVTETensorCheck(histogram),
-      *convertNVTETensorCheck(bin_bounds), histogram_mode, stream);
+      *convertNVTETensorCheck(bin_bounds), histogram_mode, /*validate_bin_bounds=*/true, stream);
+}
+
+void nvte_fused_topk_with_score_function_forward_qb_with_indices_unchecked(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor topk_indices,
+    NVTETensor intermediate_output, NVTETensor cutoff, NVTETensor histogram, NVTETensor bin_bounds,
+    NVTEQBHistogramMode histogram_mode, cudaStream_t stream) {
+  NVTE_API_CALL(nvte_fused_topk_with_score_function_forward_qb_with_indices_unchecked);
+  using namespace transformer_engine;
+  fused_router::fused_topk_with_score_function_forward_qb_with_indices(
+      *convertNVTETensorCheck(logits), num_tokens, num_experts, topk, scaling_factor,
+      *convertNVTETensorCheck(expert_bias), *convertNVTETensorCheck(probs),
+      *convertNVTETensorCheck(topk_indices), *convertNVTETensorCheck(intermediate_output),
+      *convertNVTETensorCheck(cutoff), *convertNVTETensorCheck(histogram),
+      *convertNVTETensorCheck(bin_bounds), histogram_mode, /*validate_bin_bounds=*/false, stream);
 }
 
 void nvte_qb_histogram_accumulate(const NVTETensor raw_scores, const NVTETensor cutoff,
@@ -1776,7 +1828,19 @@ void nvte_qb_histogram_accumulate(const NVTETensor raw_scores, const NVTETensor 
   using namespace transformer_engine;
   fused_router::qb_histogram_accumulate(
       *convertNVTETensorCheck(raw_scores), *convertNVTETensorCheck(cutoff),
-      *convertNVTETensorCheck(bin_bounds), *convertNVTETensorCheck(histogram), stream);
+      *convertNVTETensorCheck(bin_bounds), *convertNVTETensorCheck(histogram),
+      /*validate_bin_bounds=*/true, stream);
+}
+
+void nvte_qb_histogram_accumulate_unchecked(const NVTETensor raw_scores, const NVTETensor cutoff,
+                                            const NVTETensor bin_bounds, NVTETensor histogram,
+                                            cudaStream_t stream) {
+  NVTE_API_CALL(nvte_qb_histogram_accumulate_unchecked);
+  using namespace transformer_engine;
+  fused_router::qb_histogram_accumulate(
+      *convertNVTETensorCheck(raw_scores), *convertNVTETensorCheck(cutoff),
+      *convertNVTETensorCheck(bin_bounds), *convertNVTETensorCheck(histogram),
+      /*validate_bin_bounds=*/false, stream);
 }
 
 void nvte_fused_topk_with_score_function_backward_v2(const NVTETensor routing_map,

--- a/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
+++ b/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
@@ -8,7 +8,9 @@
 #include <cuda_runtime.h>
 #include <transformer_engine/fused_router.h>
 
+#include <algorithm>
 #include <climits>
+#include <cmath>
 #include <type_traits>
 #include <vector>
 
@@ -20,6 +22,59 @@
 namespace transformer_engine {
 namespace fused_router {
 
+enum class QBMode {
+  Disabled,
+  TwoKernel,
+  FusedAtomic,
+};
+
+template <QBMode Mode>
+__device__ inline CompType extract_qb_cutoff_and_compact(int *topk_indices, CompType *topk_scores,
+                                                         int topk, int lane_id) {
+  if constexpr (Mode == QBMode::Disabled) {
+    return 0.0f;
+  } else {
+    CompType cutoff = 0.0f;
+    if (lane_id == 0) {
+      int cutoff_pos = 0;
+      cutoff = topk_scores[0];
+      int cutoff_expert = topk_indices[0];
+      for (int i = 1; i < topk + 1; ++i) {
+        const CompType score = topk_scores[i];
+        const int expert = topk_indices[i];
+        if (score < cutoff || (score == cutoff && expert > cutoff_expert)) {
+          cutoff = score;
+          cutoff_expert = expert;
+          cutoff_pos = i;
+        }
+      }
+      for (int i = cutoff_pos; i < topk; ++i) {
+        topk_scores[i] = topk_scores[i + 1];
+        topk_indices[i] = topk_indices[i + 1];
+      }
+    }
+    __syncwarp();
+    return __shfl_sync(0xffffffff, cutoff, 0);
+  }
+}
+
+template <QBMode Mode>
+__device__ inline void accumulate_qb_histogram_epilogue(const CompType *raw_scores, CompType cutoff,
+                                                        int num_experts, int lane_id,
+                                                        const CompType *bin_bounds, int num_bins,
+                                                        int32_t *histogram) {
+  if constexpr (Mode == QBMode::FusedAtomic) {
+    const CompType lower = bin_bounds[0];
+    const CompType upper = bin_bounds[1];
+    const CompType scale = static_cast<CompType>(num_bins) / (upper - lower);
+    for (int expert = lane_id; expert < num_experts; expert += kThreadsPerWarp) {
+      int bin = static_cast<int>(floorf((cutoff - raw_scores[expert] - lower) * scale));
+      bin = max(0, min(bin, num_bins - 1));
+      atomicAdd(histogram + static_cast<size_t>(expert) * num_bins + bin, 1);
+    }
+  }
+}
+
 // =============================================================================
 // Simple forward kernel — exact upstream structure (no async loader, no
 // persistent grid, runtime score_function dispatch).  Faster for small topk
@@ -27,13 +82,17 @@ namespace fused_router {
 // =============================================================================
 
 template <typename DataType, typename BiasType, NVTERoutingMapFormat RoutingMapFormat,
-          TopkFuncType TopkFunc = TopkFuncType::Naive, typename IndexType = int32_t>
+          TopkFuncType TopkFunc = TopkFuncType::Naive, typename IndexType = int32_t,
+          QBMode QbMode = QBMode::Disabled>
 __global__ void fused_topk_forward_simple_kernel(
     const DataType *logits, int num_tokens, int num_experts, int topk, bool use_pre_softmax,
     int num_groups, int group_topk, float scaling_factor, int score_function,
     const BiasType *expert_bias, DataType *probs, uint8_t *routing_map,
-    CompType *intermediate_output, IndexType *topk_indices_output) {
+    CompType *intermediate_output, IndexType *topk_indices_output, CompType *qb_cutoff,
+    int32_t *qb_histogram, const CompType *qb_bin_bounds, int qb_num_bins) {
   constexpr bool kIsBitmap = (RoutingMapFormat == NVTE_ROUTING_MAP_FORMAT_BITMAP_U8);
+  constexpr bool kUseQB = QbMode != QBMode::Disabled;
+  const int selection_topk = topk + (kUseQB ? 1 : 0);
   int num_token_per_block = blockDim.x / kThreadsPerWarp;
   int warp_id = threadIdx.x / kThreadsPerWarp;
   int lane_id = threadIdx.x % kThreadsPerWarp;
@@ -43,23 +102,25 @@ __global__ void fused_topk_forward_simple_kernel(
   CompType *group_scores_buf = nullptr, *masked_scores_buf = nullptr;
   int *topk_indices_buf = nullptr;
   if (group_topk > 0) {
-    masked_scores_buf = topk_scores_buf + topk * num_token_per_block;
+    masked_scores_buf = topk_scores_buf + selection_topk * num_token_per_block;
     group_scores_buf = masked_scores_buf + num_experts * num_token_per_block;
     topk_indices_buf = reinterpret_cast<int *>(group_scores_buf + num_groups * num_token_per_block);
   } else {
-    topk_indices_buf = reinterpret_cast<int *>(topk_scores_buf + topk * num_token_per_block);
+    topk_indices_buf =
+        reinterpret_cast<int *>(topk_scores_buf + selection_topk * num_token_per_block);
   }
   const int bitmap_words_per_warp = (num_experts + 31) / 32;
   const int bitmap_row_bytes = (num_experts + 7) / 8;
   uint32_t *bitmap_words_buf = nullptr;
   if constexpr (kIsBitmap) {
-    bitmap_words_buf = reinterpret_cast<uint32_t *>(topk_indices_buf + topk * num_token_per_block);
+    bitmap_words_buf =
+        reinterpret_cast<uint32_t *>(topk_indices_buf + selection_topk * num_token_per_block);
   }
   CompType *scores = scores_buf + warp_id * num_experts;
-  CompType *topk_scores = topk_scores_buf + warp_id * topk;
+  CompType *topk_scores = topk_scores_buf + warp_id * selection_topk;
   CompType *masked_scores = masked_scores_buf + warp_id * num_experts;
   CompType *group_scores = group_scores_buf + warp_id * num_groups;
-  int *topk_indices = topk_indices_buf + warp_id * topk;
+  int *topk_indices = topk_indices_buf + warp_id * selection_topk;
   uint32_t *local_bitmap_words =
       (bitmap_words_buf != nullptr) ? bitmap_words_buf + warp_id * bitmap_words_per_warp : nullptr;
 
@@ -131,8 +192,11 @@ __global__ void fused_topk_forward_simple_kernel(
       __syncwarp();
     }
 
-    // Topk selection
-    if (group_topk > 0) {
+    // Topk selection. QB is only supported without grouped Top-k.
+    if constexpr (kUseQB) {
+      topk_and_mask<TopkFunc>(scores, num_experts, selection_topk, topk_indices, topk_scores,
+                              lane_id);
+    } else if (group_topk > 0) {
       int group_size = num_experts / num_groups;
       for (int i = 0; i < num_groups; i++) {
         topk_and_mask<TopkFunc>(scores + i * group_size, group_size, topk / group_topk,
@@ -161,6 +225,19 @@ __global__ void fused_topk_forward_simple_kernel(
       topk_and_mask<TopkFunc>(masked_scores, num_experts, topk, topk_indices, topk_scores, lane_id);
     } else {
       topk_and_mask<TopkFunc>(scores, num_experts, topk, topk_indices, topk_scores, lane_id);
+    }
+    __syncwarp();
+
+    const CompType cutoff =
+        extract_qb_cutoff_and_compact<QbMode>(topk_indices, topk_scores, topk, lane_id);
+    if constexpr (QbMode == QBMode::TwoKernel) {
+      if (lane_id == 0) {
+        qb_cutoff[token_offset_cur_warp] = cutoff;
+      }
+    } else if constexpr (QbMode == QBMode::FusedAtomic) {
+      accumulate_qb_histogram_epilogue<QbMode>(intermediate_output + pos_offset, cutoff,
+                                               num_experts, lane_id, qb_bin_bounds, qb_num_bins,
+                                               qb_histogram);
     }
     __syncwarp();
 
@@ -233,13 +310,16 @@ __global__ void fused_topk_forward_simple_kernel(
 
 template <typename DataType, typename BiasType, NVTERoutingMapFormat RoutingMapFormat,
           TopkFuncType TopkFunc = TopkFuncType::Naive, int ScoreFunc = 0,
-          typename IndexType = int32_t>
+          typename IndexType = int32_t, QBMode QbMode = QBMode::Disabled>
 __global__ void fused_topk_with_score_function_forward_kernel(
     const DataType *logits, int num_tokens, int num_experts, int topk, bool use_pre_softmax,
     int num_groups, int group_topk, float scaling_factor, const BiasType *expert_bias,
     DataType *probs, uint8_t *routing_map, CompType *intermediate_output,
-    IndexType *topk_indices_output, int num_buffers) {
+    IndexType *topk_indices_output, int num_buffers, CompType *qb_cutoff, int32_t *qb_histogram,
+    const CompType *qb_bin_bounds, int qb_num_bins) {
   constexpr bool kIsBitmap = (RoutingMapFormat == NVTE_ROUTING_MAP_FORMAT_BITMAP_U8);
+  constexpr bool kUseQB = QbMode != QBMode::Disabled;
+  const int selection_topk = topk + (kUseQB ? 1 : 0);
   /***
      * Section: Global Variables/Addresses init
      * - Each warp is responsible for one token, and has own shared memory buffer.
@@ -265,26 +345,28 @@ __global__ void fused_topk_with_score_function_forward_kernel(
   CompType *group_scores_buf = nullptr, *masked_scores_buf = nullptr;
   int *topk_indices_buf = nullptr;
   if (group_topk > 0) {
-    masked_scores_buf = topk_scores_buf + topk * num_token_per_block;
+    masked_scores_buf = topk_scores_buf + selection_topk * num_token_per_block;
     group_scores_buf = masked_scores_buf + num_experts * num_token_per_block;
     topk_indices_buf = reinterpret_cast<int *>(group_scores_buf + num_groups * num_token_per_block);
   } else {
-    topk_indices_buf = reinterpret_cast<int *>(topk_scores_buf + topk * num_token_per_block);
+    topk_indices_buf =
+        reinterpret_cast<int *>(topk_scores_buf + selection_topk * num_token_per_block);
   }
   const int bitmap_words_per_warp = (num_experts + 31) / 32;
   const int bitmap_row_bytes = (num_experts + 7) / 8;
   uint32_t *bitmap_words_buf = nullptr;
   if constexpr (kIsBitmap) {
-    bitmap_words_buf = reinterpret_cast<uint32_t *>(topk_indices_buf + topk * num_token_per_block);
+    bitmap_words_buf =
+        reinterpret_cast<uint32_t *>(topk_indices_buf + selection_topk * num_token_per_block);
   }
   // The address of buffers on the current warp
   CompType *scores = scores_buf + warp_id * num_experts;
-  CompType *topk_scores = topk_scores_buf + warp_id * topk;
+  CompType *topk_scores = topk_scores_buf + warp_id * selection_topk;
   CompType *masked_scores =
       (masked_scores_buf != nullptr) ? masked_scores_buf + warp_id * num_experts : nullptr;
   CompType *group_scores =
       (group_scores_buf != nullptr) ? group_scores_buf + warp_id * num_groups : nullptr;
-  int *topk_indices = topk_indices_buf + warp_id * topk;
+  int *topk_indices = topk_indices_buf + warp_id * selection_topk;
   uint32_t *local_bitmap_words =
       (bitmap_words_buf != nullptr) ? bitmap_words_buf + warp_id * bitmap_words_per_warp : nullptr;
 
@@ -411,9 +493,12 @@ __global__ void fused_topk_with_score_function_forward_kernel(
          * - naive topk
          * - topk with expert bias
          */
-    // Topk on the scores
-    // The bias being not empty happens at the sigmoid/sqrtsoftplus case
-    if (group_topk > 0) {
+    // Topk on the scores. QB is only supported without grouped Top-k.
+    // The bias being not empty happens at the sigmoid/sqrtsoftplus case.
+    if constexpr (kUseQB) {
+      topk_and_mask<TopkFunc>(scores, num_experts, selection_topk, topk_indices, topk_scores,
+                              lane_id);
+    } else if (group_topk > 0) {
       int group_size = num_experts / num_groups;
       // Top2
       for (int i = 0; i < num_groups; i++) {
@@ -458,6 +543,19 @@ __global__ void fused_topk_with_score_function_forward_kernel(
 
     } else {
       topk_and_mask<TopkFunc>(scores, num_experts, topk, topk_indices, topk_scores, lane_id);
+    }
+    __syncwarp();
+
+    const CompType cutoff =
+        extract_qb_cutoff_and_compact<QbMode>(topk_indices, topk_scores, topk, lane_id);
+    if constexpr (QbMode == QBMode::TwoKernel) {
+      if (lane_id == 0) {
+        qb_cutoff[token_offset_cur_warp] = cutoff;
+      }
+    } else if constexpr (QbMode == QBMode::FusedAtomic) {
+      accumulate_qb_histogram_epilogue<QbMode>(intermediate_output + pos_offset, cutoff,
+                                               num_experts, lane_id, qb_bin_bounds, qb_num_bins,
+                                               qb_histogram);
     }
     __syncwarp();
 
@@ -539,12 +637,15 @@ __global__ void fused_topk_with_score_function_forward_kernel(
   }
 }
 
-template <typename DataType, typename BiasType, NVTERoutingMapFormat RoutingMapFormat>
+template <typename DataType, typename BiasType, NVTERoutingMapFormat RoutingMapFormat,
+          QBMode QbMode = QBMode::Disabled>
 void fused_topk_with_score_function_forward_kernel_launcher(
     const DataType *logits, int num_tokens, int num_experts, int topk, bool use_pre_softmax,
     int num_groups, int group_topk, float scaling_factor, int score_function,
     const BiasType *expert_bias, DataType *probs, uint8_t *routing_map,
-    CompType *intermediate_output, cudaStream_t stream) {
+    CompType *intermediate_output, CompType *qb_cutoff, int32_t *qb_histogram,
+    const CompType *qb_bin_bounds, int qb_num_bins, cudaStream_t stream) {
+  constexpr bool kUseQB = QbMode != QBMode::Disabled;
   NVTE_CHECK(num_experts > 0, "num_experts must be positive, got ", num_experts);
   NVTE_CHECK(topk > 0 && topk <= num_experts, "topk must be in [1, num_experts], got topk=", topk,
              " num_experts=", num_experts);
@@ -569,9 +670,10 @@ void fused_topk_with_score_function_forward_kernel_launcher(
   }
   size_t num_token_per_block = kThreadsPerBlock / kThreadsPerWarp;
   size_t total_blocks = (num_tokens + num_token_per_block - 1) / num_token_per_block;
+  size_t selection_topk = topk + (kUseQB ? 1 : 0);
   size_t scores_shmem = num_experts * num_token_per_block * sizeof(CompType);
-  size_t scratch_shmem =
-      topk * num_token_per_block * sizeof(CompType) + topk * num_token_per_block * sizeof(int);
+  size_t scratch_shmem = selection_topk * num_token_per_block * sizeof(CompType) +
+                         selection_topk * num_token_per_block * sizeof(int);
   if (group_topk > 0) {
     scratch_shmem += num_groups * num_token_per_block * sizeof(CompType);
     scratch_shmem += num_experts * num_token_per_block * sizeof(CompType);
@@ -596,7 +698,8 @@ void fused_topk_with_score_function_forward_kernel_launcher(
     kernel<<<grid_size, kThreadsPerBlock, shared_memory_size, stream>>>(
         logits, num_tokens, num_experts, topk, use_pre_softmax, num_groups, group_topk,
         scaling_factor, expert_bias, probs, routing_map, intermediate_output,
-        static_cast<int32_t *>(nullptr), num_buffers);
+        static_cast<int32_t *>(nullptr), num_buffers, qb_cutoff, qb_histogram, qb_bin_bounds,
+        qb_num_bins);
     NVTE_CHECK_CUDA(cudaGetLastError());
   };
 
@@ -614,26 +717,29 @@ void fused_topk_with_score_function_forward_kernel_launcher(
       kernel<<<total_blocks, kThreadsPerBlock, other_shmem, stream>>>(
           logits, num_tokens, num_experts, topk, use_pre_softmax, num_groups, group_topk,
           scaling_factor, score_function, expert_bias, probs, routing_map, intermediate_output,
-          static_cast<int32_t *>(nullptr));
+          static_cast<int32_t *>(nullptr), qb_cutoff, qb_histogram, qb_bin_bounds, qb_num_bins);
       NVTE_CHECK_CUDA(cudaGetLastError());
     };
 
     launch_simple(fused_topk_forward_simple_kernel<DataType, BiasType, RoutingMapFormat,
-                                                   TopkFuncType::Naive>);
+                                                   TopkFuncType::Naive, int32_t, QbMode>);
   } else {
     // Optimized path: async loader + persistent grid + radix topk.
     switch (score_function) {
       case 0:
-        launch(fused_topk_with_score_function_forward_kernel<DataType, BiasType, RoutingMapFormat,
-                                                             TopkFuncType::Radix, 0>);
+        launch(
+            fused_topk_with_score_function_forward_kernel<DataType, BiasType, RoutingMapFormat,
+                                                          TopkFuncType::Radix, 0, int32_t, QbMode>);
         break;
       case 1:
-        launch(fused_topk_with_score_function_forward_kernel<DataType, BiasType, RoutingMapFormat,
-                                                             TopkFuncType::Radix, 1>);
+        launch(
+            fused_topk_with_score_function_forward_kernel<DataType, BiasType, RoutingMapFormat,
+                                                          TopkFuncType::Radix, 1, int32_t, QbMode>);
         break;
       case 2:
-        launch(fused_topk_with_score_function_forward_kernel<DataType, BiasType, RoutingMapFormat,
-                                                             TopkFuncType::Radix, 2>);
+        launch(
+            fused_topk_with_score_function_forward_kernel<DataType, BiasType, RoutingMapFormat,
+                                                          TopkFuncType::Radix, 2, int32_t, QbMode>);
         break;
       default:
         NVTE_ERROR("Unsupported score_function: " + std::to_string(score_function));
@@ -641,12 +747,15 @@ void fused_topk_with_score_function_forward_kernel_launcher(
   }
 }
 
-template <typename DataType, typename BiasType, typename IndexType>
+template <typename DataType, typename BiasType, typename IndexType,
+          QBMode QbMode = QBMode::Disabled>
 void fused_topk_with_score_function_forward_with_indices_kernel_launcher(
     const DataType *logits, int num_tokens, int num_experts, int topk, bool use_pre_softmax,
     int num_groups, int group_topk, float scaling_factor, int score_function,
     const BiasType *expert_bias, DataType *probs, IndexType *topk_indices,
-    CompType *intermediate_output, cudaStream_t stream) {
+    CompType *intermediate_output, CompType *qb_cutoff, int32_t *qb_histogram,
+    const CompType *qb_bin_bounds, int qb_num_bins, cudaStream_t stream) {
+  constexpr bool kUseQB = QbMode != QBMode::Disabled;
   NVTE_CHECK(num_experts > 0, "num_experts must be positive, got ", num_experts);
   NVTE_CHECK(topk > 0 && topk <= num_experts, "topk must be in [1, num_experts], got topk=", topk,
              " num_experts=", num_experts);
@@ -676,9 +785,10 @@ void fused_topk_with_score_function_forward_with_indices_kernel_launcher(
 
   size_t num_token_per_block = kThreadsPerBlock / kThreadsPerWarp;
   size_t total_blocks = (num_tokens + num_token_per_block - 1) / num_token_per_block;
+  size_t selection_topk = topk + (kUseQB ? 1 : 0);
   size_t scores_shmem = num_experts * num_token_per_block * sizeof(CompType);
-  size_t scratch_shmem =
-      topk * num_token_per_block * sizeof(CompType) + topk * num_token_per_block * sizeof(int);
+  size_t scratch_shmem = selection_topk * num_token_per_block * sizeof(CompType) +
+                         selection_topk * num_token_per_block * sizeof(int);
   if (group_topk > 0) {
     scratch_shmem += num_groups * num_token_per_block * sizeof(CompType);
     scratch_shmem += num_experts * num_token_per_block * sizeof(CompType);
@@ -700,7 +810,7 @@ void fused_topk_with_score_function_forward_with_indices_kernel_launcher(
     kernel<<<grid_size, kThreadsPerBlock, shared_memory_size, stream>>>(
         logits, num_tokens, num_experts, topk, use_pre_softmax, num_groups, group_topk,
         scaling_factor, expert_bias, probs, static_cast<uint8_t *>(nullptr), intermediate_output,
-        topk_indices, num_buffers);
+        topk_indices, num_buffers, qb_cutoff, qb_histogram, qb_bin_bounds, qb_num_bins);
     NVTE_CHECK_CUDA(cudaGetLastError());
   };
 
@@ -715,34 +825,118 @@ void fused_topk_with_score_function_forward_with_indices_kernel_launcher(
       kernel<<<total_blocks, kThreadsPerBlock, other_shmem, stream>>>(
           logits, num_tokens, num_experts, topk, use_pre_softmax, num_groups, group_topk,
           scaling_factor, score_function, expert_bias, probs, static_cast<uint8_t *>(nullptr),
-          intermediate_output, topk_indices);
+          intermediate_output, topk_indices, qb_cutoff, qb_histogram, qb_bin_bounds, qb_num_bins);
       NVTE_CHECK_CUDA(cudaGetLastError());
     };
 
     launch_simple(
         fused_topk_forward_simple_kernel<DataType, BiasType, NVTE_ROUTING_MAP_FORMAT_BYTEMAP,
-                                         TopkFuncType::Naive, IndexType>);
+                                         TopkFuncType::Naive, IndexType, QbMode>);
   } else {
     switch (score_function) {
       case 0:
-        launch(fused_topk_with_score_function_forward_kernel<DataType, BiasType,
-                                                             NVTE_ROUTING_MAP_FORMAT_BYTEMAP,
-                                                             TopkFuncType::Radix, 0, IndexType>);
+        launch(fused_topk_with_score_function_forward_kernel<
+               DataType, BiasType, NVTE_ROUTING_MAP_FORMAT_BYTEMAP, TopkFuncType::Radix, 0,
+               IndexType, QbMode>);
         break;
       case 1:
-        launch(fused_topk_with_score_function_forward_kernel<DataType, BiasType,
-                                                             NVTE_ROUTING_MAP_FORMAT_BYTEMAP,
-                                                             TopkFuncType::Radix, 1, IndexType>);
+        launch(fused_topk_with_score_function_forward_kernel<
+               DataType, BiasType, NVTE_ROUTING_MAP_FORMAT_BYTEMAP, TopkFuncType::Radix, 1,
+               IndexType, QbMode>);
         break;
       case 2:
-        launch(fused_topk_with_score_function_forward_kernel<DataType, BiasType,
-                                                             NVTE_ROUTING_MAP_FORMAT_BYTEMAP,
-                                                             TopkFuncType::Radix, 2, IndexType>);
+        launch(fused_topk_with_score_function_forward_kernel<
+               DataType, BiasType, NVTE_ROUTING_MAP_FORMAT_BYTEMAP, TopkFuncType::Radix, 2,
+               IndexType, QbMode>);
         break;
       default:
         NVTE_ERROR("Unsupported score_function: " + std::to_string(score_function));
     }
   }
+}
+
+constexpr int kQBExpertsPerBlock = 8;
+constexpr int kQBHistogramThreads = 256;
+
+__global__ void qb_histogram_accumulate_kernel(const CompType *raw_scores, const CompType *cutoff,
+                                               int num_tokens, int num_experts,
+                                               const CompType *bin_bounds, int num_bins,
+                                               int32_t *histogram) {
+  extern __shared__ int32_t local_histogram[];
+  const int local_histogram_size = kQBExpertsPerBlock * num_bins;
+  for (int i = threadIdx.x; i < local_histogram_size; i += blockDim.x) {
+    local_histogram[i] = 0;
+  }
+  __syncthreads();
+
+  const int expert_begin = blockIdx.x * kQBExpertsPerBlock;
+  const int token_partition = blockIdx.y;
+  const int num_token_partitions = gridDim.y;
+  const int tokens_in_partition =
+      (num_tokens - token_partition + num_token_partitions - 1) / num_token_partitions;
+  const int num_items = tokens_in_partition * kQBExpertsPerBlock;
+  const CompType lower = bin_bounds[0];
+  const CompType upper = bin_bounds[1];
+  const CompType scale = static_cast<CompType>(num_bins) / (upper - lower);
+
+  for (int item = threadIdx.x; item < num_items; item += blockDim.x) {
+    const int token_in_partition = item / kQBExpertsPerBlock;
+    const int local_expert = item % kQBExpertsPerBlock;
+    const int token = token_partition + token_in_partition * num_token_partitions;
+    const int expert = expert_begin + local_expert;
+    if (token < num_tokens && expert < num_experts) {
+      const CompType required_bias =
+          cutoff[token] - raw_scores[static_cast<size_t>(token) * num_experts + expert];
+      int bin = static_cast<int>(floorf((required_bias - lower) * scale));
+      bin = max(0, min(bin, num_bins - 1));
+      atomicAdd(local_histogram + local_expert * num_bins + bin, 1);
+    }
+  }
+  __syncthreads();
+
+  for (int i = threadIdx.x; i < local_histogram_size; i += blockDim.x) {
+    const int count = local_histogram[i];
+    const int local_expert = i / num_bins;
+    const int expert = expert_begin + local_expert;
+    if (count != 0 && expert < num_experts) {
+      atomicAdd(histogram + static_cast<size_t>(expert) * num_bins + i % num_bins, count);
+    }
+  }
+}
+
+void qb_histogram_accumulate(const Tensor raw_scores, const Tensor cutoff, const Tensor bin_bounds,
+                             Tensor histogram, cudaStream_t stream) {
+  NVTE_CHECK(raw_scores.data.dtype == DType::kFloat32, "QB raw_scores must have FP32 dtype");
+  NVTE_CHECK(cutoff.data.dtype == DType::kFloat32, "QB cutoff must have FP32 dtype");
+  NVTE_CHECK(bin_bounds.data.dtype == DType::kFloat32, "QB bin_bounds must have FP32 dtype");
+  NVTE_CHECK(histogram.data.dtype == DType::kInt32, "QB histogram must have int32 dtype");
+  NVTE_CHECK(raw_scores.data.shape.size() == 2,
+             "QB raw_scores must have shape [num_tokens, num_experts]");
+  const int num_tokens = static_cast<int>(raw_scores.data.shape[0]);
+  const int num_experts = static_cast<int>(raw_scores.data.shape[1]);
+  NVTE_CHECK(cutoff.data.shape == std::vector<size_t>{static_cast<size_t>(num_tokens)},
+             "QB cutoff must have shape [num_tokens]");
+  NVTE_CHECK(bin_bounds.data.shape == std::vector<size_t>{2}, "QB bin_bounds must have shape [2]");
+  NVTE_CHECK(histogram.data.shape.size() == 2 &&
+                 histogram.data.shape[0] == static_cast<size_t>(num_experts),
+             "QB histogram must have shape [num_experts, num_bins]");
+  const int num_bins = static_cast<int>(histogram.data.shape[1]);
+  NVTE_CHECK(num_bins > 0, "QB num_bins must be positive");
+
+  const int token_partitions = std::min(4, std::max(1, (num_tokens + 1023) / 1024));
+  const dim3 grid((num_experts + kQBExpertsPerBlock - 1) / kQBExpertsPerBlock, token_partitions);
+  const size_t shared_memory_size =
+      static_cast<size_t>(kQBExpertsPerBlock) * num_bins * sizeof(int32_t);
+  check_shared_memory_capacity_num_experts(shared_memory_size, num_experts);
+  NVTE_CHECK_CUDA(cudaFuncSetAttribute(qb_histogram_accumulate_kernel,
+                                       cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                       static_cast<int>(shared_memory_size)));
+  qb_histogram_accumulate_kernel<<<grid, kQBHistogramThreads, shared_memory_size, stream>>>(
+      reinterpret_cast<const CompType *>(raw_scores.data.dptr),
+      reinterpret_cast<const CompType *>(cutoff.data.dptr), num_tokens, num_experts,
+      reinterpret_cast<const CompType *>(bin_bounds.data.dptr), num_bins,
+      reinterpret_cast<int32_t *>(histogram.data.dptr));
+  NVTE_CHECK_CUDA(cudaGetLastError());
 }
 
 // Build the expected routing_map shape for a given NVTERoutingMapFormat.
@@ -801,7 +995,8 @@ void fused_topk_with_score_function_forward(const Tensor logits, int num_tokens,
                 reinterpret_cast<BiasType *>(expert_bias.data.dptr),                           \
                 reinterpret_cast<DataType *>(probs.data.dptr),                                 \
                 reinterpret_cast<uint8_t *>(routing_map.data.dptr),                            \
-                reinterpret_cast<CompType *>(intermediate_output.data.dptr), stream););        \
+                reinterpret_cast<CompType *>(intermediate_output.data.dptr), nullptr, nullptr, \
+                nullptr, 0, stream););                                                         \
       } else {                                                                                 \
         fused_topk_with_score_function_forward_kernel_launcher<DataType, DataType,             \
                                                                RoutingMapFormatVal>(           \
@@ -809,7 +1004,8 @@ void fused_topk_with_score_function_forward(const Tensor logits, int num_tokens,
             use_pre_softmax, num_groups, group_topk, scaling_factor, score_function, nullptr,  \
             reinterpret_cast<DataType *>(probs.data.dptr),                                     \
             reinterpret_cast<uint8_t *>(routing_map.data.dptr),                                \
-            reinterpret_cast<CompType *>(intermediate_output.data.dptr), stream);              \
+            reinterpret_cast<CompType *>(intermediate_output.data.dptr), nullptr, nullptr,     \
+            nullptr, 0, stream);                                                               \
       });
   if (routing_map_format == NVTE_ROUTING_MAP_FORMAT_BITMAP_U8) {
     ROUTER_FORWARD_DISPATCH(NVTE_ROUTING_MAP_FORMAT_BITMAP_U8)
@@ -851,32 +1047,158 @@ void fused_topk_with_score_function_forward_with_indices(
   }
   // Dispatch logits dtype and output-index dtype first; expert-bias dtype is only
   // dispatched when an expert-bias tensor exists, otherwise the kernel receives nullptr.
-#define ROUTER_FORWARD_WITH_INDICES_DISPATCH(DataType, IndexType)                               \
-  if (expert_bias.has_data()) {                                                                 \
-    TE_ROUTER_PROBS_TYPE_SWITCH_ALL(                                                            \
-        expert_bias.data.dtype, BiasType,                                                       \
-        fused_topk_with_score_function_forward_with_indices_kernel_launcher<DataType, BiasType, \
-                                                                            IndexType>(         \
-            reinterpret_cast<DataType *>(logits.data.dptr), num_tokens, num_experts, topk,      \
-            use_pre_softmax, num_groups, group_topk, scaling_factor, score_function,            \
-            reinterpret_cast<BiasType *>(expert_bias.data.dptr),                                \
-            reinterpret_cast<DataType *>(probs.data.dptr),                                      \
-            reinterpret_cast<IndexType *>(topk_indices.data.dptr),                              \
-            reinterpret_cast<CompType *>(intermediate_output.data.dptr), stream););             \
-  } else {                                                                                      \
-    fused_topk_with_score_function_forward_with_indices_kernel_launcher<DataType, DataType,     \
-                                                                        IndexType>(             \
-        reinterpret_cast<DataType *>(logits.data.dptr), num_tokens, num_experts, topk,          \
-        use_pre_softmax, num_groups, group_topk, scaling_factor, score_function, nullptr,       \
-        reinterpret_cast<DataType *>(probs.data.dptr),                                          \
-        reinterpret_cast<IndexType *>(topk_indices.data.dptr),                                  \
-        reinterpret_cast<CompType *>(intermediate_output.data.dptr), stream);                   \
+#define ROUTER_FORWARD_WITH_INDICES_DISPATCH(DataType, IndexType)                                  \
+  if (expert_bias.has_data()) {                                                                    \
+    TE_ROUTER_PROBS_TYPE_SWITCH_ALL(                                                               \
+        expert_bias.data.dtype, BiasType,                                                          \
+        fused_topk_with_score_function_forward_with_indices_kernel_launcher<DataType, BiasType,    \
+                                                                            IndexType>(            \
+            reinterpret_cast<DataType *>(logits.data.dptr), num_tokens, num_experts, topk,         \
+            use_pre_softmax, num_groups, group_topk, scaling_factor, score_function,               \
+            reinterpret_cast<BiasType *>(expert_bias.data.dptr),                                   \
+            reinterpret_cast<DataType *>(probs.data.dptr),                                         \
+            reinterpret_cast<IndexType *>(topk_indices.data.dptr),                                 \
+            reinterpret_cast<CompType *>(intermediate_output.data.dptr), nullptr, nullptr,         \
+            nullptr, 0, stream););                                                                 \
+  } else {                                                                                         \
+    fused_topk_with_score_function_forward_with_indices_kernel_launcher<DataType, DataType,        \
+                                                                        IndexType>(                \
+        reinterpret_cast<DataType *>(logits.data.dptr), num_tokens, num_experts, topk,             \
+        use_pre_softmax, num_groups, group_topk, scaling_factor, score_function, nullptr,          \
+        reinterpret_cast<DataType *>(probs.data.dptr),                                             \
+        reinterpret_cast<IndexType *>(topk_indices.data.dptr),                                     \
+        reinterpret_cast<CompType *>(intermediate_output.data.dptr), nullptr, nullptr, nullptr, 0, \
+        stream);                                                                                   \
   }
   TE_ROUTER_PROBS_TYPE_SWITCH_ALL(logits.data.dtype, DataType,
                                   TE_ROUTER_DENSE_INDEX_TYPE_SWITCH_ALL(
                                       topk_indices.data.dtype, IndexType,
                                       ROUTER_FORWARD_WITH_INDICES_DISPATCH(DataType, IndexType);););
 #undef ROUTER_FORWARD_WITH_INDICES_DISPATCH
+}
+
+static int check_qb_forward_tensors(const Tensor logits, int num_tokens, int num_experts, int topk,
+                                    const Tensor expert_bias, const Tensor probs,
+                                    const Tensor intermediate_output, const Tensor cutoff,
+                                    const Tensor histogram, const Tensor bin_bounds) {
+  NVTE_CHECK(num_tokens > 0 && num_experts > 0, "QB num_tokens and num_experts must be positive");
+  NVTE_CHECK(topk > 0 && topk < num_experts, "QB topk must be in [1, num_experts), got topk=", topk,
+             " num_experts=", num_experts);
+  const std::vector<size_t> dense_shape{static_cast<size_t>(num_tokens),
+                                        static_cast<size_t>(num_experts)};
+  NVTE_CHECK(logits.data.shape == dense_shape,
+             "QB logits must have shape [num_tokens, num_experts]");
+  NVTE_CHECK(probs.data.shape == dense_shape, "QB probs must have shape [num_tokens, num_experts]");
+  NVTE_CHECK(intermediate_output.data.shape == dense_shape,
+             "QB intermediate_output must have shape [num_tokens, num_experts]");
+  NVTE_CHECK(intermediate_output.data.dtype == DType::kFloat32,
+             "QB intermediate_output must have FP32 dtype");
+  NVTE_CHECK(expert_bias.has_data(), "QB requires an expert_bias tensor");
+  NVTE_CHECK(expert_bias.data.dtype == DType::kFloat32, "QB expert_bias must have FP32 dtype");
+  NVTE_CHECK(expert_bias.data.shape == std::vector<size_t>{static_cast<size_t>(num_experts)},
+             "QB expert_bias must have shape [num_experts]");
+  NVTE_CHECK(cutoff.data.dtype == DType::kFloat32, "QB cutoff must have FP32 dtype");
+  NVTE_CHECK(cutoff.data.shape == std::vector<size_t>{static_cast<size_t>(num_tokens)},
+             "QB cutoff must have shape [num_tokens]");
+  NVTE_CHECK(histogram.data.dtype == DType::kInt32, "QB histogram must have int32 dtype");
+  NVTE_CHECK(histogram.data.shape.size() == 2 &&
+                 histogram.data.shape[0] == static_cast<size_t>(num_experts),
+             "QB histogram must have shape [num_experts, num_bins]");
+  const int num_bins = static_cast<int>(histogram.data.shape[1]);
+  NVTE_CHECK(num_bins > 0, "QB num_bins must be positive");
+  NVTE_CHECK(bin_bounds.data.dtype == DType::kFloat32, "QB bin_bounds must have FP32 dtype");
+  NVTE_CHECK(bin_bounds.data.shape == std::vector<size_t>{2}, "QB bin_bounds must have shape [2]");
+  return num_bins;
+}
+
+void fused_topk_with_score_function_forward_qb(
+    const Tensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const Tensor expert_bias, Tensor probs, Tensor routing_map,
+    NVTERoutingMapFormat routing_map_format, Tensor intermediate_output, Tensor cutoff,
+    Tensor histogram, Tensor bin_bounds, NVTEQBHistogramMode histogram_mode, cudaStream_t stream) {
+  check_routing_map_format(routing_map_format);
+  const int num_bins =
+      check_qb_forward_tensors(logits, num_tokens, num_experts, topk, expert_bias, probs,
+                               intermediate_output, cutoff, histogram, bin_bounds);
+  const auto routing_map_shape =
+      expected_routing_map_shape(num_tokens, num_experts, routing_map_format);
+  NVTE_CHECK(routing_map.data.shape == routing_map_shape,
+             "QB routing_map shape does not match routing_map_format");
+
+#define QB_ROUTER_FORWARD_LAUNCH(RoutingMapFormatVal, QbModeVal)                                   \
+  TE_ROUTER_PROBS_TYPE_SWITCH_ALL(                                                                 \
+      logits.data.dtype, DataType,                                                                 \
+      fused_topk_with_score_function_forward_kernel_launcher<DataType, float, RoutingMapFormatVal, \
+                                                             QbModeVal>(                           \
+          reinterpret_cast<DataType *>(logits.data.dptr), num_tokens, num_experts, topk, false,    \
+          -1, -1, scaling_factor, 0, reinterpret_cast<float *>(expert_bias.data.dptr),             \
+          reinterpret_cast<DataType *>(probs.data.dptr),                                           \
+          reinterpret_cast<uint8_t *>(routing_map.data.dptr),                                      \
+          reinterpret_cast<CompType *>(intermediate_output.data.dptr),                             \
+          reinterpret_cast<CompType *>(cutoff.data.dptr),                                          \
+          reinterpret_cast<int32_t *>(histogram.data.dptr),                                        \
+          reinterpret_cast<const CompType *>(bin_bounds.data.dptr), num_bins, stream););
+
+#define QB_ROUTER_FORWARD_MODE_DISPATCH(RoutingMapFormatVal)           \
+  if (histogram_mode == NVTE_QB_HISTOGRAM_TWO_KERNEL) {                \
+    QB_ROUTER_FORWARD_LAUNCH(RoutingMapFormatVal, QBMode::TwoKernel)   \
+  } else if (histogram_mode == NVTE_QB_HISTOGRAM_FUSED_ATOMIC) {       \
+    QB_ROUTER_FORWARD_LAUNCH(RoutingMapFormatVal, QBMode::FusedAtomic) \
+  } else {                                                             \
+    NVTE_ERROR("Unsupported QB histogram mode: " +                     \
+               std::to_string(static_cast<int>(histogram_mode)));      \
+  }
+
+  if (routing_map_format == NVTE_ROUTING_MAP_FORMAT_BITMAP_U8) {
+    QB_ROUTER_FORWARD_MODE_DISPATCH(NVTE_ROUTING_MAP_FORMAT_BITMAP_U8)
+  } else {
+    QB_ROUTER_FORWARD_MODE_DISPATCH(NVTE_ROUTING_MAP_FORMAT_BYTEMAP)
+  }
+#undef QB_ROUTER_FORWARD_MODE_DISPATCH
+#undef QB_ROUTER_FORWARD_LAUNCH
+}
+
+void fused_topk_with_score_function_forward_qb_with_indices(
+    const Tensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const Tensor expert_bias, Tensor probs, Tensor topk_indices, Tensor intermediate_output,
+    Tensor cutoff, Tensor histogram, Tensor bin_bounds, NVTEQBHistogramMode histogram_mode,
+    cudaStream_t stream) {
+  const int num_bins =
+      check_qb_forward_tensors(logits, num_tokens, num_experts, topk, expert_bias, probs,
+                               intermediate_output, cutoff, histogram, bin_bounds);
+  const std::vector<size_t> indices_shape{static_cast<size_t>(num_tokens),
+                                          static_cast<size_t>(topk)};
+  NVTE_CHECK(topk_indices.data.shape == indices_shape,
+             "QB topk_indices must have shape [num_tokens, topk]");
+
+#define QB_ROUTER_FORWARD_WITH_INDICES_LAUNCH(DataType, IndexType, QbModeVal)                     \
+  fused_topk_with_score_function_forward_with_indices_kernel_launcher<DataType, float, IndexType, \
+                                                                      QbModeVal>(                 \
+      reinterpret_cast<DataType *>(logits.data.dptr), num_tokens, num_experts, topk, false, -1,   \
+      -1, scaling_factor, 0, reinterpret_cast<float *>(expert_bias.data.dptr),                    \
+      reinterpret_cast<DataType *>(probs.data.dptr),                                              \
+      reinterpret_cast<IndexType *>(topk_indices.data.dptr),                                      \
+      reinterpret_cast<CompType *>(intermediate_output.data.dptr),                                \
+      reinterpret_cast<CompType *>(cutoff.data.dptr),                                             \
+      reinterpret_cast<int32_t *>(histogram.data.dptr),                                           \
+      reinterpret_cast<const CompType *>(bin_bounds.data.dptr), num_bins, stream)
+
+#define QB_ROUTER_FORWARD_WITH_INDICES_MODE(DataType, IndexType)                     \
+  if (histogram_mode == NVTE_QB_HISTOGRAM_TWO_KERNEL) {                              \
+    QB_ROUTER_FORWARD_WITH_INDICES_LAUNCH(DataType, IndexType, QBMode::TwoKernel);   \
+  } else if (histogram_mode == NVTE_QB_HISTOGRAM_FUSED_ATOMIC) {                     \
+    QB_ROUTER_FORWARD_WITH_INDICES_LAUNCH(DataType, IndexType, QBMode::FusedAtomic); \
+  } else {                                                                           \
+    NVTE_ERROR("Unsupported QB histogram mode: " +                                   \
+               std::to_string(static_cast<int>(histogram_mode)));                    \
+  }
+
+  TE_ROUTER_PROBS_TYPE_SWITCH_ALL(logits.data.dtype, DataType,
+                                  TE_ROUTER_DENSE_INDEX_TYPE_SWITCH_ALL(
+                                      topk_indices.data.dtype, IndexType,
+                                      QB_ROUTER_FORWARD_WITH_INDICES_MODE(DataType, IndexType);););
+#undef QB_ROUTER_FORWARD_WITH_INDICES_MODE
+#undef QB_ROUTER_FORWARD_WITH_INDICES_LAUNCH
 }
 
 // Backward: grad_probs + intermediate_output + routing_map → grad_logits.
@@ -1405,6 +1727,48 @@ void nvte_fused_topk_with_score_function_forward_with_indices(
       static_cast<bool>(use_pre_softmax), num_groups, group_topk, scaling_factor, score_function,
       *convertNVTETensorCheck(expert_bias), *convertNVTETensorCheck(probs),
       *convertNVTETensorCheck(topk_indices), *convertNVTETensorCheck(intermediate_output), stream);
+}
+
+void nvte_fused_topk_with_score_function_forward_qb_v2(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor routing_map,
+    NVTERoutingMapFormat routing_map_format, NVTETensor intermediate_output, NVTETensor cutoff,
+    NVTETensor histogram, NVTETensor bin_bounds, NVTEQBHistogramMode histogram_mode,
+    cudaStream_t stream) {
+  NVTE_API_CALL(nvte_fused_topk_with_score_function_forward_qb_v2);
+  using namespace transformer_engine;
+  fused_router::fused_topk_with_score_function_forward_qb(
+      *convertNVTETensorCheck(logits), num_tokens, num_experts, topk, scaling_factor,
+      *convertNVTETensorCheck(expert_bias), *convertNVTETensorCheck(probs),
+      *convertNVTETensorCheck(routing_map), routing_map_format,
+      *convertNVTETensorCheck(intermediate_output), *convertNVTETensorCheck(cutoff),
+      *convertNVTETensorCheck(histogram), *convertNVTETensorCheck(bin_bounds), histogram_mode,
+      stream);
+}
+
+void nvte_fused_topk_with_score_function_forward_qb_with_indices(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor topk_indices,
+    NVTETensor intermediate_output, NVTETensor cutoff, NVTETensor histogram, NVTETensor bin_bounds,
+    NVTEQBHistogramMode histogram_mode, cudaStream_t stream) {
+  NVTE_API_CALL(nvte_fused_topk_with_score_function_forward_qb_with_indices);
+  using namespace transformer_engine;
+  fused_router::fused_topk_with_score_function_forward_qb_with_indices(
+      *convertNVTETensorCheck(logits), num_tokens, num_experts, topk, scaling_factor,
+      *convertNVTETensorCheck(expert_bias), *convertNVTETensorCheck(probs),
+      *convertNVTETensorCheck(topk_indices), *convertNVTETensorCheck(intermediate_output),
+      *convertNVTETensorCheck(cutoff), *convertNVTETensorCheck(histogram),
+      *convertNVTETensorCheck(bin_bounds), histogram_mode, stream);
+}
+
+void nvte_qb_histogram_accumulate(const NVTETensor raw_scores, const NVTETensor cutoff,
+                                  const NVTETensor bin_bounds, NVTETensor histogram,
+                                  cudaStream_t stream) {
+  NVTE_API_CALL(nvte_qb_histogram_accumulate);
+  using namespace transformer_engine;
+  fused_router::qb_histogram_accumulate(
+      *convertNVTETensorCheck(raw_scores), *convertNVTETensorCheck(cutoff),
+      *convertNVTETensorCheck(bin_bounds), *convertNVTETensorCheck(histogram), stream);
 }
 
 void nvte_fused_topk_with_score_function_backward_v2(const NVTETensor routing_map,

--- a/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
+++ b/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
@@ -36,11 +36,6 @@ struct QBBinParams {
 __device__ inline QBBinParams load_qb_bin_params(const CompType *bin_bounds, int num_bins) {
   const CompType lower = bin_bounds[0];
   const CompType upper = bin_bounds[1];
-  if (!isfinite(lower) || !isfinite(upper) || upper <= lower) {
-    // Bounds are caller-owned CUDA data, so host-side value validation would add a
-    // synchronization and break CUDA graph capture. Trap on the consuming stream instead.
-    __trap();
-  }
   return {lower, static_cast<CompType>(num_bins) / (upper - lower)};
 }
 

--- a/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
+++ b/transformer_engine/common/fused_router/fused_topk_with_score_function.cu
@@ -28,6 +28,22 @@ enum class QBMode {
   FusedAtomic,
 };
 
+struct QBBinParams {
+  CompType lower;
+  CompType scale;
+};
+
+__device__ inline QBBinParams load_qb_bin_params(const CompType *bin_bounds, int num_bins) {
+  const CompType lower = bin_bounds[0];
+  const CompType upper = bin_bounds[1];
+  if (!isfinite(lower) || !isfinite(upper) || upper <= lower) {
+    // Bounds are caller-owned CUDA data, so host-side value validation would add a
+    // synchronization and break CUDA graph capture. Trap on the consuming stream instead.
+    __trap();
+  }
+  return {lower, static_cast<CompType>(num_bins) / (upper - lower)};
+}
+
 template <QBMode Mode>
 __device__ inline CompType extract_qb_cutoff_and_compact(int *topk_indices, CompType *topk_scores,
                                                          int topk, int lane_id) {
@@ -64,11 +80,10 @@ __device__ inline void accumulate_qb_histogram_epilogue(const CompType *raw_scor
                                                         const CompType *bin_bounds, int num_bins,
                                                         int32_t *histogram) {
   if constexpr (Mode == QBMode::FusedAtomic) {
-    const CompType lower = bin_bounds[0];
-    const CompType upper = bin_bounds[1];
-    const CompType scale = static_cast<CompType>(num_bins) / (upper - lower);
+    const QBBinParams bin_params = load_qb_bin_params(bin_bounds, num_bins);
     for (int expert = lane_id; expert < num_experts; expert += kThreadsPerWarp) {
-      int bin = static_cast<int>(floorf((cutoff - raw_scores[expert] - lower) * scale));
+      int bin = static_cast<int>(
+          floorf((cutoff - raw_scores[expert] - bin_params.lower) * bin_params.scale));
       bin = max(0, min(bin, num_bins - 1));
       atomicAdd(histogram + static_cast<size_t>(expert) * num_bins + bin, 1);
     }
@@ -875,9 +890,7 @@ __global__ void qb_histogram_accumulate_kernel(const CompType *raw_scores, const
   const int tokens_in_partition =
       (num_tokens - token_partition + num_token_partitions - 1) / num_token_partitions;
   const int num_items = tokens_in_partition * kQBExpertsPerBlock;
-  const CompType lower = bin_bounds[0];
-  const CompType upper = bin_bounds[1];
-  const CompType scale = static_cast<CompType>(num_bins) / (upper - lower);
+  const QBBinParams bin_params = load_qb_bin_params(bin_bounds, num_bins);
 
   for (int item = threadIdx.x; item < num_items; item += blockDim.x) {
     const int token_in_partition = item / kQBExpertsPerBlock;
@@ -887,7 +900,7 @@ __global__ void qb_histogram_accumulate_kernel(const CompType *raw_scores, const
     if (token < num_tokens && expert < num_experts) {
       const CompType required_bias =
           cutoff[token] - raw_scores[static_cast<size_t>(token) * num_experts + expert];
-      int bin = static_cast<int>(floorf((required_bias - lower) * scale));
+      int bin = static_cast<int>(floorf((required_bias - bin_params.lower) * bin_params.scale));
       bin = max(0, min(bin, num_bins - 1));
       atomicAdd(local_histogram + local_expert * num_bins + bin, 1);
     }

--- a/transformer_engine/common/include/transformer_engine/fused_router.h
+++ b/transformer_engine/common/include/transformer_engine/fused_router.h
@@ -109,7 +109,8 @@ void nvte_fused_topk_with_score_function_forward_with_indices(
  *  The router selects Top-(k+1) from biased sigmoid scores, writes only the first
  *  k routes, and exposes the final selected value as the per-token cutoff.
  *  In FUSED_ATOMIC mode it also directly accumulates the QB histogram.
- *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper.
+ *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper. This entry point
+ *  validates the device-resident values and synchronizes stream before launching the router.
  */
 void nvte_fused_topk_with_score_function_forward_qb_v2(
     const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
@@ -118,9 +119,23 @@ void nvte_fused_topk_with_score_function_forward_qb_v2(
     NVTETensor histogram, NVTETensor bin_bounds, NVTEQBHistogramMode histogram_mode,
     cudaStream_t stream);
 
+/*! \brief Same as nvte_fused_topk_with_score_function_forward_qb_v2, but skips bin_bounds value
+ *         validation.
+ *
+ *  The caller must have validated that bin_bounds contains finite FP32 values [lower, upper] with
+ *  lower < upper. Use this variant to avoid host synchronization in a hot path or CUDA graph.
+ */
+void nvte_fused_topk_with_score_function_forward_qb_v2_unchecked(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor routing_map,
+    NVTERoutingMapFormat routing_map_format, NVTETensor intermediate_output, NVTETensor cutoff,
+    NVTETensor histogram, NVTETensor bin_bounds, NVTEQBHistogramMode histogram_mode,
+    cudaStream_t stream);
+
 /*! \brief Kimi K3 Quantile Balancing fused-router forward with dense Top-k indices.
  *
- *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper.
+ *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper. This entry point
+ *  validates the device-resident values and synchronizes stream before launching the router.
  */
 void nvte_fused_topk_with_score_function_forward_qb_with_indices(
     const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
@@ -128,13 +143,35 @@ void nvte_fused_topk_with_score_function_forward_qb_with_indices(
     NVTETensor intermediate_output, NVTETensor cutoff, NVTETensor histogram, NVTETensor bin_bounds,
     NVTEQBHistogramMode histogram_mode, cudaStream_t stream);
 
+/*! \brief Same as nvte_fused_topk_with_score_function_forward_qb_with_indices, but skips
+ *         bin_bounds value validation.
+ *
+ *  The caller must have validated that bin_bounds contains finite FP32 values [lower, upper] with
+ *  lower < upper. Use this variant to avoid host synchronization in a hot path or CUDA graph.
+ */
+void nvte_fused_topk_with_score_function_forward_qb_with_indices_unchecked(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor topk_indices,
+    NVTETensor intermediate_output, NVTETensor cutoff, NVTETensor histogram, NVTETensor bin_bounds,
+    NVTEQBHistogramMode histogram_mode, cudaStream_t stream);
+
 /*! \brief Accumulate a QB histogram from raw sigmoid scores and Top-(k+1) cutoffs.
  *
- *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper.
+ *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper. This entry point
+ *  validates the device-resident values and synchronizes stream before launching the kernel.
  */
 void nvte_qb_histogram_accumulate(const NVTETensor raw_scores, const NVTETensor cutoff,
                                   const NVTETensor bin_bounds, NVTETensor histogram,
                                   cudaStream_t stream);
+
+/*! \brief Same as nvte_qb_histogram_accumulate, but skips bin_bounds value validation.
+ *
+ *  The caller must have validated that bin_bounds contains finite FP32 values [lower, upper] with
+ *  lower < upper. Use this variant to avoid host synchronization in a hot path or CUDA graph.
+ */
+void nvte_qb_histogram_accumulate_unchecked(const NVTETensor raw_scores, const NVTETensor cutoff,
+                                            const NVTETensor bin_bounds, NVTETensor histogram,
+                                            cudaStream_t stream);
 
 /*! \brief Backward pass for fused topk + softmax/sigmoid (deprecated).
  *

--- a/transformer_engine/common/include/transformer_engine/fused_router.h
+++ b/transformer_engine/common/include/transformer_engine/fused_router.h
@@ -31,7 +31,8 @@ typedef enum {
  *
  *  TWO_KERNEL   — router writes the Top-(k+1) cutoff and a second kernel accumulates
  *                 the histogram from the saved raw sigmoid scores.
- *  FUSED_ATOMIC — router directly accumulates the histogram with global atomics.
+ *  FUSED_ATOMIC — router writes the cutoff and directly accumulates the histogram with
+ *                 global atomics.
  */
 typedef enum {
   NVTE_QB_HISTOGRAM_TWO_KERNEL = 0,
@@ -107,8 +108,8 @@ void nvte_fused_topk_with_score_function_forward_with_indices(
 /*! \brief Kimi K3 Quantile Balancing fused-router forward.
  *
  *  The router selects Top-(k+1) from biased sigmoid scores, writes only the first
- *  k routes, and exposes the final selected value as the per-token cutoff.
- *  In FUSED_ATOMIC mode it also directly accumulates the QB histogram.
+ *  k routes, and writes the final selected value as the per-token cutoff in both
+ *  histogram modes. In FUSED_ATOMIC mode it also directly accumulates the QB histogram.
  *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper. This entry point
  *  validates the device-resident values and synchronizes stream before launching the router.
  */

--- a/transformer_engine/common/include/transformer_engine/fused_router.h
+++ b/transformer_engine/common/include/transformer_engine/fused_router.h
@@ -109,6 +109,7 @@ void nvte_fused_topk_with_score_function_forward_with_indices(
  *  The router selects Top-(k+1) from biased sigmoid scores, writes only the first
  *  k routes, and exposes the final selected value as the per-token cutoff.
  *  In FUSED_ATOMIC mode it also directly accumulates the QB histogram.
+ *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper.
  */
 void nvte_fused_topk_with_score_function_forward_qb_v2(
     const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
@@ -117,14 +118,20 @@ void nvte_fused_topk_with_score_function_forward_qb_v2(
     NVTETensor histogram, NVTETensor bin_bounds, NVTEQBHistogramMode histogram_mode,
     cudaStream_t stream);
 
-/*! \brief Kimi K3 Quantile Balancing fused-router forward with dense Top-k indices. */
+/*! \brief Kimi K3 Quantile Balancing fused-router forward with dense Top-k indices.
+ *
+ *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper.
+ */
 void nvte_fused_topk_with_score_function_forward_qb_with_indices(
     const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
     const NVTETensor expert_bias, NVTETensor probs, NVTETensor topk_indices,
     NVTETensor intermediate_output, NVTETensor cutoff, NVTETensor histogram, NVTETensor bin_bounds,
     NVTEQBHistogramMode histogram_mode, cudaStream_t stream);
 
-/*! \brief Accumulate a QB histogram from raw sigmoid scores and Top-(k+1) cutoffs. */
+/*! \brief Accumulate a QB histogram from raw sigmoid scores and Top-(k+1) cutoffs.
+ *
+ *  bin_bounds must contain finite FP32 values [lower, upper] with lower < upper.
+ */
 void nvte_qb_histogram_accumulate(const NVTETensor raw_scores, const NVTETensor cutoff,
                                   const NVTETensor bin_bounds, NVTETensor histogram,
                                   cudaStream_t stream);

--- a/transformer_engine/common/include/transformer_engine/fused_router.h
+++ b/transformer_engine/common/include/transformer_engine/fused_router.h
@@ -27,6 +27,17 @@ typedef enum {
   NVTE_ROUTING_MAP_FORMAT_BITMAP_U8 = 1,
 } NVTERoutingMapFormat;
 
+/*! \brief Quantile Balancing histogram implementation.
+ *
+ *  TWO_KERNEL   — router writes the Top-(k+1) cutoff and a second kernel accumulates
+ *                 the histogram from the saved raw sigmoid scores.
+ *  FUSED_ATOMIC — router directly accumulates the histogram with global atomics.
+ */
+typedef enum {
+  NVTE_QB_HISTOGRAM_TWO_KERNEL = 0,
+  NVTE_QB_HISTOGRAM_FUSED_ATOMIC = 1,
+} NVTEQBHistogramMode;
+
 /*! \brief Apply topk + softmax/sigmoid to the input tensor. Grouped topk is supported (deprecated).
  *
  *  \deprecated This function has been deprecated in favor of
@@ -92,6 +103,31 @@ void nvte_fused_topk_with_score_function_forward_with_indices(
     int num_groups, int group_topk, float scaling_factor, int score_function,
     const NVTETensor expert_bias, NVTETensor probs, NVTETensor topk_indices,
     NVTETensor intermediate_output, cudaStream_t stream);
+
+/*! \brief Kimi K3 Quantile Balancing fused-router forward.
+ *
+ *  The router selects Top-(k+1) from biased sigmoid scores, writes only the first
+ *  k routes, and exposes the final selected value as the per-token cutoff.
+ *  In FUSED_ATOMIC mode it also directly accumulates the QB histogram.
+ */
+void nvte_fused_topk_with_score_function_forward_qb_v2(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor routing_map,
+    NVTERoutingMapFormat routing_map_format, NVTETensor intermediate_output, NVTETensor cutoff,
+    NVTETensor histogram, NVTETensor bin_bounds, NVTEQBHistogramMode histogram_mode,
+    cudaStream_t stream);
+
+/*! \brief Kimi K3 Quantile Balancing fused-router forward with dense Top-k indices. */
+void nvte_fused_topk_with_score_function_forward_qb_with_indices(
+    const NVTETensor logits, int num_tokens, int num_experts, int topk, float scaling_factor,
+    const NVTETensor expert_bias, NVTETensor probs, NVTETensor topk_indices,
+    NVTETensor intermediate_output, NVTETensor cutoff, NVTETensor histogram, NVTETensor bin_bounds,
+    NVTEQBHistogramMode histogram_mode, cudaStream_t stream);
+
+/*! \brief Accumulate a QB histogram from raw sigmoid scores and Top-(k+1) cutoffs. */
+void nvte_qb_histogram_accumulate(const NVTETensor raw_scores, const NVTETensor cutoff,
+                                  const NVTETensor bin_bounds, NVTETensor histogram,
+                                  cudaStream_t stream);
 
 /*! \brief Backward pass for fused topk + softmax/sigmoid (deprecated).
  *

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -43,7 +43,8 @@ fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
                                       std::optional<float> scaling_factor, at::Tensor expert_bias,
                                       int routing_map_format,
                                       std::optional<at::Tensor> topk_indices, at::Tensor histogram,
-                                      at::Tensor bin_bounds, int histogram_mode);
+                                      at::Tensor bin_bounds, int histogram_mode,
+                                      bool bin_bounds_validated = false);
 
 void fused_topk_with_score_function_bwd(
     at::Tensor routing_map, at::Tensor intermediate_output, at::Tensor grad_probs,

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -38,6 +38,13 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_topk_with_score_function_fw
     int routing_map_format = static_cast<int>(NVTE_ROUTING_MAP_FORMAT_BYTEMAP),
     std::optional<at::Tensor> topk_indices = std::nullopt);
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
+                                      std::optional<float> scaling_factor, at::Tensor expert_bias,
+                                      int routing_map_format,
+                                      std::optional<at::Tensor> topk_indices, at::Tensor histogram,
+                                      at::Tensor bin_bounds, int histogram_mode);
+
 void fused_topk_with_score_function_bwd(
     at::Tensor routing_map, at::Tensor intermediate_output, at::Tensor grad_probs,
     at::Tensor grad_logits, int topk, bool use_pre_softmax, std::optional<float> scaling_factor,

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -149,7 +149,7 @@ void init_router_bindings(pybind11::module &m) {
   m.def("fused_topk_with_score_function_qb_fwd", &fused_topk_with_score_function_qb_fwd,
         py::arg("logits"), py::arg("topk"), py::arg("scaling_factor"), py::arg("expert_bias"),
         py::arg("routing_map_format"), py::arg("topk_indices"), py::arg("histogram"),
-        py::arg("bin_bounds"), py::arg("histogram_mode"),
+        py::arg("bin_bounds"), py::arg("histogram_mode"), py::arg("bin_bounds_validated") = false,
         "Kimi K3 QB fused topk with histogram accumulation");
   m.def("fused_topk_with_score_function_bwd", &fused_topk_with_score_function_bwd,
         py::arg("routing_map"), py::arg("intermediate_output"), py::arg("grad_probs"),

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -137,12 +137,20 @@ void init_router_bindings(pybind11::module &m) {
   pybind11::enum_<NVTERoutingMapFormat>(m, "NVTERoutingMapFormat", pybind11::module_local())
       .value("BYTEMAP", NVTE_ROUTING_MAP_FORMAT_BYTEMAP)
       .value("BITMAP_U8", NVTE_ROUTING_MAP_FORMAT_BITMAP_U8);
+  pybind11::enum_<NVTEQBHistogramMode>(m, "NVTEQBHistogramMode", pybind11::module_local())
+      .value("TWO_KERNEL", NVTE_QB_HISTOGRAM_TWO_KERNEL)
+      .value("FUSED_ATOMIC", NVTE_QB_HISTOGRAM_FUSED_ATOMIC);
   m.def("fused_topk_with_score_function_fwd", &fused_topk_with_score_function_fwd,
         py::arg("logits"), py::arg("topk"), py::arg("use_pre_softmax"), py::arg("num_groups"),
         py::arg("group_topk"), py::arg("scaling_factor"), py::arg("score_function"),
         py::arg("expert_bias"),
         py::arg("routing_map_format") = static_cast<int>(NVTE_ROUTING_MAP_FORMAT_BYTEMAP),
         py::arg("topk_indices") = std::nullopt, "Fused topk with score function fwd");
+  m.def("fused_topk_with_score_function_qb_fwd", &fused_topk_with_score_function_qb_fwd,
+        py::arg("logits"), py::arg("topk"), py::arg("scaling_factor"), py::arg("expert_bias"),
+        py::arg("routing_map_format"), py::arg("topk_indices"), py::arg("histogram"),
+        py::arg("bin_bounds"), py::arg("histogram_mode"),
+        "Kimi K3 QB fused topk with histogram accumulation");
   m.def("fused_topk_with_score_function_bwd", &fused_topk_with_score_function_bwd,
         py::arg("routing_map"), py::arg("intermediate_output"), py::arg("grad_probs"),
         py::arg("grad_logits"), py::arg("topk"), py::arg("use_pre_softmax"),

--- a/transformer_engine/pytorch/csrc/extensions/router.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/router.cpp
@@ -4,7 +4,6 @@
  * See LICENSE for license information.
  ************************************************************************/
 
-#include <cmath>
 #include <numeric>
 
 #include "../extensions.h"
@@ -194,14 +193,6 @@ fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
   TORCH_CHECK(
       bin_bounds.scalar_type() == at::kFloat && bin_bounds.dim() == 1 && bin_bounds.numel() == 2,
       "QB bin_bounds must be float32 with shape [2]");
-  if (!bin_bounds_validated) {
-    const at::Tensor bin_bounds_cpu = bin_bounds.cpu();
-    const float lower = bin_bounds_cpu.data_ptr<float>()[0];
-    const float upper = bin_bounds_cpu.data_ptr<float>()[1];
-    TORCH_CHECK(std::isfinite(lower) && std::isfinite(upper) && lower < upper,
-                "QB bin_bounds values must be finite with lower < upper, got [", lower, ", ", upper,
-                "]");
-  }
   TORCH_CHECK(histogram_mode == NVTE_QB_HISTOGRAM_TWO_KERNEL ||
                   histogram_mode == NVTE_QB_HISTOGRAM_FUSED_ATOMIC,
               "Unsupported QB histogram mode: ", histogram_mode);
@@ -248,21 +239,37 @@ fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
   auto stream = at::cuda::getCurrentCUDAStream();
 
   if (topk_indices.has_value()) {
-    nvte_fused_topk_with_score_function_forward_qb_with_indices(
-        logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
-        scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
-        intermediate_output_cu.data(), cutoff_cu.data(), histogram_cu.data(), bin_bounds_cu.data(),
-        mode, stream);
+    if (bin_bounds_validated) {
+      nvte_fused_topk_with_score_function_forward_qb_with_indices_unchecked(
+          logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
+          scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
+          intermediate_output_cu.data(), cutoff_cu.data(), histogram_cu.data(),
+          bin_bounds_cu.data(), mode, stream);
+    } else {
+      nvte_fused_topk_with_score_function_forward_qb_with_indices(
+          logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
+          scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
+          intermediate_output_cu.data(), cutoff_cu.data(), histogram_cu.data(),
+          bin_bounds_cu.data(), mode, stream);
+    }
   } else {
-    nvte_fused_topk_with_score_function_forward_qb_v2(
-        logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
-        scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
-        static_cast<NVTERoutingMapFormat>(routing_map_format), intermediate_output_cu.data(),
-        cutoff_cu.data(), histogram_cu.data(), bin_bounds_cu.data(), mode, stream);
+    if (bin_bounds_validated) {
+      nvte_fused_topk_with_score_function_forward_qb_v2_unchecked(
+          logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
+          scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
+          static_cast<NVTERoutingMapFormat>(routing_map_format), intermediate_output_cu.data(),
+          cutoff_cu.data(), histogram_cu.data(), bin_bounds_cu.data(), mode, stream);
+    } else {
+      nvte_fused_topk_with_score_function_forward_qb_v2(
+          logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
+          scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
+          static_cast<NVTERoutingMapFormat>(routing_map_format), intermediate_output_cu.data(),
+          cutoff_cu.data(), histogram_cu.data(), bin_bounds_cu.data(), mode, stream);
+    }
   }
   if (mode == NVTE_QB_HISTOGRAM_TWO_KERNEL) {
-    nvte_qb_histogram_accumulate(intermediate_output_cu.data(), cutoff_cu.data(),
-                                 bin_bounds_cu.data(), histogram_cu.data(), stream);
+    nvte_qb_histogram_accumulate_unchecked(intermediate_output_cu.data(), cutoff_cu.data(),
+                                           bin_bounds_cu.data(), histogram_cu.data(), stream);
   }
 
   return std::make_tuple(probs, routing_output, intermediate_output, cutoff, histogram);

--- a/transformer_engine/pytorch/csrc/extensions/router.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/router.cpp
@@ -154,6 +154,109 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_topk_with_score_function_fw
   return std::make_tuple(probs, routing_map, intermediate_output);
 }
 
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
+                                      std::optional<float> scaling_factor, at::Tensor expert_bias,
+                                      int routing_map_format,
+                                      std::optional<at::Tensor> topk_indices, at::Tensor histogram,
+                                      at::Tensor bin_bounds, int histogram_mode) {
+  check_routing_map_format(routing_map_format);
+  TORCH_CHECK(logits.dim() >= 1, "logits must have at least 1 dim");
+  TORCH_CHECK(logits.is_cuda() && logits.is_contiguous(),
+              "logits must be a contiguous CUDA tensor");
+  const auto sizes = logits.sizes();
+  const int64_t num_experts = sizes.back();
+  const int64_t num_tokens =
+      std::accumulate(sizes.begin(), sizes.end() - 1, int64_t{1}, std::multiplies<int64_t>());
+  TORCH_CHECK(num_tokens > 0 && num_experts > 0,
+              "num_tokens and num_experts must be greater than 0");
+  TORCH_CHECK(topk > 0 && topk < num_experts,
+              "QB topk must be in [1, num_experts), got topk=", topk, " num_experts=", num_experts);
+  TORCH_CHECK(expert_bias.is_cuda() && expert_bias.is_contiguous(),
+              "QB expert_bias must be a contiguous CUDA tensor");
+  TORCH_CHECK(expert_bias.device() == logits.device(),
+              "QB expert_bias must be on the logits device");
+  TORCH_CHECK(expert_bias.scalar_type() == at::kFloat, "QB expert_bias must have float32 dtype");
+  TORCH_CHECK(expert_bias.dim() == 1 && expert_bias.numel() == num_experts,
+              "QB expert_bias must have shape [num_experts]");
+  TORCH_CHECK(histogram.is_cuda() && histogram.is_contiguous(),
+              "QB histogram must be a contiguous CUDA tensor");
+  TORCH_CHECK(histogram.device() == logits.device(), "QB histogram must be on the logits device");
+  TORCH_CHECK(histogram.scalar_type() == at::kInt, "QB histogram must have int32 dtype");
+  TORCH_CHECK(histogram.dim() == 2 && histogram.size(0) == num_experts && histogram.size(1) > 0,
+              "QB histogram must have shape [num_experts, num_bins]");
+  TORCH_CHECK(bin_bounds.is_cuda() && bin_bounds.is_contiguous(),
+              "QB bin_bounds must be a contiguous CUDA tensor");
+  TORCH_CHECK(bin_bounds.device() == logits.device(), "QB bin_bounds must be on the logits device");
+  TORCH_CHECK(
+      bin_bounds.scalar_type() == at::kFloat && bin_bounds.dim() == 1 && bin_bounds.numel() == 2,
+      "QB bin_bounds must be float32 with shape [2]");
+  TORCH_CHECK(histogram_mode == NVTE_QB_HISTOGRAM_TWO_KERNEL ||
+                  histogram_mode == NVTE_QB_HISTOGRAM_FUSED_ATOMIC,
+              "Unsupported QB histogram mode: ", histogram_mode);
+  if (topk_indices.has_value()) {
+    TORCH_CHECK(routing_map_format == NVTE_ROUTING_MAP_FORMAT_BYTEMAP,
+                "dense Top-k indices cannot be combined with a non-default routing-map format");
+    check_dense_topk_indices(topk_indices.value(), logits, sizes.slice(0, sizes.size() - 1), topk);
+  }
+
+  const float scaling_factor_value = scaling_factor.has_value() ? scaling_factor.value() : 1.0f;
+  at::Tensor probs = at::empty(sizes, at::dtype(logits.scalar_type()).device(logits.device()));
+  at::Tensor routing_output =
+      topk_indices.has_value()
+          ? topk_indices.value()
+          : allocate_routing_map(sizes.slice(0, sizes.size() - 1), num_experts, routing_map_format);
+  at::Tensor intermediate_output = at::empty(sizes, at::dtype(at::kFloat).device(logits.device()));
+  at::Tensor cutoff = at::empty({num_tokens}, at::dtype(at::kFloat).device(logits.device()));
+
+  const std::vector<size_t> shape_2d = {static_cast<size_t>(num_tokens),
+                                        static_cast<size_t>(num_experts)};
+  const std::vector<size_t> routing_output_shape_2d =
+      topk_indices.has_value()
+          ? std::vector<size_t>{static_cast<size_t>(num_tokens), static_cast<size_t>(topk)}
+          : std::vector<size_t>{
+                static_cast<size_t>(num_tokens),
+                static_cast<size_t>(routing_map_format == NVTE_ROUTING_MAP_FORMAT_BITMAP_U8
+                                        ? (num_experts + 7) / 8
+                                        : num_experts)};
+  auto logits_cu = makeTransformerEngineTensor(logits.data_ptr(), shape_2d,
+                                               GetTransformerEngineDType(logits.scalar_type()));
+  auto probs_cu = makeTransformerEngineTensor(probs.data_ptr(), shape_2d,
+                                              GetTransformerEngineDType(probs.scalar_type()));
+  auto routing_output_cu =
+      makeTransformerEngineTensor(routing_output.data_ptr(), routing_output_shape_2d,
+                                  GetTransformerEngineDType(routing_output.scalar_type()));
+  auto intermediate_output_cu =
+      makeTransformerEngineTensor(intermediate_output.data_ptr(), shape_2d, DType::kFloat32);
+  const std::vector<size_t> cutoff_shape = {static_cast<size_t>(num_tokens)};
+  auto cutoff_cu = makeTransformerEngineTensor(cutoff.data_ptr(), cutoff_shape, DType::kFloat32);
+  auto expert_bias_cu = makeTransformerEngineTensor(expert_bias);
+  auto histogram_cu = makeTransformerEngineTensor(histogram);
+  auto bin_bounds_cu = makeTransformerEngineTensor(bin_bounds);
+  const auto mode = static_cast<NVTEQBHistogramMode>(histogram_mode);
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  if (topk_indices.has_value()) {
+    nvte_fused_topk_with_score_function_forward_qb_with_indices(
+        logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
+        scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
+        intermediate_output_cu.data(), cutoff_cu.data(), histogram_cu.data(), bin_bounds_cu.data(),
+        mode, stream);
+  } else {
+    nvte_fused_topk_with_score_function_forward_qb_v2(
+        logits_cu.data(), static_cast<int>(num_tokens), static_cast<int>(num_experts), topk,
+        scaling_factor_value, expert_bias_cu.data(), probs_cu.data(), routing_output_cu.data(),
+        static_cast<NVTERoutingMapFormat>(routing_map_format), intermediate_output_cu.data(),
+        cutoff_cu.data(), histogram_cu.data(), bin_bounds_cu.data(), mode, stream);
+  }
+  if (mode == NVTE_QB_HISTOGRAM_TWO_KERNEL) {
+    nvte_qb_histogram_accumulate(intermediate_output_cu.data(), cutoff_cu.data(),
+                                 bin_bounds_cu.data(), histogram_cu.data(), stream);
+  }
+
+  return std::make_tuple(probs, routing_output, intermediate_output, cutoff, histogram);
+}
+
 void fused_topk_with_score_function_bwd(at::Tensor routing_map, at::Tensor intermediate_output,
                                         at::Tensor grad_probs, at::Tensor grad_logits, int topk,
                                         bool use_pre_softmax, std::optional<float> scaling_factor,

--- a/transformer_engine/pytorch/csrc/extensions/router.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/router.cpp
@@ -4,6 +4,7 @@
  * See LICENSE for license information.
  ************************************************************************/
 
+#include <cmath>
 #include <numeric>
 
 #include "../extensions.h"
@@ -159,7 +160,8 @@ fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
                                       std::optional<float> scaling_factor, at::Tensor expert_bias,
                                       int routing_map_format,
                                       std::optional<at::Tensor> topk_indices, at::Tensor histogram,
-                                      at::Tensor bin_bounds, int histogram_mode) {
+                                      at::Tensor bin_bounds, int histogram_mode,
+                                      bool bin_bounds_validated) {
   check_routing_map_format(routing_map_format);
   TORCH_CHECK(logits.dim() >= 1, "logits must have at least 1 dim");
   TORCH_CHECK(logits.is_cuda() && logits.is_contiguous(),
@@ -192,6 +194,14 @@ fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
   TORCH_CHECK(
       bin_bounds.scalar_type() == at::kFloat && bin_bounds.dim() == 1 && bin_bounds.numel() == 2,
       "QB bin_bounds must be float32 with shape [2]");
+  if (!bin_bounds_validated) {
+    const at::Tensor bin_bounds_cpu = bin_bounds.cpu();
+    const float lower = bin_bounds_cpu.data_ptr<float>()[0];
+    const float upper = bin_bounds_cpu.data_ptr<float>()[1];
+    TORCH_CHECK(std::isfinite(lower) && std::isfinite(upper) && lower < upper,
+                "QB bin_bounds values must be finite with lower < upper, got [", lower, ", ", upper,
+                "]");
+  }
   TORCH_CHECK(histogram_mode == NVTE_QB_HISTOGRAM_TWO_KERNEL ||
                   histogram_mode == NVTE_QB_HISTOGRAM_FUSED_ATOMIC,
               "Unsupported QB histogram mode: ", histogram_mode);

--- a/transformer_engine/pytorch/csrc/extensions/router.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/router.cpp
@@ -164,6 +164,7 @@ fused_topk_with_score_function_qb_fwd(at::Tensor logits, int topk,
   TORCH_CHECK(logits.dim() >= 1, "logits must have at least 1 dim");
   TORCH_CHECK(logits.is_cuda() && logits.is_contiguous(),
               "logits must be a contiguous CUDA tensor");
+  at::cuda::CUDAGuard device_guard(logits.device());
   const auto sizes = logits.sizes();
   const int64_t num_experts = sizes.back();
   const int64_t num_tokens =

--- a/transformer_engine/pytorch/router.py
+++ b/transformer_engine/pytorch/router.py
@@ -13,11 +13,11 @@ Precision Notes:
 - Only cast to low-precision when necessary and the casting only happens in writing to
   global memory. For example, the gradient is required to have the same dtype as the input.
 """
+
 from typing import Optional, Union
 
 import torch
 import transformer_engine_torch as tex
-
 
 # Re-export the C++ enum NVTERoutingMapFormat under a friendlier Python name.
 # Members:
@@ -26,6 +26,7 @@ import transformer_engine_torch as tex
 #                                LSB-first / little-endian packing along the
 #                                expert axis.
 RoutingMapFormat = tex.NVTERoutingMapFormat
+QBHistogramMode = tex.NVTEQBHistogramMode
 
 
 _ROUTING_MAP_FORMAT_FROM_STRING = {
@@ -33,9 +34,15 @@ _ROUTING_MAP_FORMAT_FROM_STRING = {
     "bitmap_u8": int(RoutingMapFormat.BITMAP_U8),
 }
 _VALID_ROUTING_MAP_FORMAT_INTS = frozenset(_ROUTING_MAP_FORMAT_FROM_STRING.values())
+_QB_HISTOGRAM_MODE_FROM_STRING = {
+    "two_kernel": int(QBHistogramMode.TWO_KERNEL),
+    "fused_atomic": int(QBHistogramMode.FUSED_ATOMIC),
+}
 
 
-def _validate_routing_map_format(routing_map_format: Union[str, RoutingMapFormat, int]) -> int:
+def _validate_routing_map_format(
+    routing_map_format: Union[str, RoutingMapFormat, int],
+) -> int:
     """Coerce user-supplied routing_map_format into a plain int (0 or 1).
 
     Accepts the enum, an int matching one of the enum's values, or the
@@ -134,6 +141,74 @@ class FusedTopkScoreFunction(torch.autograd.Function):
         return grad_logits, None, None, None, None, None, None, None, None, None
 
 
+class FusedTopkScoreFunctionQB(torch.autograd.Function):
+    """Kimi K3 QB router with histogram accumulation."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        logits: torch.Tensor,
+        topk: int,
+        scaling_factor: Optional[float],
+        expert_bias: torch.Tensor,
+        routing_map_format: int,
+        topk_indices: Optional[torch.Tensor],
+        histogram: torch.Tensor,
+        bin_bounds: torch.Tensor,
+        histogram_mode: int,
+    ):
+        # pylint: disable=missing-function-docstring
+        (
+            probs,
+            routing_output,
+            intermediate_output,
+            _cutoff,
+            histogram_output,
+        ) = tex.fused_topk_with_score_function_qb_fwd(
+            logits,
+            topk,
+            scaling_factor,
+            expert_bias,
+            routing_map_format,
+            topk_indices,
+            histogram,
+            bin_bounds,
+            histogram_mode,
+        )
+        if topk_indices is not None:
+            routing_output = topk_indices
+            ctx.mark_dirty(topk_indices)
+        ctx.mark_dirty(histogram)
+        ctx.mark_non_differentiable(routing_output, histogram_output)
+        ctx.save_for_backward(routing_output, intermediate_output)
+        ctx.topk = topk
+        ctx.scaling_factor = scaling_factor
+        ctx.routing_map_format = routing_map_format
+        ctx.use_dense_indices = topk_indices is not None
+        return probs, routing_output, histogram_output
+
+    @staticmethod
+    def backward(ctx, grad_probs, _, _histogram_grad):
+        # pylint: disable=missing-function-docstring
+        routing_output, intermediate_output = ctx.saved_tensors
+        if not grad_probs.is_contiguous():
+            grad_probs = grad_probs.contiguous()
+        grad_logits = torch.empty_like(grad_probs)
+        tex.fused_topk_with_score_function_bwd(
+            routing_output,
+            intermediate_output,
+            grad_probs,
+            grad_logits,
+            ctx.topk,
+            False,
+            ctx.scaling_factor,
+            "sigmoid",
+            ctx.use_dense_indices,
+            ctx.routing_map_format,
+        )
+        return grad_logits, None, None, None, None, None, None, None, None
+
+
 def fused_topk_with_score_function(
     logits: torch.Tensor,
     topk: int,
@@ -145,6 +220,9 @@ def fused_topk_with_score_function(
     expert_bias: Optional[torch.Tensor],
     routing_map_format: Union[str, RoutingMapFormat, int] = RoutingMapFormat.BYTEMAP,
     topk_indices: Optional[torch.Tensor] = None,
+    qb_histogram: Optional[torch.Tensor] = None,
+    qb_bin_bounds: Optional[torch.Tensor] = None,
+    qb_histogram_mode: Optional[str] = None,
 ):
     """
     Fused topk with score function router.
@@ -172,6 +250,12 @@ def fused_topk_with_score_function(
     topk_indices : torch.Tensor, optional
         Optional output buffer with shape [num_tokens, topk]. When provided, its dtype
         controls the dense index output dtype and the routing map is not materialized.
+    qb_histogram : torch.Tensor, optional
+        Caller-owned int32 ``[num_experts, num_bins]`` histogram accumulated in place.
+    qb_bin_bounds : torch.Tensor, optional
+        FP32 CUDA tensor ``[lower, upper]`` defining uniform QB histogram bins.
+    qb_histogram_mode : str, optional
+        ``"two_kernel"`` or ``"fused_atomic"``. Must be provided with the two QB tensors.
 
     Returns
     -------
@@ -187,6 +271,36 @@ def fused_topk_with_score_function(
     if logits.dtype == torch.float64:
         raise ValueError("Current TE does not support float64 router type.")
     routing_map_format = _validate_routing_map_format(routing_map_format)
+    qb_arguments = (qb_histogram, qb_bin_bounds, qb_histogram_mode)
+    if any(value is not None for value in qb_arguments):
+        if any(value is None for value in qb_arguments):
+            raise ValueError(
+                "qb_histogram, qb_bin_bounds, and qb_histogram_mode must be provided together"
+            )
+        if score_function != "sigmoid":
+            raise ValueError("Quantile Balancing only supports score_function='sigmoid'")
+        if expert_bias is None:
+            raise ValueError("Quantile Balancing requires expert_bias")
+        if num_groups is not None or group_topk is not None:
+            raise ValueError("Quantile Balancing does not support grouped Top-k")
+        mode = _QB_HISTOGRAM_MODE_FROM_STRING.get(qb_histogram_mode)
+        if mode is None:
+            raise ValueError(
+                "qb_histogram_mode must be 'two_kernel' or 'fused_atomic', "
+                f"got {qb_histogram_mode!r}"
+            )
+        probs, routing_output, _ = FusedTopkScoreFunctionQB.apply(
+            logits,
+            topk,
+            scaling_factor,
+            expert_bias,
+            routing_map_format,
+            topk_indices,
+            qb_histogram,
+            qb_bin_bounds,
+            mode,
+        )
+        return probs, routing_output
     return FusedTopkScoreFunction.apply(
         logits,
         topk,

--- a/transformer_engine/pytorch/router.py
+++ b/transformer_engine/pytorch/router.py
@@ -14,6 +14,7 @@ Precision Notes:
   global memory. For example, the gradient is required to have the same dtype as the input.
 """
 
+import math
 from typing import Optional, Union
 
 import torch
@@ -38,6 +39,36 @@ _QB_HISTOGRAM_MODE_FROM_STRING = {
     "two_kernel": int(QBHistogramMode.TWO_KERNEL),
     "fused_atomic": int(QBHistogramMode.FUSED_ATOMIC),
 }
+_QB_BOUNDS_VALIDATED_VERSION_ATTR = "_nvte_qb_bounds_validated_version"
+
+
+def _validate_qb_bin_bounds(bin_bounds: torch.Tensor) -> bool:
+    """Validate CUDA-resident QB bounds once per PyTorch tensor version."""
+    if not (
+        isinstance(bin_bounds, torch.Tensor)
+        and bin_bounds.is_cuda
+        and bin_bounds.is_contiguous()
+        and bin_bounds.dtype == torch.float32
+        and bin_bounds.shape == (2,)
+    ):
+        # The C++ binding owns metadata validation and its detailed error messages.
+        return False
+
+    version = bin_bounds._version
+    if getattr(bin_bounds, _QB_BOUNDS_VALIDATED_VERSION_ATTR, None) == version:
+        return True
+    with torch.cuda.device(bin_bounds.device):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "QB bin_bounds must be validated by an eager router call before CUDA graph capture"
+            )
+    lower, upper = bin_bounds.detach().cpu().tolist()
+    if not (math.isfinite(lower) and math.isfinite(upper) and lower < upper):
+        raise ValueError(
+            f"QB bin_bounds values must be finite with lower < upper, got [{lower}, {upper}]"
+        )
+    setattr(bin_bounds, _QB_BOUNDS_VALIDATED_VERSION_ATTR, version)
+    return True
 
 
 def _validate_routing_map_format(
@@ -158,6 +189,7 @@ class FusedTopkScoreFunctionQB(torch.autograd.Function):
         histogram_mode: int,
     ):
         # pylint: disable=missing-function-docstring
+        bin_bounds_validated = _validate_qb_bin_bounds(bin_bounds)
         (
             probs,
             routing_output,
@@ -174,6 +206,7 @@ class FusedTopkScoreFunctionQB(torch.autograd.Function):
             histogram,
             bin_bounds,
             histogram_mode,
+            bin_bounds_validated,
         )
         if topk_indices is not None:
             routing_output = topk_indices
@@ -253,7 +286,9 @@ def fused_topk_with_score_function(
     qb_histogram : torch.Tensor, optional
         Caller-owned int32 ``[num_experts, num_bins]`` histogram accumulated in place.
     qb_bin_bounds : torch.Tensor, optional
-        FP32 CUDA tensor ``[lower, upper]`` defining uniform QB histogram bins.
+        FP32 CUDA tensor ``[lower, upper]`` defining uniform QB histogram bins. Values must be
+        finite with ``lower < upper``. Bounds are revalidated after PyTorch-tracked in-place
+        updates; validate once with an eager call before CUDA graph capture.
     qb_histogram_mode : str, optional
         ``"two_kernel"`` or ``"fused_atomic"``. Must be provided with the two QB tensors.
 


### PR DESCRIPTION
# Description

Add opt-in Quantile Balancing (QB) support to the fused sigmoid router used by
Kimi-K3-style MoE models. The router now has statically dispatched QB specializations that
select Top-(k+1), retain the actual Top-k routes, and accumulate the per-expert histogram
needed by the QB bias update without materializing a `[num_tokens, num_experts]` bin-index
tensor.

The existing non-QB specialization and API behavior are unchanged when the three QB
arguments are omitted.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Quantile Balancing math

This implementation follows the
[Kimi K3 Technical Report, Section 2.3.3, Eqs. (13)-(14), and Appendices C-D](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf).
Let `m` be the number of tokens in the global training step, `E` the number of experts, and
`k` the number of experts routed per token. Perfect balance gives every expert the target
load

```text
q = m * k / E.
```

The exact derivation assumes `q` is integral and that cutoff ties do not occur; the practical
histogram recovery below uses `ceil(q)`, and TE supplies deterministic cutoff tie handling.

### Routing and the token-side cutoff

For token `i` and expert `j`, the raw router score and biased selection score at step `t` are

```text
s_ij = sigmoid(z_ij)
u_ij^(t) = s_ij + b_j^(t).
```

The bias is used only for expert selection. Mixture weights omit it, as in report Eq. (13):

```text
T_i = Top-k_j(u_ij^(t))
p_ij = s_ij / sum_{l in T_i} s_il,  j in T_i.
```

To derive the next bias, QB selects `Top-(k+1)` under `u^(t)`. The first `k` experts are the
actual routes; the `(k+1)`-th score is the token-side cutoff

```text
alpha_i^(t) = (k+1)-th largest_j(s_ij + b_j^(t)).
```

An expert must exceed `alpha_i^(t)` to enter token `i`'s Top-k. The report assumes no ties.
This implementation makes ties deterministic by discarding the largest expert ID among equal
cutoff candidates, leaving exactly `k` output routes.

### Expert-side quantile update

Hold the cutoffs from the current forward pass fixed and consider a candidate next-step bias
`bhat_j^(t+1)`. Its implied load for expert `j` is

```text
load_j(bhat_j^(t+1))
  = sum_i 1[s_ij + bhat_j^(t+1) > alpha_i^(t)].
```

Setting this count to `q` means exactly `q` values of the margin
`g_ij = s_ij - alpha_i^(t)` exceed `-bhat_j^(t+1)`. Therefore report Eq. (14) gives

```text
bhat_j^(t+1) = -Quantile_(1-k/E)(s_:,j - alpha^(t)).
```

Appendix D expresses the same update using the required bias

```text
r_ij = alpha_i^(t) - s_ij.
```

Indeed, `s_ij + bhat_j^(t+1) > alpha_i^(t)` iff `bhat_j^(t+1) > r_ij`.
Negating the margin reverses its ordering, so the update is equivalently

```text
bhat_j^(t+1) = Quantile_(k/E)(r_:,j).
```

This explains both QB-specific router operations. Top-(k+1) exposes the token's current
competition boundary, while subtracting the raw score converts that boundary into the exact
bias threshold for each token/expert pair. A histogram of raw scores alone would discard the
token-local boundary created by the competing experts.

In particular, the histogram quantity is `alpha_i - s_ij`, not
`alpha_i - (s_ij + b_j)`: `alpha_i` is a biased cutoff, but `s_ij` is the raw sigmoid score.
An underloaded expert consequently receives a relatively larger recovered bias, while an
overloaded expert receives a smaller one.

The report mean-centers the recovered biases,

```text
b^(t+1) = bhat^(t+1) - mean(bhat^(t+1)) * 1,
```

because adding one common constant to every bias shifts every biased score and cutoff equally
and does not change Top-k. The update takes effect only in the next training step, so the
batch is never routed with a bias derived from itself.

### Histogram approximation

The exact update would retain `m * E` required biases. Instead, for `B` uniform bins with
bounds `[L, U]`, this PR accumulates

```text
bin_ij = clamp(floor((r_ij - L) * B / (U - L)), 0, B - 1)
H[j, bin_ij] += 1.
```

Appendix D proves a natural per-step range. Since sigmoid scores are in `(0, 1)` and the
cutoff is one current biased score,

```text
L = min(b^(t)) - 1
U = max(b^(t)) + 1.
```

The report uses `B=1000`, all-reduces the per-expert `H[E, B]` counts once per step, selects
the first bin whose cumulative count reaches `ceil(q)`, and interpolates within it. If
`beta_j` is that bin's zero-based index, `c_j` is its preceding cumulative count, `h_j` is its
own count, and `w = (U-L)/B`, Appendix D recovers

```text
bhat_j = L + (beta_j + clip((q-c_j)/h_j, 0, 1)) * w.
```

The result is then mean-centered. Its quantile error is bounded by one bin width. Counts
accumulate exactly across ranks and microbatches, so this recovers the pooled-global-batch
quantile rather than an average of per-rank quantiles.

TE receives `[L, U]` as a caller-owned CUDA tensor and only performs Top-(k+1), exact Top-k
output, and local histogram accumulation. Histogram all-reduce, within-bin interpolation,
bias update/centering, and next-step bounds update remain caller responsibilities.

## Changes

- Add `NVTEQBHistogramMode` and C/PyTorch entry points for QB routing.
- Add a QB autograd wrapper selected only when `qb_histogram`, `qb_bin_bounds`, and
  `qb_histogram_mode` are all provided.
- Support BYTEMAP, BITMAP_U8, and caller-owned dense int16/int32/int64 Top-k indices.
- Support both the simple and radix Top-k kernels, including Top-8 and Top-16 cases.
- Reuse the existing FP32 sigmoid intermediate tensor for histogram inputs.
- Keep the existing fused-router backward kernel: the histogram and discrete route selection
  are non-differentiable, while selected sigmoid probabilities use the existing gradient.
- Add a pure-PyTorch QB reference and tests for both implementation modes, routing layouts,
  forward/backward parity, deterministic cutoff ties, bin clamping, accumulation across
  microbatches, and argument validation.

### Histogram implementation choices

`two_kernel` writes one FP32 cutoff per token. A second kernel rereads the existing FP32 raw
scores, accumulates eight experts' bins in shared memory per CTA, and issues global atomics
only for nonzero shared bins. With `B=1000`, its dynamic shared-memory footprint is about
32 KB per CTA. This mode adds a launch, a `4 * num_tokens`-byte cutoff buffer, and a read of
the `[T, E]` score tensor, but substantially combines contended updates before global memory.

`fused_atomic` keeps `alpha_i` in the router warp, writes one FP32 cutoff per token to honor
the common API output contract, and directly issues one global int32 atomic per token/expert
pair in the router epilogue. It avoids the second launch and score reread, but global
contention can become configuration-dependent. The caller-owned histogram is only
`4 * E * B` bytes (3.584 MB for 896 experts and 1000 bins); neither mode creates a
`4 * T * E`-byte bin-index buffer.

Both are compile-time QB specializations, so ordinary routing does not execute QB conditionals,
Top-(k+1), or histogram atomics.

## Performance

Measured on an NVIDIA B300 SXM6 AC with the NVIDIA PyTorch 26.06 container,
`nvidia-cutlass-dsl==4.5.0`, and `nvidia-cudnn-frontend==1.26.0`. Each case uses
896 experts, Top-16, 1,000 histogram bins, FP32 logits, 100 warmups, and 1,000 timed calls
split across 20 CUDA-event samples. The table reports milliseconds and averages the median
latency from two cutoff-writing runs that bracketed a no-write control.

| Routing output | Tokens | PyTorch QB | TE no QB | QB two-kernel | QB fused atomic | Fused / PyTorch | Fused / TE no QB | Fused / two-kernel |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| BYTEMAP | 256 | 0.460507 | 0.030977 | 0.041409 | 0.036838 | 0.080 | 1.189 | 0.890 |
| BYTEMAP | 1,024 | 0.530411 | 0.032497 | 0.050846 | 0.039474 | 0.074 | 1.215 | 0.776 |
| BYTEMAP | 4,096 | 0.559368 | 0.063485 | 0.085612 | 0.085905 | 0.154 | 1.353 | 1.003 |
| BYTEMAP | 8,192 | 0.713347 | 0.106315 | 0.141176 | 0.134075 | 0.188 | 1.261 | 0.950 |
| BYTEMAP | 16,384 | 1.198404 | 0.195790 | 0.280938 | 0.248273 | 0.207 | 1.268 | 0.884 |
| dense int16 | 256 | 0.441163 | 0.031119 | 0.040860 | 0.037275 | 0.084 | 1.198 | 0.912 |
| dense int16 | 1,024 | 0.510570 | 0.032113 | 0.051104 | 0.039511 | 0.077 | 1.230 | 0.773 |
| dense int16 | 4,096 | 0.534869 | 0.062886 | 0.085992 | 0.086992 | 0.163 | 1.383 | 1.012 |
| dense int16 | 8,192 | 0.699211 | 0.104915 | 0.137759 | 0.132246 | 0.189 | 1.261 | 0.960 |
| dense int16 | 16,384 | 1.177213 | 0.195510 | 0.278774 | 0.245874 | 0.209 | 1.258 | 0.882 |

The fused-atomic implementation takes 7.4% to 20.9% of the PyTorch QB latency
(4.8x to 13.5x faster). Relative to TE's existing no-QB router, the QB feature costs
18.9% to 38.3%; this includes Top-(k+1) selection, the per-token cutoff store, and histogram
atomics. Relative to the two-kernel QB path, fused atomic is 4.0% to 22.7% faster in eight
cases and 0.3% to 1.2% slower in the two 4,096-token cases. The two modes are retained
because larger expert/bin counts or different score distributions can change global-atomic
contention.

An A/B/A comparison against the otherwise identical fused-atomic kernel without the cutoff
store measured a mean 0.68% overhead across the 1,024-to-16,384-token cases, with individual
results from 0.44% to 1.03%. The 256-token cases were within sub-percent measurement noise.

The performance comparison includes four implementations: the pure-PyTorch QB reference,
the existing TE router without QB, QB `two_kernel`, and QB `fused_atomic`. Every case checks
route, probability, and histogram correctness before timing. The TE-no-QB comparison isolates
the feature cost; the PyTorch-QB comparison shows the value of avoiding framework-level
intermediates and launches.

## Validation

The focused QB matrix passes:

```text
25 passed, 3648 deselected, 4 warnings in 23.34s
```

The entire fused-router test file passes:

```text
3229 passed, 444 skipped, 4 warnings in 34.83s
```

The same B300 run also passed an actual CUDA tensor smoke test and confirmed that the loaded
extension exports both QB modes and all three opt-in Python arguments. Targeted pre-commit
checks (Python formatting, clang-format, whitespace, EOF, merge-conflict, large-file, and
Python-version checks) pass on the seven changed files.

Build configuration:

```text
NVTE_BUILD_THREADS_PER_JOB=4
NVTE_CUDA_ARCHS="100;103a;"
NVTE_USE_CCACHE=1
/usr/bin/python3 -m pip install --no-build-isolation -e ".[test]" --verbose
```

# Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding API docstring/header changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing fused-router unit tests pass locally with my changes
