### PR TITLE
[JAX] Support synchronous collectives in HLO collective bytes assert tests

### DIFF
--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -90,6 +90,7 @@ def generate_collectives_count(allreduce, allgather, other):
 def assert_equal_collectives(target_hlo, coll_count_ref):
     target_splitted_hlo = target_hlo.splitlines()
     start_symb = "-start"
+    sync_symb = '"is_sync":true'
 
     def count_bytes(hlo_text):
         bytes_count = 0
@@ -130,7 +131,12 @@ def assert_equal_collectives(target_hlo, coll_count_ref):
 
         for line in splitted_hlo:
             txt = line.split()
-            if len(txt) > 0 and start_symb in txt[0]:
+            # Asynchronous collectives are represented by *-start and *-done
+            # instructions, so count only *-start. Synchronous collectives are
+            # represented by a single instruction without either suffix.
+            is_async_start = len(txt) > 0 and start_symb in txt[0]
+            is_sync_collective = "collective_backend_config" in line and sync_symb in line
+            if is_async_start or is_sync_collective:
                 if COLL_AR_KEY in txt[0]:
                     result[COLL_AR_KEY] += count_bytes(txt)
                 elif COLL_AG_KEY in txt[0]:


### PR DESCRIPTION
# Description

Fixes HLO assertions on TestDistributedLayernom that assert collective communication bytes. With the latest nightly JAX/XLA, the implementation now uses synchronous collectives instead of async `-start` and `-done` collectives. This caused our tests to erroneously see zero bytes being communicated. With this PR that is now fixed

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Support synchronous collectives in distributed collective byte assertions test

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
