### PR TITLE
[PyTorch] Bound FusedAdam tensor-handle usage

### DIFF
--- a/tests/pytorch/test_fused_optimizer.py
+++ b/tests/pytorch/test_fused_optimizer.py
@@ -12,6 +12,9 @@ import transformer_engine.pytorch as te
 from transformer_engine.common.recipe import DelayedScaling, MXFP8BlockScaling, Float8BlockScaling
 from transformer_engine.pytorch import MultiheadAttention, quantized_model_init, is_bf16_available
 from transformer_engine.pytorch import QuantizedTensor
+from transformer_engine.pytorch.optimizers.fused_adam import (
+    _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL,
+)
 from transformer_engine.pytorch.utils import gpu_autocast_ctx
 
 # Check if FP8 is supported
@@ -173,6 +176,76 @@ class TestFusedAdam(TestFusedOptimizer):
             tst_optim.step()
 
             torch.testing.assert_close(ref_param, tst_param)
+
+    @pytest.mark.parametrize(
+        "param_dtype,master_weights,capturable",
+        [
+            (torch.float32, False, False),
+            (torch.bfloat16, True, True),
+        ],
+    )
+    def test_many_small_parameters(self, param_dtype, master_weights, capturable):
+        """FusedAdam chunks large parameter groups without changing optimizer semantics."""
+        if param_dtype == torch.bfloat16 and not is_bf16_available():
+            pytest.skip("BF16 is not supported")
+
+        # Keep this above the default 20 MiB handle-pool capacity so the test
+        # fails without FusedAdam's per-call bound, not just at the slice boundary.
+        num_params = 8 * _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL + 1
+        values = torch.linspace(-1, 1, num_params, dtype=param_dtype, device="cuda")
+        coefficients = torch.linspace(-0.5, 0.5, num_params, dtype=param_dtype, device="cuda")
+        ref_param = torch.nn.Parameter(values.float())
+        tst_params = [torch.nn.Parameter(value.reshape(1).clone()) for value in values]
+        ref_optim = torch.optim.Adam([ref_param], **self.options)
+        tst_optim = te.optimizers.FusedAdam(
+            tst_params,
+            capturable=capturable,
+            master_weights=master_weights,
+            **self.options,
+        )
+
+        def backward():
+            ref_optim.zero_grad()
+            tst_optim.zero_grad()
+            ref_loss = (ref_param.to(param_dtype).float() * coefficients.float()).sum()
+            tst_loss = (torch.cat(tst_params).float() * coefficients.float()).sum()
+            torch.testing.assert_close(tst_loss, ref_loss)
+            ref_loss.backward()
+            tst_loss.backward()
+            torch.testing.assert_close(
+                torch.cat([param.grad.float() for param in tst_params]), ref_param.grad
+            )
+
+        backward()
+        ref_optim.step()
+        tst_optim.step()
+
+        backward()
+        if capturable:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                tst_optim.step()
+            graph.replay()
+        else:
+            tst_optim.step()
+        ref_optim.step()
+
+        torch.testing.assert_close(
+            torch.cat([param.detach() for param in tst_params]), ref_param.detach().to(param_dtype)
+        )
+        torch.testing.assert_close(
+            torch.cat([tst_optim.state[param]["exp_avg"] for param in tst_params]),
+            ref_optim.state[ref_param]["exp_avg"],
+        )
+        torch.testing.assert_close(
+            torch.cat([tst_optim.state[param]["exp_avg_sq"] for param in tst_params]),
+            ref_optim.state[ref_param]["exp_avg_sq"],
+        )
+        if master_weights:
+            torch.testing.assert_close(
+                torch.cat([tst_optim.state[param]["master_param"] for param in tst_params]),
+                ref_param,
+            )
 
     def test_adam_option(self):
         nelem = 1

--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -19,6 +19,10 @@ from ..constants import DType
 from .multi_tensor_apply import multi_tensor_applier
 
 
+# Bound temporary NVTETensor handles created before the CUDA launcher chunks its metadata.
+_MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL = 1024
+
+
 def get_fp8_meta(fp8_tensor):
     """FP8 metadata getter."""
     assert isinstance(fp8_tensor, Float8Tensor), "Fused optimizer supports only Float8Tensor class"
@@ -755,21 +759,39 @@ class FusedAdam(torch.optim.Optimizer):
                 # pylint: disable=cell-var-from-loop
                 inv_scale_arg = () if inv_scale is None else (inv_scale,)
                 out_dtype_arg = () if out_dtype is None else (out_dtype,)
