### PR TITLE
[Common][PyTorch] Add SiTU-GLU activation

### DIFF
--- a/tests/cpp/operator/test_scaled_activation.cu
+++ b/tests/cpp/operator/test_scaled_activation.cu
@@ -4,16 +4,15 @@
  * See LICENSE for license information.
  ************************************************************************/
 
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <transformer_engine/activation.h>
+
 #include <algorithm>
 #include <cmath>
 #include <memory>
 #include <string>
 #include <tuple>
-
-#include <cuda_runtime.h>
-#include <gtest/gtest.h>
-
-#include <transformer_engine/activation.h>
 
 #include "../test_common.h"
 
@@ -23,6 +22,7 @@ namespace {
 
 enum class ScaledActivationCase {
   kSwiGLU,
+  kSiTUGLU,
   kClampedSwiGLU,
   kSReLU,
 };
@@ -30,11 +30,15 @@ enum class ScaledActivationCase {
 constexpr float kClampedLimit = 0.5f;
 constexpr float kClampedAlpha = 1.702f;
 constexpr float kClampedLinearOffset = 0.5f;
+constexpr float kSiTUBeta1 = 4.0f;
+constexpr float kSiTUBeta2 = 25.0f;
 
 const char *activation_name(ScaledActivationCase activation) {
   switch (activation) {
     case ScaledActivationCase::kSwiGLU:
       return "scaled_swiglu";
+    case ScaledActivationCase::kSiTUGLU:
+      return "scaled_situglu";
     case ScaledActivationCase::kClampedSwiGLU:
       return "scaled_clamped_swiglu";
     case ScaledActivationCase::kSReLU:
@@ -66,6 +70,19 @@ inline void gated_grads(const ScaledActivationCase activation, const float act_i
       *unscaled = act * linear_in;
       *dact = test::dsilu(act_in) * linear_in;
       *dlinear = act;
+      return;
+    }
+    case ScaledActivationCase::kSiTUGLU: {
+      const float gate_tanh = tanhf(act_in / kSiTUBeta1);
+      const float gate_sigmoid = 1.0f / (1.0f + expf(-act_in));
+      const float gate = kSiTUBeta1 * gate_tanh * gate_sigmoid;
+      const float up_tanh = tanhf(linear_in / kSiTUBeta2);
+      const float up = kSiTUBeta2 * up_tanh;
+      *unscaled = gate * up;
+      *dact = ((1.0f - gate_tanh * gate_tanh) * gate_sigmoid +
+               kSiTUBeta1 * gate_tanh * gate_sigmoid * (1.0f - gate_sigmoid)) *
+              up;
+      *dlinear = gate * (1.0f - up_tanh * up_tanh);
       return;
     }
     case ScaledActivationCase::kClampedSwiGLU: {
@@ -158,9 +175,8 @@ void run_scaled_activation_test(ScaledActivationCase activation, const size_t ro
   std::unique_ptr<DataT[]> ref_grad_scales = std::make_unique<DataT[]>(rows);
 
   compute_reference(activation, input.rowwise_cpu_dptr<DataT>(), scales.rowwise_cpu_dptr<ScaleT>(),
-                    grad_output.rowwise_cpu_dptr<DataT>(), ref_output.get(),
-                    ref_grad_input.get(), ref_grad_scales.get(), rows, hidden, interleave,
-                    compute_grad_scales);
+                    grad_output.rowwise_cpu_dptr<DataT>(), ref_output.get(), ref_grad_input.get(),
+                    ref_grad_scales.get(), rows, hidden, interleave, compute_grad_scales);
 
   switch (activation) {
     case ScaledActivationCase::kSwiGLU:
@@ -168,13 +184,20 @@ void run_scaled_activation_test(ScaledActivationCase activation, const size_t ro
       nvte_scaled_dswiglu(grad_output.data(), input.data(), scales.data(), grad_input.data(),
                           compute_grad_scales ? grad_scales.data() : nullptr, interleave, 0);
       break;
+    case ScaledActivationCase::kSiTUGLU:
+      nvte_scaled_situglu(input.data(), scales.data(), output.data(), kSiTUBeta1, kSiTUBeta2,
+                          interleave, 0);
+      nvte_scaled_dsituglu(grad_output.data(), input.data(), scales.data(), grad_input.data(),
+                           compute_grad_scales ? grad_scales.data() : nullptr, kSiTUBeta1,
+                           kSiTUBeta2, interleave, 0);
+      break;
     case ScaledActivationCase::kClampedSwiGLU:
       nvte_scaled_clamped_swiglu(input.data(), scales.data(), output.data(), kClampedLimit,
                                  kClampedAlpha, kClampedLinearOffset, interleave, 0);
-      nvte_scaled_clamped_dswiglu(
-          grad_output.data(), input.data(), scales.data(), grad_input.data(),
-          compute_grad_scales ? grad_scales.data() : nullptr, kClampedLimit, kClampedAlpha,
-          kClampedLinearOffset, interleave, 0);
+      nvte_scaled_clamped_dswiglu(grad_output.data(), input.data(), scales.data(),
+                                  grad_input.data(),
+                                  compute_grad_scales ? grad_scales.data() : nullptr, kClampedLimit,
+                                  kClampedAlpha, kClampedLinearOffset, interleave, 0);
       break;
     case ScaledActivationCase::kSReLU:
       nvte_scaled_srelu(input.data(), scales.data(), output.data(), 0);
@@ -202,10 +225,8 @@ void run_scaled_activation_test(ScaledActivationCase activation, const size_t ro
 }
 
 class ScaledActivationTest
-    : public ::testing::TestWithParam<
-          std::tuple<ScaledActivationCase, DType, DType, std::pair<size_t, size_t>, int64_t,
-                     bool>> {
-};
+    : public ::testing::TestWithParam<std::tuple<ScaledActivationCase, DType, DType,
+                                                 std::pair<size_t, size_t>, int64_t, bool>> {};
 
 std::string test_name_generator(
     const testing::TestParamInfo<ScaledActivationTest::ParamType> &info) {
@@ -264,28 +285,29 @@ TEST_P(ScaledActivationTest, ForwardBackward) {
 INSTANTIATE_TEST_SUITE_P(
     OperatorTest_ScaledActivation, ScaledActivationTest,
     ::testing::Combine(
-        ::testing::Values(ScaledActivationCase::kSwiGLU, ScaledActivationCase::kClampedSwiGLU,
-                          ScaledActivationCase::kSReLU),
-        ::testing::Values(DType::kFloat32, DType::kBFloat16),   // data dtype
-        ::testing::Values(DType::kFloat32, DType::kBFloat16),   // scale dtype
-        ::testing::Values(std::pair<size_t, size_t>{17, 64},      // aligned + interleaved
-                          std::pair<size_t, size_t>{13, 100},     // scalar fallback
+        ::testing::Values(ScaledActivationCase::kSwiGLU, ScaledActivationCase::kSiTUGLU,
+                          ScaledActivationCase::kClampedSwiGLU, ScaledActivationCase::kSReLU),
+        ::testing::Values(DType::kFloat32, DType::kBFloat16),      // data dtype
+        ::testing::Values(DType::kFloat32, DType::kBFloat16),      // scale dtype
+        ::testing::Values(std::pair<size_t, size_t>{17, 64},       // aligned + interleaved
+                          std::pair<size_t, size_t>{13, 100},      // scalar fallback
                           std::pair<size_t, size_t>{1024, 2048}),  // large FFN-ish width
-        ::testing::Values(0, 32),                                // contiguous + interleaved
-        ::testing::Values(false, true)),                         // grad_act_scales off / on
+        ::testing::Values(0, 32),                                  // contiguous + interleaved
+        ::testing::Values(false, true)),                           // grad_act_scales off / on
     test_name_generator);
 
 // Keep FP16 coverage focused on representative aligned and scalar-fallback shapes instead of
 // multiplying it across the full shape matrix above.
 INSTANTIATE_TEST_SUITE_P(
     OperatorTest_ScaledActivation_FP16, ScaledActivationTest,
-    ::testing::Combine(
-        ::testing::Values(ScaledActivationCase::kSwiGLU, ScaledActivationCase::kClampedSwiGLU,
-                          ScaledActivationCase::kSReLU),
-        ::testing::Values(DType::kFloat16),                       // data dtype
-        ::testing::Values(DType::kFloat32, DType::kFloat16),      // scale dtype
-        ::testing::Values(std::pair<size_t, size_t>{17, 64},      // aligned/interleaved
-                          std::pair<size_t, size_t>{13, 100}),    // scalar fallback
-        ::testing::Values(0, 32),                                 // contiguous + interleaved
-        ::testing::Values(false, true)),                          // grad_act_scales off / on
+    ::testing::Combine(::testing::Values(ScaledActivationCase::kSwiGLU,
+                                         ScaledActivationCase::kSiTUGLU,
+                                         ScaledActivationCase::kClampedSwiGLU,
+                                         ScaledActivationCase::kSReLU),
+                       ::testing::Values(DType::kFloat16),                   // data dtype
+                       ::testing::Values(DType::kFloat32, DType::kFloat16),  // scale dtype
+                       ::testing::Values(std::pair<size_t, size_t>{17, 64},  // aligned/interleaved
+                                         std::pair<size_t, size_t>{13, 100}),  // scalar fallback
+                       ::testing::Values(0, 32),         // contiguous + interleaved
+                       ::testing::Values(false, true)),  // grad_act_scales off / on
     test_name_generator);

--- a/tests/cpp/operator/test_scaled_activation.cu
+++ b/tests/cpp/operator/test_scaled_activation.cu
@@ -108,7 +108,7 @@ inline void gated_grads(const ScaledActivationCase activation, const float act_i
 template <typename DataT, typename ScaleT>
 void compute_reference(ScaledActivationCase activation, const DataT *input, const ScaleT *scales,
                        const DataT *grad_output, DataT *output, DataT *grad_input,
-                       DataT *grad_scales, const size_t rows, const size_t hidden,
+                       ScaleT *grad_scales, const size_t rows, const size_t hidden,
                        const int64_t interleave, const bool compute_grad_scales) {
   const bool is_gated = activation != ScaledActivationCase::kSReLU;
   const size_t input_cols = is_gated ? hidden * 2 : hidden;
@@ -144,7 +144,7 @@ void compute_reference(ScaledActivationCase activation, const DataT *input, cons
       scale_grad += static_cast<float>(grad_output[out_idx]) * unscaled;
     }
     if (compute_grad_scales) {
-      grad_scales[row] = static_cast<DataT>(scale_grad);
+      grad_scales[row] = static_cast<ScaleT>(scale_grad);
     }
   }
 }
@@ -164,7 +164,7 @@ void run_scaled_activation_test(ScaledActivationCase activation, const size_t ro
   Tensor output("output", std::vector<size_t>{rows, hidden}, data_type);
   Tensor grad_output("grad_output", std::vector<size_t>{rows, hidden}, data_type);
   Tensor grad_input("grad_input", std::vector<size_t>{rows, input_cols}, data_type);
-  Tensor grad_scales("grad_scales", std::vector<size_t>{rows}, data_type);
+  Tensor grad_scales("grad_scales", std::vector<size_t>{rows}, scale_type);
 
   fillUniform(&input);
   fillUniform(&scales);
@@ -172,7 +172,7 @@ void run_scaled_activation_test(ScaledActivationCase activation, const size_t ro
 
   std::unique_ptr<DataT[]> ref_output = std::make_unique<DataT[]>(rows * hidden);
   std::unique_ptr<DataT[]> ref_grad_input = std::make_unique<DataT[]>(rows * input_cols);
-  std::unique_ptr<DataT[]> ref_grad_scales = std::make_unique<DataT[]>(rows);
+  std::unique_ptr<ScaleT[]> ref_grad_scales = std::make_unique<ScaleT[]>(rows);
 
   compute_reference(activation, input.rowwise_cpu_dptr<DataT>(), scales.rowwise_cpu_dptr<ScaleT>(),
                     grad_output.rowwise_cpu_dptr<DataT>(), ref_output.get(), ref_grad_input.get(),
@@ -219,8 +219,11 @@ void run_scaled_activation_test(ScaledActivationCase activation, const size_t ro
   compareResults("scaled_activation_grad_input", grad_input, ref_grad_input.get(), true, atol,
                  rtol);
   if (compute_grad_scales) {
-    compareResults("scaled_activation_grad_scales", grad_scales, ref_grad_scales.get(), true, atol,
-                   rtol);
+    // Scale gradients are floating-point reductions, so their CUDA and CPU summation orders can
+    // differ. Use a wider absolute tolerance near zero while retaining the dtype-relative bound.
+    constexpr double kGradScaleAtol = 5e-5;
+    compareResults("scaled_activation_grad_scales", grad_scales, ref_grad_scales.get(), true,
+                   std::max(atol, kGradScaleAtol), rtol);
   }
 }
 

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -3113,7 +3113,6 @@ class TestBasicOps:
         "op_cls",
         (
             te_ops.ScaledSwiGLU,
-            te_ops.ScaledSiTUGLU,
             te_ops.ScaledSReLU,
             te_ops.ScaledClampedQGeGLU,
         ),

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -2404,6 +2404,98 @@ class TestBasicOps:
         )
 
     @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("glu_interleave_size", (None, 32))
+    @pytest.mark.parametrize("betas", ((4.0, 25.0), (3.0, 12.0)))
+    def test_situglu(
+        self,
+        *,
+        dtype: torch.dtype,
+        glu_interleave_size: Optional[int],
+        betas: tuple[float, float],
+        device: torch.device = "cuda",
+    ) -> None:
+        """SiTU-GLU forward and backward."""
+        in_shape = (17, 192)
+        out_shape = (17, 96)
+        beta1, beta2 = betas
+        x_ref, x_test = make_reference_and_test_tensors(
+            in_shape,
+            test_dtype=dtype,
+            test_device=device,
+        )
+        dy_ref, dy_test = make_reference_and_test_tensors(
+            out_shape,
+            test_dtype=dtype,
+            test_device=device,
+            requires_grad=False,
+        )
+
+        x = x_ref
+        if glu_interleave_size is not None:
+            x = x.reshape(-1, 3, 2, glu_interleave_size).transpose(1, 2).reshape(in_shape)
+        gate, up = x.chunk(2, dim=-1)
+        y_ref = (
+            beta1 * torch.tanh(gate / beta1) * torch.sigmoid(gate) * beta2 * torch.tanh(up / beta2)
+        )
+        y_ref.backward(dy_ref)
+
+        op = te_ops.SiTUGLU(
+            beta1=beta1,
+            beta2=beta2,
+            glu_interleave_size=glu_interleave_size,
+        )
+        y_test = op(x_test)
+        y_test.backward(dy_test)
+
+        tols = dtype_tols(dtype)
+        assert_close(y_test, y_ref, **tols)
+        assert_close_grads(x_test, x_ref, **tols)
+
+    @pytest.mark.parametrize("name,value", (("beta1", 0.0), ("beta2", float("inf"))))
+    def test_situglu_invalid_beta(self, name: str, value: float) -> None:
+        """SiTU-GLU soft-cap parameters must be finite and positive."""
+        with pytest.raises(ValueError, match=name):
+            te_ops.SiTUGLU(**{name: value})
+        with pytest.raises(ValueError, match=name):
+            te_ops.ScaledSiTUGLU(**{name: value})
+
+    def test_situglu_mxfp8_quantization(self, device: torch.device = "cuda") -> None:
+        """SiTU-GLU supports fused MXFP8 output and input-gradient quantization."""
+        dtype = torch.bfloat16
+        quantization = "mxfp8"
+        in_shape = (256, 256)
+        out_shape = (256, 128)
+        maybe_skip_quantization(quantization, dims=in_shape, device=device, dtype=dtype)
+        x_ref, x_test = make_reference_and_test_tensors(
+            in_shape,
+            test_dtype=dtype,
+            test_device=device,
+        )
+        dy_ref, dy_test = make_reference_and_test_tensors(
+            out_shape,
+            test_dtype=dtype,
+            test_device=device,
+            requires_grad=False,
+        )
+
+        gate, up = x_ref.chunk(2, dim=-1)
+        y_ref = 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate) * 25.0 * torch.tanh(up / 25.0)
+        y_ref.backward(dy_ref)
+
+        forward = te_ops.Sequential(
+            te_ops.Quantize(forward=False, backward=True),
+            te_ops.SiTUGLU(),
+            te_ops.Quantize(forward=True, backward=False),
+        )
+        with te.autocast(enabled=True, recipe=make_recipe(quantization)):
+            y_test = forward(x_test)
+        y_test.backward(dy_test)
+
+        tols = quantization_tols(quantization)
+        assert_close(y_test, y_ref, **tols)
+        assert_close_grads(x_test, x_ref, **tols)
+
+    @pytest.mark.parametrize("dtype", _dtypes)
     @pytest.mark.parametrize("quantization", _quantization_list)
     @pytest.mark.parametrize("quantize_forward", (False, True))
     @pytest.mark.parametrize("quantize_backward", (False, True))
@@ -2907,6 +2999,54 @@ class TestBasicOps:
         assert_close_grads(x_test, x_ref, **tols)
         assert_close_grads(scales_test, scales_ref, **tols)
 
+    @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("glu_interleave_size", (None, 32))
+    def test_scaled_situglu(
+        self,
+        *,
+        dtype: torch.dtype,
+        glu_interleave_size: Optional[int],
+        device: torch.device = "cuda",
+    ) -> None:
+        """SiTU-GLU with a differentiable row-wise post-scale."""
+        in_shape = (17, 192)
+        out_shape = (17, 96)
+        x_ref, x_test = make_reference_and_test_tensors(
+            in_shape,
+            test_dtype=dtype,
+            test_device=device,
+        )
+        scales_ref, scales_test = make_reference_and_test_tensors(
+            in_shape[:-1],
+            test_dtype=dtype,
+            test_device=device,
+        )
+        dy_ref, dy_test = make_reference_and_test_tensors(
+            out_shape,
+            test_dtype=dtype,
+            test_device=device,
+            requires_grad=False,
+        )
+
+        x = x_ref
+        if glu_interleave_size is not None:
+            x = x.reshape(-1, 3, 2, glu_interleave_size).transpose(1, 2).reshape(in_shape)
+        gate, up = x.chunk(2, dim=-1)
+        activation = (
+            4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate) * 25.0 * torch.tanh(up / 25.0)
+        )
+        y_ref = scales_ref.unsqueeze(-1) * activation
+        y_ref.backward(dy_ref)
+
+        op = te_ops.ScaledSiTUGLU(glu_interleave_size=glu_interleave_size)
+        y_test = op(x_test, scales_test)
+        y_test.backward(dy_test)
+
+        tols = dtype_tols(dtype)
+        assert_close(y_test, y_ref, **tols)
+        assert_close_grads(x_test, x_ref, **tols)
+        assert_close_grads(scales_test, scales_ref, **tols)
+
     @pytest.mark.parametrize("in_shape", ((71, 192), (5, 7, 128)))
     @pytest.mark.parametrize("input_requires_grad", (False, True))
     @pytest.mark.parametrize("scales_requires_grad", (False, True))
@@ -2971,7 +3111,12 @@ class TestBasicOps:
 
     @pytest.mark.parametrize(
         "op_cls",
-        (te_ops.ScaledSwiGLU, te_ops.ScaledSReLU, te_ops.ScaledClampedQGeGLU),
+        (
+            te_ops.ScaledSwiGLU,
+            te_ops.ScaledSiTUGLU,
+            te_ops.ScaledSReLU,
+            te_ops.ScaledClampedQGeGLU,
+        ),
     )
     def test_scaled_activation_recompute_in_mlp_config(self, op_cls) -> None:
         """Scaled activations expose a per-op recompute knob."""

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -3113,14 +3113,20 @@ class TestBasicOps:
         "op_cls",
         (
             te_ops.ScaledSwiGLU,
-            te_ops.ScaledSReLU,
+            te_ops.ScaledSiTUGLU,
             te_ops.ScaledClampedQGeGLU,
         ),
     )
-    def test_scaled_activation_recompute_in_mlp_config(self, op_cls) -> None:
-        """Scaled activations expose a per-op recompute knob."""
+    def test_scaled_glu_rejects_activation_recompute_in_mlp(self, op_cls) -> None:
+        """Scaled GLUs reject unsupported activation recomputation."""
         assert op_cls().activation_recompute_in_mlp is False
-        assert op_cls(activation_recompute_in_mlp=True).activation_recompute_in_mlp is True
+        with pytest.raises(ValueError, match="does not support activation recomputation"):
+            op_cls(activation_recompute_in_mlp=True)
+
+    def test_scaled_srelu_activation_recompute_in_mlp_config(self) -> None:
+        """Scaled SReLU exposes its supported activation recompute knob."""
+        assert te_ops.ScaledSReLU().activation_recompute_in_mlp is False
+        assert te_ops.ScaledSReLU(activation_recompute_in_mlp=True).activation_recompute_in_mlp
 
     @pytest.mark.parametrize("in_shape", ((71, 192), (5, 7, 128)))
     @pytest.mark.parametrize("input_requires_grad", (False, True))

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -22,7 +22,6 @@ from transformer_engine.pytorch.constants import TE_DType
 import transformer_engine.pytorch.ops.fused.grouped_mlp as grouped_mlp_module
 from transformer_engine.pytorch.ops.fused.grouped_mlp import (
     _cudnn_frontend_supports_grouped_gemm_situglu,
-    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard,
     _cudnn_frontend_supports_grouped_gemm_srelu,
     _cudnn_frontend_version_supported,
 )
@@ -88,8 +87,16 @@ def _reset_rng_states_per_test():
     yield
 
 
-def test_cudnn_frontend_situglu_feature_detection(monkeypatch) -> None:
-    """Detect grouped SiTU-GLU from callable signatures, not package versions."""
+@pytest.mark.parametrize(
+    "unsupported_wrapper",
+    (
+        "grouped_gemm_glu_wrapper_sm100",
+        "grouped_gemm_dglu_wrapper_sm100",
+        "grouped_gemm_glu_hadamard_wrapper_sm100",
+    ),
+)
+def test_cudnn_frontend_situglu_feature_detection(monkeypatch, unsupported_wrapper: str) -> None:
+    """Require SiTU-GLU support from every cuDNN wrapper used by grouped MLP."""
 
     def _with_situglu(*, situ_beta1=4.0, situ_beta2=25.0):
         del situ_beta1, situ_beta2
@@ -100,42 +107,23 @@ def test_cudnn_frontend_situglu_feature_detection(monkeypatch) -> None:
     fake_cudnn = types.ModuleType("cudnn")
     fake_cudnn.grouped_gemm_glu_wrapper_sm100 = _with_situglu
     fake_cudnn.grouped_gemm_dglu_wrapper_sm100 = _with_situglu
-    monkeypatch.setitem(sys.modules, "cudnn", fake_cudnn)
-    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
-    assert _cudnn_frontend_supports_grouped_gemm_situglu()
-
-    fake_cudnn.grouped_gemm_dglu_wrapper_sm100 = _without_situglu
-    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
-    assert not _cudnn_frontend_supports_grouped_gemm_situglu()
-    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
-
-
-def test_cudnn_frontend_situglu_hadamard_feature_detection(monkeypatch) -> None:
-    """Require SiTU parameters on the GLU-Hadamard wrapper itself."""
-
-    def _with_situglu(*, situ_beta1=4.0, situ_beta2=25.0):
-        del situ_beta1, situ_beta2
-
-    def _without_situglu():
-        return None
-
-    fake_cudnn = types.ModuleType("cudnn")
     fake_cudnn.grouped_gemm_glu_hadamard_wrapper_sm100 = _with_situglu
     monkeypatch.setitem(sys.modules, "cudnn", fake_cudnn)
-    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
-    assert _cudnn_frontend_supports_grouped_gemm_situglu_hadamard()
+    try:
+        _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
+        assert _cudnn_frontend_supports_grouped_gemm_situglu()
 
-    fake_cudnn.grouped_gemm_glu_hadamard_wrapper_sm100 = _without_situglu
-    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
-    assert not _cudnn_frontend_supports_grouped_gemm_situglu_hadamard()
-    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
+        setattr(fake_cudnn, unsupported_wrapper, _without_situglu)
+        _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
+        assert not _cudnn_frontend_supports_grouped_gemm_situglu()
+    finally:
+        _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
 
 
 def _clear_grouped_glu_kernel_caches() -> None:
     """Clear cached cuDNN wrapper lookups after tests monkeypatch them."""
     fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMGLU
     _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
-    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
     fused_cls.is_supported.cache_clear()
     fused_cls.grouped_gemm_activation_kernel.cache_clear()
     fused_cls.grouped_gemm_act_hadamard_kernel.cache_clear()
@@ -1413,7 +1401,7 @@ class TestGroupedMLPFusedOp:
 
         # Check for expected fusions
         cudnn_frontend_supports_grouped_mlp = (
-            _cudnn_frontend_supports_grouped_gemm_situglu()
+            grouped_mlp_module._cudnn_frontend_supports_grouped_gemm_situglu()
             if activation == "scaled_situglu"
             else (
                 _cudnn_frontend_supports_grouped_gemm_srelu()
@@ -1446,6 +1434,7 @@ class TestGroupedMLPFusedOp:
                 fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMUnary
             if strict_fusion is True:
                 assert fused_cls.is_supported()
+            if fused_cls.is_supported():
                 forward_ops = module._module_groups[0]._forward_ops
                 backward_ops = module._module_groups[0]._backward_ops
                 assert len(forward_ops) == 1
@@ -1454,13 +1443,6 @@ class TestGroupedMLPFusedOp:
                     forward_ops[0][0],
                     fused_cls,
                 )
-                assert backward_ops[0][0] is forward_ops[0][0]
-            elif fused_cls.is_supported():
-                forward_ops = module._module_groups[0]._forward_ops
-                backward_ops = module._module_groups[0]._backward_ops
-                assert len(forward_ops) == 1
-                assert len(backward_ops) == 1
-                assert isinstance(forward_ops[0][0], fused_cls)
                 assert backward_ops[0][0] is forward_ops[0][0]
         if strict_fusion is False:
             forward_ops = module._module_groups[0]._forward_ops
@@ -1537,9 +1519,7 @@ class TestGroupedMLPFusedOp:
     def test_grouped_mlp_situglu_mxfp8_fallback(
         self, monkeypatch, situ_betas: tuple[float, float]
     ) -> None:
-        """An installed cuDNN without SiTU support executes the native activation."""
-        if _cudnn_frontend_supports_grouped_gemm_situglu():
-            pytest.skip("Installed cuDNN frontend has grouped SiTU-GLU; test fused execution")
+        """A cuDNN frontend without SiTU support executes the native activation."""
         native_calls = []
         original_native_fwd = tex.scaled_situglu
         original_native_bwd = tex.scaled_dsituglu
@@ -1554,18 +1534,31 @@ class TestGroupedMLPFusedOp:
 
         monkeypatch.setattr(tex, "scaled_situglu", traced_native_fwd)
         monkeypatch.setattr(tex, "scaled_dsituglu", traced_native_bwd)
-        self.test_grouped_mlp(
-            group_size=4,
-            bias=True,
-            hidden_size=128,
-            quantization="mxfp8",
-            single_grouped_weight=False,
-            activation="scaled_situglu",
-            situ_betas=situ_betas,
-            strict_fusion=False,
+        monkeypatch.setattr(
+            grouped_mlp_module,
+            "_cudnn_frontend_supports_grouped_gemm_situglu",
+            lambda: False,
         )
-        torch.cuda.synchronize()
-        assert native_calls == ["fwd", "bwd"]
+        # The unfused GroupedLinear bias-gradient path uses an atomic Triton
+        # reduction. This test intentionally exercises that fallback even when
+        # the surrounding test job requests deterministic algorithms.
+        monkeypatch.setenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "1")
+        _clear_grouped_glu_kernel_caches()
+        try:
+            self.test_grouped_mlp(
+                group_size=4,
+                bias=True,
+                hidden_size=128,
+                quantization="mxfp8",
+                single_grouped_weight=False,
+                activation="scaled_situglu",
+                situ_betas=situ_betas,
+                strict_fusion=False,
+            )
+            torch.cuda.synchronize()
+            assert native_calls == ["fwd", "bwd"]
+        finally:
+            _clear_grouped_glu_kernel_caches()
 
     @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
     @pytest.mark.parametrize("single_grouped_weight", (False, True), ids=("discrete", "dense"))
@@ -1593,6 +1586,8 @@ class TestGroupedMLPFusedOp:
             pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU")
         fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMGLU
         assert fused_cls.is_supported()
+        # FC2 bias-gradient accumulation uses an atomic Triton reduction.
+        monkeypatch.setenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "1")
         if single_grouped_weight:
             monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
 
@@ -1647,15 +1642,16 @@ class TestGroupedMLPFusedOp:
     @pytest.mark.parametrize("situ_betas", ((4.0, 25.0), (2.0, 8.0)))
     def test_grouped_mlp_situglu_nvfp4_real_cudnn_hadamard_fusion(
         self,
+        monkeypatch,
         traced_cudnn_grouped_glu_wrappers,
         situ_betas: tuple[float, float],
     ) -> None:
         """NVFP4 SiTU uses cuDNN's fused GLU-Hadamard forward when available."""
         if not _cudnn_frontend_supports_grouped_gemm_situglu():
             pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU")
-        if not _cudnn_frontend_supports_grouped_gemm_situglu_hadamard():
-            pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU Hadamard fusion")
         assert te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported()
+        # FC2 bias-gradient accumulation uses an atomic Triton reduction.
+        monkeypatch.setenv("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "1")
 
         self.test_grouped_mlp(
             group_size=4,
@@ -1700,39 +1696,6 @@ class TestGroupedMLPFusedOp:
                 "generate_dbias": True,
             },
         ]
-
-    @pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4)
-    def test_grouped_mlp_situglu_nvfp4_without_cudnn_hadamard(
-        self,
-        monkeypatch,
-        traced_cudnn_grouped_glu_wrappers,
-    ) -> None:
-        """NVFP4 SiTU keeps the regular grouped-GLU fallback for older cuDNN frontends."""
-        if not _cudnn_frontend_supports_grouped_gemm_situglu():
-            pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU")
-        monkeypatch.setattr(
-            grouped_mlp_module,
-            "_cudnn_frontend_supports_grouped_gemm_situglu_hadamard",
-            lambda: False,
-        )
-
-        self.test_grouped_mlp(
-            group_size=4,
-            bias=True,
-            hidden_size=128,
-            dtype=torch.bfloat16,
-            quantization="nvfp4_rht",
-            single_grouped_weight=False,
-            activation="scaled_situglu",
-            situ_betas=(4.0, 25.0),
-            strict_fusion=True,
-        )
-        torch.cuda.synchronize()
-
-        assert [call["kind"] for call in traced_cudnn_grouped_glu_wrappers] == ["fwd", "bwd"]
-        forward_call = traced_cudnn_grouped_glu_wrappers[0]
-        assert forward_call["act_func"] == "situglu"
-        assert forward_call["situ_betas"] == (4.0, 25.0)
 
     @pytest.mark.parametrize("weight_requires_grad", (False, True))
     def test_grouped_mlp_prequantized_mxfp8_input(

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -8,6 +8,8 @@ from collections.abc import Iterable
 import os
 import math
 import random
+import sys
+import types
 from typing import Optional
 
 import pytest
@@ -18,6 +20,7 @@ import transformer_engine.pytorch as te
 from transformer_engine.pytorch.constants import TE_DType
 import transformer_engine.pytorch.ops.fused.grouped_mlp as grouped_mlp_module
 from transformer_engine.pytorch.ops.fused.grouped_mlp import (
+    _cudnn_frontend_supports_grouped_gemm_situglu,
     _cudnn_frontend_supports_grouped_gemm_srelu,
     _cudnn_frontend_version_supported,
 )
@@ -81,6 +84,28 @@ def _reset_rng_states_per_test():
     """Restore torch, CUDA, and Python ``random`` before each test in this module."""
     reset_rng_states()
     yield
+
+
+def test_cudnn_frontend_situglu_feature_detection(monkeypatch) -> None:
+    """Detect grouped SiTU-GLU from callable signatures, not package versions."""
+
+    def _with_situglu(*, situ_beta1=4.0, situ_beta2=25.0):
+        del situ_beta1, situ_beta2
+
+    def _without_situglu():
+        return None
+
+    fake_cudnn = types.ModuleType("cudnn")
+    fake_cudnn.grouped_gemm_glu_wrapper_sm100 = _with_situglu
+    fake_cudnn.grouped_gemm_dglu_wrapper_sm100 = _with_situglu
+    monkeypatch.setitem(sys.modules, "cudnn", fake_cudnn)
+    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
+    assert _cudnn_frontend_supports_grouped_gemm_situglu()
+
+    fake_cudnn.grouped_gemm_dglu_wrapper_sm100 = _without_situglu
+    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
+    assert not _cudnn_frontend_supports_grouped_gemm_situglu()
+    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
 
 
 def maybe_skip_quantization(
@@ -946,6 +971,7 @@ class TestGroupedMLPFusedOp:
         split_alignment: int = 256,
         delay_wgrad_compute: bool = False,
         activation: str,
+        situ_betas: tuple[float, float] = (4.0, 25.0),
     ) -> None:
         """GroupedLinear + scaled activation + GroupedLinear"""
 
@@ -965,6 +991,7 @@ class TestGroupedMLPFusedOp:
 
         activation_is_glu = activation in (
             "scaled_swiglu",
+            "scaled_situglu",
             "scaled_clamped_qgeglu",
             "scaled_clamped_qgeglu_custom",
         )
@@ -1106,6 +1133,16 @@ class TestGroupedMLPFusedOp:
             if activation == "scaled_swiglu":
                 x1, x2 = x.chunk(2, dim=-1)
                 return torch.nn.functional.silu(x1) * x2
+            if activation == "scaled_situglu":
+                x1, x2 = x.chunk(2, dim=-1)
+                beta1, beta2 = situ_betas
+                return (
+                    beta1
+                    * torch.tanh(x1 / beta1)
+                    * torch.sigmoid(x1)
+                    * beta2
+                    * torch.tanh(x2 / beta2)
+                )
             if activation.startswith("scaled_clamped_qgeglu"):
                 x1, x2 = x.chunk(2, dim=-1)
                 lim = torch.tensor(geglu_limit, device=x1.device, dtype=x1.dtype)
@@ -1140,6 +1177,12 @@ class TestGroupedMLPFusedOp:
         def _make_scaled_act():
             if activation == "scaled_swiglu":
                 return te.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size)
+            if activation == "scaled_situglu":
+                return te.ops.ScaledSiTUGLU(
+                    glu_interleave_size=glu_interleave_size,
+                    beta1=situ_betas[0],
+                    beta2=situ_betas[1],
+                )
             if activation == "scaled_clamped_qgeglu_custom":
                 return te.ops.ScaledClampedQGeGLU(
                     glu_interleave_size=glu_interleave_size,
@@ -1238,9 +1281,13 @@ class TestGroupedMLPFusedOp:
 
         # Check for expected fusions
         cudnn_frontend_supports_grouped_mlp = (
-            _cudnn_frontend_supports_grouped_gemm_srelu()
-            if activation == "scaled_srelu"
-            else _cudnn_frontend_version_supported()
+            _cudnn_frontend_supports_grouped_gemm_situglu()
+            if activation == "scaled_situglu"
+            else (
+                _cudnn_frontend_supports_grouped_gemm_srelu()
+                if activation == "scaled_srelu"
+                else _cudnn_frontend_version_supported()
+            )
         )
         expected_grouped_mlp_fusion = cudnn_frontend_supports_grouped_mlp and (
             (
@@ -1336,6 +1383,20 @@ class TestGroupedMLPFusedOp:
         elif single_grouped_weight:
             assert_close(fc1.weight.grad, fc1_w_ref_grad, **tols)
             assert_close(fc2.weight.grad, fc2_w_ref_grad, **tols)
+
+    @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+    @pytest.mark.parametrize("situ_betas", ((4.0, 25.0), (2.0, 8.0)))
+    def test_grouped_mlp_situglu_mxfp8(self, situ_betas: tuple[float, float]) -> None:
+        """Grouped MLP SiTU-GLU path, fused when the cuDNN feature is available."""
+        self.test_grouped_mlp(
+            group_size=4,
+            bias=False,
+            hidden_size=128,
+            quantization="mxfp8",
+            single_grouped_weight=False,
+            activation="scaled_situglu",
+            situ_betas=situ_betas,
+        )
 
     @pytest.mark.parametrize("weight_requires_grad", (False, True))
     def test_grouped_mlp_prequantized_mxfp8_input(

--- a/tests/pytorch/test_grouped_mlp.py
+++ b/tests/pytorch/test_grouped_mlp.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import functools
 import os
 import math
 import random
@@ -21,6 +22,7 @@ from transformer_engine.pytorch.constants import TE_DType
 import transformer_engine.pytorch.ops.fused.grouped_mlp as grouped_mlp_module
 from transformer_engine.pytorch.ops.fused.grouped_mlp import (
     _cudnn_frontend_supports_grouped_gemm_situglu,
+    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard,
     _cudnn_frontend_supports_grouped_gemm_srelu,
     _cudnn_frontend_version_supported,
 )
@@ -106,6 +108,133 @@ def test_cudnn_frontend_situglu_feature_detection(monkeypatch) -> None:
     _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
     assert not _cudnn_frontend_supports_grouped_gemm_situglu()
     _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
+
+
+def test_cudnn_frontend_situglu_hadamard_feature_detection(monkeypatch) -> None:
+    """Require SiTU parameters on the GLU-Hadamard wrapper itself."""
+
+    def _with_situglu(*, situ_beta1=4.0, situ_beta2=25.0):
+        del situ_beta1, situ_beta2
+
+    def _without_situglu():
+        return None
+
+    fake_cudnn = types.ModuleType("cudnn")
+    fake_cudnn.grouped_gemm_glu_hadamard_wrapper_sm100 = _with_situglu
+    monkeypatch.setitem(sys.modules, "cudnn", fake_cudnn)
+    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
+    assert _cudnn_frontend_supports_grouped_gemm_situglu_hadamard()
+
+    fake_cudnn.grouped_gemm_glu_hadamard_wrapper_sm100 = _without_situglu
+    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
+    assert not _cudnn_frontend_supports_grouped_gemm_situglu_hadamard()
+    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
+
+
+def _clear_grouped_glu_kernel_caches() -> None:
+    """Clear cached cuDNN wrapper lookups after tests monkeypatch them."""
+    fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMGLU
+    _cudnn_frontend_supports_grouped_gemm_situglu.cache_clear()
+    _cudnn_frontend_supports_grouped_gemm_situglu_hadamard.cache_clear()
+    fused_cls.is_supported.cache_clear()
+    fused_cls.grouped_gemm_activation_kernel.cache_clear()
+    fused_cls.grouped_gemm_act_hadamard_kernel.cache_clear()
+    fused_cls.grouped_gemm_dactivation_kernel.cache_clear()
+
+
+@pytest.fixture
+def traced_cudnn_grouped_glu_wrappers(monkeypatch):
+    """Trace real cuDNN grouped GLU wrappers while preserving their execution."""
+    try:
+        import cudnn
+    except ImportError:
+        pytest.skip("cuDNN frontend is not installed")
+
+    original_fwd = cudnn.grouped_gemm_glu_wrapper_sm100
+    original_bwd = cudnn.grouped_gemm_dglu_wrapper_sm100
+    original_hadamard = getattr(cudnn, "grouped_gemm_glu_hadamard_wrapper_sm100", None)
+    calls = []
+
+    def _weight_dtype(kwargs):
+        b_tensor = kwargs.get("b_tensor")
+        return b_tensor.dtype if b_tensor is not None else kwargs.get("b_dtype")
+
+    @functools.wraps(original_fwd)
+    def traced_fwd(*args, **kwargs):
+        calls.append(
+            {
+                "kind": "fwd",
+                "weight_mode": "dense" if kwargs.get("b_tensor") is not None else "discrete",
+                "a_dtype": kwargs["a_tensor"].dtype,
+                "b_dtype": _weight_dtype(kwargs),
+                "alpha_dtype": kwargs["alpha_tensor"].dtype,
+                "prob_dtype": (
+                    None if kwargs.get("prob_tensor") is None else kwargs["prob_tensor"].dtype
+                ),
+                "c_dtype": kwargs["c_dtype"],
+                "d_dtype": kwargs["d_dtype"],
+                "act_func": kwargs["act_func"],
+                "situ_betas": (kwargs.get("situ_beta1"), kwargs.get("situ_beta2")),
+                "with_bias": kwargs.get("bias_tensor") is not None,
+            }
+        )
+        return original_fwd(*args, **kwargs)
+
+    @functools.wraps(original_bwd)
+    def traced_bwd(*args, **kwargs):
+        calls.append(
+            {
+                "kind": "bwd",
+                "weight_mode": "dense" if kwargs.get("b_tensor") is not None else "discrete",
+                "a_dtype": kwargs["a_tensor"].dtype,
+                "b_dtype": _weight_dtype(kwargs),
+                "c_dtype": kwargs["c_tensor"].dtype,
+                "alpha_dtype": kwargs["alpha_tensor"].dtype,
+                "beta_dtype": kwargs["beta_tensor"].dtype,
+                "prob_dtype": (
+                    None if kwargs.get("prob_tensor") is None else kwargs["prob_tensor"].dtype
+                ),
+                "dprob_dtype": (
+                    None if kwargs.get("dprob_tensor") is None else kwargs["dprob_tensor"].dtype
+                ),
+                "d_dtype": kwargs["d_dtype"],
+                "act_func": kwargs["act_func"],
+                "situ_betas": (kwargs.get("situ_beta1"), kwargs.get("situ_beta2")),
+                "generate_dbias": kwargs.get("generate_dbias", False),
+            }
+        )
+        return original_bwd(*args, **kwargs)
+
+    if original_hadamard is not None:
+
+        @functools.wraps(original_hadamard)
+        def traced_hadamard(*args, **kwargs):
+            calls.append(
+                {
+                    "kind": "fwd_hadamard",
+                    "weight_mode": "dense" if kwargs.get("b_tensor") is not None else "discrete",
+                    "a_dtype": kwargs["a_tensor"].dtype,
+                    "b_dtype": _weight_dtype(kwargs),
+                    "alpha_dtype": kwargs["alpha_tensor"].dtype,
+                    "prob_dtype": kwargs["prob_tensor"].dtype,
+                    "c_dtype": kwargs["c_dtype"],
+                    "d_dtype": kwargs["d_dtype"],
+                    "act_func": kwargs["act_func"],
+                    "situ_betas": (kwargs.get("situ_beta1"), kwargs.get("situ_beta2")),
+                    "with_bias": kwargs.get("bias_tensor") is not None,
+                }
+            )
+            return original_hadamard(*args, **kwargs)
+
+    _clear_grouped_glu_kernel_caches()
+    monkeypatch.setattr(cudnn, "grouped_gemm_glu_wrapper_sm100", traced_fwd)
+    monkeypatch.setattr(cudnn, "grouped_gemm_dglu_wrapper_sm100", traced_bwd)
+    if original_hadamard is not None:
+        monkeypatch.setattr(cudnn, "grouped_gemm_glu_hadamard_wrapper_sm100", traced_hadamard)
+    try:
+        yield calls
+    finally:
+        _clear_grouped_glu_kernel_caches()
 
 
 def maybe_skip_quantization(
@@ -972,6 +1101,7 @@ class TestGroupedMLPFusedOp:
         delay_wgrad_compute: bool = False,
         activation: str,
         situ_betas: tuple[float, float] = (4.0, 25.0),
+        strict_fusion: Optional[bool] = None,
     ) -> None:
         """GroupedLinear + scaled activation + GroupedLinear"""
 
@@ -1027,8 +1157,10 @@ class TestGroupedMLPFusedOp:
         if quantization == "nvfp4_rht":
             if activation == "scaled_swiglu" and (bias or glu_interleave_size != 32):
                 pytest.skip("NVFP4 RHT SwiGLU grouped MLP coverage is limited to no-bias")
-            if activation not in ("scaled_swiglu", "scaled_srelu"):
-                pytest.skip("NVFP4 RHT grouped MLP coverage is limited to SwiGLU and SReLU")
+            if activation not in ("scaled_swiglu", "scaled_situglu", "scaled_srelu"):
+                pytest.skip(
+                    "NVFP4 RHT grouped MLP coverage is limited to SwiGLU, SiTU-GLU, and SReLU"
+                )
         if (
             with_quantization
             and quantization in ("nvfp4", "nvfp4_row_scaled", "nvfp4_4over6", "nvfp4_rht")
@@ -1312,7 +1444,8 @@ class TestGroupedMLPFusedOp:
                 fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMGLU
             else:
                 fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMUnary
-            if fused_cls.is_supported():
+            if strict_fusion is True:
+                assert fused_cls.is_supported()
                 forward_ops = module._module_groups[0]._forward_ops
                 backward_ops = module._module_groups[0]._backward_ops
                 assert len(forward_ops) == 1
@@ -1322,6 +1455,21 @@ class TestGroupedMLPFusedOp:
                     fused_cls,
                 )
                 assert backward_ops[0][0] is forward_ops[0][0]
+            elif fused_cls.is_supported():
+                forward_ops = module._module_groups[0]._forward_ops
+                backward_ops = module._module_groups[0]._backward_ops
+                assert len(forward_ops) == 1
+                assert len(backward_ops) == 1
+                assert isinstance(forward_ops[0][0], fused_cls)
+                assert backward_ops[0][0] is forward_ops[0][0]
+        if strict_fusion is False:
+            forward_ops = module._module_groups[0]._forward_ops
+            backward_ops = module._module_groups[0]._backward_ops
+            fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMGLU
+            assert not any(isinstance(op, fused_cls) for op, _ in forward_ops)
+            assert not any(isinstance(op, fused_cls) for op, _ in backward_ops)
+            assert any(isinstance(op, te.ops.ScaledSiTUGLU) for op, _ in forward_ops)
+            assert any(isinstance(op, te.ops.ScaledSiTUGLU) for op, _ in backward_ops)
 
         # Loose tols for sanity checking
         tols = {"rtol": 0.125, "atol": 0.25}
@@ -1386,17 +1534,205 @@ class TestGroupedMLPFusedOp:
 
     @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
     @pytest.mark.parametrize("situ_betas", ((4.0, 25.0), (2.0, 8.0)))
-    def test_grouped_mlp_situglu_mxfp8(self, situ_betas: tuple[float, float]) -> None:
-        """Grouped MLP SiTU-GLU path, fused when the cuDNN feature is available."""
+    def test_grouped_mlp_situglu_mxfp8_fallback(
+        self, monkeypatch, situ_betas: tuple[float, float]
+    ) -> None:
+        """An installed cuDNN without SiTU support executes the native activation."""
+        if _cudnn_frontend_supports_grouped_gemm_situglu():
+            pytest.skip("Installed cuDNN frontend has grouped SiTU-GLU; test fused execution")
+        native_calls = []
+        original_native_fwd = tex.scaled_situglu
+        original_native_bwd = tex.scaled_dsituglu
+
+        def traced_native_fwd(*args, **kwargs):
+            native_calls.append("fwd")
+            return original_native_fwd(*args, **kwargs)
+
+        def traced_native_bwd(*args, **kwargs):
+            native_calls.append("bwd")
+            return original_native_bwd(*args, **kwargs)
+
+        monkeypatch.setattr(tex, "scaled_situglu", traced_native_fwd)
+        monkeypatch.setattr(tex, "scaled_dsituglu", traced_native_bwd)
         self.test_grouped_mlp(
             group_size=4,
-            bias=False,
+            bias=True,
             hidden_size=128,
             quantization="mxfp8",
             single_grouped_weight=False,
             activation="scaled_situglu",
             situ_betas=situ_betas,
+            strict_fusion=False,
         )
+        torch.cuda.synchronize()
+        assert native_calls == ["fwd", "bwd"]
+
+    @pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+    @pytest.mark.parametrize("single_grouped_weight", (False, True), ids=("discrete", "dense"))
+    @pytest.mark.parametrize(
+        "activation,situ_betas,act_func,dact_func",
+        (
+            ("scaled_situglu", (4.0, 25.0), "situglu", "dsituglu"),
+            ("scaled_situglu", (2.0, 8.0), "situglu", "dsituglu"),
+            ("scaled_swiglu", (4.0, 25.0), "swiglu", "dswiglu"),
+        ),
+        ids=("situ-k3", "situ-generic", "swiglu"),
+    )
+    def test_grouped_mlp_glu_mxfp8_real_cudnn_fusion(
+        self,
+        monkeypatch,
+        traced_cudnn_grouped_glu_wrappers,
+        single_grouped_weight: bool,
+        activation: str,
+        situ_betas: tuple[float, float],
+        act_func: str,
+        dact_func: str,
+    ) -> None:
+        """Real cuDNN MXFP8 GLU wrappers execute with TE's generated argument dtypes."""
+        if not _cudnn_frontend_supports_grouped_gemm_situglu():
+            pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU")
+        fused_cls = te.ops.fused.GroupedMLP_CuTeGEMMGLU
+        assert fused_cls.is_supported()
+        if single_grouped_weight:
+            monkeypatch.setenv("NVTE_GROUPED_LINEAR_SINGLE_PARAM", "1")
+
+        self.test_grouped_mlp(
+            group_size=4,
+            bias=True,
+            hidden_size=128,
+            dtype=torch.bfloat16,
+            quantization="mxfp8",
+            single_grouped_weight=single_grouped_weight,
+            activation=activation,
+            situ_betas=situ_betas,
+            strict_fusion=True,
+        )
+        torch.cuda.synchronize()
+
+        expected_mode = "dense" if single_grouped_weight else "discrete"
+        expected_situ_betas = situ_betas if activation == "scaled_situglu" else (None, None)
+        expected_calls = [
+            {
+                "kind": "fwd",
+                "weight_mode": expected_mode,
+                "a_dtype": torch.float8_e4m3fn,
+                "b_dtype": torch.float8_e4m3fn,
+                "alpha_dtype": torch.bfloat16,
+                "prob_dtype": torch.bfloat16,
+                "c_dtype": torch.bfloat16,
+                "d_dtype": torch.float8_e4m3fn,
+                "act_func": act_func,
+                "situ_betas": expected_situ_betas,
+                "with_bias": True,
+            },
+            {
+                "kind": "bwd",
+                "weight_mode": expected_mode,
+                "a_dtype": torch.float8_e4m3fn,
+                "b_dtype": torch.float8_e4m3fn,
+                "c_dtype": torch.bfloat16,
+                "alpha_dtype": torch.bfloat16,
+                "beta_dtype": torch.bfloat16,
+                "prob_dtype": torch.float32,
+                "dprob_dtype": torch.float32,
+                "d_dtype": torch.float8_e4m3fn,
+                "act_func": dact_func,
+                "situ_betas": expected_situ_betas,
+                "generate_dbias": True,
+            },
+        ]
+        assert traced_cudnn_grouped_glu_wrappers == expected_calls
+
+    @pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4)
+    @pytest.mark.parametrize("situ_betas", ((4.0, 25.0), (2.0, 8.0)))
+    def test_grouped_mlp_situglu_nvfp4_real_cudnn_hadamard_fusion(
+        self,
+        traced_cudnn_grouped_glu_wrappers,
+        situ_betas: tuple[float, float],
+    ) -> None:
+        """NVFP4 SiTU uses cuDNN's fused GLU-Hadamard forward when available."""
+        if not _cudnn_frontend_supports_grouped_gemm_situglu():
+            pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU")
+        if not _cudnn_frontend_supports_grouped_gemm_situglu_hadamard():
+            pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU Hadamard fusion")
+        assert te.ops.fused.GroupedMLP_CuTeGEMMGLU.is_supported()
+
+        self.test_grouped_mlp(
+            group_size=4,
+            bias=True,
+            hidden_size=128,
+            dtype=torch.bfloat16,
+            quantization="nvfp4_rht",
+            single_grouped_weight=False,
+            activation="scaled_situglu",
+            situ_betas=situ_betas,
+            strict_fusion=True,
+        )
+        torch.cuda.synchronize()
+
+        assert traced_cudnn_grouped_glu_wrappers == [
+            {
+                "kind": "fwd_hadamard",
+                "weight_mode": "discrete",
+                "a_dtype": torch.float4_e2m1fn_x2,
+                "b_dtype": torch.float4_e2m1fn_x2,
+                "alpha_dtype": torch.float32,
+                "prob_dtype": torch.float32,
+                "c_dtype": torch.bfloat16,
+                "d_dtype": torch.bfloat16,
+                "act_func": "situglu",
+                "situ_betas": situ_betas,
+                "with_bias": True,
+            },
+            {
+                "kind": "bwd",
+                "weight_mode": "discrete",
+                "a_dtype": torch.float4_e2m1fn_x2,
+                "b_dtype": torch.float4_e2m1fn_x2,
+                "c_dtype": torch.bfloat16,
+                "alpha_dtype": torch.float32,
+                "beta_dtype": torch.float32,
+                "prob_dtype": torch.float32,
+                "dprob_dtype": torch.float32,
+                "d_dtype": torch.bfloat16,
+                "act_func": "dsituglu",
+                "situ_betas": situ_betas,
+                "generate_dbias": True,
+            },
+        ]
+
+    @pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4)
+    def test_grouped_mlp_situglu_nvfp4_without_cudnn_hadamard(
+        self,
+        monkeypatch,
+        traced_cudnn_grouped_glu_wrappers,
+    ) -> None:
+        """NVFP4 SiTU keeps the regular grouped-GLU fallback for older cuDNN frontends."""
+        if not _cudnn_frontend_supports_grouped_gemm_situglu():
+            pytest.skip("Installed cuDNN frontend lacks grouped SiTU-GLU")
+        monkeypatch.setattr(
+            grouped_mlp_module,
+            "_cudnn_frontend_supports_grouped_gemm_situglu_hadamard",
+            lambda: False,
+        )
+
+        self.test_grouped_mlp(
+            group_size=4,
+            bias=True,
+            hidden_size=128,
+            dtype=torch.bfloat16,
+            quantization="nvfp4_rht",
+            single_grouped_weight=False,
+            activation="scaled_situglu",
+            situ_betas=(4.0, 25.0),
+            strict_fusion=True,
+        )
+        torch.cuda.synchronize()
+
+        assert [call["kind"] for call in traced_cudnn_grouped_glu_wrappers] == ["fwd", "bwd"]
+        forward_call = traced_cudnn_grouped_glu_wrappers[0]
+        assert forward_call["act_func"] == "situglu"
+        assert forward_call["situ_betas"] == (4.0, 25.0)
 
     @pytest.mark.parametrize("weight_requires_grad", (False, True))
     def test_grouped_mlp_prequantized_mxfp8_input(

--- a/transformer_engine/common/activation/scaled_activation.cu
+++ b/transformer_engine/common/activation/scaled_activation.cu
@@ -56,14 +56,14 @@ __device__ __forceinline__ float block_reduce_sum(float value, float *smem) {
 template <typename ParamOP, float (*ActOP)(float, const ParamOP &)>
 __device__ __forceinline__ float gated_forward_value(const float act_in, const float gate_in,
                                                      const ParamOP &param) {
+  const float act_elt = ActOP(act_in, param);
+  float gate_elt = gate_in;
   if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
-    const float gate = fminf(fmaxf(-param.limit, gate_in), param.limit) + param.glu_linear_offset;
-    return ActOP(act_in, param) * gate;
+    gate_elt = fminf(fmaxf(-param.limit, gate_in), param.limit) + param.glu_linear_offset;
   } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
-    return ActOP(act_in, param) * situ_up<float, float>(gate_in, param);
-  } else {
-    return ActOP(act_in, param) * gate_in;
+    gate_elt = situ_up<float, float>(gate_in, param);
   }
+  return act_elt * gate_elt;
 }
 
 template <typename ParamOP, float (*ActOP)(float, const ParamOP &),
@@ -72,40 +72,42 @@ __device__ __forceinline__ void gated_backward_values(const float act_in, const 
                                                       const ParamOP &param, float *dact,
                                                       float *dgate, float *unscaled) {
   Empty empty = {};
-  float act_x = 0.0f;
-  float dact_x = 0.0f;
-  float gate = gate_in;
-  bool dgate_mask = true;
+  float act_elt = 0.0f;
+  float gate_elt = gate_in;
+  float dact_elt = 0.0f;
+  float dgate_elt = 1.0f;
 
   if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
-    dgate_mask = gate_in <= param.limit && gate_in >= -param.limit;
-    gate = fminf(fmaxf(-param.limit, gate_in), param.limit) + param.glu_linear_offset;
+    dgate_elt = gate_in <= param.limit && gate_in >= -param.limit;
+    gate_elt = fminf(fmaxf(-param.limit, gate_in), param.limit) + param.glu_linear_offset;
+  } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+    dgate_elt = dsitu_up<float, float>(gate_in, param);
+    gate_elt = situ_up<float, float>(gate_in, param);
+  }
+
+  if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
     const bool dact_mask = act_in <= param.limit;
     const float clamped_act_in = fminf(act_in, param.limit);
     const float s = sigmoid<float, float>(param.alpha * clamped_act_in, empty);
-    act_x = clamped_act_in * s;
-    dact_x = dact_mask ? s + param.alpha * clamped_act_in * s * (1.0f - s) : 0.0f;
-  } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
-    act_x = ActOP(act_in, param);
-    dact_x = DActOP(act_in, param);
-    dgate_mask = false;
-    gate = situ_up<float, float>(gate_in, param);
-  } else if constexpr ((ActOP == &silu<fp32, fp32>) && (DActOP == &dsilu<fp32, fp32>)) {
-    const float s = sigmoid<float, float>(act_in, empty);
-    act_x = act_in * s;
-    dact_x = s + act_in * s * (1.0f - s);
+    act_elt = clamped_act_in * s;
+    dact_elt = dact_mask ? s + param.alpha * clamped_act_in * s * (1.0f - s) : 0.0f;
+  } else if constexpr (std::is_same<ParamOP, Empty>::value) {
+    if constexpr ((ActOP == &silu<fp32, fp32>) && (DActOP == &dsilu<fp32, fp32>)) {
+      const float s = sigmoid<float, float>(act_in, empty);
+      act_elt = act_in * s;
+      dact_elt = s + act_in * s * (1.0f - s);
+    } else {
+      act_elt = ActOP(act_in, param);
+      dact_elt = DActOP(act_in, param);
+    }
   } else {
-    act_x = ActOP(act_in, param);
-    dact_x = DActOP(act_in, param);
+    act_elt = ActOP(act_in, param);
+    dact_elt = DActOP(act_in, param);
   }
 
-  *unscaled = act_x * gate;
-  *dact = dact_x * gate;
-  if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
-    *dgate = act_x * dsitu_up<float, float>(gate_in, param);
-  } else {
-    *dgate = dgate_mask ? act_x : 0.0f;
-  }
+  *unscaled = act_elt * gate_elt;
+  *dact = dact_elt * gate_elt;
+  *dgate = act_elt * dgate_elt;
 }
 
 // ---------------------------------------------------------------------------

--- a/transformer_engine/common/activation/scaled_activation.cu
+++ b/transformer_engine/common/activation/scaled_activation.cu
@@ -78,7 +78,9 @@ __device__ __forceinline__ void gated_backward_values(const float act_in, const 
   float dgate_elt = 1.0f;
 
   if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
-    dgate_elt = gate_in <= param.limit && gate_in >= -param.limit;
+    if (gate_in > param.limit || gate_in < -param.limit) {
+      dgate_elt = 0.f;
+    }
     gate_elt = fminf(fmaxf(-param.limit, gate_in), param.limit) + param.glu_linear_offset;
   } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
     dgate_elt = dsitu_up<float, float>(gate_in, param);

--- a/transformer_engine/common/activation/scaled_activation.cu
+++ b/transformer_engine/common/activation/scaled_activation.cu
@@ -59,6 +59,8 @@ __device__ __forceinline__ float gated_forward_value(const float act_in, const f
   if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
     const float gate = fminf(fmaxf(-param.limit, gate_in), param.limit) + param.glu_linear_offset;
     return ActOP(act_in, param) * gate;
+  } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+    return ActOP(act_in, param) * situ_up<float, float>(gate_in, param);
   } else {
     return ActOP(act_in, param) * gate_in;
   }
@@ -83,6 +85,11 @@ __device__ __forceinline__ void gated_backward_values(const float act_in, const 
     const float s = sigmoid<float, float>(param.alpha * clamped_act_in, empty);
     act_x = clamped_act_in * s;
     dact_x = dact_mask ? s + param.alpha * clamped_act_in * s * (1.0f - s) : 0.0f;
+  } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+    act_x = ActOP(act_in, param);
+    dact_x = DActOP(act_in, param);
+    dgate_mask = false;
+    gate = situ_up<float, float>(gate_in, param);
   } else if constexpr ((ActOP == &silu<fp32, fp32>) && (DActOP == &dsilu<fp32, fp32>)) {
     const float s = sigmoid<float, float>(act_in, empty);
     act_x = act_in * s;
@@ -94,7 +101,11 @@ __device__ __forceinline__ void gated_backward_values(const float act_in, const 
 
   *unscaled = act_x * gate;
   *dact = dact_x * gate;
-  *dgate = dgate_mask ? act_x : 0.0f;
+  if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+    *dgate = act_x * dsitu_up<float, float>(gate_in, param);
+  } else {
+    *dgate = dgate_mask ? act_x : 0.0f;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -630,6 +641,14 @@ template void launch_scaled_gated_backward<ClampedSwiGLUParam, clamped_silu<fp32
                                            clamped_dsilu<fp32, fp32>>(
     const NVTETensor, const NVTETensor, const NVTETensor, NVTETensor, NVTETensor,
     ClampedSwiGLUParam, int64_t, cudaStream_t, const char *);
+
+template void launch_scaled_gated_forward<SiTUGLUParam, situ_gate<fp32, fp32>>(
+    const NVTETensor, const NVTETensor, NVTETensor, SiTUGLUParam, int64_t, cudaStream_t,
+    const char *);
+template void
+launch_scaled_gated_backward<SiTUGLUParam, situ_gate<fp32, fp32>, dsitu_gate<fp32, fp32>>(
+    const NVTETensor, const NVTETensor, const NVTETensor, NVTETensor, NVTETensor, SiTUGLUParam,
+    int64_t, cudaStream_t, const char *);
 
 template void launch_scaled_unary_forward<Empty, srelu<fp32, fp32>>(const NVTETensor,
                                                                     const NVTETensor, NVTETensor,

--- a/transformer_engine/common/activation/scaled_swiglu.cu
+++ b/transformer_engine/common/activation/scaled_swiglu.cu
@@ -6,6 +6,8 @@
 
 #include <transformer_engine/activation.h>
 
+#include <cmath>
+
 #include "../common.h"
 #include "../util/math.h"
 #include "./scaled_activation.h"
@@ -28,6 +30,32 @@ void nvte_scaled_dswiglu(const NVTETensor grad, const NVTETensor input, const NV
   launch_scaled_gated_backward<Empty, silu<fp32, fp32>, dsilu<fp32, fp32>>(
       grad, input, act_scales, grad_input, grad_act_scales, param, glu_interleave_size, stream,
       "nvte_scaled_dswiglu");
+}
+
+void nvte_scaled_situglu(const NVTETensor input, const NVTETensor act_scales, NVTETensor output,
+                         float beta1, float beta2, int64_t glu_interleave_size,
+                         cudaStream_t stream) {
+  NVTE_API_CALL(nvte_scaled_situglu);
+  using namespace transformer_engine;
+  NVTE_CHECK(beta1 > 0.0f && std::isfinite(beta1), "beta1 must be finite and positive.");
+  NVTE_CHECK(beta2 > 0.0f && std::isfinite(beta2), "beta2 must be finite and positive.");
+  SiTUGLUParam param = {beta1, beta2};
+  launch_scaled_gated_forward<SiTUGLUParam, situ_gate<fp32, fp32>>(
+      input, act_scales, output, param, glu_interleave_size, stream, "nvte_scaled_situglu");
+}
+
+void nvte_scaled_dsituglu(const NVTETensor grad, const NVTETensor input,
+                          const NVTETensor act_scales, NVTETensor grad_input,
+                          NVTETensor grad_act_scales, float beta1, float beta2,
+                          int64_t glu_interleave_size, cudaStream_t stream) {
+  NVTE_API_CALL(nvte_scaled_dsituglu);
+  using namespace transformer_engine;
+  NVTE_CHECK(beta1 > 0.0f && std::isfinite(beta1), "beta1 must be finite and positive.");
+  NVTE_CHECK(beta2 > 0.0f && std::isfinite(beta2), "beta2 must be finite and positive.");
+  SiTUGLUParam param = {beta1, beta2};
+  launch_scaled_gated_backward<SiTUGLUParam, situ_gate<fp32, fp32>, dsitu_gate<fp32, fp32>>(
+      grad, input, act_scales, grad_input, grad_act_scales, param, glu_interleave_size, stream,
+      "nvte_scaled_dsituglu");
 }
 
 void nvte_scaled_clamped_swiglu(const NVTETensor input, const NVTETensor act_scales,

--- a/transformer_engine/common/activation/swiglu.cu
+++ b/transformer_engine/common/activation/swiglu.cu
@@ -4,6 +4,8 @@
  * See LICENSE for license information.
  ************************************************************************/
 
+#include <cmath>
+
 #include "../util/math.h"
 #include "./activation_template.h"
 
@@ -33,6 +35,27 @@ void nvte_dswiglu(const NVTETensor grad, const NVTETensor input, NVTETensor outp
   using namespace transformer_engine;
   Empty e = {};
   dgated_act_fn<fp32, Empty, silu<fp32, fp32>, dsilu<fp32, fp32>>(grad, input, output, e, stream);
+}
+
+void nvte_situglu(const NVTETensor input, NVTETensor output, float beta1, float beta2,
+                  cudaStream_t stream) {
+  NVTE_API_CALL(nvte_situglu);
+  using namespace transformer_engine;
+  NVTE_CHECK(beta1 > 0.0f && std::isfinite(beta1), "beta1 must be finite and positive.");
+  NVTE_CHECK(beta2 > 0.0f && std::isfinite(beta2), "beta2 must be finite and positive.");
+  SiTUGLUParam param = {beta1, beta2};
+  gated_act_fn<fp32, SiTUGLUParam, situ_gate<fp32, fp32>>(input, output, param, stream);
+}
+
+void nvte_dsituglu(const NVTETensor grad, const NVTETensor input, NVTETensor output, float beta1,
+                   float beta2, cudaStream_t stream) {
+  NVTE_API_CALL(nvte_dsituglu);
+  using namespace transformer_engine;
+  NVTE_CHECK(beta1 > 0.0f && std::isfinite(beta1), "beta1 must be finite and positive.");
+  NVTE_CHECK(beta2 > 0.0f && std::isfinite(beta2), "beta2 must be finite and positive.");
+  SiTUGLUParam param = {beta1, beta2};
+  dgated_act_fn<fp32, SiTUGLUParam, situ_gate<fp32, fp32>, dsitu_gate<fp32, fp32>>(
+      grad, input, output, param, stream);
 }
 
 void nvte_clamped_swiglu(const NVTETensor input, NVTETensor output, float limit, float alpha,

--- a/transformer_engine/common/cast/fp8/gated_fp8.cuh
+++ b/transformer_engine/common/cast/fp8/gated_fp8.cuh
@@ -203,12 +203,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           }
         }
         float after_dact = dact_x * grad_elt * gate_elt;
-        float after_dgate;
-        if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
-          after_dgate = dgate_elt * act_x * grad_elt;
-        } else {
-          after_dgate = dgate_elt ? act_x * grad_elt : 0.0f;
-        }
+        float after_dgate = dgate_elt * act_x * grad_elt;
 
         out_act_sh_curr[shmem_idx] = static_cast<OType>(scale * after_dact);
         out_gate_sh_curr[shmem_idx] = static_cast<OType>(scale * after_dgate);

--- a/transformer_engine/common/cast/fp8/gated_fp8.cuh
+++ b/transformer_engine/common/cast/fp8/gated_fp8.cuh
@@ -165,10 +165,13 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
       float act_elt = static_cast<float>(in_act_sh_curr[shmem_idx]);
       float gate_elt = static_cast<float>(in_gate_sh_curr[shmem_idx]);
-      bool dgate_elt = true;  // gating is ideally an identity function
+      float dgate_elt = 1.0f;  // gating is ideally an identity function
       if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
         dgate_elt = gate_elt <= p.limit && gate_elt >= -p.limit;
         gate_elt = min(max(-p.limit, gate_elt), p.limit) + p.glu_linear_offset;
+      } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+        dgate_elt = dsitu_up<float, float>(gate_elt, p);
+        gate_elt = situ_up<float, float>(gate_elt, p);
       }
 
       if constexpr (IS_BWD) {
@@ -186,6 +189,9 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           } else {
             dact_x = 0.0f;
           }
+        } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+          act_x = ActOP(x, p);
+          dact_x = DActOP(x, p);
         } else {
           if constexpr ((ActOP == &silu<fp32, fp32>) && (DActOP == &dsilu<fp32, fp32>)) {
             const float s = sigmoidf(x);
@@ -197,7 +203,12 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           }
         }
         float after_dact = dact_x * grad_elt * gate_elt;
