### PR TITLE
Fix PyTorch EP tests sharing a single timeout

### DIFF
--- a/tests/pytorch/distributed/test_ep.py
+++ b/tests/pytorch/distributed/test_ep.py
@@ -19,13 +19,12 @@ LAUNCHER = TEST_ROOT / "run_test_ep.sh"
 def test_multi_process_ep():
     """Launch the EP unit-test suite across all visible GPUs.
 
-    Short timeout so a hang on any rank surfaces fast rather than burning CI time.
+    The launcher applies its timeout independently to every torchrun pass.
     """
     timeout_s = int(os.environ.get("NVTE_TEST_EP_TIMEOUT_S", "180"))
     proc = subprocess.run(
         ["bash", str(LAUNCHER)],
         env={**os.environ, "KEEP_EP_LOGS": "1", "TEST_TIMEOUT_S": str(timeout_s)},
-        timeout=timeout_s + 30,
         check=False,
     )
     assert proc.returncode == 0, f"EP test suite failed (rc={proc.returncode})"


### PR DESCRIPTION
# Description

[This PR](https://github.com/NVIDIA/TransformerEngine/pull/3270) added [several additional PyTorch EP tests](https://github.com/NVIDIA/TransformerEngine/pull/3270/changes#diff-1b8da96db5567476e182fcb89dc199012ac7aa5e9dce528d140c65f67d2ac0eeR77-R82) which push the test script over the 210s limit.

I've removed this limit entirely because [already has a 10s timeout](https://github.com/NVIDIA/TransformerEngine/pull/3270/changes#diff-1b8da96db5567476e182fcb89dc199012ac7aa5e9dce528d140c65f67d2ac0eeR56). Having both is redundant, and causes the tests to collectively fail when the total runtime is > 210s.

This is blocking the 2.19 QA build.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix duplicate test timeout causing premature termination and failure of PyTorch EP test suite

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
