### PR TITLE
[JAX] Bump min compute_on version

### DIFF
--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -66,7 +66,10 @@ def is_triton_autotuned_alias_safe() -> bool:
 
 # XLA gained the ``gpu_stream:collective`` stream annotation in openxla/xla#39604,
 # first shipping in JAX 0.10.1. Older XLA fatally fails on it.
-_COLLECTIVE_STREAM_MIN_JAX_VERSION = "0.10.1"
+# However, JAX 0.10.1 renamed this API to compute_on2 and slightly changed the 
+# signature, then 0.11.0 renamed it back to compute_on. For simplicity, 
+# we will support 0.11.0+
+_COLLECTIVE_STREAM_MIN_JAX_VERSION = "0.11.0"
 
 
 @lru_cache(maxsize=None)

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -66,8 +66,8 @@ def is_triton_autotuned_alias_safe() -> bool:
 
 # XLA gained the ``gpu_stream:collective`` stream annotation in openxla/xla#39604,
 # first shipping in JAX 0.10.1. Older XLA fatally fails on it.
-# However, JAX 0.10.1 renamed this API to compute_on2 and slightly changed the 
-# signature, then 0.11.1 renamed it back to compute_on. For simplicity, 
+# However, JAX 0.10.1 renamed this API to compute_on2 and slightly changed the
+# signature, then 0.11.1 renamed it back to compute_on. For simplicity,
 # we will support 0.11.1+
 _COLLECTIVE_STREAM_MIN_JAX_VERSION = "0.11.1"
 

--- a/transformer_engine/jax/version_utils.py
+++ b/transformer_engine/jax/version_utils.py
@@ -67,9 +67,9 @@ def is_triton_autotuned_alias_safe() -> bool:
 # XLA gained the ``gpu_stream:collective`` stream annotation in openxla/xla#39604,
 # first shipping in JAX 0.10.1. Older XLA fatally fails on it.
 # However, JAX 0.10.1 renamed this API to compute_on2 and slightly changed the 
-# signature, then 0.11.0 renamed it back to compute_on. For simplicity, 
-# we will support 0.11.0+
-_COLLECTIVE_STREAM_MIN_JAX_VERSION = "0.11.0"
+# signature, then 0.11.1 renamed it back to compute_on. For simplicity, 
+# we will support 0.11.1+
+_COLLECTIVE_STREAM_MIN_JAX_VERSION = "0.11.1"
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
# Description

Bump min compute_on version due to breaking rename changes in 0.10.1 release.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