-        float after_dgate = dgate_elt ? act_x * grad_elt : 0.0f;
+        float after_dgate;
+        if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+          after_dgate = dgate_elt * act_x * grad_elt;
+        } else {
+          after_dgate = dgate_elt ? act_x * grad_elt : 0.0f;
+        }
 
         out_act_sh_curr[shmem_idx] = static_cast<OType>(scale * after_dact);
         out_gate_sh_curr[shmem_idx] = static_cast<OType>(scale * after_dgate);

--- a/transformer_engine/common/cast/fp8/gated_fp8.cuh
+++ b/transformer_engine/common/cast/fp8/gated_fp8.cuh
@@ -167,7 +167,9 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       float gate_elt = static_cast<float>(in_gate_sh_curr[shmem_idx]);
       float dgate_elt = 1.0f;  // gating is ideally an identity function
       if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
-        dgate_elt = gate_elt <= p.limit && gate_elt >= -p.limit;
+        if (gate_elt > p.limit || gate_elt < -p.limit) {
+          dgate_elt = 0.f;
+        }
         gate_elt = min(max(-p.limit, gate_elt), p.limit) + p.glu_linear_offset;
       } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
         dgate_elt = dsitu_up<float, float>(gate_elt, p);

--- a/transformer_engine/common/cast/mxfp8/gated_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/gated_mxfp8.cuh
@@ -274,11 +274,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           }
 
           after_act_elt = dact_x * grad_elt * gate_elt;