-                multi_tensor_applier(
-                    adam_func,
-                    self._dummy_overflow_buf,
-                    tensor_lists,
-                    group["lr"],
-                    beta1,
-                    beta2,
-                    group["eps"],
-                    group["step"],
-                    self.adam_w_mode,
-                    bias_correction,
-                    group["weight_decay"],
-                    *inv_scale_arg,
-                    *out_dtype_arg,
-                )
+
+                tensor_list_chunks = (tensor_lists,)
+                if len(tensor_lists[0]) > _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL:
+                    tensor_list_chunks = (
+                        [
+                            tensors[
+                                start : start + _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL
+                            ]
+                            for tensors in tensor_lists
+                        ]
+                        for start in range(
+                            0,
+                            len(tensor_lists[0]),
+                            _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL,
+                        )
+                    )
+
+                for tensor_list_chunk in tensor_list_chunks:
+                    multi_tensor_applier(
+                        adam_func,
+                        self._dummy_overflow_buf,
+                        tensor_list_chunk,
+                        group["lr"],
+                        beta1,
+                        beta2,
+                        group["eps"],
+                        group["step"],
+                        self.adam_w_mode,
+                        bias_correction,
+                        group["weight_decay"],
+                        *inv_scale_arg,
+                        *out_dtype_arg,
+                    )
 
             if self.capturable:
                 # If the optimizer is capturable, then if there's a grad scaler it works

--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -764,9 +764,7 @@ class FusedAdam(torch.optim.Optimizer):
                 if len(tensor_lists[0]) > _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL:
                     tensor_list_chunks = (
                         [
-                            tensors[
-                                start : start + _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL
-                            ]
+                            tensors[start : start + _MAX_TENSORS_PER_MULTI_TENSOR_ADAM_CALL]
                             for tensors in tensor_lists
                         ]
                         for start in range(


### PR DESCRIPTION
## Summary

- split large aligned FusedAdam tensor lists into at most 1,024 optimizer tensors per extension call
- preserve the existing single-call path for parameter groups at or below that bound
- add eager FP32 and BF16 master-weight/capturable CUDA graph coverage with 8,193 scalar parameters

## Motivation

`FusedAdam.step()` currently passes every tensor in an optimizer group to one
`multi_tensor_applier` call. The PyTorch extension creates temporary `NVTETensor` handles for all
aligned lists before its CUDA launcher chunks metadata, so sufficiently fragmented models exhaust
the default 20 MiB process-wide handle pool.

On `ea1a165decdd09c1ef98b273d965796c89c47473`, a deterministic 21,000-parameter FP32 workload
failed on the first step at 20,321 handles. Raising the pool to 64 MiB still failed at 65,027
handles; 128 MiB passed. The patch passes with the unchanged 20 MiB default.

The update is elementwise by tensor index. Each slice uses the same step, learning rate, beta
values, epsilon, weight decay, overflow flag, inverse scale, and output dtype, and all aligned lists
use identical slice boundaries. The generic multi-tensor path is unchanged.

## Validation

Environment: RTX 3090 (SM86), CUDA 13.0, PyTorch 2.13.0+cu130, BF16/FP32. FP8/FP4 behavior is not
claimed on this hardware.

All benchmarks use 5 warmups, 30 measured steps, seed 20260823, and identical shapes/dtypes. The
base control uses a 128 MiB pool only because the default cannot run the workload. Pure kernel time
is the sum of CUPTI `multi_tensor_apply_kernel` events over 10 separately profiled steps.

| Workload | Source / pool | Host API P50 | Kernel P50 | E2E P50 / P95 / P99 | Peak RSS | Peak torch HBM |
|---|---:|---:|---:|---:|---:|---:|
| FP32, 21k tensors | base / 128 MiB | 337.99 ms | 1.784 ms | 338.74 / 523.68 / 588.25 ms | 1070.14 MiB | 41.18 MiB |
| FP32, 21k tensors | patch / default | 269.03 ms | 1.814 ms | 269.57 / 441.89 / 446.93 ms | 986.72 MiB | 41.18 MiB |
| BF16 + master, 21k tensors | base / 128 MiB | 583.44 ms | 2.242 ms | 584.82 / 782.79 / 824.23 ms | 1142.02 MiB | 51.35 MiB |
| BF16 + master, 21k tensors | patch / default | 400.04 ms | 2.295 ms | 401.09 / 548.29 / 564.96 ms | 1037.46 MiB | 51.35 MiB |

The extra extension calls increase kernel P50 by 1.66% (FP32) and 2.37% (BF16/master), but remove
the larger host handle-allocation bottleneck. E2E P50 improves by 20.42% and 31.42%, respectively;
peak RSS falls by 7.80% and 9.16%, with no observed torch or NVML HBM increase. A 1,000-tensor group
keeps the original path; its E2E P50 was 9.79 ms base versus 9.43 ms patched. Its P95 was +0.98% and
one shared-host P99 outlier was +10.19%.

CUDA graph capture/replay with BF16 master weights and 21,000 tensors also passed with the default
pool (host replay P50 0.0059 ms, stream/E2E P50 20.65/20.66 ms).

Tests:

```text
python -m pytest -q tests/pytorch/test_fused_optimizer.py
31 passed, 8 skipped

python -m pylint transformer_engine/pytorch/optimizers/fused_adam.py
10.00/10 (exit 0)

git diff --check
```

Addresses #2189.
