### PR TITLE
Reduce Grouped MLP Fuser CPU Overhead

### DIFF
--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -146,11 +146,12 @@ def maybe_skip_quantization(
             pytest.skip("NVFP4 quantization is only supported with BF16 data")
 
 
-def test_operation_fuser_reuses_plan_when_grad_requirement_changes(monkeypatch) -> None:
-    """Grad-mode changes update runtime state without rebuilding the fusion plan."""
+def test_operation_fuser_caches_plans_by_grad_requirement(monkeypatch) -> None:
+    """Cache and restore fusion plans for checkpoint forward and recompute."""
 
     # Count fusion-plan construction without depending on any particular real
-    # fusion implementation. A cache hit must bypass this function entirely.
+    # fusion implementation. Each distinct fusion configuration invokes this
+    # hook once, while a cache hit must bypass it entirely.
     fusion_calls = 0
 
     def track_fusion(ops, *, recipe):  # pylint: disable=unused-argument
@@ -180,27 +181,43 @@ def test_operation_fuser_reuses_plan_when_grad_requirement_changes(monkeypatch) 
     extra_inputs = [()]
 
     # Phase 1: the original checkpointed forward runs with grad disabled. This
-    # is the first invocation, so the fuser must construct and cache one plan.
-    # Grad being disabled moves the runtime backward boundary past the only op.
+    # is the first invocation, so the fuser must construct and cache the no-grad
+    # configuration. The runtime backward boundary is past the only op.
     fuser.maybe_fuse_ops(False, None, x, extra_inputs)
     assert fusion_calls == 1
     assert fuser.first_op_requiring_backward == 1
+    no_grad_forward_ops = fuser._forward_ops
+    no_grad_backward_ops = fuser._backward_ops
 
     # Phase 2: backward replays the checkpointed region with grad enabled. The
-    # recipe and operation topology have not changed, so rebuilding the fusion
-    # plan would be wasted CPU work. The runtime boundary must nevertheless be
-    # updated before maybe_fuse_ops takes its cache-hit early return.
+    # backward boundary is part of the fusion key, allowing future fusion rules
+    # to choose a training-specific topology. The first grad-enabled invocation
+    # therefore constructs and caches a second configuration.
     fuser.maybe_fuse_ops(True, None, x, extra_inputs)
-    assert fusion_calls == 1
+    assert fusion_calls == 2
     assert fuser.first_op_requiring_backward == 0
+    grad_forward_ops = fuser._forward_ops
+    grad_backward_ops = fuser._backward_ops
+    assert grad_forward_ops is not no_grad_forward_ops
+    assert grad_backward_ops is not no_grad_backward_ops
 
-    # Phase 3: model the next checkpointed forward. This changes the runtime
-    # boundary back to "no backward" but still must reuse the original plan.
-    # Before the fix, the boundary was part of the cache key, so the three
-    # phases called track_fusion three times instead of once.
+    # Phase 3: the next checkpointed forward must select the exact no-grad lists
+    # cached in phase 1. Before the cache was added, every boundary transition
+    # rebuilt the fused operations and called track_fusion again.
     fuser.maybe_fuse_ops(False, None, x, extra_inputs)
-    assert fusion_calls == 1
+    assert fusion_calls == 2
     assert fuser.first_op_requiring_backward == 1
+    assert fuser._forward_ops is no_grad_forward_ops
+    assert fuser._backward_ops is no_grad_backward_ops
+
+    # Phase 4: another recomputation must likewise restore the grad-enabled
+    # lists from phase 2. The full alternating sequence has built only the two
+    # configurations represented by its two fusion keys.
+    fuser.maybe_fuse_ops(True, None, x, extra_inputs)
+    assert fusion_calls == 2
+    assert fuser.first_op_requiring_backward == 0
+    assert fuser._forward_ops is grad_forward_ops
+    assert fuser._backward_ops is grad_backward_ops
 
 
 @torch.no_grad()

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -146,6 +146,63 @@ def maybe_skip_quantization(
             pytest.skip("NVFP4 quantization is only supported with BF16 data")
 
 
+def test_operation_fuser_reuses_plan_when_grad_requirement_changes(monkeypatch) -> None:
+    """Grad-mode changes update runtime state without rebuilding the fusion plan."""
+
+    # Count fusion-plan construction without depending on any particular real
+    # fusion implementation. A cache hit must bypass this function entirely.
+    fusion_calls = 0
+
+    def track_fusion(ops, *, recipe):  # pylint: disable=unused-argument
+        nonlocal fusion_calls
+        fusion_calls += 1
+        # Preserve the operation list so this hook observes plan construction
+        # without changing the topology under test.
+        return ops
+
+    # The fusion registries are class attributes shared by every OperationFuser.
+    # pytest's monkeypatch fixture restores all three after the test, preventing
+    # this synthetic fusion function from leaking into other tests. Keep only a
+    # joint forward-backward fusion hook so each plan build has one countable
+    # callback and no registered TE fusion can affect the result.
+    monkeypatch.setattr(OperationFuser, "forward_backward_fusion_functions", [track_fusion])
+    monkeypatch.setattr(OperationFuser, "forward_fusion_functions", [])
+    monkeypatch.setattr(OperationFuser, "backward_fusion_functions", [])
+
+    # One Identity op is enough to exercise the cache. With one basic op,
+    # first_op_requiring_backward has an intentionally simple interpretation:
+    #   0: backward starts at the Identity op;
+    #   1: the boundary is past the only op, so no backward work is required.
+    fuser = OperationFuser([te_ops.Identity()])
+    x = torch.ones(1, requires_grad=True)
+    # maybe_fuse_ops expects one extra-input collection per basic op. Identity
+    # has no extra inputs, so its collection is an empty tuple.
+    extra_inputs = [()]
+
+    # Phase 1: the original checkpointed forward runs with grad disabled. This
+    # is the first invocation, so the fuser must construct and cache one plan.
+    # Grad being disabled moves the runtime backward boundary past the only op.
+    fuser.maybe_fuse_ops(False, None, x, extra_inputs)
+    assert fusion_calls == 1
+    assert fuser.first_op_requiring_backward == 1
+
+    # Phase 2: backward replays the checkpointed region with grad enabled. The
+    # recipe and operation topology have not changed, so rebuilding the fusion
+    # plan would be wasted CPU work. The runtime boundary must nevertheless be
+    # updated before maybe_fuse_ops takes its cache-hit early return.
+    fuser.maybe_fuse_ops(True, None, x, extra_inputs)
+    assert fusion_calls == 1
+    assert fuser.first_op_requiring_backward == 0
+
+    # Phase 3: model the next checkpointed forward. This changes the runtime
+    # boundary back to "no backward" but still must reuse the original plan.
+    # Before the fix, the boundary was part of the cache key, so the three
+    # phases called track_fusion three times instead of once.
+    fuser.maybe_fuse_ops(False, None, x, extra_inputs)
+    assert fusion_calls == 1
+    assert fuser.first_op_requiring_backward == 1
+
+
 @torch.no_grad()
 def make_reference_and_test_tensors(
     shape: int | Iterable[int],

--- a/tests/pytorch/test_fusible_ops.py
+++ b/tests/pytorch/test_fusible_ops.py
@@ -220,6 +220,99 @@ def test_operation_fuser_caches_plans_by_grad_requirement(monkeypatch) -> None:
     assert fuser._backward_ops is grad_backward_ops
 
 
+def test_operation_fuser_resets_recipe_state_independently_from_plan_cache(monkeypatch) -> None:
+    """Track recipe-state resets independently from fusion-plan construction."""
+
+    fusion_calls = 0
+
+    def track_fusion(ops, *, recipe):  # pylint: disable=unused-argument
+        nonlocal fusion_calls
+        fusion_calls += 1
+        return ops
+
+    # Replace the process-wide fusion registries so one callback corresponds to
+    # one plan construction. monkeypatch restores the registries after the test.
+    monkeypatch.setattr(OperationFuser, "forward_backward_fusion_functions", [track_fusion])
+    monkeypatch.setattr(OperationFuser, "forward_fusion_functions", [])
+    monkeypatch.setattr(OperationFuser, "backward_fusion_functions", [])
+
+    op = te_ops.Identity()
+    reset_recipes = []
+    first_forward_calls = 0
+
+    def track_recipe_reset(*, recipe):
+        reset_recipes.append(recipe)
+
+    def track_first_forward():
+        nonlocal first_forward_calls
+        first_forward_calls += 1
+
+    # Identity has no quantizers, so replace its state hooks with counters. This
+    # keeps the test CPU-only and isolates OperationFuser's reset decisions.
+    monkeypatch.setattr(op, "reset_recipe_state", track_recipe_reset)
+    monkeypatch.setattr(op, "pre_first_fuser_forward", track_first_forward)
+
+    fuser = OperationFuser([op])
+    x = torch.ones(1)
+    extra_inputs = [()]
+
+    current_scaling = transformer_engine.common.recipe.Float8CurrentScaling(backward_override=None)
+    fuser.maybe_fuse_ops(False, current_scaling, x, extra_inputs)
+    assert reset_recipes == [current_scaling]
+    assert first_forward_calls == 1
+    assert fusion_calls == 1
+
+    # A fresh but equivalent recipe does not invalidate state or the plan.
+    equivalent_current_scaling = transformer_engine.common.recipe.Float8CurrentScaling(
+        backward_override=None
+    )
+    fuser.maybe_fuse_ops(False, equivalent_current_scaling, x, extra_inputs)
+    assert reset_recipes == [current_scaling]
+    assert first_forward_calls == 1
+    assert fusion_calls == 1
+
+    # Backward override affects both recipe state and fusion topology, so it
+    # triggers one reset and constructs a distinct cached plan.
+    overridden_current_scaling = transformer_engine.common.recipe.Float8CurrentScaling(
+        backward_override="high_precision"
+    )
+    fuser.maybe_fuse_ops(False, overridden_current_scaling, x, extra_inputs)
+    assert reset_recipes == [current_scaling, overridden_current_scaling]
+    assert first_forward_calls == 1
+    assert fusion_calls == 2
+
+    delayed_scaling = transformer_engine.common.recipe.DelayedScaling(
+        amax_history_len=8,
+        backward_override=None,
+    )
+    fuser.maybe_fuse_ops(False, delayed_scaling, x, extra_inputs)
+    assert reset_recipes == [current_scaling, overridden_current_scaling, delayed_scaling]
+    assert first_forward_calls == 1
+    assert fusion_calls == 3
+
+    # Amax history length only affects delayed-scaling recipe state. Reset that
+    # state, but restore the existing DelayedScaling fusion plan from the cache.
+    resized_delayed_scaling = transformer_engine.common.recipe.DelayedScaling(
+        amax_history_len=16,
+        backward_override=None,
+    )
+    fuser.maybe_fuse_ops(False, resized_delayed_scaling, x, extra_inputs)
+    assert reset_recipes == [
+        current_scaling,
+        overridden_current_scaling,
+        delayed_scaling,
+        resized_delayed_scaling,
+    ]
+    assert first_forward_calls == 1
+    assert fusion_calls == 3
+
+    # Repeating the exact recipe parameters performs neither operation again.
+    fuser.maybe_fuse_ops(False, resized_delayed_scaling, x, extra_inputs)
+    assert len(reset_recipes) == 4
+    assert first_forward_calls == 1
+    assert fusion_calls == 3
+
+
 @torch.no_grad()
 def make_reference_and_test_tensors(
     shape: int | Iterable[int],

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -534,7 +534,7 @@ def _cudnn_compute_wgrad(
           b = X  = (total_tokens, in_features) column-major.
     """
     if current_stream is None:
-        current_stream = torch.cuda.current_stream(grouped_dy.device.index).cuda_stream
+        current_stream = torch.cuda.current_stream().cuda_stream
 
     out_features, in_features = weight_shape
     total_tokens = grouped_dy.logical_shape[0]

--- a/transformer_engine/pytorch/ops/fused/grouped_mlp.py
+++ b/transformer_engine/pytorch/ops/fused/grouped_mlp.py
@@ -534,7 +534,7 @@ def _cudnn_compute_wgrad(
           b = X  = (total_tokens, in_features) column-major.
     """
     if current_stream is None:
-        current_stream = torch.cuda.current_stream().cuda_stream
+        current_stream = torch.cuda.current_stream(grouped_dy.device.index).cuda_stream
 
     out_features, in_features = weight_shape
     total_tokens = grouped_dy.logical_shape[0]
@@ -1398,7 +1398,7 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
 
         alpha_tensor = get_cached_ones_tensor(num_groups, dtype, device)
         norm_const_tensor = get_cached_ones_tensor(1, torch.float32, device)
-        current_stream = torch.cuda.current_stream().cuda_stream
+        current_stream = torch.cuda.current_stream(device.index).cuda_stream
 
         fc1_bias_packed = _pack_grouped_linear_bias_for_cudnn(fc1_op)
         fc2_bias_packed = _pack_grouped_linear_bias_for_cudnn(fc2_op)
@@ -2082,7 +2082,7 @@ class _GroupedMLP_CuTeGEMMBase(FusedOperation):
         # Kernel scaling factors
         alpha_tensor = get_cached_ones_tensor(num_groups, dtype, device)
         norm_const_tensor = get_cached_ones_tensor(1, torch.float32, device)
-        current_stream = torch.cuda.current_stream().cuda_stream
+        current_stream = torch.cuda.current_stream(device.index).cuda_stream
 
         unit_activation_scale = bool(getattr(fc1_ctx, "unit_activation_scale", False))
         scales_f32 = None

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -48,6 +48,8 @@ def _is_graph_capturing() -> bool:
 OperationFusionFunction: TypeAlias = (
     "Callable[tuple[list[FusibleOperation], ...], list[FusibleOperation]]"
 )
+_FusedOpList: TypeAlias = list[tuple[FusibleOperation, list[int]]]
+_FusionParams: TypeAlias = tuple[type, int, Optional[str]]
 
 
 class _OperationFuserAutogradFunction(torch.autograd.Function):
@@ -535,16 +537,20 @@ class OperationFuser:
             op._lock_extra_tensor_channels()
 
         # Ops for forward and backward pass, will be populated in maybe_fuse_ops
-        self._forward_ops: list[tuple[FusibleOperation, list[int]]]
-        self._backward_ops: list[tuple[FusibleOperation, list[int]]]
+        self._forward_ops: _FusedOpList
+        self._backward_ops: _FusedOpList
+
+        # Fused operation configurations are reusable wrappers around the basic
+        # ops, so cache each configuration by the state that selected it.
+        self._fused_ops_cache: dict[_FusionParams, tuple[_FusedOpList, _FusedOpList]] = {}
 
         # Cache and detect change of state relevant for fusing operations
         self.recipe_type = None
         self.backward_override = None
         self._last_amax_history_len = 0
 
-        # Runtime backward boundary. This may change between checkpointed
-        # forward and recompute without changing the fused operation plan.
+        # Runtime backward boundary. Full activation recompute alternates this
+        # between the checkpointed forward and the grad-enabled recomputation.
         self.first_op_requiring_backward = 0
 
         # Flatten list of parameters
@@ -629,39 +635,52 @@ class OperationFuser:
                     first_op_requiring_backward = op_idx
                     break
 
-        # Grad requirements control runtime execution, not fusion topology.
-        # Update them on every invocation, including the early-return path.
+        # Update the runtime backward boundary on every invocation, including
+        # paths that reuse a cached fused operation configuration.
         self.first_op_requiring_backward = first_op_requiring_backward
 
-        # Early exit if fusion parameters haven't changed
-        need_reset = False
+        # Recipe state belongs to the basic ops and is independent of the
+        # runtime backward boundary. Only reconfigure it when recipe settings
+        # that are relevant to operation fusion change.
         recipe_type = type(recipe)
         backward_override = recipe.backward_override if recipe is not None else None
-        fusion_params = (recipe_type, backward_override)
-        if fusion_params != (
+        recipe_params = (recipe_type, backward_override)
+        need_reset = recipe_params != (
             self.recipe_type,
             self.backward_override,
-        ):
-            # Recipe type or backward override has changed
-            need_reset = True
-        elif (
-            recipe is not None
+        )
+        if (
+            not need_reset
+            and recipe is not None
             and recipe.delayed()
             and self._last_amax_history_len != recipe.amax_history_len
         ):
-            # FP8 delayed scaling has changed amax history length
+            # Delayed-scaling history affects quantizer state, but it does not
+            # select a different fused operation configuration.
             need_reset = True
-        if not need_reset:
-            return
-
-        # Reset recipe state
-        for op in self._basic_ops:
-            op.reset_recipe_state(recipe=recipe)
-
-        # Check if this is the first iteration
-        if self.recipe_type is None:
+        if need_reset:
             for op in self._basic_ops:
-                op.pre_first_fuser_forward()
+                op.reset_recipe_state(recipe=recipe)
+
+            # Check if this is the first iteration
+            if self.recipe_type is None:
+                for op in self._basic_ops:
+                    op.pre_first_fuser_forward()
+
+            self.recipe_type, self.backward_override = recipe_params
+            self._last_amax_history_len = (
+                recipe.amax_history_len if isinstance(recipe, DelayedScaling) else 0
+            )
+
+        # Training and inference may support different fusions. Keep the
+        # backward boundary in the key, but pay construction cost only once for
+        # each configuration. Full recompute therefore builds at most one
+        # no-grad plan and one grad-enabled plan for a stable recipe.
+        fusion_params = (recipe_type, first_op_requiring_backward, backward_override)
+        cached_ops = self._fused_ops_cache.get(fusion_params)
+        if cached_ops is not None:
+            self._forward_ops, self._backward_ops = cached_ops
+            return
 
         # Apply joint forward-backward fusions first
         joint_ops = OperationFuser._apply_fusions(
@@ -688,14 +707,9 @@ class OperationFuser:
             self._basic_ops,
         )
 
-        # Save current fusion params
-        self.recipe_type, self.backward_override = fusion_params
-
-        # Save amax history length
-        if isinstance(recipe, DelayedScaling):
-            self._last_amax_history_len = recipe.amax_history_len
-        else:
-            self._last_amax_history_len = 0
+        # The FusedOperation contract excludes parameters and per-invocation
+        # state, so the mapped lists can be selected directly on cache hits.
+        self._fused_ops_cache[fusion_params] = (self._forward_ops, self._backward_ops)
 
     def __call__(
         self,

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -540,9 +540,12 @@ class OperationFuser:
 
         # Cache and detect change of state relevant for fusing operations
         self.recipe_type = None
-        self.first_op_requiring_backward = 0
         self.backward_override = None
         self._last_amax_history_len = 0
+
+        # Runtime backward boundary. This may change between checkpointed
+        # forward and recompute without changing the fused operation plan.
+        self.first_op_requiring_backward = 0
 
         # Flatten list of parameters
         self._basic_op_params = [list(op.parameters()) for op in self._basic_ops]
@@ -626,17 +629,20 @@ class OperationFuser:
                     first_op_requiring_backward = op_idx
                     break
 
+        # Grad requirements control runtime execution, not fusion topology.
+        # Update them on every invocation, including the early-return path.
+        self.first_op_requiring_backward = first_op_requiring_backward
+
         # Early exit if fusion parameters haven't changed
         need_reset = False
         recipe_type = type(recipe)
         backward_override = recipe.backward_override if recipe is not None else None
-        fusion_params = (recipe_type, first_op_requiring_backward, backward_override)
+        fusion_params = (recipe_type, backward_override)
         if fusion_params != (
             self.recipe_type,
-            self.first_op_requiring_backward,
             self.backward_override,
         ):
-            # Recipe type, backward override, or grad requirements have changed
+            # Recipe type or backward override has changed
             need_reset = True
         elif (
             recipe is not None
@@ -683,7 +689,7 @@ class OperationFuser:
         )
 
         # Save current fusion params
-        self.recipe_type, self.first_op_requiring_backward, self.backward_override = fusion_params
+        self.recipe_type, self.backward_override = fusion_params
 
         # Save amax history length
         if isinstance(recipe, DelayedScaling):

--- a/transformer_engine/pytorch/ops/fuser.py
+++ b/transformer_engine/pytorch/ops/fuser.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, TypeAlias
 
 import torch
 
-from ..quantization import FP8GlobalStateManager, Recipe, DelayedScaling
+from ..quantization import FP8GlobalStateManager, Recipe
 from ..quantized_tensor import prepare_for_saving, restore_from_func_ctx
 from .op import (
     BasicOperation,
@@ -639,26 +639,25 @@ class OperationFuser:
         # paths that reuse a cached fused operation configuration.
         self.first_op_requiring_backward = first_op_requiring_backward
 
-        # Recipe state belongs to the basic ops and is independent of the
-        # runtime backward boundary. Only reconfigure it when recipe settings
-        # that are relevant to operation fusion change.
+        # Check if recipe parameters don't match cached values. In this case,
+        # the recipe state in the basic ops might be invalid, so reset it.
         recipe_type = type(recipe)
+        need_to_reset_recipe_state = self.recipe_type != recipe_type
+
         backward_override = recipe.backward_override if recipe is not None else None
-        recipe_params = (recipe_type, backward_override)
-        need_reset = recipe_params != (
-            self.recipe_type,
-            self.backward_override,
-        )
+        if backward_override != self.backward_override:
+            self.backward_override = backward_override
+            need_to_reset_recipe_state = True
+
         if (
-            not need_reset
-            and recipe is not None
+            recipe is not None
             and recipe.delayed()
             and self._last_amax_history_len != recipe.amax_history_len
         ):
-            # Delayed-scaling history affects quantizer state, but it does not
-            # select a different fused operation configuration.
-            need_reset = True
-        if need_reset:
+            self._last_amax_history_len = recipe.amax_history_len
+            need_to_reset_recipe_state = True
+
+        if need_to_reset_recipe_state:
             for op in self._basic_ops:
                 op.reset_recipe_state(recipe=recipe)
 
@@ -667,10 +666,7 @@ class OperationFuser:
                 for op in self._basic_ops:
                     op.pre_first_fuser_forward()
 
-            self.recipe_type, self.backward_override = recipe_params
-            self._last_amax_history_len = (
-                recipe.amax_history_len if isinstance(recipe, DelayedScaling) else 0
-            )
+            self.recipe_type = recipe_type
 
         # Training and inference may support different fusions. Keep the
         # backward boundary in the key, but pay construction cost only once for


### PR DESCRIPTION

# Description

Reuse fused operation plans when full activation recompute changes grad mode, and avoid redundant CUDA current-device discovery for grouped MLP stream lookups.

Fixes # (issue)

https://github.com/NVIDIA/TransformerEngine/issues/2897

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