-          if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
-            after_gate_elt = dgate_elt * act_x * grad_elt;
-          } else {
-            after_gate_elt = dgate_elt ? act_x * grad_elt : 0.0f;
-          }
+          after_gate_elt = dgate_elt * act_x * grad_elt;
         } else {
           after_act_elt = ActOP(act_elt, p) * gate_elt;
         }
@@ -548,11 +544,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
               }
 
               after_act_elt = dact_x * grad_elt * gate_elt;
-              if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
-                after_gate_elt = dgate_elt * act_x * grad_elt;
-              } else {
-                after_gate_elt = dgate_elt ? act_x * grad_elt : 0.0f;
-              }
+              after_gate_elt = dgate_elt * act_x * grad_elt;
               after_act_rowwise[j] = after_act_elt;
               after_gate_rowwise[j] = after_gate_elt;
             } else {

--- a/transformer_engine/common/cast/mxfp8/gated_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/gated_mxfp8.cuh
@@ -241,10 +241,13 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
         float gate_elt = static_cast<float>(in_gate_sh[shmem_offset_colwise]);
         float after_act_elt;
         float after_gate_elt;
-        bool dgate_elt = true;  // gating is ideally an identity function
+        float dgate_elt = 1.0f;  // gating is ideally an identity function
         if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
           dgate_elt = gate_elt <= p.limit && gate_elt >= -p.limit;
           gate_elt = min(max(-p.limit, gate_elt), p.limit) + p.glu_linear_offset;
+        } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+          dgate_elt = dsitu_up<float, float>(gate_elt, p);
+          gate_elt = situ_up<float, float>(gate_elt, p);
         }
         if constexpr (IS_BWD) {
           float grad_elt = static_cast<float>(in_grad_sh[shmem_offset_colwise]);
@@ -256,6 +259,9 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
             const float s = sigmoidf(p.alpha * x);
             act_x = x * s;
             dact_x = act_elt <= p.limit ? s + s * (1 - s) * p.alpha * x : 0.0f;
+          } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+            act_x = ActOP(x, p);
+            dact_x = DActOP(x, p);
           } else {
             if constexpr ((ActOP == &silu<fp32, fp32>) && (DActOP == &dsilu<fp32, fp32>)) {
               const float s = sigmoidf(x);
@@ -268,7 +274,11 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
           }
 
           after_act_elt = dact_x * grad_elt * gate_elt;
-          after_gate_elt = dgate_elt ? act_x * grad_elt : 0.0f;
+          if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+            after_gate_elt = dgate_elt * act_x * grad_elt;
+          } else {
+            after_gate_elt = dgate_elt ? act_x * grad_elt : 0.0f;
+          }
         } else {
           after_act_elt = ActOP(act_elt, p) * gate_elt;
         }
