### PR TITLE
Ring Attention: free unused kv comm buffers

### DIFF
--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -1715,6 +1715,12 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         )
 
                     kv_inputs[i % 2] = p2p_comm_buffers[i]
+
+                    # Release the KV chunk from two steps back.
+                    if i >= 2 and not is_graph_capturing():
+                        p2p_comm_buffers[i - 2].record_stream(flash_attn_streams[i % 2])
+                        p2p_comm_buffers[i - 2] = None
+
                     k_part = kv_inputs[i % 2][:k_numel].view(*k_shape)
                     v_part = kv_inputs[i % 2][k_numel:].view(*v_shape)
                     q_part = q


### PR DESCRIPTION
# Description

In Ring Attention, `p2p_comm_buffers[i]` holds KV chunks received from other ranks. As the ring rotates, each rank receives KV chunks from its peers, and `p2p_comm_buffers` grows to eventually hold the full KV cache. Depending on the context length, head size, and data type, this can consume several GB of GPU memory.

To put this into perspective, consider a sequence of 1M tokens with a head size of 256, 8 KV heads, and `bfloat16`. The KV cache requires approximately:

`1e6 × 256 × 8 × 2 × 2B = 8 GB`

This can significantly reduce the available GPU memory by the end of Ring Attention.

However, the buffer appears to be larger than necessary. At time step `i`, a rank only needs:

* `p2p_comm_buffers[i]`, which is used to run FlashAttention and send the current KV chunk to the next rank.
* `p2p_comm_buffers[i+1]`, which is used to receive the next KV chunk.

There are no references to `p2p_comm_buffers[j]` for `j < i`. Therefore, once a KV chunk has been processed and forwarded, it can be deallocated. At any point, only the current and next KV chunks need to remain allocated.

I ran the relevant tests on A100 GPUs, which are the hardware currently available to me, and all tests passed.

At extreme context lengths, this three-line change saves several GB of GPU memory and enables Ring Attention to scale to 1M-token contexts. Without this change, we hit an OOM.

Fixes # (issue)

## Type of change

* [ ] Documentation change (change only to the documentation, either a fix or a new content)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Infra/Build change
* [ ] Code refactoring

## Changes

* Deallocate unused KV chunks from `p2p_comm_buffers` during Ring Attention.

# Checklist

* [x] I have read and followed the [[contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
* [x] The functionality is complete
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes