### PR TITLE
Fix include after ptx move

### DIFF
--- a/transformer_engine/common/cast/fused_group_requantize.cu
+++ b/transformer_engine/common/cast/fused_group_requantize.cu
@@ -17,7 +17,7 @@
 #include <type_traits>
 
 #include "../common.h"
-#include "../util/ptx.cuh"
+#include "../util/ptx_arch_spec.cuh"
 #include "../utils.cuh"
 #include "mxfp8/swizzle.cuh"
 


### PR DESCRIPTION
# Description

Please include a brief summary of the changes, relevant motivation and context.


Because: 
- 4670342a (PR #3392, "Move arch specific helpers in ptx.cuh to a new header") moved float_to_e8m0 out of util/ptx.cuh into the new util/ptx_arch_spec.cuh and swapped the include in all 9 pre-existing callers.
- 8d9325fa (PR #3359, "Fused grouped MXFP8 requantization") is its direct child — git rev-parse 8d9325fa^ == 4670342a — branched before the move, adding a file that calls ptx::float_to_e8m0 while including only ptx.cuh.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix include ptx_arch_spec.cuh in transformer_engine/common/cast/fused_group_requantize.cu


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