@@ -505,10 +515,13 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
             float gate_elt = static_cast<float>(in_gate.data.elt[e]);
             float after_act_elt;
             float after_gate_elt;
-            bool dgate_elt = true;
+            float dgate_elt = 1.0f;
             if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
               dgate_elt = gate_elt <= p.limit && gate_elt >= -p.limit;
               gate_elt = min(max(-p.limit, gate_elt), p.limit) + p.glu_linear_offset;
+            } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+              dgate_elt = dsitu_up<float, float>(gate_elt, p);
+              gate_elt = situ_up<float, float>(gate_elt, p);
             }
             if constexpr (IS_BWD) {
               float grad_elt = static_cast<float>(in_grad.data.elt[e]);
@@ -520,6 +533,9 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
                 const float s = sigmoidf(p.alpha * x);
                 act_x = x * s;
                 dact_x = act_elt <= p.limit ? s + s * (1 - s) * p.alpha * x : 0.0f;
+              } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+                act_x = ActOP(x, p);
+                dact_x = DActOP(x, p);
               } else {
                 if constexpr ((ActOP == &silu<fp32, fp32>) && (DActOP == &dsilu<fp32, fp32>)) {
                   const float s = sigmoidf(x);
@@ -532,7 +548,11 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
               }
 
               after_act_elt = dact_x * grad_elt * gate_elt;
-              after_gate_elt = dgate_elt ? act_x * grad_elt : 0.0f;
+              if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
+                after_gate_elt = dgate_elt * act_x * grad_elt;
+              } else {
+                after_gate_elt = dgate_elt ? act_x * grad_elt : 0.0f;
+              }
               after_act_rowwise[j] = after_act_elt;
               after_gate_rowwise[j] = after_gate_elt;
             } else {

--- a/transformer_engine/common/cast/mxfp8/gated_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/gated_mxfp8.cuh
@@ -243,7 +243,9 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
         float after_gate_elt;
         float dgate_elt = 1.0f;  // gating is ideally an identity function
         if constexpr (std::is_same<ParamOP, ClampedSwiGLUParam>::value) {
-          dgate_elt = gate_elt <= p.limit && gate_elt >= -p.limit;
+          if (gate_elt > p.limit || gate_elt < -p.limit) {
+            dgate_elt = 0.f;
+          }
           gate_elt = min(max(-p.limit, gate_elt), p.limit) + p.glu_linear_offset;
         } else if constexpr (std::is_same<ParamOP, SiTUGLUParam>::value) {
           dgate_elt = dsitu_up<float, float>(gate_elt, p);

--- a/transformer_engine/common/include/transformer_engine/activation.h
+++ b/transformer_engine/common/include/transformer_engine/activation.h
@@ -321,6 +321,21 @@ void nvte_geglu(const NVTETensor input, NVTETensor output, cudaStream_t stream);
  */
 void nvte_swiglu(const NVTETensor input, NVTETensor output, cudaStream_t stream);
 
+/*! \brief Computes SiTU-GLU with configurable soft-cap parameters.
+ *
+ *  Computes beta1 * tanh(gate / beta1) * sigmoid(gate) times
+ *  beta2 * tanh(up / beta2), where gate and up are the two input halves.
+ *  MXFP8 output quantization is supported on SM100+.
+ *
+ *  \param[in]     input     Input tensor of shape [N, H * 2].
+ *  \param[in,out] output    Output tensor of shape [N, H].
+ *  \param[in]     beta1     Positive gate soft-cap parameter.
+ *  \param[in]     beta2     Positive up-branch soft-cap parameter.
+ *  \param[in]     stream    CUDA stream used for the operation.
+ */
+void nvte_situglu(const NVTETensor input, NVTETensor output, float beta1, float beta2,
+                  cudaStream_t stream);
+
 /*! \brief Computes the gated Swish activation of the input used in GPT OSS.
  *
  *  \deprecated This function has been deprecated in favor of nvte_clamped_swiglu_v2,
@@ -383,6 +398,21 @@ void nvte_clamped_swiglu_v2(const NVTETensor input, NVTETensor output, float lim
  */
 void nvte_scaled_swiglu(const NVTETensor input, const NVTETensor act_scales, NVTETensor output,
                         int64_t glu_interleave_size, cudaStream_t stream);
+
+/*! \brief Computes row-scaled SiTU-GLU without materializing GLU deinterleave.
+ *
+ *  \param[in]     input                Input tensor of shape [N, H * 2].
+ *  \param[in]     act_scales           Row-wise activation scales of shape [N].
+ *  \param[in,out] output               Output tensor of shape [N, H].
+ *  \param[in]     beta1                Positive gate soft-cap parameter.
+ *  \param[in]     beta2                Positive up-branch soft-cap parameter.
+ *  \param[in]     glu_interleave_size  0 for contiguous layout; otherwise a positive multiple
+ *                                      of 32 that divides H.
+ *  \param[in]     stream               CUDA stream used for the operation.
+ */
+void nvte_scaled_situglu(const NVTETensor input, const NVTETensor act_scales, NVTETensor output,
+                         float beta1, float beta2, int64_t glu_interleave_size,
+                         cudaStream_t stream);
 
 /*! \brief Computes ScaledClampedSwiGLU without materializing GLU deinterleave.
  *
@@ -462,6 +492,18 @@ void nvte_dgeglu(const NVTETensor grad, const NVTETensor input, NVTETensor outpu
 void nvte_dswiglu(const NVTETensor grad, const NVTETensor input, NVTETensor output,
                   cudaStream_t stream);
 
+/*! \brief Computes the SiTU-GLU activation gradient.
+ *
+ *  \param[in]     grad      Incoming gradient of shape [N, H].
+ *  \param[in]     input     Forward input tensor of shape [N, H * 2].
+ *  \param[in,out] output    Outgoing gradient of shape [N, H * 2].
+ *  \param[in]     beta1     Positive gate soft-cap parameter.
+ *  \param[in]     beta2     Positive up-branch soft-cap parameter.
+ *  \param[in]     stream    CUDA stream used for the operation.
+ */
+void nvte_dsituglu(const NVTETensor grad, const NVTETensor input, NVTETensor output, float beta1,
+                   float beta2, cudaStream_t stream);
+
 /*! \brief Computes the gradient of gated Swish activation of the input used in GPT OSS.
  *
  *  \deprecated This function has been deprecated in favor of nvte_clamped_dswiglu_v2,
@@ -527,6 +569,27 @@ void nvte_clamped_dswiglu_v2(const NVTETensor grad, const NVTETensor input, NVTE
 void nvte_scaled_dswiglu(const NVTETensor grad, const NVTETensor input, const NVTETensor act_scales,
                          NVTETensor grad_input, NVTETensor grad_act_scales,
                          int64_t glu_interleave_size, cudaStream_t stream);
+
+/*! \brief Computes row-scaled SiTU-GLU backward without materializing GLU deinterleave.
+ *
+ *  When grad_act_scales is non-null, it receives the reduction
+ *  sum(dY * SiTUGLU(input), dim=-1).
+ *
+ *  \param[in]     grad                 Incoming gradient of shape [N, H].
+ *  \param[in]     input                Forward input tensor of shape [N, H * 2].
+ *  \param[in]     act_scales           Row-wise activation scales of shape [N].
+ *  \param[in,out] grad_input           Outgoing gradient of shape [N, H * 2].
+ *  \param[in,out] grad_act_scales      Optional row-wise scale gradient of shape [N], or null.
+ *  \param[in]     beta1                Positive gate soft-cap parameter.
+ *  \param[in]     beta2                Positive up-branch soft-cap parameter.
+ *  \param[in]     glu_interleave_size  0 for contiguous layout; otherwise a positive multiple
+ *                                      of 32 that divides H.
+ *  \param[in]     stream               CUDA stream used for the operation.
+ */
+void nvte_scaled_dsituglu(const NVTETensor grad, const NVTETensor input,
+                          const NVTETensor act_scales, NVTETensor grad_input,
+                          NVTETensor grad_act_scales, float beta1, float beta2,
+                          int64_t glu_interleave_size, cudaStream_t stream);
 
 /*! \brief Computes ScaledClampedSwiGLU backward without materializing GLU deinterleave.
  *

--- a/transformer_engine/common/util/math.h
+++ b/transformer_engine/common/util/math.h
@@ -17,6 +17,11 @@ struct ClampedSwiGLUParam {
   float glu_linear_offset = 1.0f;  // Offset added to the linear (gate) component after clamping
 };
 
+struct SiTUGLUParam {
+  float beta1 = 4.0f;
+  float beta2 = 25.0f;
+};
+
 template <typename OType, typename IType>
 __device__ inline OType gelu(const IType val, const Empty&) {
   const float cval = val;
@@ -87,6 +92,35 @@ template <typename OType, typename IType>
 __device__ inline OType dsilu(const IType val, const Empty& e) {
   const float cval = val;
   return cval * dsigmoid<float, float>(cval, e) + sigmoid<float, float>(cval, e);
+}
+
+template <typename OType, typename IType>
+__device__ inline OType situ_gate(const IType val, const SiTUGLUParam& p) {
+  const float x = static_cast<float>(val);
+  Empty e = {};
+  return p.beta1 * tanhf(x / p.beta1) * sigmoid<float, float>(x, e);
+}
+
+template <typename OType, typename IType>
+__device__ inline OType dsitu_gate(const IType val, const SiTUGLUParam& p) {
+  const float x = static_cast<float>(val);
+  const float t = tanhf(x / p.beta1);
+  Empty e = {};
+  const float s = sigmoid<float, float>(x, e);
+  return (1.0f - t * t) * s + p.beta1 * t * s * (1.0f - s);
+}
+
+template <typename OType, typename IType>
+__device__ inline OType situ_up(const IType val, const SiTUGLUParam& p) {
+  const float x = static_cast<float>(val);
+  return p.beta2 * tanhf(x / p.beta2);
+}
+
+template <typename OType, typename IType>
+__device__ inline OType dsitu_up(const IType val, const SiTUGLUParam& p) {
+  const float x = static_cast<float>(val);
+  const float t = tanhf(x / p.beta2);
+  return 1.0f - t * t;
 }
 
 template <typename OType, typename IType>

--- a/transformer_engine/common/util/vectorized_pointwise.h
+++ b/transformer_engine/common/util/vectorized_pointwise.h
@@ -436,6 +436,8 @@ __launch_bounds__(unary_kernel_threads) __global__
       if constexpr (std::is_same<Param, ClampedSwiGLUParam>::value) {
         ComputeType limit = p.limit;
         val2 = std::min(std::max(-limit, val2), limit) + p.glu_linear_offset;
+      } else if constexpr (std::is_same<Param, SiTUGLUParam>::value) {
+        val2 = situ_up<ComputeType, ComputeType>(val2, p);
       }
       ComputeType temp = static_cast<ComputeType>(Activation(val, p) * val2);
       if (requires_amax) {
@@ -538,16 +540,24 @@ __launch_bounds__(unary_kernel_threads) __global__
       const ComputeType grad_val = static_cast<ComputeType>(grad_loader.separate()[i]);
       const ComputeType gelu_in = static_cast<ComputeType>(input_loader0.separate()[i]);
       ComputeType gate_in = static_cast<ComputeType>(input_loader1.separate()[i]);
-      bool dgate_in = true;
+      ComputeType dgate_in = 1.0f;
 
       if constexpr (std::is_same<Param, ClampedSwiGLUParam>::value) {
         const ComputeType limit = p.limit;
         dgate_in = gate_in <= limit && gate_in >= -limit;
         gate_in = std::min(std::max(-limit, gate_in), limit) + p.glu_linear_offset;
+      } else if constexpr (std::is_same<Param, SiTUGLUParam>::value) {
+        dgate_in = dsitu_up<ComputeType, ComputeType>(gate_in, p);
+        gate_in = situ_up<ComputeType, ComputeType>(gate_in, p);
       }
 
       ComputeType after_dgelu = Dactivation(gelu_in, p) * grad_val * gate_in;
-      ComputeType after_dgate = dgate_in ? grad_val * Activation(gelu_in, p) : 0.0f;
+      ComputeType after_dgate;
+      if constexpr (std::is_same<Param, SiTUGLUParam>::value) {
+        after_dgate = grad_val * Activation(gelu_in, p) * dgate_in;
+      } else {
+        after_dgate = dgate_in ? grad_val * Activation(gelu_in, p) : 0.0f;
+      }
 
       if (requires_amax) {
         __builtin_assume(max >= 0);

--- a/transformer_engine/common/util/vectorized_pointwise.h
+++ b/transformer_engine/common/util/vectorized_pointwise.h
@@ -552,12 +552,7 @@ __launch_bounds__(unary_kernel_threads) __global__
       }
 
       ComputeType after_dgelu = Dactivation(gelu_in, p) * grad_val * gate_in;
-      ComputeType after_dgate;
-      if constexpr (std::is_same<Param, SiTUGLUParam>::value) {
-        after_dgate = grad_val * Activation(gelu_in, p) * dgate_in;
-      } else {
-        after_dgate = dgate_in ? grad_val * Activation(gelu_in, p) : 0.0f;
-      }
+      ComputeType after_dgate = dgate_in * grad_val * Activation(gelu_in, p);
 
       if (requires_amax) {
         __builtin_assume(max >= 0);

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -285,6 +285,11 @@ py::object swiglu(const at::Tensor &input, py::handle quantizer);
 
 py::object dswiglu(const at::Tensor &grad, const at::Tensor &input, py::handle quantizer);
 
+py::object situglu(const at::Tensor &input, py::handle quantizer, float beta1, float beta2);
+
+py::object dsituglu(const at::Tensor &grad, const at::Tensor &input, py::handle quantizer,
+                    float beta1, float beta2);
+
 py::object clamped_swiglu(const at::Tensor &input, py::handle quantizer, float limit, float alpha,
                           float glu_linear_offset);
 
@@ -294,6 +299,10 @@ py::object clamped_dswiglu(const at::Tensor &grad, const at::Tensor &input, py::
 /* Scaled activation */
 py::object scaled_swiglu(const at::Tensor &input, const at::Tensor &act_scales,
                          py::handle quantizer, int64_t glu_interleave_size);
+
+py::object scaled_situglu(const at::Tensor &input, const at::Tensor &act_scales,
+                          py::handle quantizer, float beta1, float beta2,
+                          int64_t glu_interleave_size);
 
 py::object scaled_clamped_swiglu(const at::Tensor &input, const at::Tensor &act_scales,
                                  py::handle quantizer, float limit, float alpha,
@@ -305,6 +314,10 @@ py::object scaled_srelu(const at::Tensor &input, const at::Tensor &act_scales,
 py::tuple scaled_dswiglu(const at::Tensor &grad, const at::Tensor &input,
                          const at::Tensor &act_scales, py::handle quantizer,
                          int64_t glu_interleave_size, bool compute_scale_grad);
+
+py::tuple scaled_dsituglu(const at::Tensor &grad, const at::Tensor &input,
+                          const at::Tensor &act_scales, py::handle quantizer, float beta1,
+                          float beta2, int64_t glu_interleave_size, bool compute_scale_grad);
 
 py::tuple scaled_clamped_dswiglu(const at::Tensor &grad, const at::Tensor &input,
                                  const at::Tensor &act_scales, py::handle quantizer, float limit,

--- a/transformer_engine/pytorch/csrc/extensions/activation.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/activation.cpp
@@ -329,6 +329,15 @@ py::object dswiglu(const at::Tensor& grad, const at::Tensor& input, py::handle q
   return dactivation_helper<nvte_dswiglu, nullptr>(grad, input, quantizer);
 }
 
+py::object situglu(const at::Tensor& input, py::handle quantizer, float beta1, float beta2) {
+  return activation_helper<nullptr, nvte_situglu>(input, quantizer, 2, beta1, beta2);
+}
+
+py::object dsituglu(const at::Tensor& grad, const at::Tensor& input, py::handle quantizer,
+                    float beta1, float beta2) {
+  return dactivation_helper<nullptr, nvte_dsituglu>(grad, input, quantizer, beta1, beta2);
+}
+
 /* clamped functions */
 py::object clamped_swiglu(const at::Tensor& input, py::handle quantizer, float limit, float alpha,
                           float glu_linear_offset) {
@@ -450,6 +459,13 @@ py::object scaled_swiglu(const at::Tensor& input, const at::Tensor& act_scales,
                                                       /*shape_divisor=*/2, glu_interleave_size);
 }
 
+py::object scaled_situglu(const at::Tensor& input, const at::Tensor& act_scales,
+                          py::handle quantizer, float beta1, float beta2,
+                          int64_t glu_interleave_size) {
+  return scaled_activation_helper<nvte_scaled_situglu>(
+      input, act_scales, quantizer, /*shape_divisor=*/2, beta1, beta2, glu_interleave_size);
+}
+
 py::object scaled_clamped_swiglu(const at::Tensor& input, const at::Tensor& act_scales,
                                  py::handle quantizer, float limit, float alpha,
                                  float glu_linear_offset, int64_t glu_interleave_size) {
@@ -469,6 +485,13 @@ py::tuple scaled_dswiglu(const at::Tensor& grad, const at::Tensor& input,
                          int64_t glu_interleave_size, bool compute_scale_grad) {
   return scaled_dactivation_helper<nvte_scaled_dswiglu>(grad, input, act_scales, quantizer,
                                                         compute_scale_grad, glu_interleave_size);
+}
+
+py::tuple scaled_dsituglu(const at::Tensor& grad, const at::Tensor& input,
+                          const at::Tensor& act_scales, py::handle quantizer, float beta1,
+                          float beta2, int64_t glu_interleave_size, bool compute_scale_grad) {
+  return scaled_dactivation_helper<nvte_scaled_dsituglu>(
+      grad, input, act_scales, quantizer, compute_scale_grad, beta1, beta2, glu_interleave_size);
 }
 
 py::tuple scaled_clamped_dswiglu(const at::Tensor& grad, const at::Tensor& input,

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -258,6 +258,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("quantizer"));
   m.def("swiglu", transformer_engine::pytorch::swiglu, "SwiGLU activation", py::arg("input"),
         py::arg("quantizer"));
+  m.def("situglu", transformer_engine::pytorch::situglu, "SiTU-GLU activation", py::arg("input"),
+        py::arg("quantizer"), py::arg("beta1") = 4.0f, py::arg("beta2") = 25.0f);
   m.def("clamped_swiglu", transformer_engine::pytorch::clamped_swiglu,
         "SwiGLU activation used in GPT OSS", py::arg("input"), py::arg("quantizer"),
         py::arg("limit") = 7.0f, py::arg("alpha") = 1.702f, py::arg("glu_linear_offset") = 1.0f);
@@ -287,6 +289,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("fwd_input"), py::arg("quantizer"));
   m.def("dswiglu", transformer_engine::pytorch::dswiglu, "Backward of SwiGLU", py::arg("grad"),
         py::arg("fwd_input"), py::arg("quantizer"));
+  m.def("dsituglu", transformer_engine::pytorch::dsituglu, "Backward of SiTU-GLU", py::arg("grad"),
+        py::arg("fwd_input"), py::arg("quantizer"), py::arg("beta1") = 4.0f,
+        py::arg("beta2") = 25.0f);
   m.def("clamped_dswiglu", transformer_engine::pytorch::clamped_dswiglu,
         "Backward of SwiGLU used in GPT OSS", py::arg("grad"), py::arg("fwd_input"),
         py::arg("quantizer"), py::arg("limit") = 7.0f, py::arg("alpha") = 1.702f,
@@ -295,6 +300,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("scaled_swiglu", transformer_engine::pytorch::scaled_swiglu, "Scaled SwiGLU activation",
         py::arg("input"), py::arg("act_scales"), py::arg("quantizer"),
         py::arg("glu_interleave_size") = 0);
+  m.def("scaled_situglu", transformer_engine::pytorch::scaled_situglu, "Scaled SiTU-GLU activation",
+        py::arg("input"), py::arg("act_scales"), py::arg("quantizer"), py::arg("beta1") = 4.0f,
+        py::arg("beta2") = 25.0f, py::arg("glu_interleave_size") = 0);
   m.def("scaled_clamped_swiglu", transformer_engine::pytorch::scaled_clamped_swiglu,
         "Scaled clamped SwiGLU activation", py::arg("input"), py::arg("act_scales"),
         py::arg("quantizer"), py::arg("limit") = 7.0f, py::arg("alpha") = 1.702f,
@@ -304,6 +312,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("scaled_dswiglu", transformer_engine::pytorch::scaled_dswiglu, "Scaled SwiGLU backward",
         py::arg("grad"), py::arg("fwd_input"), py::arg("act_scales"), py::arg("quantizer"),
         py::arg("glu_interleave_size") = 0, py::arg("compute_scale_grad") = true);
+  m.def("scaled_dsituglu", transformer_engine::pytorch::scaled_dsituglu, "Scaled SiTU-GLU backward",
+        py::arg("grad"), py::arg("fwd_input"), py::arg("act_scales"), py::arg("quantizer"),
+        py::arg("beta1") = 4.0f, py::arg("beta2") = 25.0f, py::arg("glu_interleave_size") = 0,
+        py::arg("compute_scale_grad") = true);
   m.def("scaled_clamped_dswiglu", transformer_engine::pytorch::scaled_clamped_dswiglu,
         "Scaled clamped SwiGLU backward", py::arg("grad"), py::arg("fwd_input"),
         py::arg("act_scales"), py::arg("quantizer"), py::arg("limit") = 7.0f,

--- a/transformer_engine/pytorch/ops/basic/__init__.py
+++ b/transformer_engine/pytorch/ops/basic/__init__.py
@@ -33,4 +33,11 @@ from .quantize import Quantize
 from .reduce_scatter import ReduceScatter
 from .reshape import Reshape
 from .rmsnorm import RMSNorm
-from .swiglu import ClampedSwiGLU, ScaledClampedQGeGLU, ScaledSwiGLU, SwiGLU
+from .swiglu import (
+    ClampedSwiGLU,
+    ScaledClampedQGeGLU,
+    ScaledSiTUGLU,
+    ScaledSwiGLU,
+    SiTUGLU,
+    SwiGLU,
+)

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -470,6 +470,11 @@ class _ScaledGLU(BasicOperation):
     ) -> None:
         super().__init__()
         self.glu_interleave_size: Optional[int] = glu_interleave_size
+        if activation_recompute_in_mlp:
+            raise ValueError(
+                f"{self.__class__.__name__} does not support activation recomputation "
+                "in the fused grouped MLP"
+            )
         self.activation_recompute_in_mlp: bool = activation_recompute_in_mlp
 
     def _scaled_glu_forward(
@@ -603,8 +608,8 @@ class ScaledSwiGLU(_ScaledGLU):
         interleaved format. See the corresponding option in the SwiGLU
         operation for more details.
     activation_recompute_in_mlp : bool, default = ``False``
-        Enable fused grouped MLP kernels to recompute activation outputs
-        during backward when supported instead of saving them.
+        Must be ``False``. Fused grouped-MLP activation recomputation is not
+        implemented for SwiGLU.
 
     """
 
@@ -652,16 +657,23 @@ class ScaledSiTUGLU(_ScaledGLU):
         Positive up-branch soft-cap parameter.
     glu_interleave_size : int, optional
         Block-interleaved GLU layout, as in :class:`ScaledSwiGLU`.
+    activation_recompute_in_mlp : bool, default = ``False``
+        Must be ``False``. Fused grouped-MLP activation recomputation is not
+        implemented for SiTU-GLU.
     """
 
     def __init__(
         self,
         glu_interleave_size: Optional[int] = None,
         *,
+        activation_recompute_in_mlp: bool = False,
         beta1: float = 4.0,
         beta2: float = 25.0,
     ) -> None:
-        super().__init__(glu_interleave_size)
+        super().__init__(
+            glu_interleave_size,
+            activation_recompute_in_mlp=activation_recompute_in_mlp,
+        )
         self.beta1 = float(beta1)
         self.beta2 = float(beta2)
         if not math.isfinite(self.beta1) or self.beta1 <= 0.0:
@@ -717,8 +729,8 @@ class ScaledClampedQGeGLU(_ScaledGLU):
         When set, the GLU activations will use an experimental block
         interleaved format. See :class:`ClampedSwiGLU`.
     activation_recompute_in_mlp : bool, default = ``False``
-        Enable fused grouped MLP kernels to recompute activation outputs
-        during backward when supported instead of saving them.
+        Must be ``False``. Fused grouped-MLP activation recomputation is not
+        implemented for clamped QGeGLU.
     limit : float, default ``7.0``
         Clamp limit (see :class:`ClampedSwiGLU`).
     alpha : float, default ``1.702``

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 from collections.abc import Iterable, Sequence
+import math
 from typing import Any, Optional
 
 import torch
@@ -18,7 +19,14 @@ from ...utils import clear_tensor_data
 from ..op import BasicOperation, OperationContext
 from .._common import maybe_dequantize
 
-__all__ = ["SwiGLU", "ClampedSwiGLU", "ScaledSwiGLU", "ScaledClampedQGeGLU"]
+__all__ = [
+    "SwiGLU",
+    "SiTUGLU",
+    "ClampedSwiGLU",
+    "ScaledSwiGLU",
+    "ScaledSiTUGLU",
+    "ScaledClampedQGeGLU",
+]
 
 
 class SwiGLU(BasicOperation):
@@ -80,6 +88,23 @@ class SwiGLU(BasicOperation):
         self.cache_quantized_input: bool = cache_quantized_input
         self.glu_interleave_size: Optional[int] = glu_interleave_size
 
+    def _tex_swiglu_forward(
+        self,
+        input_: torch.Tensor,
+        quantizer: Optional[Quantizer],
+    ) -> torch.Tensor:
+        """Call the Transformer Engine SwiGLU forward kernel."""
+        return tex.swiglu(input_, quantizer)
+
+    def _tex_swiglu_backward(
+        self,
+        grad_output: torch.Tensor,
+        input_: torch.Tensor,
+        quantizer: Optional[Quantizer],
+    ) -> torch.Tensor:
+        """Call the Transformer Engine SwiGLU backward kernel."""
+        return tex.dswiglu(grad_output, input_, quantizer)
+
     def op_forward(
         self,
         ctx: OperationContext,
@@ -114,7 +139,7 @@ class SwiGLU(BasicOperation):
             swiglu_in = swiglu_in.view(shape)
 
         # Launch kernel
-        out = tex.swiglu(swiglu_in, next_op_input_quantizer)
+        out = self._tex_swiglu_forward(swiglu_in, next_op_input_quantizer)
 
         # Quantize input to FP8 before caching if needed
         if self.cache_quantized_input:
@@ -167,7 +192,7 @@ class SwiGLU(BasicOperation):
             quantizer = None
 
         # Launch kernel
-        grad_swiglu_in = tex.dswiglu(dy, swiglu_in, quantizer)
+        grad_swiglu_in = self._tex_swiglu_backward(dy, swiglu_in, quantizer)
 
         # Apply interleaving if needed
         dx = grad_swiglu_in
@@ -186,6 +211,66 @@ class SwiGLU(BasicOperation):
         clear_tensor_data(input_)
 
         return dx, ()
+
+
+class SiTUGLU(SwiGLU):
+    r"""Soft-capped SiLU gated linear unit used by Kimi K3.
+
+    See the `Kimi K3 technical report
+    <https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf>`__.
+
+    The input is split into gate and up-projection halves and computes
+
+    .. math::
+
+       \beta_1 \tanh(a / \beta_1) \sigma(a)
+       \; \beta_2 \tanh(b / \beta_2).
+
+    Parameters
+    ----------
+    beta1 : float, default = 4.0
+        Positive gate soft-cap parameter.
+    beta2 : float, default = 25.0
+        Positive up-branch soft-cap parameter.
+    cache_quantized_input : bool, default = False
+        Quantize the saved input for backward, as in :class:`SwiGLU`.
+    glu_interleave_size : int, optional
+        Block-interleaved GLU layout, as in :class:`SwiGLU`.
+    """
+
+    def __init__(
+        self,
+        *,
+        beta1: float = 4.0,
+        beta2: float = 25.0,
+        cache_quantized_input: bool = False,
+        glu_interleave_size: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            cache_quantized_input=cache_quantized_input,
+            glu_interleave_size=glu_interleave_size,
+        )
+        self.beta1 = float(beta1)
+        self.beta2 = float(beta2)
+        if not math.isfinite(self.beta1) or self.beta1 <= 0.0:
+            raise ValueError(f"beta1 must be finite and positive, got {self.beta1}")
+        if not math.isfinite(self.beta2) or self.beta2 <= 0.0:
+            raise ValueError(f"beta2 must be finite and positive, got {self.beta2}")
+
+    def _tex_swiglu_forward(
+        self,
+        input_: torch.Tensor,
+        quantizer: Optional[Quantizer],
+    ) -> torch.Tensor:
+        return tex.situglu(input_, quantizer, self.beta1, self.beta2)
+
+    def _tex_swiglu_backward(
+        self,
+        grad_output: torch.Tensor,
+        input_: torch.Tensor,
+        quantizer: Optional[Quantizer],
+    ) -> torch.Tensor:
+        return tex.dsituglu(grad_output, input_, quantizer, self.beta1, self.beta2)
 
 
 class ClampedSwiGLU(BasicOperation):
@@ -548,6 +633,77 @@ class ScaledSwiGLU(_ScaledGLU):
             input_,
             scales,
             None,
+            int(self.glu_interleave_size or 0),
+            compute_scale_grad,
+        )
+
+
+class ScaledSiTUGLU(_ScaledGLU):
+    r"""SiTU-GLU with a row-wise post-activation scale.
+
+    This is the native fallback and the pattern marker for cuDNN-frontend's
+    block-scaled grouped-MLP SiTU-GLU fusion.
+
+    Parameters
+    ----------
+    beta1 : float, default = 4.0
+        Positive gate soft-cap parameter.
+    beta2 : float, default = 25.0
+        Positive up-branch soft-cap parameter.
+    glu_interleave_size : int, optional
+        Block-interleaved GLU layout, as in :class:`ScaledSwiGLU`.
+    activation_recompute_in_mlp : bool, default = False
+        Enable activation recomputation in the fused grouped MLP.
+    """
+
+    def __init__(
+        self,
+        glu_interleave_size: Optional[int] = None,
+        *,
+        activation_recompute_in_mlp: bool = False,
+        beta1: float = 4.0,
+        beta2: float = 25.0,
+    ) -> None:
+        super().__init__(
+            glu_interleave_size,
+            activation_recompute_in_mlp=activation_recompute_in_mlp,
+        )
+        self.beta1 = float(beta1)
+        self.beta2 = float(beta2)
+        if not math.isfinite(self.beta1) or self.beta1 <= 0.0:
+            raise ValueError(f"beta1 must be finite and positive, got {self.beta1}")
+        if not math.isfinite(self.beta2) or self.beta2 <= 0.0:
+            raise ValueError(f"beta2 must be finite and positive, got {self.beta2}")
+
+    def _scaled_glu_forward(
+        self,
+        input_: torch.Tensor,
+        scales: torch.Tensor,
+    ) -> torch.Tensor:
+        return tex.scaled_situglu(
+            input_,
+            scales,
+            None,
+            self.beta1,
+            self.beta2,
+            int(self.glu_interleave_size or 0),
+        )
+
+    def _scaled_glu_backward(
+        self,
+        grad_output: torch.Tensor,
+        input_: torch.Tensor,
+        scales: torch.Tensor,
+        *,
+        compute_scale_grad: bool,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        return tex.scaled_dsituglu(
+            grad_output,
+            input_,
+            scales,
+            None,
+            self.beta1,
+            self.beta2,
             int(self.glu_interleave_size or 0),
             compute_scale_grad,
         )

--- a/transformer_engine/pytorch/ops/basic/swiglu.py
+++ b/transformer_engine/pytorch/ops/basic/swiglu.py
@@ -652,22 +652,16 @@ class ScaledSiTUGLU(_ScaledGLU):
         Positive up-branch soft-cap parameter.
     glu_interleave_size : int, optional
         Block-interleaved GLU layout, as in :class:`ScaledSwiGLU`.
-    activation_recompute_in_mlp : bool, default = False
-        Enable activation recomputation in the fused grouped MLP.
     """
 
     def __init__(
         self,
         glu_interleave_size: Optional[int] = None,
         *,
-        activation_recompute_in_mlp: bool = False,
         beta1: float = 4.0,
         beta2: float = 25.0,
     ) -> None:
-        super().__init__(
-            glu_interleave_size,
-            activation_recompute_in_mlp=activation_recompute_in_mlp,
-        )
+        super().__init__(glu_interleave_size)
         self.beta1 = float(beta1)
         self.beta2 = float(beta2)
         if not math.isfinite(self.beta1) or self.beta1 <= 0.0:

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -100,37 +100,27 @@ def _cudnn_frontend_supports_grouped_gemm_srelu_hadamard() -> bool:
 
 @functools.lru_cache(maxsize=None)
 def _cudnn_frontend_supports_grouped_gemm_situglu() -> bool:
-    """Feature-detect cuDNN frontend grouped SiTU-GLU support."""
+    """Feature-detect complete cuDNN frontend grouped SiTU-GLU support."""
     try:
         from cudnn import (  # pylint: disable=import-outside-toplevel
             grouped_gemm_dglu_wrapper_sm100,
+            grouped_gemm_glu_hadamard_wrapper_sm100,
             grouped_gemm_glu_wrapper_sm100,
         )
     except ImportError:
         return False
     try:
-        forward_params = inspect.signature(grouped_gemm_glu_wrapper_sm100).parameters
-        backward_params = inspect.signature(grouped_gemm_dglu_wrapper_sm100).parameters
-    except (TypeError, ValueError):
-        return False
-    situ_params = {"situ_beta1", "situ_beta2"}
-    return situ_params.issubset(forward_params) and situ_params.issubset(backward_params)
-
-
-@functools.lru_cache(maxsize=None)
-def _cudnn_frontend_supports_grouped_gemm_situglu_hadamard() -> bool:
-    """Feature-detect cuDNN frontend grouped SiTU-GLU Hadamard support."""
-    try:
-        from cudnn import (  # pylint: disable=import-outside-toplevel
+        wrappers = (
+            grouped_gemm_glu_wrapper_sm100,
+            grouped_gemm_dglu_wrapper_sm100,
             grouped_gemm_glu_hadamard_wrapper_sm100,
         )
-    except ImportError:
-        return False
-    try:
-        params = inspect.signature(grouped_gemm_glu_hadamard_wrapper_sm100).parameters
+        situ_params = {"situ_beta1", "situ_beta2"}
+        return all(
+            situ_params.issubset(inspect.signature(wrapper).parameters) for wrapper in wrappers
+        )
     except (TypeError, ValueError):
         return False
-    return {"situ_beta1", "situ_beta2"}.issubset(params)
 
 
 def _nvidia_cudnn_frontend_supports_wgrad() -> bool:
@@ -1397,13 +1387,8 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
             and fc2_input_quantizer.with_post_rht_amax
         )
         activation_is_srelu = isinstance(activation_op, ScaledSReLU)
-        activation_supports_hadamard = (
-            self._cudnn_act_func == "swiglu"
-            or (
-                self._cudnn_act_func == "situglu"
-                and _cudnn_frontend_supports_grouped_gemm_situglu_hadamard()
-            )
-            or (activation_is_srelu and _cudnn_frontend_supports_grouped_gemm_srelu_hadamard())
+        activation_supports_hadamard = self._cudnn_act_func in ("swiglu", "situglu") or (
+            activation_is_srelu and _cudnn_frontend_supports_grouped_gemm_srelu_hadamard()
         )
         if use_nvfp4_rht_amax and activation_supports_hadamard:
             kernel_getter = getattr(self, "grouped_gemm_act_hadamard_kernel", None)

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
 import functools
+import inspect
 import os
 from importlib.metadata import PackageNotFoundError, version as get_pkg_version
 from typing import Any, Optional
@@ -43,6 +44,7 @@ from ...utils import (
 from ..basic import (
     GroupedLinear,
     ScaledClampedQGeGLU,
+    ScaledSiTUGLU,
     ScaledSReLU,
     ScaledSwiGLU,
 )
@@ -94,6 +96,25 @@ def _cudnn_frontend_supports_grouped_gemm_srelu() -> bool:
 def _cudnn_frontend_supports_grouped_gemm_srelu_hadamard() -> bool:
     """Check cuDNN frontend min version for grouped GEMM SReLU hadamard kernels."""
     return _cudnn_frontend_version_at_least("1.26.0")
+
+
+@functools.lru_cache(maxsize=None)
+def _cudnn_frontend_supports_grouped_gemm_situglu() -> bool:
+    """Feature-detect cuDNN frontend grouped SiTU-GLU support."""
+    try:
+        from cudnn import (  # pylint: disable=import-outside-toplevel
+            grouped_gemm_dglu_wrapper_sm100,
+            grouped_gemm_glu_wrapper_sm100,
+        )
+    except ImportError:
+        return False
+    try:
+        forward_params = inspect.signature(grouped_gemm_glu_wrapper_sm100).parameters
+        backward_params = inspect.signature(grouped_gemm_dglu_wrapper_sm100).parameters
+    except (TypeError, ValueError):
+        return False
+    situ_params = {"situ_beta1", "situ_beta2"}
+    return situ_params.issubset(forward_params) and situ_params.issubset(backward_params)
 
 
 def _nvidia_cudnn_frontend_supports_wgrad() -> bool:
@@ -750,7 +771,7 @@ def _compute_grad_params(
 
 def is_glu_activation(activation_op) -> bool:
     """Whether an activation consumes a GLU-style doubled input."""
-    return isinstance(activation_op, (ScaledSwiGLU, ScaledClampedQGeGLU))
+    return isinstance(activation_op, (ScaledSwiGLU, ScaledSiTUGLU, ScaledClampedQGeGLU))
 
 
 def validate_grouped_mlp_dims(fc1, activation_op, fc2) -> None:
@@ -818,7 +839,10 @@ def fuse_grouped_mlp_ops(
     if recipe.nvfp4() and recipe.disable_rht:
         return ops
     if activation_op_types is None:
-        activation_op_types = (ScaledSwiGLU, ScaledClampedQGeGLU)
+        activation_op_types = [ScaledSwiGLU, ScaledClampedQGeGLU]
+        if _cudnn_frontend_supports_grouped_gemm_situglu():
+            activation_op_types.append(ScaledSiTUGLU)
+        activation_op_types = tuple(activation_op_types)
 
     out = []
     window, ops = ops[:3], ops[3:]
@@ -951,12 +975,15 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
         else:
             # The cuDNN geglu implementations correspond to ScaledClampedQGeGLU.
             # The act_func strings should be fixed on the cuDNN FE side.
-            self._cudnn_act_func = (
-                "geglu" if isinstance(activation, ScaledClampedQGeGLU) else "swiglu"
-            )
-            self._cudnn_dact_func = (
-                "dgeglu" if isinstance(activation, ScaledClampedQGeGLU) else "dswiglu"
-            )
+            if isinstance(activation, ScaledClampedQGeGLU):
+                self._cudnn_act_func = "geglu"
+                self._cudnn_dact_func = "dgeglu"
+            elif isinstance(activation, ScaledSiTUGLU):
+                self._cudnn_act_func = "situglu"
+                self._cudnn_dact_func = "dsituglu"
+            else:
+                self._cudnn_act_func = "swiglu"
+                self._cudnn_dact_func = "dswiglu"
 
         # cuDNN-frontend >= 1.24.0 exposes runtime-configurable GeGLU
         # parameters; pass them through when the activation carries
@@ -969,6 +996,11 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
             self._cudnn_geglu_alpha: float = activation._clamped.alpha
             self._cudnn_glu_clamp_max: float = activation._clamped.limit
             self._cudnn_glu_clamp_min: float = -activation._clamped.limit
+
+        self._pass_situglu_params: bool = isinstance(activation, ScaledSiTUGLU)
+        if self._pass_situglu_params:
+            self._cudnn_situ_beta1: float = activation.beta1
+            self._cudnn_situ_beta2: float = activation.beta2
 
     def fuser_forward(
         self,
@@ -1390,6 +1422,11 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                 geglu_alpha=self._cudnn_geglu_alpha,
                 glu_clamp_max=self._cudnn_glu_clamp_max,
                 glu_clamp_min=self._cudnn_glu_clamp_min,
+            )
+        if self._pass_situglu_params:
+            fc1_activation_kwargs.update(
+                situ_beta1=self._cudnn_situ_beta1,
+                situ_beta2=self._cudnn_situ_beta2,
             )
 
         if fc1_op.single_grouped_weight:
@@ -2049,6 +2086,11 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
                 geglu_alpha=self._cudnn_geglu_alpha,
                 glu_clamp_max=self._cudnn_glu_clamp_max,
                 glu_clamp_min=self._cudnn_glu_clamp_min,
+            )
+        if self._pass_situglu_params:
+            fc2_dactivation_kwargs.update(
+                situ_beta1=self._cudnn_situ_beta1,
+                situ_beta2=self._cudnn_situ_beta2,
             )
 
         fc2_leader = fc2_op.weight if fc2_op.single_grouped_weight else fc2_op.weight0

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -117,6 +117,22 @@ def _cudnn_frontend_supports_grouped_gemm_situglu() -> bool:
     return situ_params.issubset(forward_params) and situ_params.issubset(backward_params)
 
 
+@functools.lru_cache(maxsize=None)
+def _cudnn_frontend_supports_grouped_gemm_situglu_hadamard() -> bool:
+    """Feature-detect cuDNN frontend grouped SiTU-GLU Hadamard support."""
+    try:
+        from cudnn import (  # pylint: disable=import-outside-toplevel
+            grouped_gemm_glu_hadamard_wrapper_sm100,
+        )
+    except ImportError:
+        return False
+    try:
+        params = inspect.signature(grouped_gemm_glu_hadamard_wrapper_sm100).parameters
+    except (TypeError, ValueError):
+        return False
+    return {"situ_beta1", "situ_beta2"}.issubset(params)
+
+
 def _nvidia_cudnn_frontend_supports_wgrad() -> bool:
     """Check cuDNN FE min version for grouped GEMM wgrad kernel."""
     return _cudnn_frontend_version_supported()
@@ -1381,8 +1397,13 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
             and fc2_input_quantizer.with_post_rht_amax
         )
         activation_is_srelu = isinstance(activation_op, ScaledSReLU)
-        activation_supports_hadamard = self._cudnn_act_func == "swiglu" or (
-            activation_is_srelu and _cudnn_frontend_supports_grouped_gemm_srelu_hadamard()
+        activation_supports_hadamard = (
+            self._cudnn_act_func == "swiglu"
+            or (
+                self._cudnn_act_func == "situglu"
+                and _cudnn_frontend_supports_grouped_gemm_situglu_hadamard()
+            )
+            or (activation_is_srelu and _cudnn_frontend_supports_grouped_gemm_srelu_hadamard())
         )
         if use_nvfp4_rht_amax and activation_supports_hadamard:
             kernel_getter = getattr(self, "grouped_gemm_act_hadamard_kernel", None)


### PR DESCRIPTION
# Description

Add native and row-scaled SiTU-GLU operations and connect them to the fused grouped-MLP path when the installed cuDNN frontend exposes SiTU-GLU support.

SiTU-GLU is the soft-capped gated activation used by Kimi K3. For gate input `a`, up input `b`, and positive cap parameters `beta1`, `beta2`, this PR computes

```text
gate(a) = beta1 * tanh(a / beta1) * sigmoid(a)
up(b)   = beta2 * tanh(b / beta2)
y       = gate(a) * up(b)
```

The backward kernels use

```text
d gate / da = (1 - tanh(a / beta1)^2) * sigmoid(a)
              + beta1 * tanh(a / beta1) * sigmoid(a) * (1 - sigmoid(a))
d up / db   = 1 - tanh(b / beta2)^2
```

The default values `beta1=4` and `beta2=25` follow the [Kimi K3 technical report](https://github.com/MoonshotAI/Kimi-K3/blob/main/k3_tech_report.pdf).

The grouped-GEMM integration depends on the cuDNN frontend support proposed at https://github.com/NVIDIA/cudnn-frontend/pull/645. Compatibility is detected from the forward and backward wrapper signatures instead of from a package-version threshold. An older or unpatched cuDNN frontend therefore keeps the correct native `GroupedLinear -> ScaledSiTUGLU -> GroupedLinear` fallback, while a frontend that exposes both `situ_beta1` and `situ_beta2` parameters enables the fused path.

## Type of change

- [ ] Documentation change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Add public C APIs and PyTorch bindings for SiTU-GLU forward/backward.
- Add `te.ops.SiTUGLU` with contiguous and block-interleaved layouts and existing FP8/MXFP8 quantizer integration.
- Add row-scaled `te.ops.ScaledSiTUGLU`, including optional scale gradients and a constructor-compatible recomputation flag that explicitly rejects unsupported `True` requests.
- Reject `activation_recompute_in_mlp=True` for scaled SwiGLU, SiTU-GLU, and clamped QGeGLU instead of silently ignoring it in the fused grouped MLP. Scaled SReLU remains supported.
- Reuse TE's vectorized, FP8, and MXFP8 gated kernels for native execution; no PyTorch-composed activation or intermediate gate/up tensors are required.
- Add `ScaledSiTUGLU` to grouped-MLP dimension validation and pass `situglu`/`dsituglu` plus both cap parameters to cuDNN frontend forward/backward wrappers.
- Cache a feature probe that requires both cap parameters in both grouped wrapper signatures before registering the fusion.
- Add common C++ references and PyTorch forward/backward, quantization, interleave, fallback, feature-detection, and fused grouped-MLP tests.

## Performance and compatibility

- Native BF16/FP16/FP32 execution is a single TE gated activation kernel. FP8/MXFP8 quantization remains fused into the existing gated kernels.
- Row scaling is handled by TE's existing scaled-activation kernels rather than a separate PyTorch multiply.
- With https://github.com/NVIDIA/cudnn-frontend/pull/645, SiTU-GLU stays inside the grouped FC1 epilogue and dSiTU-GLU inside the grouped backward kernel, so the grouped path does not add a standalone activation launch or materialized FC1 activation.
- The signature probe is cached and only runs during fusion setup; it is not in the per-iteration GPU path.
- The stock 26.06 container stack (`nvidia-cudnn-frontend==1.26.0`, `nvidia-cutlass-dsl==4.5.0`) correctly reports the feature as unavailable and uses the native fallback.
- A private build of https://github.com/NVIDIA/cudnn-frontend/pull/645 (package version 1.27.0) with the same CuTe DSL 4.5.0 runtime reports the feature as available and passes fused MXFP8 forward/backward tests.

## Validation

Run on one NVIDIA B300 GPU in the 26.06 container using an isolated private venv:

- TE build for `NVTE_CUDA_ARCHS="100;103a;"` passed. Optional NCCL-EP was disabled because the separately reused NCCL-EP headers predate upstream TE's current API; no SiTU code depends on NCCL-EP.
- `24 passed`: focused native/scaled SiTU-GLU tests with stock cuDNN frontend, including FP32/FP16/BF16, interleaving, invalid parameters, MXFP8 output/input-gradient quantization, scale gradients, unsupported recomputation rejection, feature detection, and grouped fallback.
- `2 passed`: grouped MXFP8 fallback with `(beta1, beta2)=(4,25)` and `(2,8)` on stock cuDNN frontend 1.26.0.
- `2 passed`: fused grouped MXFP8 forward/backward with the same two parameter pairs using https://github.com/NVIDIA/cudnn-frontend/pull/645.
- `244 passed, 206 skipped`: existing SwiGLU-focused native, quantized, grouped-MLP, and MCore-integration regression selection.
- All targeted pre-commit hooks passed (Black 24.4.2, clang-format 18.1.6, whitespace, merge-conflict, large-file, and Python 3.10 checks).

# Checklist

- [x] I have read and followed the contributing guidelines
- [x] The functionality is complete
- [x] I have commented hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing focused unit tests pass locally with my changes
