### PR TITLE
[PyTorch] Add native transport for dynamic context parallelism

### DIFF
--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -38,6 +38,13 @@ def setup_pytorch_extension(
 
     # Source files
     sources = all_files_in_dir(Path(csrc_source_files), name_extension="cpp")
+    build_native_cp_transport = bool(int(os.getenv("NVTE_WITH_NCCL_DEVICE_CP", "0")))
+    if build_native_cp_transport:
+        sources.extend(
+            path
+            for path in all_files_in_dir(Path(csrc_source_files), name_extension="cu")
+            if path.name == "cp_native_transport.cu"
+        )
 
     # Header files
     include_dirs = get_cuda_include_dirs()
@@ -87,16 +94,37 @@ def setup_pytorch_extension(
         libraries.append("nvshmem_host")
         cxx_flags.append("-DNVTE_ENABLE_NVSHMEM")
 
+    extra_compile_args = {"cxx": cxx_flags}
+    if build_native_cp_transport:
+        nvcc_flags = ["-O3", "-std=c++17"]
+        nccl_home = os.getenv("NCCL_HOME")
+        nccl_include_dir = os.getenv("NVTE_NCCL_INCLUDE_DIR")
+        nccl_library_dir = os.getenv("NVTE_NCCL_LIBRARY_DIR")
+        if nccl_home:
+            nccl_home = Path(nccl_home)
+            nccl_include_dir = nccl_include_dir or str(nccl_home / "include")
+            nccl_library_dir = nccl_library_dir or str(nccl_home / "lib")
+        if nccl_include_dir:
+            include_dirs.append(Path(nccl_include_dir))
+        if nccl_library_dir:
+            library_dirs.append(Path(nccl_library_dir))
+        libraries.append("nccl")
+        cxx_flags.append("-DNVTE_WITH_NCCL_DEVICE_CP")
+        nvcc_flags.append("-DNVTE_WITH_NCCL_DEVICE_CP")
+        extra_compile_args["nvcc"] = nvcc_flags
+
     # Construct PyTorch CUDA extension
     sources = [str(path) for path in sources]
     include_dirs = [str(path) for path in include_dirs]
-    from torch.utils.cpp_extension import CppExtension
+    from torch.utils.cpp_extension import CppExtension, CUDAExtension
 
-    return CppExtension(
+    extension_cls = CUDAExtension if build_native_cp_transport else CppExtension
+
+    return extension_cls(
         name="transformer_engine_torch",
         sources=[str(src) for src in sources],
         include_dirs=[str(inc) for inc in include_dirs],
-        extra_compile_args={"cxx": cxx_flags},
+        extra_compile_args=extra_compile_args,
         libraries=[str(lib) for lib in libraries],
         library_dirs=[str(lib_dir) for lib_dir in library_dirs],
     )

--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -484,10 +484,17 @@ def run_dpa_with_cp(
     if native_cp_transport:
         kv_bytes = (k_.numel() + v_.numel()) * k_.element_size()
         pair_bytes = 2 * kv_bytes
+        gin_env_names = (
+            "NCCL_GIN_NCONTEXTS",
+            "NCCL_GIN_SIGNAL_POOL_SIZE",
+            "NCCL_GIN_COUNTER_POOL_SIZE",
+        )
+        gin_env_before = {name: os.environ.get(name) for name in gin_env_names}
         initialize_native_cp_transport(
             cp_comm_group,
             ((pair_bytes + 255) // 256) * 256 + pair_bytes,
         )
+        assert {name: os.environ.get(name) for name in gin_env_names} == gin_env_before
         if logical_cp_ring:
             set_native_cp_parent_group(cp_group, cp_comm_group)
     # set up environment

--- a/tests/pytorch/attention/run_attention_with_cp.py
+++ b/tests/pytorch/attention/run_attention_with_cp.py
@@ -5,15 +5,38 @@
 import os
 import sys
 import logging
+import copy
 from contextlib import nullcontext
 import torch
 import torch.distributed as dist
 from transformer_engine.pytorch.attention.dot_product_attention.context_parallel import (
     get_cu_seqlens_on_cp_rank,
 )
+from transformer_engine.pytorch.attention.native_cp_transport import (
+    destroy_native_cp_transport,
+    initialize_native_cp_transport,
+    set_native_cp_parent_group,
+)
 from transformer_engine.pytorch.attention.dot_product_attention.utils import combine_and_quantize
 import transformer_engine_torch as tex
 from test_attention_with_cp import model_configs_flash_attn, model_configs_fused_attn
+
+
+class _LogicalCPGroup:
+    """Minimal topology descriptor used by native-transport tests."""
+
+    def __init__(self, ranks, rank):
+        self.ranks = tuple(ranks)
+        self.cp_size = len(self.ranks)
+        self.cp_rank = self.ranks.index(rank)
+
+    def size(self):
+        return self.cp_size
+
+    def rank(self):
+        return self.cp_rank
+
+
 from transformer_engine.pytorch import (
     autocast,
     DotProductAttention,
@@ -180,6 +203,9 @@ def run_dpa_with_cp(
     scaling_mode="delayed",
     f16_O="False",
     is_training="True",
+    native_cp_transport="False",
+    logical_cp_ring="False",
+    max_seqlen=None,
     log_level=logging.WARNING,
 ):
     """Test DotProductAttention module with context parallelism"""
@@ -202,6 +228,14 @@ def run_dpa_with_cp(
     if kernel_backend == "FusedAttention":
         os.environ["NVTE_FUSED_ATTN"] = "1"
         config = model_configs_fused_attn[model]
+    config = copy.deepcopy(config)
+    native_cp_transport = native_cp_transport == "True"
+    logical_cp_ring = logical_cp_ring == "True"
+    if logical_cp_ring and not native_cp_transport:
+        raise ValueError("logical_cp_ring requires native_cp_transport=True")
+    if max_seqlen is not None:
+        config.max_seqlen_q = int(max_seqlen)
+        config.max_seqlen_kv = int(max_seqlen)
     assert config.attn_mask_type in [
         "causal",
         "no_mask",
@@ -229,6 +263,14 @@ def run_dpa_with_cp(
     cp_comm_ranks = range(world_size)
     assert rank in cp_comm_ranks
     cp_comm_group = dist.new_group(cp_comm_ranks, backend="nccl")
+    cp_group = cp_comm_group
+    cp_rank = rank
+    cp_global_ranks = tuple(cp_comm_ranks)
+    if logical_cp_ring:
+        offsets = [0, *range(1, world_size, 2), *reversed(range(2, world_size, 2))]
+        cp_global_ranks = tuple(cp_comm_ranks[offset] for offset in offsets)
+        cp_group = _LogicalCPGroup(cp_global_ranks, rank)
+        cp_rank = cp_group.rank()
     if cp_comm_type == "a2a+p2p":
         assert world_size % 2 == 0, (
             "{cp_comm_type=} requires world_size % 2 = 0 as it assumes the a2a level has cp_size"
@@ -390,17 +432,17 @@ def run_dpa_with_cp(
             )
             for x in [q_, k_, v_, dout_]
         ]
-        seq_idx = torch.tensor([rank, 2 * world_size - rank - 1], device=q_.device)
+        seq_idx = torch.tensor([cp_rank, 2 * world_size - cp_rank - 1], device=q_.device)
         q_, k_, v_, dout_ = [x.index_select(seq_dim, seq_idx) for x in [q_, k_, v_, dout_]]
         q_, k_, v_, dout_ = [
             x.view(*x.shape[:seq_dim], -1, *x.shape[(seq_dim + 2) :]) for x in [q_, k_, v_, dout_]
         ]
     elif qkv_format == "thd":
         seq_idx_q = tex.thd_get_partitioned_indices(
-            cu_seqlens_q_padded, q_.shape[0], world_size, rank
+            cu_seqlens_q_padded, q_.shape[0], world_size, cp_rank
         )
         seq_idx_kv = tex.thd_get_partitioned_indices(
-            cu_seqlens_kv_padded, k_.shape[0], world_size, rank
+            cu_seqlens_kv_padded, k_.shape[0], world_size, cp_rank
         )
         q_, dout_ = [x.index_select(0, seq_idx_q) for x in [q_, dout_]]
         k_, v_ = [x.index_select(0, seq_idx_kv) for x in [k_, v_]]
@@ -438,10 +480,20 @@ def run_dpa_with_cp(
             bias_ = bias_.index_select(seq_q_dim, bias_seq_idx)
             bias_ = bias_.view(*shape_before_seq, -1, seq_kv_size)
             bias_.requires_grad = True
+
+    if native_cp_transport:
+        kv_bytes = (k_.numel() + v_.numel()) * k_.element_size()
+        pair_bytes = 2 * kv_bytes
+        initialize_native_cp_transport(
+            cp_comm_group,
+            ((pair_bytes + 255) // 256) * 256 + pair_bytes,
+        )
+        if logical_cp_ring:
+            set_native_cp_parent_group(cp_group, cp_comm_group)
     # set up environment
     core_attn.set_context_parallel_group(
-        cp_comm_sub_groups if cp_comm_type == "a2a+p2p" else cp_comm_group,
-        cp_comm_ranks,
+        cp_comm_sub_groups if cp_comm_type == "a2a+p2p" else cp_group,
+        cp_global_ranks,
         torch.cuda.Stream(),
         cp_comm_type,
     )
@@ -562,7 +614,7 @@ def run_dpa_with_cp(
             dq_, dk_, dv_, out_ = [dq_, dk_, dv_, out_]
             cu_seqlens_q_padded = cu_seqlens_q_padded // world_size
             cu_seqlens_q = get_cu_seqlens_on_cp_rank(
-                cu_seqlens_q, cu_seqlens_q_padded, world_size, rank, True, True
+                cu_seqlens_q, cu_seqlens_q_padded, world_size, cp_rank, True, True
             )
             cu_pads_q = cu_seqlens_q_padded - cu_seqlens_q
             num_pads_q = cu_pads_q[1:] - cu_pads_q[:-1]
@@ -582,7 +634,7 @@ def run_dpa_with_cp(
                     )
             cu_seqlens_kv_padded = cu_seqlens_kv_padded // world_size
             cu_seqlens_kv = get_cu_seqlens_on_cp_rank(
-                cu_seqlens_kv, cu_seqlens_kv_padded, world_size, rank, True, True
+                cu_seqlens_kv, cu_seqlens_kv_padded, world_size, cp_rank, True, True
             )
             cu_pads_kv = cu_seqlens_kv_padded - cu_seqlens_kv
             num_pads_kv = cu_pads_kv[1:] - cu_pads_kv[:-1]
@@ -732,6 +784,9 @@ def run_dpa_with_cp(
                     t, tensors_cp[i], names_no_cp[i], names_cp[i], atol, rtol, rmse_tol, is_fp8
                 )
             logging.info(f"[Rank {rank}] CP vs no-CP: {names[i]} matches")
+
+    if native_cp_transport:
+        destroy_native_cp_transport(cp_comm_group)
 
     # destroy distribution group
     dist.destroy_process_group()

--- a/tests/pytorch/attention/test_native_cp_transport.py
+++ b/tests/pytorch/attention/test_native_cp_transport.py
@@ -14,20 +14,9 @@ import pytest
 import torch
 
 
-@pytest.mark.parametrize("configured_value", [None, "512"])
-def test_native_cp_preserves_nccl_environment(monkeypatch, configured_value):
-    """Creating a transport must not limit GIN resources for other communicators."""
-    gin_env_names = (
-        "NCCL_GIN_NCONTEXTS",
-        "NCCL_GIN_SIGNAL_POOL_SIZE",
-        "NCCL_GIN_COUNTER_POOL_SIZE",
-    )
-    for name in gin_env_names:
-        if configured_value is None:
-            monkeypatch.delenv(name, raising=False)
-        else:
-            monkeypatch.setenv(name, configured_value)
-
+@pytest.fixture
+def native_module(monkeypatch):
+    """Load the transport without importing GPU-only TE modules."""
     extension = Mock(cp_native_transport_create=Mock(return_value=(1, None)))
     monkeypatch.setitem(sys.modules, "transformer_engine_torch", extension)
     monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
@@ -40,6 +29,23 @@ def test_native_cp_preserves_nccl_environment(monkeypatch, configured_value):
     spec = importlib.util.spec_from_file_location("native_cp_transport_policy_test", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    return module, extension
+
+
+@pytest.mark.parametrize("configured_value", [None, "512"])
+def test_native_cp_preserves_nccl_environment(monkeypatch, native_module, configured_value):
+    """Creating a transport must not limit GIN resources for other communicators."""
+    gin_env_names = (
+        "NCCL_GIN_NCONTEXTS",
+        "NCCL_GIN_SIGNAL_POOL_SIZE",
+        "NCCL_GIN_COUNTER_POOL_SIZE",
+    )
+    for name in gin_env_names:
+        if configured_value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, configured_value)
+    module, extension = native_module
     parent = Mock()
     parent._get_backend.return_value._comm_ptr.return_value = 123
 
@@ -49,3 +55,59 @@ def test_native_cp_preserves_nccl_environment(monkeypatch, configured_value):
     assert {name: os.environ.get(name) for name in gin_env_names} == {
         name: configured_value for name in gin_env_names
     }
+
+
+@pytest.mark.parametrize("dtype", [torch.int64, torch.bool, torch.float32])
+@pytest.mark.parametrize("peers", [(7, 11), (None, 11), (7, None), (None, None)])
+def test_native_cp_halo_stages_noncontiguous_tensors(native_module, dtype, peers):
+    """Halo staging reuses the arena and preserves missing-receive boundary fills."""
+    module, extension = native_module
+    transport = module.NativeCPTransport.__new__(module.NativeCPTransport)
+    transport.handle = 123
+    transport.arena = torch.empty(512, dtype=torch.uint8)
+    transport._parent_rank = {7: 1, 11: 2}
+    source = torch.arange(6).reshape(3, 2).to(dtype).t()
+    output = torch.zeros(3, 2, dtype=dtype).t()
+    expected = torch.ones_like(output)
+
+    def exchange(handle, send, recv, send_peer, recv_peer, channel):
+        assert handle == 123 and channel == 3
+        assert send_peer == (-1 if peers[0] is None else 1)
+        assert recv_peer == (-1 if peers[1] is None else 2)
+        assert send.is_contiguous() and recv.is_contiguous()
+        assert send.untyped_storage().data_ptr() == transport.arena.data_ptr()
+        assert recv.untyped_storage().data_ptr() == transport.arena.data_ptr()
+        if peers[0] is not None:
+            torch.testing.assert_close(send, source, rtol=0, atol=0)
+        if peers[1] is not None:
+            recv.copy_(expected)
+        return channel
+
+    extension.cp_native_transport_send_recv.side_effect = exchange
+    transport.exchange(source, peers[0], output, peers[1])
+    torch.testing.assert_close(
+        output, expected if peers[1] is not None else torch.zeros_like(output), rtol=0, atol=0
+    )
+    if peers == (None, None):
+        extension.cp_native_transport_send_recv.assert_not_called()
+        extension.cp_native_transport_wait.assert_not_called()
+    else:
+        extension.cp_native_transport_send_recv.assert_called_once()
+        extension.cp_native_transport_wait.assert_called_once_with(123, 3)
+
+
+def test_native_cp_halo_rejects_incompatible_buffers(native_module):
+    """Bad halo metadata must fail before entering the communication kernel."""
+    module, extension = native_module
+    transport = module.NativeCPTransport.__new__(module.NativeCPTransport)
+    transport.handle = 123
+    transport.arena = torch.empty(512, dtype=torch.uint8)
+    transport._parent_rank = {7: 1}
+    with pytest.raises(ValueError, match="matching shapes and dtypes"):
+        transport.exchange(torch.zeros(2), 7, torch.zeros(3), 7)
+    with pytest.raises(ValueError, match="matching shapes and dtypes"):
+        transport.exchange(torch.zeros(2), 7, torch.zeros(2, dtype=torch.int64), 7)
+    with pytest.raises(RuntimeError, match="arena needs"):
+        transport.exchange(torch.zeros(512), 7, torch.zeros(512), 7)
+    transport.exchange(torch.empty(0), 7, torch.empty(0), 7)
+    extension.cp_native_transport_send_recv.assert_not_called()

--- a/tests/pytorch/attention/test_native_cp_transport.py
+++ b/tests/pytorch/attention/test_native_cp_transport.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""CPU-only checks for native CP initialization policy."""
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("configured_value", [None, "512"])
+def test_native_cp_preserves_nccl_environment(monkeypatch, configured_value):
+    """Creating a transport must not limit GIN resources for other communicators."""
+    gin_env_names = (
+        "NCCL_GIN_NCONTEXTS",
+        "NCCL_GIN_SIGNAL_POOL_SIZE",
+        "NCCL_GIN_COUNTER_POOL_SIZE",
+    )
+    for name in gin_env_names:
+        if configured_value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, configured_value)
+
+    extension = Mock(cp_native_transport_create=Mock(return_value=(1, None)))
+    monkeypatch.setitem(sys.modules, "transformer_engine_torch", extension)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda **kwargs: None)
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda group: [0])
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "transformer_engine/pytorch/attention/native_cp_transport.py"
+    )
+    spec = importlib.util.spec_from_file_location("native_cp_transport_policy_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    parent = Mock()
+    parent._get_backend.return_value._comm_ptr.return_value = 123
+
+    module.NativeCPTransport(parent, 256)
+
+    extension.cp_native_transport_create.assert_called_once_with(123, 256)
+    assert {name: os.environ.get(name) for name in gin_env_names} == {
+        name: configured_value for name in gin_env_names
+    }

--- a/tests/pytorch/test_cuda_graphs.py
+++ b/tests/pytorch/test_cuda_graphs.py
@@ -2,6 +2,8 @@
 #
 # See LICENSE for license information.
 
+import gc
+import weakref
 from typing import Callable, Dict, Iterable, List, Tuple, Union
 import pytest
 
@@ -22,6 +24,16 @@ from transformer_engine.pytorch import (
     is_bf16_available,
 )
 from transformer_engine.pytorch.quantization import FP8GlobalStateManager
+from transformer_engine.pytorch.attention.dot_product_attention.context_parallel import (
+    _get_cp_p2p_transport_group,
+    set_cp_p2p_transport_group,
+)
+from transformer_engine.pytorch.distributed import (
+    get_distributed_group_ranks,
+    get_distributed_rank,
+    get_distributed_world_size,
+    is_logical_process_group,
+)
 import transformer_engine.pytorch.ops as te_ops
 from transformer_engine.common import recipe
 from utils import ModelConfig, reset_rng_states
@@ -37,6 +49,61 @@ reset_rng_states()
 model_configs = {
     "small": ModelConfig(2, 32, 2, 32),
 }
+
+
+def test_cp_p2p_transport_group_override():
+    class Group:
+        pass
+
+    logical_group = Group()
+    transport_group = Group()
+
+    assert _get_cp_p2p_transport_group(logical_group) == (logical_group, False)
+    set_cp_p2p_transport_group(logical_group, transport_group)
+    assert _get_cp_p2p_transport_group(logical_group) == (transport_group, True)
+    set_cp_p2p_transport_group(logical_group, None)
+    assert _get_cp_p2p_transport_group(logical_group) == (logical_group, False)
+
+    set_cp_p2p_transport_group(logical_group, transport_group)
+    logical_group_ref = weakref.ref(logical_group)
+    del logical_group
+    gc.collect()
+    assert logical_group_ref() is None
+
+    self_transport_group = Group()
+    self_transport_group_ref = weakref.ref(self_transport_group)
+    set_cp_p2p_transport_group(self_transport_group, self_transport_group)
+    del self_transport_group
+    gc.collect()
+    assert self_transport_group_ref() is None
+
+
+def test_logical_cp_group_uses_registered_parent_transport():
+    class LogicalGroup:
+        ranks = (2, 3, 6, 7)
+        cp_size = 4
+        cp_rank = 2
+
+    class ParentGroup:
+        pass
+
+    logical_group = LogicalGroup()
+    parent_group = ParentGroup()
+
+    assert is_logical_process_group(logical_group)
+    assert get_distributed_world_size(logical_group) == 4
+    assert get_distributed_rank(logical_group) == 2
+    assert get_distributed_group_ranks(logical_group) == (2, 3, 6, 7)
+    with pytest.raises(RuntimeError, match="requires a registered parent"):
+        _get_cp_p2p_transport_group(logical_group)
+
+    set_cp_p2p_transport_group(logical_group, parent_group)
+    assert _get_cp_p2p_transport_group(logical_group) == (parent_group, True)
+
+    logical_group_ref = weakref.ref(logical_group)
+    del logical_group
+    gc.collect()
+    assert logical_group_ref() is None
 
 
 def nvfp4_vanilla():

--- a/transformer_engine/pytorch/attention/dot_product_attention/backends.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/backends.py
@@ -48,7 +48,10 @@ from transformer_engine.pytorch.cpp_extensions.fused_attn import (
     META_QKV,
 )
 from transformer_engine.pytorch.quantization import get_fp8_torch_dtype, FP8GlobalStateManager
-from transformer_engine.pytorch.distributed import get_distributed_world_size
+from transformer_engine.pytorch.distributed import (
+    get_distributed_world_size,
+    is_logical_process_group,
+)
 from transformer_engine.pytorch.jit import no_torch_dynamo
 from transformer_engine.pytorch.attention.dot_product_attention.context_parallel import (
     attn_forward_func_with_cp,
@@ -757,7 +760,7 @@ class FlashAttention(torch.nn.Module):
         ), f"FlashAttention does not support qkv_layout = {qkv_layout}!"
 
         cp_size = 1
-        if isinstance(cp_group, dist_group_type):
+        if isinstance(cp_group, dist_group_type) or is_logical_process_group(cp_group):
             cp_size = get_distributed_world_size(cp_group)
         elif isinstance(cp_group, list):
             for group in cp_group:
@@ -1828,7 +1831,7 @@ class FusedAttention(torch.nn.Module):
         ), f"FusedAttention does not support qkv_layout = {qkv_layout}!"
 
         cp_size = 1
-        if isinstance(cp_group, dist_group_type):
+        if isinstance(cp_group, dist_group_type) or is_logical_process_group(cp_group):
             cp_size = get_distributed_world_size(cp_group)
         elif isinstance(cp_group, list):
             for group in cp_group:

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -3,9 +3,11 @@
 # See LICENSE for license information.
 
 """Context Parallelism."""
-import os
+
 import itertools
-from typing import List, Union, Tuple
+import os
+import weakref
+from typing import List, Tuple, Union
 import torch
 import transformer_engine_torch as tex
 
@@ -30,9 +32,11 @@ from transformer_engine.pytorch.constants import (
     TE_DType,
 )
 from transformer_engine.pytorch.distributed import (
+    get_distributed_group_ranks,
     get_distributed_world_size,
     get_distributed_rank,
     gather_along_first_dim,
+    is_logical_process_group,
     reduce_scatter_along_first_dim,
 )
 
@@ -54,6 +58,28 @@ _cu_seqlens_info_with_cp_cache = {}
 _seq_chunk_ids_cache_for_reordering_before_attn = {}
 _seq_chunk_ids_cache_for_reordering_after_attn = {}
 _softmax_offset_chunk_ids_cache = {}
+_cp_p2p_transport_groups = weakref.WeakKeyDictionary()
+
+
+def set_cp_p2p_transport_group(cp_group, transport_group):
+    """Override only the P2P transport group for a logical CP group."""
+    if transport_group is None:
+        _cp_p2p_transport_groups.pop(cp_group, None)
+        return
+    _cp_p2p_transport_groups[cp_group] = weakref.ref(transport_group)
+
+
+def _get_cp_p2p_transport_group(cp_group):
+    transport_group_ref = _cp_p2p_transport_groups.get(cp_group)
+    if transport_group_ref is not None:
+        transport_group = transport_group_ref()
+        if transport_group is not None:
+            return transport_group, True
+        _cp_p2p_transport_groups.pop(cp_group, None)
+    if is_logical_process_group(cp_group):
+        raise RuntimeError("A logical CP group requires a registered parent P2P transport group.")
+    return cp_group, False
+
 
 # Float8CurrentScaling: fused_attn_bwd takes O in FP8 by default, this flag allows it in F16
 _dpa_fp8_cs_o_in_f16 = os.getenv("NVTE_DPA_FP8CS_O_in_F16", "1") == "1"
@@ -64,41 +90,109 @@ def flash_attn_p2p_communicate(
 ):
     """Point-to-point communications of KV and dKV in Attention with context parallelism"""
     send_recv_ops = []
+    transport_group, transport_overridden = _get_cp_p2p_transport_group(cp_group)
+    if transport_overridden:
+        batch_p2p_comm = True
 
     if batch_p2p_comm:
         if rank % 2 == 0:
             send_op = torch.distributed.P2POp(
-                torch.distributed.isend, send_tensor, send_dst, cp_group
+                torch.distributed.isend, send_tensor, send_dst, transport_group
             )
             recv_op = torch.distributed.P2POp(
-                torch.distributed.irecv, recv_tensor, recv_src, cp_group
+                torch.distributed.irecv, recv_tensor, recv_src, transport_group
             )
             send_recv_ops.append(send_op)
             send_recv_ops.append(recv_op)
         else:
             recv_op = torch.distributed.P2POp(
-                torch.distributed.irecv, recv_tensor, recv_src, cp_group
+                torch.distributed.irecv, recv_tensor, recv_src, transport_group
             )
             send_op = torch.distributed.P2POp(
-                torch.distributed.isend, send_tensor, send_dst, cp_group
+                torch.distributed.isend, send_tensor, send_dst, transport_group
             )
             send_recv_ops.append(recv_op)
             send_recv_ops.append(send_op)
         send_recv_reqs = torch.distributed.batch_isend_irecv(send_recv_ops)
     else:
         if rank % 2 == 0:
-            send_op = torch.distributed.isend(send_tensor, send_dst, cp_group)
-            recv_op = torch.distributed.irecv(recv_tensor, recv_src, cp_group)
+            send_op = torch.distributed.isend(send_tensor, send_dst, transport_group)
+            recv_op = torch.distributed.irecv(recv_tensor, recv_src, transport_group)
             send_recv_ops.append(send_op)
             send_recv_ops.append(recv_op)
         else:
-            recv_op = torch.distributed.irecv(recv_tensor, recv_src, cp_group)
-            send_op = torch.distributed.isend(send_tensor, send_dst, cp_group)
+            recv_op = torch.distributed.irecv(recv_tensor, recv_src, transport_group)
+            send_op = torch.distributed.isend(send_tensor, send_dst, transport_group)
             send_recv_ops.append(recv_op)
             send_recv_ops.append(send_op)
         send_recv_reqs = send_recv_ops
 
     return send_recv_reqs
+
+
+def _logical_cp_all_reduce_max_(tensor, cp_group):
+    """Apply an in-place max reduction using a logical ring on the parent group."""
+    cp_size = get_distributed_world_size(cp_group)
+    if cp_size == 1:
+        return tensor
+
+    cp_rank = get_distributed_rank(cp_group)
+    cp_global_ranks = get_distributed_group_ranks(cp_group)
+    send_dst = cp_global_ranks[(cp_rank + 1) % cp_size]
+    recv_src = cp_global_ranks[(cp_rank - 1) % cp_size]
+    send_buffer = tensor.clone()
+    for _ in range(cp_size - 1):
+        recv_buffer = torch.empty_like(send_buffer)
+        requests = flash_attn_p2p_communicate(
+            cp_rank,
+            send_buffer,
+            send_dst,
+            recv_buffer,
+            recv_src,
+            cp_group,
+            True,
+        )
+        for request in requests:
+            request.wait()
+        torch.maximum(tensor, recv_buffer, out=tensor)
+        send_buffer = recv_buffer
+    return tensor
+
+
+def _logical_cp_all_to_all_single(output, input_, cp_group):
+    """Run equal-split all-to-all as subgroup P2P through the parent group."""
+    cp_size = get_distributed_world_size(cp_group)
+    cp_rank = get_distributed_rank(cp_group)
+    cp_global_ranks = get_distributed_group_ranks(cp_group)
+    transport_group, _ = _get_cp_p2p_transport_group(cp_group)
+
+    if input_.shape[0] % cp_size != 0 or output.shape[0] % cp_size != 0:
+        raise RuntimeError("Logical CP all-to-all requires equal splits along dimension 0.")
+
+    input_chunks = input_.chunk(cp_size, dim=0)
+    output_chunks = output.chunk(cp_size, dim=0)
+    output_chunks[cp_rank].copy_(input_chunks[cp_rank])
+    operations = []
+    for peer_rank, peer_global_rank in enumerate(cp_global_ranks):
+        if peer_rank == cp_rank:
+            continue
+        operations.extend(
+            [
+                torch.distributed.P2POp(
+                    torch.distributed.isend,
+                    input_chunks[peer_rank],
+                    peer_global_rank,
+                    transport_group,
+                ),
+                torch.distributed.P2POp(
+                    torch.distributed.irecv,
+                    output_chunks[peer_rank],
+                    peer_global_rank,
+                    transport_group,
+                ),
+            ]
+        )
+    return torch.distributed.batch_isend_irecv(operations) if operations else []
 
 
 @jit_fuser
@@ -540,7 +634,9 @@ def flash_attn_a2a_communicate_softmax_offset(
             )
         torch.cuda.current_stream().wait_stream(cp_stream)
         output = output.view(
-            *tensor.shape[:h_dim], cp_size * tensor.shape[h_dim], *tensor.shape[h_dim + 1 :]
+            *tensor.shape[:h_dim],
+            cp_size * tensor.shape[h_dim],
+            *tensor.shape[h_dim + 1 :],
         )
     return output
 
@@ -1382,7 +1478,13 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 q, k, v = (q._data, k._data, v._data)
             chunk_ids_for_a2a = get_seq_chunk_ids_for_reordering_before_attn(cp_size_a2a, q.device)
             q, k, v = flash_attn_a2a_communicate(
-                [q, k, v], chunk_ids_for_a2a, seq_dim, cp_size_a2a, cp_group_a2a, cp_stream, True
+                [q, k, v],
+                chunk_ids_for_a2a,
+                seq_dim,
+                cp_size_a2a,
+                cp_group_a2a,
+                cp_stream,
+                True,
             )
             if fp8 and is_input_fp8:
                 q_fp8, k_fp8, v_fp8 = [
@@ -1480,7 +1582,9 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 ), "Sequence length does not meet divisible requirements!"
                 # [b, h, sq, sk] -> [b, h, sq, 2*cp, sk//(2*cp)]
                 attn_bias_ = attn_bias.view(
-                    *attn_bias.shape[:-1], 2 * cp_size, attn_bias.shape[-1] // (2 * cp_size)
+                    *attn_bias.shape[:-1],
+                    2 * cp_size,
+                    attn_bias.shape[-1] // (2 * cp_size),
                 )
 
             # [b, h, sq, sk] -> [b, h, sq, 2*cp, sk//(2*cp)]
@@ -1683,10 +1787,12 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
-                                    cp_p2p_fwd_flash_attn(
-                                        *flash_attn_inputs, *prepare_outputs, section
-                                    )
+                                (
+                                    out_per_step[i],
+                                    softmax_lse_per_step[i],
+                                    rng_states[i],
+                                ) = cp_p2p_fwd_flash_attn(
+                                    *flash_attn_inputs, *prepare_outputs, section
                                 )
                         elif i <= rank:
                             section = "lower-triangle"
@@ -1710,10 +1816,12 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
-                                    cp_p2p_fwd_flash_attn(
-                                        *flash_attn_inputs, *prepare_outputs, section
-                                    )
+                                (
+                                    out_per_step[i],
+                                    softmax_lse_per_step[i],
+                                    rng_states[i],
+                                ) = cp_p2p_fwd_flash_attn(
+                                    *flash_attn_inputs, *prepare_outputs, section
                                 )
                         else:
                             section = "upper-triangle"
@@ -1737,10 +1845,12 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                                     *fused_attn_inputs, *prepare_outputs, section
                                 )
                             else:
-                                out_per_step[i], softmax_lse_per_step[i], rng_states[i] = (
-                                    cp_p2p_fwd_flash_attn(
-                                        *flash_attn_inputs, *prepare_outputs, section
-                                    )
+                                (
+                                    out_per_step[i],
+                                    softmax_lse_per_step[i],
+                                    rng_states[i],
+                                ) = cp_p2p_fwd_flash_attn(
+                                    *flash_attn_inputs, *prepare_outputs, section
                                 )
                     else:
                         # all tiles
@@ -1831,9 +1941,12 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
 
         torch.cuda.current_stream().wait_stream(flash_attn_streams[1])
         if return_max_logit:
-            torch.distributed.all_reduce(
-                max_logit, op=torch.distributed.ReduceOp.MAX, group=cp_group
-            )
+            if is_logical_process_group(cp_group):
+                _logical_cp_all_reduce_max_(max_logit, cp_group)
+            else:
+                torch.distributed.all_reduce(
+                    max_logit, op=torch.distributed.ReduceOp.MAX, group=cp_group
+                )
 
         second_half_lse_seqlen = None
         if causal and rank < (cp_size - 1):
@@ -1902,7 +2015,13 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         if cp_size_a2a > 1:
             chunk_ids_for_a2a = get_seq_chunk_ids_for_reordering_after_attn(cp_size_a2a, out.device)
             out = flash_attn_a2a_communicate(
-                out, chunk_ids_for_a2a, seq_dim, cp_size_a2a, cp_group_a2a, cp_stream, False
+                out,
+                chunk_ids_for_a2a,
+                seq_dim,
+                cp_size_a2a,
+                cp_group_a2a,
+                cp_stream,
+                False,
             )
             if use_fused_attention:
                 if qkv_format == "bshd":
@@ -2106,12 +2225,17 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         if attn_biases[0] is not None:
             # [b, h, sq, 2*cp, sk//(2*cp)]
             attn_dbias = torch.zeros(
-                *ctx.attn_bias_shape, dtype=attn_biases[0].dtype, device=attn_biases[0].device
+                *ctx.attn_bias_shape,
+                dtype=attn_biases[0].dtype,
+                device=attn_biases[0].device,
             )
             # [b, h, sq, 2*cp, sk//(2*cp)] -> [b, h, 2, sq//2, 2*cp, sk//(2*cp)] only when sq > 1 (i.e. all supported bias shapes except 111s)
             if attn_dbias.shape[-3] > 1:
                 attn_dbias_ = attn_dbias.view(
-                    *attn_dbias.shape[:-3], 2, attn_dbias.shape[-3] // 2, *attn_dbias.shape[-2:]
+                    *attn_dbias.shape[:-3],
+                    2,
+                    attn_dbias.shape[-3] // 2,
+                    *attn_dbias.shape[-2:],
                 )
             else:
                 attn_dbias_ = None
@@ -2216,7 +2340,10 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 device=kv.device,
             )
             dkv_recv_buffer = torch.empty_like(dkv_send_buffer)
-            p2p_comm_buffers = [[kv, dkv_send_buffer], [kv_recv_buffer, dkv_recv_buffer]]
+            p2p_comm_buffers = [
+                [kv, dkv_send_buffer],
+                [kv_recv_buffer, dkv_recv_buffer],
+            ]
             if ctx.fp8_recipe.float8_current_scaling():
                 dkv_buffer = torch.zeros(
                     kv.shape,
@@ -2326,13 +2453,18 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         batch_p2p_comm,
                     )
                 else:
-                    dkv_a2a_req = torch.distributed.all_to_all_single(
-                        dkv_send_buffer,
-                        dkv_recv_buffer,
-                        group=ctx.cp_group,
-                        async_op=True,
-                    )
-                    send_recv_reqs = [dkv_a2a_req]
+                    if is_logical_process_group(ctx.cp_group):
+                        send_recv_reqs = _logical_cp_all_to_all_single(
+                            dkv_send_buffer, dkv_recv_buffer, ctx.cp_group
+                        )
+                    else:
+                        dkv_a2a_req = torch.distributed.all_to_all_single(
+                            dkv_send_buffer,
+                            dkv_recv_buffer,
+                            group=ctx.cp_group,
+                            async_op=True,
+                        )
+                        send_recv_reqs = [dkv_a2a_req]
             else:
                 if i == 0:
                     send_tensor = send_tensor[0]
@@ -2341,7 +2473,13 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                     send_tensor = send_tensor[1]
                     recv_tensor = recv_tensor[1]
                 send_recv_reqs = flash_attn_p2p_communicate(
-                    rank, send_tensor, send_dst, recv_tensor, recv_src, ctx.cp_group, batch_p2p_comm
+                    rank,
+                    send_tensor,
+                    send_dst,
+                    recv_tensor,
+                    recv_src,
+                    ctx.cp_group,
+                    batch_p2p_comm,
                 )
 
             kv = p2p_comm_buffers[i % 2][0]
@@ -2656,7 +2794,9 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                 dv = dkv_recv_buffer[:, ctx.k_numel :].view(cp_size, *ctx.v_shape)
                 dq, dk, dv = [
                     ctx.dQKV_quantizer.create_tensor_from_data(
-                        x, fake_dtype=bwd_nominal_dtype, internal=ctx.dQKV_quantizer.internal
+                        x,
+                        fake_dtype=bwd_nominal_dtype,
+                        internal=ctx.dQKV_quantizer.internal,
                     )
                     for x in [dq, dk, dv]
                 ]
@@ -3081,7 +3221,7 @@ class AttnFuncWithCPAndKVAllGather(torch.autograd.Function):
         rank = get_distributed_rank(ctx.cp_group)
 
         (*saved_tensors,) = ctx.saved_tensors
-        (q, k, v, cu_seqlens_q, cu_seqlens_q_padded) = saved_tensors[:5]
+        q, k, v, cu_seqlens_q, cu_seqlens_q_padded = saved_tensors[:5]
         cu_seqlens_kv_per_step = saved_tensors[5:7]
         out_per_step = saved_tensors[7:9]
         softmax_lse_per_step = saved_tensors[9:11]
@@ -3430,9 +3570,14 @@ class AttnFuncWithCPAndQKVOA2A(torch.autograd.Function):
         fused_attn_backend = None
         max_logit = None
 
-        QKV_quantizer, O_quantizer, S_quantizer, dQKV_quantizer, dO_quantizer, dP_quantizer = (
-            dpa_utils.get_attention_quantizers(fp8, quantizers)
-        )
+        (
+            QKV_quantizer,
+            O_quantizer,
+            S_quantizer,
+            dQKV_quantizer,
+            dO_quantizer,
+            dP_quantizer,
+        ) = dpa_utils.get_attention_quantizers(fp8, quantizers)
 
         q_fp8, k_fp8, v_fp8 = (None, None, None)
         if fp8:
@@ -4041,9 +4186,14 @@ def attn_forward_func_with_cp(
             cp_group = cp_group[0]
             cp_comm_type = "a2a"
     else:
-        assert isinstance(
-            cp_group, dist_group_type
-        ), f"cp_group must be {dist_group_type} type for {cp_comm_type=}!"
+        if is_logical_process_group(cp_group):
+            assert (
+                cp_comm_type == "p2p"
+            ), f"A logical CP group can only be used with cp_comm_type='p2p'; got {cp_comm_type=}."
+        else:
+            assert isinstance(
+                cp_group, dist_group_type
+            ), f"cp_group must be {dist_group_type} type for {cp_comm_type=}!"
 
     assert qkv_format in [
         "bshd",
@@ -4286,9 +4436,9 @@ def get_batch_on_this_cp_rank(
         raise ValueError(f"Unsupported qvk_format: {qvk_format}!")
     if qvk_format == "thd":
         # Get context parallel size and rank
-        cp_size = torch.distributed.get_world_size(group=cp_group)
+        cp_size = get_distributed_world_size(cp_group)
         if cp_size > 1:
-            cp_rank = torch.distributed.get_rank(group=cp_group)
+            cp_rank = get_distributed_rank(cp_group)
 
             # Calculate the chunk sizes for each sequence
             total_slices_of_any_sequence = 2 * cp_size

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -25,6 +25,7 @@ from transformer_engine.pytorch.tensor.float8_tensor import Float8Tensor
 from transformer_engine.pytorch.quantized_tensor import QuantizedTensorStorage
 from transformer_engine.pytorch.jit import jit_fuser
 from transformer_engine.pytorch.graph import is_graph_capturing
+from transformer_engine.pytorch.attention.native_cp_transport import get_native_cp_transport
 from transformer_engine.pytorch.constants import (
     dist_group_type,
     TE_DType,
@@ -33,6 +34,7 @@ from transformer_engine.pytorch.distributed import (
     get_distributed_world_size,
     get_distributed_rank,
     gather_along_first_dim,
+    is_logical_process_group,
     reduce_scatter_along_first_dim,
 )
 
@@ -60,10 +62,24 @@ _dpa_fp8_cs_o_in_f16 = os.getenv("NVTE_DPA_FP8CS_O_in_F16", "1") == "1"
 
 
 def flash_attn_p2p_communicate(
-    rank, send_tensor, send_dst, recv_tensor, recv_src, cp_group, batch_p2p_comm
+    rank,
+    send_tensor,
+    send_dst,
+    recv_tensor,
+    recv_src,
+    cp_group,
+    batch_p2p_comm,
+    native_channel=0,
 ):
     """Point-to-point communications of KV and dKV in Attention with context parallelism"""
     send_recv_ops = []
+    native_transport = get_native_cp_transport(cp_group)
+    if native_transport is not None:
+        return [
+            native_transport.send_recv(
+                send_tensor, send_dst, recv_tensor, recv_src, channel=native_channel
+            )
+        ]
 
     if batch_p2p_comm:
         if rank % 2 == 0:
@@ -1557,11 +1573,22 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         # synchronize fwd results correction across steps
         fwd_results_correction_done = torch.cuda.Event()
 
-        p2p_comm_buffers = [None for _ in range(cp_size)]
         k_shape = k.shape
         k_numel = k.numel()
         v_shape = v.shape
-        p2p_comm_buffers[0] = torch.cat((k.view(-1), v.view(-1)), dim=-1)
+        p2p_shape = (k_numel + v.numel(),)
+        native_transport = get_native_cp_transport(cp_group)
+        if native_transport is not None and fp8:
+            raise RuntimeError("Native CP transport does not support FP8 attention yet")
+        if native_transport is None:
+            p2p_comm_buffers = [None for _ in range(cp_size)]
+            p2p_comm_buffers[0] = torch.cat((k.view(-1), v.view(-1)), dim=-1)
+        else:
+            native_pair = native_transport.attention_buffer_pair(p2p_shape, k.dtype)
+            arena_buffers = (native_pair[0][0], native_pair[0][1], native_pair[1][0])
+            p2p_comm_buffers = [arena_buffers[i % 3] for i in range(cp_size)]
+            p2p_comm_buffers[0][:k_numel].copy_(k.view(-1))
+            p2p_comm_buffers[0][k_numel:].copy_(v.view(-1))
         send_recv_reqs = [[], []]
 
         # P2P communication and compute: each rank has cp_size steps
@@ -1576,7 +1603,8 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                         req.wait()
 
                     if i < (cp_size - 1):
-                        p2p_comm_buffers[i + 1] = torch.empty_like(p2p_comm_buffers[i])
+                        if native_transport is None:
+                            p2p_comm_buffers[i + 1] = torch.empty_like(p2p_comm_buffers[i])
                         send_recv_reqs[i % 2] = flash_attn_p2p_communicate(
                             rank,
                             p2p_comm_buffers[i],
@@ -1585,6 +1613,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                             recv_src,
                             cp_group,
                             batch_p2p_comm,
+                            native_channel=0,
                         )
 
                     kv_inputs[i % 2] = p2p_comm_buffers[i]
@@ -1953,6 +1982,8 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
 
         kv_fp8 = None
         kv = p2p_comm_buffers[-1]
+        if native_transport is not None:
+            kv = kv.clone()
         if fp8:
             q_fp8, kv_fp8 = [
                 Float8Tensor.make_like(x, data=y, dtype=fwd_nominal_dtype)
@@ -2003,6 +2034,7 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
         ctx.cp_size_a2a = cp_size_a2a
         ctx.rank_a2a = rank_a2a
         ctx.cp_group = cp_group
+        ctx.native_cp_transport = native_transport
         ctx.cp_global_ranks = cp_global_ranks
         ctx.cp_stream = cp_stream
         ctx.dropout_p = dropout_p
@@ -2238,10 +2270,15 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
             if isinstance(dout, QuantizedTensorStorage):
                 dout = dout.dequantize(dtype=bwd_nominal_dtype)
             dq_buffer = torch.empty_like(q)
-            p2p_comm_buffers = [
-                torch.empty((2, *kv.shape), dtype=kv.dtype, device=kv.device),
-                torch.empty((2, *kv.shape), dtype=kv.dtype, device=kv.device),
-            ]
+            if ctx.native_cp_transport is None:
+                p2p_comm_buffers = [
+                    torch.empty((2, *kv.shape), dtype=kv.dtype, device=kv.device),
+                    torch.empty((2, *kv.shape), dtype=kv.dtype, device=kv.device),
+                ]
+            else:
+                p2p_comm_buffers = list(
+                    ctx.native_cp_transport.attention_buffer_pair(kv.shape, kv.dtype)
+                )
             p2p_comm_buffers[0][0].copy_(kv)
             if ctx.use_fused_attention:
                 bwd_output_te_dtype = TE_DType[bwd_nominal_dtype]
@@ -2341,7 +2378,14 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
                     send_tensor = send_tensor[1]
                     recv_tensor = recv_tensor[1]
                 send_recv_reqs = flash_attn_p2p_communicate(
-                    rank, send_tensor, send_dst, recv_tensor, recv_src, ctx.cp_group, batch_p2p_comm
+                    rank,
+                    send_tensor,
+                    send_dst,
+                    recv_tensor,
+                    recv_src,
+                    ctx.cp_group,
+                    batch_p2p_comm,
+                    native_channel=1,
                 )
 
             kv = p2p_comm_buffers[i % 2][0]
@@ -2729,6 +2773,13 @@ class AttnFuncWithCPAndKVP2P(torch.autograd.Function):
             # [b, h, sq, 2*cp, sk//(2*cp)] -> [b, h, sq, sk]
             attn_dbias = attn_dbias.view(*attn_dbias.shape[:-2], -1)
 
+        if ctx.native_cp_transport is not None and not ctx.fp8:
+            dkv_out = torch.empty((dk.numel() + dv.numel(),), dtype=dk.dtype, device=dk.device)
+            dkv_out[: dk.numel()].copy_(dk.reshape(-1))
+            dkv_out[dk.numel() :].copy_(dv.reshape(-1))
+            dk = dkv_out[: dk.numel()].view_as(dk)
+            dv = dkv_out[dk.numel() :].view_as(dv)
+
         nvtx_range_pop(f"{nvtx_label}")
 
         return (
@@ -3081,7 +3132,7 @@ class AttnFuncWithCPAndKVAllGather(torch.autograd.Function):
         rank = get_distributed_rank(ctx.cp_group)
 
         (*saved_tensors,) = ctx.saved_tensors
-        (q, k, v, cu_seqlens_q, cu_seqlens_q_padded) = saved_tensors[:5]
+        q, k, v, cu_seqlens_q, cu_seqlens_q_padded = saved_tensors[:5]
         cu_seqlens_kv_per_step = saved_tensors[5:7]
         out_per_step = saved_tensors[7:9]
         softmax_lse_per_step = saved_tensors[9:11]
@@ -4041,9 +4092,19 @@ def attn_forward_func_with_cp(
             cp_group = cp_group[0]
             cp_comm_type = "a2a"
     else:
-        assert isinstance(
-            cp_group, dist_group_type
-        ), f"cp_group must be {dist_group_type} type for {cp_comm_type=}!"
+        assert isinstance(cp_group, dist_group_type) or is_logical_process_group(
+            cp_group
+        ), f"cp_group must be a ProcessGroup or logical CP descriptor for {cp_comm_type=}!"
+
+    if is_logical_process_group(cp_group):
+        if cp_comm_type != "p2p":
+            raise RuntimeError("Logical CP groups only support cp_comm_type='p2p'.")
+        if fp8:
+            raise RuntimeError("Native CP transport does not support FP8 attention yet.")
+        if softmax_type != "vanilla" or return_max_logit:
+            raise RuntimeError(
+                "Native CP transport currently supports vanilla softmax without max-logit output."
+            )
 
     assert qkv_format in [
         "bshd",
@@ -4286,9 +4347,9 @@ def get_batch_on_this_cp_rank(
         raise ValueError(f"Unsupported qvk_format: {qvk_format}!")
     if qvk_format == "thd":
         # Get context parallel size and rank
-        cp_size = torch.distributed.get_world_size(group=cp_group)
+        cp_size = get_distributed_world_size(cp_group)
         if cp_size > 1:
-            cp_rank = torch.distributed.get_rank(group=cp_group)
+            cp_rank = get_distributed_rank(cp_group)
 
             # Calculate the chunk sizes for each sequence
             total_slices_of_any_sequence = 2 * cp_size

--- a/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/dot_product_attention.py
@@ -40,6 +40,7 @@ from transformer_engine.pytorch.constants import (
 )
 from transformer_engine.pytorch.distributed import (
     get_distributed_world_size,
+    is_logical_process_group,
     checkpoint,
     set_all_rng_states,
     CudaRNGStatesTracker,
@@ -1236,7 +1237,9 @@ class DotProductAttention(TransformerEngineBaseModule):
 
             # adjust max_seqlen and cu_seqlens for CP
             cp_size = 1
-            if isinstance(self.cp_group, dist_group_type):
+            if isinstance(self.cp_group, dist_group_type) or is_logical_process_group(
+                self.cp_group
+            ):
                 cp_size = get_distributed_world_size(self.cp_group)
             elif isinstance(self.cp_group, list):
                 for group in self.cp_group:

--- a/transformer_engine/pytorch/attention/multi_head_attention.py
+++ b/transformer_engine/pytorch/attention/multi_head_attention.py
@@ -26,6 +26,7 @@ from transformer_engine.pytorch.constants import (
 from transformer_engine.pytorch.distributed import (
     get_distributed_world_size,
     get_distributed_rank,
+    is_logical_process_group,
 )
 
 from transformer_engine.pytorch.attention.dot_product_attention import DotProductAttention
@@ -609,7 +610,7 @@ class MultiheadAttention(torch.nn.Module):
                         across each CP sub-group (e.g., via NVLink), then exchanging KV with
                         p2p between sub-groups (e.g., via IBLink).
         """
-        if isinstance(cp_group, dist_group_type):
+        if isinstance(cp_group, dist_group_type) or is_logical_process_group(cp_group):
             self.cp_size = get_distributed_world_size(cp_group)
             self.cp_rank = get_distributed_rank(cp_group)
         elif isinstance(cp_group, list):

--- a/transformer_engine/pytorch/attention/native_cp_transport.py
+++ b/transformer_engine/pytorch/attention/native_cp_transport.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""NCCL Device API transport for context-parallel rings."""
+
+import math
+import os
+import weakref
+from typing import Iterable, Optional
+
+import torch
+
+import transformer_engine_torch as tex
+
+_group_transports = weakref.WeakKeyDictionary()
+
+
+class _Work:
+    """Stream dependency compatible with ProcessGroup work handles."""
+
+    def __init__(self, handle: int, channel: int) -> None:
+        self.handle = handle
+        self.channel = channel
+
+    def wait(self) -> bool:
+        """Wait until the native operation has completed."""
+        if self.handle:
+            tex.cp_native_transport_wait(self.handle, self.channel)
+            self.handle = 0
+        return True
+
+
+class NativeCPTransport:
+    """One symmetric arena attached to a borrowed parent NCCL communicator."""
+
+    def __init__(self, parent_group, payload_bytes: int) -> None:
+        if not hasattr(tex, "cp_native_transport_create"):
+            raise RuntimeError("Transformer Engine was not built with native CP transport")
+        # This transport uses one shared context and VA-based signals.  NCCL's
+        # larger GIN defaults only reserve unused device state.
+        os.environ.setdefault("NCCL_GIN_NCONTEXTS", "1")
+        os.environ.setdefault("NCCL_GIN_SIGNAL_POOL_SIZE", "64")
+        os.environ.setdefault("NCCL_GIN_COUNTER_POOL_SIZE", "64")
+        torch.distributed.barrier(group=parent_group, device_ids=[torch.cuda.current_device()])
+        backend = parent_group._get_backend(torch.device("cuda"))
+        if not hasattr(backend, "_comm_ptr"):
+            raise RuntimeError("ProcessGroupNCCL does not expose _comm_ptr()")
+
+        self._parent = weakref.ref(parent_group)
+        self._parent_rank = {
+            global_rank: rank
+            for rank, global_rank in enumerate(
+                torch.distributed.get_process_group_ranks(parent_group)
+            )
+        }
+        self.handle, self.arena = tex.cp_native_transport_create(
+            int(backend._comm_ptr()), int(payload_bytes)
+        )
+        self.handle = int(self.handle)
+
+    @property
+    def payload_bytes(self) -> int:
+        """Return the usable size of the symmetric arena in bytes."""
+        return 0 if self.arena is None else self.arena.numel()
+
+    def _view(self, offset: int, shape: Iterable[int], dtype: torch.dtype) -> torch.Tensor:
+        shape = tuple(int(dim) for dim in shape)
+        size = math.prod(shape) * torch.empty((), dtype=dtype).element_size()
+        if offset + size > self.payload_bytes:
+            raise RuntimeError(
+                f"Native CP arena needs {offset + size} bytes, has {self.payload_bytes}"
+            )
+        return self.arena.narrow(0, offset, size).view(dtype).view(shape)
+
+    def attention_buffer_pair(self, shape: Iterable[int], dtype: torch.dtype):
+        """Return two contiguous ``[KV, dKV]`` work buffers."""
+        shape = tuple(shape)
+        pair_bytes = 2 * math.prod(shape) * torch.empty((), dtype=dtype).element_size()
+        return self._view(0, (2, *shape), dtype), self._view(
+            (pair_bytes + 255) // 256 * 256, (2, *shape), dtype
+        )
+
+    def send_recv(
+        self,
+        send_tensor: torch.Tensor,
+        send_global_rank: int,
+        recv_tensor: torch.Tensor,
+        recv_global_rank: int,
+        channel: int = 0,
+    ) -> _Work:
+        """Launch one native send and receive through the parent communicator."""
+        try:
+            send_peer = self._parent_rank[int(send_global_rank)]
+            recv_peer = self._parent_rank[int(recv_global_rank)]
+        except KeyError as error:
+            raise ValueError(f"Peer {error.args[0]} is outside the parent group") from error
+        channel = tex.cp_native_transport_send_recv(
+            self.handle, send_tensor, recv_tensor, send_peer, recv_peer, int(channel)
+        )
+        return _Work(self.handle, int(channel))
+
+    def all_reduce(self, tensor: torch.Tensor, group, channel: int = 2) -> torch.Tensor:
+        """Ring sum over a dynamic-CP subgroup."""
+        ranks = (
+            group.ranks
+            if hasattr(group, "ranks")
+            else torch.distributed.get_process_group_ranks(group)
+        )
+        result = tensor.contiguous().clone()
+        if len(ranks) == 1:
+            return result
+
+        size = tensor.nbytes
+        send = self._view(0, tensor.shape, tensor.dtype)
+        recv = self._view((size + 255) // 256 * 256, tensor.shape, tensor.dtype)
+        send.copy_(tensor)
+        rank = group.rank()
+        dst, src = ranks[(rank + 1) % len(ranks)], ranks[(rank - 1) % len(ranks)]
+        for _ in range(len(ranks) - 1):
+            self.send_recv(send, dst, recv, src, channel).wait()
+            result.add_(recv)
+            send, recv = recv, send
+        return result
+
+    def destroy(self) -> None:
+        """Collectively release the native transport and its symmetric arena."""
+        if not self.handle:
+            return
+        parent = self._parent()
+        if parent is None:
+            raise RuntimeError("Parent ProcessGroup was released before its native transport")
+        torch.distributed.barrier(group=parent, device_ids=[torch.cuda.current_device()])
+        tex.cp_native_transport_destroy(self.handle)
+        self.handle, self.arena = 0, None
+        torch.distributed.barrier(group=parent, device_ids=[torch.cuda.current_device()])
+
+
+def initialize_native_cp_transport(parent_group, payload_bytes: int) -> NativeCPTransport:
+    """Collectively initialize one transport per parent ProcessGroup."""
+    transport = get_native_cp_transport(parent_group)
+    if transport is None:
+        transport = NativeCPTransport(parent_group, payload_bytes)
+        _group_transports[parent_group] = transport
+    elif transport.payload_bytes < payload_bytes:
+        raise RuntimeError(
+            f"Existing native CP arena has {transport.payload_bytes} bytes; "
+            f"requested {payload_bytes}"
+        )
+    return transport
+
+
+def set_native_cp_parent_group(cp_group, parent_group) -> None:
+    """Route a dynamic-CP subgroup through its parent's native transport."""
+    transport = get_native_cp_transport(parent_group)
+    if transport is None:
+        raise RuntimeError("Native CP parent transport is not initialized")
+    _group_transports[cp_group] = transport
+
+
+def get_native_cp_transport(group) -> Optional[NativeCPTransport]:
+    """Return the live native transport mapped to ``group``, if any."""
+    transport = _group_transports.get(group)
+    return transport if transport is not None and transport.handle else None
+
+
+def destroy_native_cp_transport(parent_group) -> None:
+    """Destroy the transport mapped to ``parent_group`` and remove its aliases."""
+    transport = _group_transports.get(parent_group)
+    if transport is not None:
+        transport.destroy()
+        for group, mapped in list(_group_transports.items()):
+            if mapped is transport:
+                del _group_transports[group]

--- a/transformer_engine/pytorch/attention/native_cp_transport.py
+++ b/transformer_engine/pytorch/attention/native_cp_transport.py
@@ -83,21 +83,51 @@ class NativeCPTransport:
     def send_recv(
         self,
         send_tensor: torch.Tensor,
-        send_global_rank: int,
+        send_global_rank: Optional[int],
         recv_tensor: torch.Tensor,
-        recv_global_rank: int,
+        recv_global_rank: Optional[int],
         channel: int = 0,
     ) -> _Work:
-        """Launch one native send and receive through the parent communicator."""
+        """Launch an arena exchange; a ``None`` peer disables that direction."""
         try:
-            send_peer = self._parent_rank[int(send_global_rank)]
-            recv_peer = self._parent_rank[int(recv_global_rank)]
+            send_peer = -1 if send_global_rank is None else self._parent_rank[int(send_global_rank)]
+            recv_peer = -1 if recv_global_rank is None else self._parent_rank[int(recv_global_rank)]
         except KeyError as error:
             raise ValueError(f"Peer {error.args[0]} is outside the parent group") from error
         channel = tex.cp_native_transport_send_recv(
             self.handle, send_tensor, recv_tensor, send_peer, recv_peer, int(channel)
         )
         return _Work(self.handle, int(channel))
+
+    def exchange(
+        self,
+        send_tensor: torch.Tensor,
+        send_global_rank: Optional[int],
+        recv_tensor: torch.Tensor,
+        recv_global_rank: Optional[int],
+        channel: int = 3,
+    ) -> None:
+        """Exchange small halos using the existing arena, ordered on the caller stream.
+
+        Input and output may be ordinary, noncontiguous tensors. Calls must be
+        serialized with other arena users, just like ``all_reduce``. No additional
+        persistent payload storage is allocated. A missing receive leaves its
+        output unchanged, allowing callers to retain physical-boundary fills.
+        """
+        if send_tensor.shape != recv_tensor.shape or send_tensor.dtype != recv_tensor.dtype:
+            raise ValueError("Native CP halo tensors must have matching shapes and dtypes")
+        if send_tensor.device != self.arena.device or recv_tensor.device != self.arena.device:
+            raise ValueError("Native CP halo tensors must be on the arena device")
+        if send_tensor.numel() == 0 or (send_global_rank is None and recv_global_rank is None):
+            return
+        size = send_tensor.nbytes
+        send = self._view(0, send_tensor.shape, send_tensor.dtype)
+        recv = self._view((size + 255) // 256 * 256, recv_tensor.shape, recv_tensor.dtype)
+        if send_global_rank is not None:
+            send.copy_(send_tensor)
+        self.send_recv(send, send_global_rank, recv, recv_global_rank, channel).wait()
+        if recv_global_rank is not None:
+            recv_tensor.copy_(recv)
 
     def all_reduce(self, tensor: torch.Tensor, group, channel: int = 2) -> torch.Tensor:
         """Ring sum over a dynamic-CP subgroup."""

--- a/transformer_engine/pytorch/attention/native_cp_transport.py
+++ b/transformer_engine/pytorch/attention/native_cp_transport.py
@@ -2,10 +2,14 @@
 #
 # See LICENSE for license information.
 
-"""NCCL Device API transport for context-parallel rings."""
+"""NCCL Device API transport for context-parallel rings.
+
+Building with ``NVTE_WITH_NCCL_DEVICE_CP=1`` requires NCCL 2.29.7 or newer
+and matching compile/runtime versions. Process-wide GIN settings are left
+to the application; this transport does not change NCCL environment variables.
+"""
 
 import math
-import os
 import weakref
 from typing import Iterable, Optional
 
@@ -37,11 +41,6 @@ class NativeCPTransport:
     def __init__(self, parent_group, payload_bytes: int) -> None:
         if not hasattr(tex, "cp_native_transport_create"):
             raise RuntimeError("Transformer Engine was not built with native CP transport")
-        # This transport uses one shared context and VA-based signals.  NCCL's
-        # larger GIN defaults only reserve unused device state.
-        os.environ.setdefault("NCCL_GIN_NCONTEXTS", "1")
-        os.environ.setdefault("NCCL_GIN_SIGNAL_POOL_SIZE", "64")
-        os.environ.setdefault("NCCL_GIN_COUNTER_POOL_SIZE", "64")
         torch.distributed.barrier(group=parent_group, device_ids=[torch.cuda.current_device()])
         backend = parent_group._get_backend(torch.device("cuda"))
         if not hasattr(backend, "_comm_ptr"):

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -22,6 +22,16 @@ class CommOverlapP2P;
 
 namespace transformer_engine::pytorch {
 
+#ifdef NVTE_WITH_NCCL_DEVICE_CP
+std::tuple<int64_t, at::Tensor> cp_native_transport_create(int64_t nccl_comm_ptr,
+                                                           int64_t payload_bytes);
+void cp_native_transport_destroy(int64_t handle);
+int64_t cp_native_transport_send_recv(int64_t handle, at::Tensor send_tensor,
+                                      at::Tensor recv_tensor, int64_t send_peer, int64_t recv_peer,
+                                      int64_t channel);
+void cp_native_transport_wait(int64_t handle, int64_t channel);
+#endif
+
 /***************************************************************************************************
  * Router fusion
  **************************************************************************************************/

--- a/transformer_engine/pytorch/csrc/extensions/cp_native_transport.cu
+++ b/transformer_engine/pytorch/csrc/extensions/cp_native_transport.cu
@@ -9,6 +9,11 @@
 #ifdef NVTE_WITH_NCCL_DEVICE_CP
 
 #include <nccl.h>
+
+#if NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 7)
+#error "Native CP transport requires NCCL 2.29.7 or newer"
+#endif
+
 #include <nccl_device.h>
 
 #include <algorithm>
@@ -265,9 +270,6 @@ std::tuple<int64_t, at::Tensor> cp_native_transport_create(int64_t nccl_comm_ptr
 
   int runtime_version = 0;
   NVTE_CP_NCCL_CHECK(ncclGetVersion(&runtime_version));
-#if NCCL_VERSION_CODE < NCCL_VERSION(2, 28, 7)
-  TORCH_CHECK(false, "Native CP transport requires NCCL 2.28.7 or newer");
-#endif
   TORCH_CHECK(runtime_version == NCCL_VERSION_CODE,
               "NCCL Device API GIN requires matching compile/runtime versions; ", "compiled with ",
               NCCL_VERSION_CODE, ", loaded ", runtime_version);
@@ -303,13 +305,9 @@ std::tuple<int64_t, at::Tensor> cp_native_transport_create(int64_t nccl_comm_ptr
 
   ncclDevCommRequirements_t requirements = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
   if (needs_gin) {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
     requirements.ginContextCount = kGinContexts;
     requirements.ginQueueDepth = kGinQueueDepth;
     requirements.ginConnectionType = NCCL_GIN_CONNECTION_FULL;
-#else
-    TORCH_CHECK(false, "Multi-node native CP transport requires NCCL 2.29.7 or newer");
-#endif
   }
   NVTE_CP_NCCL_CHECK(ncclDevCommCreate(transport->comm, &requirements, &transport->dev_comm));
   transport->dev_comm_created = true;

--- a/transformer_engine/pytorch/csrc/extensions/cp_native_transport.cu
+++ b/transformer_engine/pytorch/csrc/extensions/cp_native_transport.cu
@@ -1,0 +1,408 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include "../extensions.h"
+
+#ifdef NVTE_WITH_NCCL_DEVICE_CP
+
+#include <nccl.h>
+#include <nccl_device.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace transformer_engine::pytorch {
+namespace {
+
+#define NVTE_CP_NCCL_CHECK(call)                                                          \
+  do {                                                                                    \
+    const ncclResult_t result_ = (call);                                                  \
+    TORCH_CHECK(result_ == ncclSuccess, #call, " failed: ", ncclGetErrorString(result_)); \
+  } while (0)
+
+#define NVTE_CP_CUDA_CHECK(call)                                                          \
+  do {                                                                                    \
+    const cudaError_t result_ = (call);                                                   \
+    TORCH_CHECK(result_ == cudaSuccess, #call, " failed: ", cudaGetErrorString(result_)); \
+  } while (0)
+
+constexpr size_t kArenaAlignment = 256;
+constexpr int kThreads = 256;
+constexpr int kMaxCopyBlocks = 16;
+constexpr int kNumChannels = 3;  // forward, backward, aux-loss
+constexpr int kGinContexts = 1;
+constexpr int kGinQueueDepth = 8;
+using Counter = unsigned long long;  // NOLINT(runtime/int)
+
+size_t align_up(size_t value) {
+  return (value + kArenaAlignment - 1) / kArenaAlignment * kArenaAlignment;
+}
+
+struct NativeCPTransport {
+  ncclComm_t comm = nullptr;
+  ncclDevComm dev_comm{};
+  ncclWindow_t window = nullptr;
+  void *allocation = nullptr;
+  void *payload = nullptr;
+  size_t payload_bytes = 0;
+  size_t payload_offset = 0;
+  size_t signal_offset = 0;
+  size_t signal_shadow_offset = 0;
+  size_t ready_offset = 0;
+  int device = -1;
+  int rank = -1;
+  int nranks = 0;
+  bool dev_comm_created = false;
+  bool window_registered = false;
+  std::array<cudaStream_t, kNumChannels> streams{};
+  std::array<cudaEvent_t, kNumChannels> ready_events{};
+  std::array<cudaEvent_t, kNumChannels> done_events{};
+  std::array<bool, kNumChannels> outstanding{};
+  std::vector<Counter> ready_expected;
+
+  ~NativeCPTransport() noexcept {
+    int previous_device = -1;
+    bool restore_device = false;
+    if (device >= 0) {
+      if (cudaGetDevice(&previous_device) == cudaSuccess) {
+        restore_device = previous_device != device;
+      }
+      if (previous_device != device) cudaSetDevice(device);
+    }
+    for (cudaStream_t stream : streams) {
+      if (stream != nullptr) cudaStreamSynchronize(stream);
+    }
+    for (cudaEvent_t event : ready_events) {
+      if (event != nullptr) cudaEventDestroy(event);
+    }
+    for (cudaEvent_t event : done_events) {
+      if (event != nullptr) cudaEventDestroy(event);
+    }
+    for (cudaStream_t stream : streams) {
+      if (stream != nullptr) cudaStreamDestroy(stream);
+    }
+    if (dev_comm_created) ncclDevCommDestroy(comm, &dev_comm);
+    if (window_registered) ncclCommWindowDeregister(comm, window);
+    if (allocation != nullptr) ncclMemFree(allocation);
+    if (restore_device) cudaSetDevice(previous_device);
+  }
+};
+
+NativeCPTransport *unwrap(int64_t handle) {
+  TORCH_CHECK(handle != 0, "Native CP transport handle is null");
+  return reinterpret_cast<NativeCPTransport *>(handle);
+}
+
+__device__ __forceinline__ Counter system_load(Counter *ptr) { return atomicAdd_system(ptr, 0ULL); }
+
+__device__ __forceinline__ void copy_to_lsa_peer(void *dst_void, const void *src_void,
+                                                 size_t bytes) {
+  auto *dst = static_cast<uint8_t *>(dst_void);
+  const auto *src = static_cast<const uint8_t *>(src_void);
+  const uintptr_t packed =
+      reinterpret_cast<uintptr_t>(dst) | reinterpret_cast<uintptr_t>(src) | bytes;
+  if ((packed & (alignof(uint4) - 1)) == 0) {
+    auto *dst4 = reinterpret_cast<uint4 *>(dst);
+    const auto *src4 = reinterpret_cast<const uint4 *>(src);
+    const size_t count4 = bytes / sizeof(uint4);
+    for (size_t index = blockIdx.x * blockDim.x + threadIdx.x; index < count4;
+         index += blockDim.x * gridDim.x) {
+      dst4[index] = src4[index];
+    }
+    return;
+  }
+  for (size_t index = blockIdx.x * blockDim.x + threadIdx.x; index < bytes;
+       index += blockDim.x * gridDim.x) {
+    dst[index] = src[index];
+  }
+}
+
+__global__ void cp_native_prepare_kernel(ncclDevComm dev_comm, ncclWindow_t window, int rank,
+                                         int recv_peer, unsigned int channel, size_t ready_offset) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+
+  const ncclTeam world = ncclTeamWorld(dev_comm);
+  const ncclTeam lsa = ncclTeamLsa(dev_comm);
+  const bool recv_is_lsa = ncclTeamRankIsMember(lsa, world, recv_peer);
+  const size_t ready_index = (static_cast<size_t>(rank) * kNumChannels + channel) * sizeof(Counter);
+
+  // A direct store has no implicit ncclRecv rendezvous. Advertise that this
+  // rank has finished with its receive buffer before the peer may overwrite it.
+  if (recv_is_lsa) {
+    const int recv_lsa_rank = ncclTeamRankToTeam(lsa, world, recv_peer);
+    auto *remote_ready = static_cast<Counter *>(
+        ncclGetLsaPointer(window, ready_offset + ready_index, recv_lsa_rank));
+    __threadfence_system();
+    atomicAdd_system(remote_ready, 1ULL);
+  } else {
+    ncclGin gin{dev_comm, 0};
+    gin.signal(world, recv_peer, ncclGin_VASignalInc{window, ready_offset + ready_index},
+               ncclCoopThread{});
+    gin.flush(ncclCoopThread{});
+  }
+}
+
+__global__ void cp_native_send_recv_kernel(ncclDevComm dev_comm, ncclWindow_t window,
+                                           size_t send_offset, size_t recv_offset, size_t bytes,
+                                           int send_peer, int recv_peer, int rank,
+                                           unsigned int channel, Counter ready_expected,
+                                           size_t signal_offset, size_t signal_shadow_offset,
+                                           size_t ready_offset) {
+  const ncclTeam world = ncclTeamWorld(dev_comm);
+  const ncclTeam lsa = ncclTeamLsa(dev_comm);
+  const bool send_is_lsa = ncclTeamRankIsMember(lsa, world, send_peer);
+  const bool recv_is_lsa = ncclTeamRankIsMember(lsa, world, recv_peer);
+
+  if (send_is_lsa) {
+    const size_t ready_index =
+        (static_cast<size_t>(send_peer) * kNumChannels + channel) * sizeof(Counter);
+    if (threadIdx.x == 0) {
+      auto *local_ready =
+          static_cast<Counter *>(ncclGetLocalPointer(window, ready_offset + ready_index));
+      while (system_load(local_ready) < ready_expected) {
+#if __CUDA_ARCH__ >= 700
+        __nanosleep(64);
+#endif
+      }
+    }
+    __syncthreads();
+    const int send_lsa_rank = ncclTeamRankToTeam(lsa, world, send_peer);
+    void *send_local = ncclGetLocalPointer(window, send_offset);
+    void *recv_remote = ncclGetLsaPointer(window, recv_offset, send_lsa_rank);
+    copy_to_lsa_peer(recv_remote, send_local, bytes);
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      __threadfence_system();
+      auto *remote_signal = static_cast<Counter *>(ncclGetLsaPointer(
+          window,
+          signal_offset + (static_cast<size_t>(rank) * kNumChannels + channel) * sizeof(Counter),
+          send_lsa_rank));
+      atomicAdd_system(remote_signal, 1ULL);
+    }
+    __syncthreads();
+  } else if (blockIdx.x == 0) {
+    ncclGin gin{dev_comm, 0};
+    const size_t ready_index =
+        (static_cast<size_t>(send_peer) * kNumChannels + channel) * sizeof(Counter);
+    gin.waitSignal(ncclCoopCta{}, window, ready_offset + ready_index, ready_expected);
+
+    const size_t completion_index =
+        (static_cast<size_t>(rank) * kNumChannels + channel) * sizeof(Counter);
+    gin.put(world, send_peer, window, recv_offset, window, send_offset, bytes,
+            ncclGin_VASignalInc{window, signal_offset + completion_index}, ncclGin_None{},
+            ncclCoopCta{});
+    gin.flush(ncclCoopCta{});
+  }
+
+  if (recv_is_lsa) {
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+      const size_t completion_index =
+          (static_cast<size_t>(recv_peer) * kNumChannels + channel) * sizeof(Counter);
+      auto *local_signal =
+          static_cast<Counter *>(ncclGetLocalPointer(window, signal_offset + completion_index));
+      auto *local_shadow = static_cast<Counter *>(
+          ncclGetLocalPointer(window, signal_shadow_offset + completion_index));
+      const Counter expected = *local_shadow + gridDim.x;
+      while (system_load(local_signal) < expected) {
+#if __CUDA_ARCH__ >= 700
+        __nanosleep(64);
+#endif
+      }
+      *local_shadow = expected;
+      __threadfence_system();
+    }
+    __syncthreads();
+  } else if (blockIdx.x == 0) {
+    ncclGin gin{dev_comm, 0};
+    const size_t completion_index =
+        (static_cast<size_t>(recv_peer) * kNumChannels + channel) * sizeof(Counter);
+    auto *local_shadow = static_cast<Counter *>(
+        ncclGetLocalPointer(window, signal_shadow_offset + completion_index));
+    const Counter expected = *local_shadow + 1ULL;
+    gin.waitSignal(ncclCoopCta{}, window, signal_offset + completion_index, expected);
+    if (threadIdx.x == 0) {
+      *local_shadow = expected;
+      __threadfence_system();
+    }
+    __syncthreads();
+  }
+}
+
+void validate_tensor(const NativeCPTransport &transport, const at::Tensor &tensor,
+                     const char *name) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+  TORCH_CHECK(tensor.get_device() == transport.device, name, " is on CUDA device ",
+              tensor.get_device(), " but transport uses ", transport.device);
+  const auto begin = reinterpret_cast<uintptr_t>(transport.payload);
+  const auto end = begin + transport.payload_bytes;
+  const auto tensor_begin = reinterpret_cast<uintptr_t>(tensor.data_ptr());
+  const auto tensor_end = tensor_begin + tensor.nbytes();
+  TORCH_CHECK(tensor_begin >= begin && tensor_end <= end, name,
+              " must be a view of the native CP transport arena");
+}
+
+}  // namespace
+
+std::tuple<int64_t, at::Tensor> cp_native_transport_create(int64_t nccl_comm_ptr,
+                                                           int64_t payload_bytes) {
+  TORCH_CHECK(nccl_comm_ptr != 0, "nccl_comm_ptr must not be null");
+  TORCH_CHECK(payload_bytes > 0, "payload_bytes must be positive");
+  TORCH_CHECK(payload_bytes <= std::numeric_limits<int64_t>::max() - 2 * kArenaAlignment,
+              "payload_bytes is too large");
+
+  std::unique_ptr<NativeCPTransport> transport(new NativeCPTransport());
+  transport->comm = reinterpret_cast<ncclComm_t>(nccl_comm_ptr);
+  transport->device = c10::cuda::current_device();
+  transport->payload_bytes = static_cast<size_t>(payload_bytes);
+
+  int runtime_version = 0;
+  NVTE_CP_NCCL_CHECK(ncclGetVersion(&runtime_version));
+#if NCCL_VERSION_CODE < NCCL_VERSION(2, 28, 7)
+  TORCH_CHECK(false, "Native CP transport requires NCCL 2.28.7 or newer");
+#endif
+  TORCH_CHECK(runtime_version == NCCL_VERSION_CODE,
+              "NCCL Device API GIN requires matching compile/runtime versions; ", "compiled with ",
+              NCCL_VERSION_CODE, ", loaded ", runtime_version);
+
+  ncclCommProperties_t properties = NCCL_COMM_PROPERTIES_INITIALIZER;
+  NVTE_CP_NCCL_CHECK(ncclCommQueryProperties(transport->comm, &properties));
+  TORCH_CHECK(properties.deviceApiSupport,
+              "The parent NCCL communicator does not support NCCL Device API");
+  transport->rank = properties.rank;
+  transport->nranks = properties.nRanks;
+  const int lsa_size = ncclTeamLsa(transport->comm).nRanks;
+  const bool needs_gin = transport->nranks != lsa_size;
+  TORCH_CHECK(transport->nranks == lsa_size || properties.ginType != NCCL_GIN_TYPE_NONE,
+              "The parent communicator spans multiple LSA domains but GIN is unavailable");
+
+  const size_t peer_channel_bytes =
+      static_cast<size_t>(transport->nranks) * kNumChannels * sizeof(Counter);
+  transport->signal_offset = 0;
+  transport->signal_shadow_offset = align_up(transport->signal_offset + peer_channel_bytes);
+  transport->ready_offset = align_up(transport->signal_shadow_offset + peer_channel_bytes);
+  transport->payload_offset = align_up(transport->ready_offset + peer_channel_bytes);
+  TORCH_CHECK(
+      transport->payload_bytes <= std::numeric_limits<size_t>::max() - transport->payload_offset,
+      "Native CP transport allocation size overflow");
+  const size_t allocation_bytes = transport->payload_offset + transport->payload_bytes;
+
+  NVTE_CP_NCCL_CHECK(ncclMemAlloc(&transport->allocation, allocation_bytes));
+  NVTE_CP_CUDA_CHECK(cudaMemset(transport->allocation, 0, transport->payload_offset));
+  NVTE_CP_NCCL_CHECK(ncclCommWindowRegister(transport->comm, transport->allocation,
+                                            allocation_bytes, &transport->window,
+                                            NCCL_WIN_DEFAULT));
+  transport->window_registered = true;
+
+  ncclDevCommRequirements_t requirements = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+  if (needs_gin) {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
+    requirements.ginContextCount = kGinContexts;
+    requirements.ginQueueDepth = kGinQueueDepth;
+    requirements.ginConnectionType = NCCL_GIN_CONNECTION_FULL;
+#else
+    TORCH_CHECK(false, "Multi-node native CP transport requires NCCL 2.29.7 or newer");
+#endif
+  }
+  NVTE_CP_NCCL_CHECK(ncclDevCommCreate(transport->comm, &requirements, &transport->dev_comm));
+  transport->dev_comm_created = true;
+
+  int least_priority = 0;
+  int greatest_priority = 0;
+  NVTE_CP_CUDA_CHECK(cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
+  transport->ready_expected.resize(transport->nranks * kNumChannels, 0);
+  for (int channel = 0; channel < kNumChannels; ++channel) {
+    NVTE_CP_CUDA_CHECK(cudaStreamCreateWithPriority(&transport->streams[channel],
+                                                    cudaStreamNonBlocking, greatest_priority));
+    NVTE_CP_CUDA_CHECK(
+        cudaEventCreateWithFlags(&transport->ready_events[channel], cudaEventDisableTiming));
+    NVTE_CP_CUDA_CHECK(
+        cudaEventCreateWithFlags(&transport->done_events[channel], cudaEventDisableTiming));
+  }
+
+  transport->payload = static_cast<uint8_t *>(transport->allocation) + transport->payload_offset;
+  auto options =
+      at::TensorOptions().device(at::Device(at::kCUDA, transport->device)).dtype(at::kByte);
+  at::Tensor arena = at::from_blob(transport->payload, {payload_bytes}, [](void *) {}, options);
+  const auto handle = reinterpret_cast<int64_t>(transport.release());
+  return {handle, arena};
+}
+
+void cp_native_transport_destroy(int64_t handle) { delete unwrap(handle); }
+
+int64_t cp_native_transport_send_recv(int64_t handle, at::Tensor send_tensor,
+                                      at::Tensor recv_tensor, int64_t send_peer, int64_t recv_peer,
+                                      int64_t channel) {
+  NativeCPTransport *transport = unwrap(handle);
+  at::cuda::CUDAGuard device_guard(at::Device(at::kCUDA, transport->device));
+  TORCH_CHECK(channel >= 0 && channel < kNumChannels,
+              "channel is outside the transport channel range");
+  TORCH_CHECK(send_peer >= 0 && send_peer < transport->nranks,
+              "send_peer is outside the parent communicator");
+  TORCH_CHECK(recv_peer >= 0 && recv_peer < transport->nranks,
+              "recv_peer is outside the parent communicator");
+  TORCH_CHECK(send_peer != transport->rank || recv_peer != transport->rank,
+              "Native CP send/recv is unnecessary when both peers are self");
+  validate_tensor(*transport, send_tensor, "send_tensor");
+  validate_tensor(*transport, recv_tensor, "recv_tensor");
+  TORCH_CHECK(send_tensor.nbytes() == recv_tensor.nbytes(),
+              "send_tensor and recv_tensor must have the same byte size");
+  TORCH_CHECK(!transport->outstanding[channel], "Native CP transport channel ", channel,
+              " is reused before its previous work is waited");
+
+  const auto base = reinterpret_cast<uintptr_t>(transport->allocation);
+  const size_t send_offset = reinterpret_cast<uintptr_t>(send_tensor.data_ptr()) - base;
+  const size_t recv_offset = reinterpret_cast<uintptr_t>(recv_tensor.data_ptr()) - base;
+  const size_t bytes = send_tensor.nbytes();
+  TORCH_CHECK(bytes > 0, "Native CP transport does not accept an empty payload");
+  const size_t bytes_per_copy_block = kThreads * sizeof(uint4);
+  const int copy_blocks = static_cast<int>(
+      std::min<size_t>(kMaxCopyBlocks, (bytes + bytes_per_copy_block - 1) / bytes_per_copy_block));
+
+  const cudaStream_t caller_stream = at::cuda::getCurrentCUDAStream().stream();
+  const int channel_index = static_cast<int>(channel);
+  Counter &ready_expected =
+      transport->ready_expected[static_cast<size_t>(send_peer) * kNumChannels + channel_index];
+  ++ready_expected;
+  NVTE_CP_CUDA_CHECK(cudaEventRecord(transport->ready_events[channel_index], caller_stream));
+  NVTE_CP_CUDA_CHECK(cudaStreamWaitEvent(transport->streams[channel_index],
+                                         transport->ready_events[channel_index], 0));
+  cp_native_prepare_kernel<<<1, 1, 0, transport->streams[channel_index]>>>(
+      transport->dev_comm, transport->window, transport->rank, static_cast<int>(recv_peer),
+      static_cast<unsigned int>(channel), transport->ready_offset);
+  NVTE_CP_CUDA_CHECK(cudaGetLastError());
+  cp_native_send_recv_kernel<<<copy_blocks, kThreads, 0, transport->streams[channel_index]>>>(
+      transport->dev_comm, transport->window, send_offset, recv_offset, bytes,
+      static_cast<int>(send_peer), static_cast<int>(recv_peer), transport->rank,
+      static_cast<unsigned int>(channel), ready_expected, transport->signal_offset,
+      transport->signal_shadow_offset, transport->ready_offset);
+  NVTE_CP_CUDA_CHECK(cudaGetLastError());
+  NVTE_CP_CUDA_CHECK(
+      cudaEventRecord(transport->done_events[channel_index], transport->streams[channel_index]));
+  transport->outstanding[channel_index] = true;
+  return channel;
+}
+
+void cp_native_transport_wait(int64_t handle, int64_t channel) {
+  NativeCPTransport *transport = unwrap(handle);
+  at::cuda::CUDAGuard device_guard(at::Device(at::kCUDA, transport->device));
+  TORCH_CHECK(channel >= 0 && channel < kNumChannels,
+              "channel is outside the transport channel range");
+  const int channel_index = static_cast<int>(channel);
+  TORCH_CHECK(transport->outstanding[channel_index], "Native CP transport channel ", channel,
+              " has no outstanding work");
+  const cudaStream_t caller_stream = at::cuda::getCurrentCUDAStream().stream();
+  NVTE_CP_CUDA_CHECK(cudaStreamWaitEvent(caller_stream, transport->done_events[channel_index], 0));
+  transport->outstanding[channel_index] = false;
+}
+
+}  // namespace transformer_engine::pytorch
+
+#endif  // NVTE_WITH_NCCL_DEVICE_CP

--- a/transformer_engine/pytorch/csrc/extensions/cp_native_transport.cu
+++ b/transformer_engine/pytorch/csrc/extensions/cp_native_transport.cu
@@ -41,7 +41,7 @@ namespace {
 constexpr size_t kArenaAlignment = 256;
 constexpr int kThreads = 256;
 constexpr int kMaxCopyBlocks = 16;
-constexpr int kNumChannels = 3;  // forward, backward, aux-loss
+constexpr int kNumChannels = 4;  // forward, backward, aux-loss, MTP halos
 constexpr int kGinContexts = 1;
 constexpr int kGinQueueDepth = 8;
 using Counter = unsigned long long;  // NOLINT(runtime/int)
@@ -131,7 +131,7 @@ __device__ __forceinline__ void copy_to_lsa_peer(void *dst_void, const void *src
 
 __global__ void cp_native_prepare_kernel(ncclDevComm dev_comm, ncclWindow_t window, int rank,
                                          int recv_peer, unsigned int channel, size_t ready_offset) {
-  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  if (recv_peer < 0 || threadIdx.x != 0 || blockIdx.x != 0) return;
 
   const ncclTeam world = ncclTeamWorld(dev_comm);
   const ncclTeam lsa = ncclTeamLsa(dev_comm);
@@ -162,8 +162,8 @@ __global__ void cp_native_send_recv_kernel(ncclDevComm dev_comm, ncclWindow_t wi
                                            size_t ready_offset) {
   const ncclTeam world = ncclTeamWorld(dev_comm);
   const ncclTeam lsa = ncclTeamLsa(dev_comm);
-  const bool send_is_lsa = ncclTeamRankIsMember(lsa, world, send_peer);
-  const bool recv_is_lsa = ncclTeamRankIsMember(lsa, world, recv_peer);
+  const bool send_is_lsa = send_peer >= 0 && ncclTeamRankIsMember(lsa, world, send_peer);
+  const bool recv_is_lsa = recv_peer >= 0 && ncclTeamRankIsMember(lsa, world, recv_peer);
 
   if (send_is_lsa) {
     const size_t ready_index =
@@ -192,7 +192,7 @@ __global__ void cp_native_send_recv_kernel(ncclDevComm dev_comm, ncclWindow_t wi
       atomicAdd_system(remote_signal, 1ULL);
     }
     __syncthreads();
-  } else if (blockIdx.x == 0) {
+  } else if (send_peer >= 0 && blockIdx.x == 0) {
     ncclGin gin{dev_comm, 0};
     const size_t ready_index =
         (static_cast<size_t>(send_peer) * kNumChannels + channel) * sizeof(Counter);
@@ -224,7 +224,7 @@ __global__ void cp_native_send_recv_kernel(ncclDevComm dev_comm, ncclWindow_t wi
       __threadfence_system();
     }
     __syncthreads();
-  } else if (blockIdx.x == 0) {
+  } else if (recv_peer >= 0 && blockIdx.x == 0) {
     ncclGin gin{dev_comm, 0};
     const size_t completion_index =
         (static_cast<size_t>(recv_peer) * kNumChannels + channel) * sizeof(Counter);
@@ -342,12 +342,13 @@ int64_t cp_native_transport_send_recv(int64_t handle, at::Tensor send_tensor,
   at::cuda::CUDAGuard device_guard(at::Device(at::kCUDA, transport->device));
   TORCH_CHECK(channel >= 0 && channel < kNumChannels,
               "channel is outside the transport channel range");
-  TORCH_CHECK(send_peer >= 0 && send_peer < transport->nranks,
+  TORCH_CHECK(send_peer >= -1 && send_peer < transport->nranks,
               "send_peer is outside the parent communicator");
-  TORCH_CHECK(recv_peer >= 0 && recv_peer < transport->nranks,
+  TORCH_CHECK(recv_peer >= -1 && recv_peer < transport->nranks,
               "recv_peer is outside the parent communicator");
-  TORCH_CHECK(send_peer != transport->rank || recv_peer != transport->rank,
-              "Native CP send/recv is unnecessary when both peers are self");
+  TORCH_CHECK(send_peer >= 0 || recv_peer >= 0, "Native CP exchange needs at least one peer");
+  TORCH_CHECK(send_peer != transport->rank && recv_peer != transport->rank,
+              "Native CP send/recv does not support self peers");
   validate_tensor(*transport, send_tensor, "send_tensor");
   validate_tensor(*transport, recv_tensor, "recv_tensor");
   TORCH_CHECK(send_tensor.nbytes() == recv_tensor.nbytes(),
@@ -366,9 +367,11 @@ int64_t cp_native_transport_send_recv(int64_t handle, at::Tensor send_tensor,
 
   const cudaStream_t caller_stream = at::cuda::getCurrentCUDAStream().stream();
   const int channel_index = static_cast<int>(channel);
-  Counter &ready_expected =
-      transport->ready_expected[static_cast<size_t>(send_peer) * kNumChannels + channel_index];
-  ++ready_expected;
+  Counter ready_expected = 0;
+  if (send_peer >= 0) {
+    ready_expected =
+        ++transport->ready_expected[static_cast<size_t>(send_peer) * kNumChannels + channel_index];
+  }
   NVTE_CP_CUDA_CHECK(cudaEventRecord(transport->ready_events[channel_index], caller_stream));
   NVTE_CP_CUDA_CHECK(cudaStreamWaitEvent(transport->streams[channel_index],
                                          transport->ready_events[channel_index], 0));

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -135,6 +135,18 @@ void init_extension() {
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   NVTE_DECLARE_COMMON_PYBIND11_HANDLES(m)
+#ifdef NVTE_WITH_NCCL_DEVICE_CP
+  m.def("cp_native_transport_create", &transformer_engine::pytorch::cp_native_transport_create,
+        py::arg("nccl_comm_ptr"), py::arg("payload_bytes"));
+  m.def("cp_native_transport_destroy", &transformer_engine::pytorch::cp_native_transport_destroy,
+        py::arg("handle"));
+  m.def("cp_native_transport_send_recv",
+        &transformer_engine::pytorch::cp_native_transport_send_recv, py::arg("handle"),
+        py::arg("send_tensor"), py::arg("recv_tensor"), py::arg("send_peer"), py::arg("recv_peer"),
+        py::arg("channel") = 0);
+  m.def("cp_native_transport_wait", &transformer_engine::pytorch::cp_native_transport_wait,
+        py::arg("handle"), py::arg("channel") = 0);
+#endif
   m.def("quantize", transformer_engine::pytorch::quantize, py::arg("tensor"), py::arg("quantizer"),
         py::arg("output") = py::none(), py::arg("noop") = py::none());
   m.def("dequantize", &transformer_engine::pytorch::dequantize, "Dequantize", py::arg("input"),

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -163,23 +163,54 @@ def set_tensor_model_parallel_attributes(
     setattr(tensor, "partition_stride", stride)
 
 
+def is_logical_process_group(group: Any) -> bool:
+    """Return whether ``group`` is a topology-only CP group descriptor."""
+    return (
+        group is not None
+        and hasattr(group, "ranks")
+        and hasattr(group, "cp_size")
+        and hasattr(group, "cp_rank")
+    )
+
+
 @lru_cache
-def get_distributed_world_size(group: Optional[dist_group_type] = None) -> int:
-    """Return world size for the distributed group."""
+def _get_distributed_world_size(group: Optional[dist_group_type] = None) -> int:
+    """Return world size for a real distributed process group."""
     if not torch.distributed.is_initialized():
         return 1
     return torch.distributed.get_world_size(group=group)
 
 
+def get_distributed_world_size(group: Optional[dist_group_type] = None) -> int:
+    """Return world size for a distributed group or logical CP descriptor."""
+    if is_logical_process_group(group):
+        return int(group.cp_size)
+    return _get_distributed_world_size(group)
+
+
 @lru_cache
-def get_distributed_rank(group: Optional[dist_group_type] = None) -> int:
-    """Return my rank for the distributed group."""
+def _get_distributed_rank(group: Optional[dist_group_type] = None) -> int:
+    """Return my rank for a real distributed process group."""
     if not torch.distributed.is_initialized():
         raise RuntimeError(
             "torch.distributed is not initialized. Call torch.distributed.init_process_group() "
             "before calling get_distributed_rank()."
         )
     return torch.distributed.get_rank(group=group)
+
+
+def get_distributed_rank(group: Optional[dist_group_type] = None) -> int:
+    """Return my rank for a distributed group or logical CP descriptor."""
+    if is_logical_process_group(group):
+        return int(group.cp_rank)
+    return _get_distributed_rank(group)
+
+
+def get_distributed_group_ranks(group) -> Tuple[int, ...]:
+    """Return global ranks for a ProcessGroup or logical CP descriptor."""
+    if is_logical_process_group(group):
+        return tuple(group.ranks)
+    return tuple(torch.distributed.get_process_group_ranks(group))
 
 
 def initialize_affine_weight_gpu(

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -166,6 +166,8 @@ def set_tensor_model_parallel_attributes(
 @lru_cache
 def get_distributed_world_size(group: Optional[dist_group_type] = None) -> int:
     """Return world size for the distributed group."""
+    if is_logical_process_group(group):
+        return int(group.cp_size)
     if not torch.distributed.is_initialized():
         return 1
     return torch.distributed.get_world_size(group=group)
@@ -174,12 +176,24 @@ def get_distributed_world_size(group: Optional[dist_group_type] = None) -> int:
 @lru_cache
 def get_distributed_rank(group: Optional[dist_group_type] = None) -> int:
     """Return my rank for the distributed group."""
+    if is_logical_process_group(group):
+        return int(group.cp_rank)
     if not torch.distributed.is_initialized():
         raise RuntimeError(
             "torch.distributed is not initialized. Call torch.distributed.init_process_group() "
             "before calling get_distributed_rank()."
         )
     return torch.distributed.get_rank(group=group)
+
+
+def is_logical_process_group(group: Any) -> bool:
+    """Return whether ``group`` is a topology-only CP descriptor."""
+    return (
+        group is not None
+        and hasattr(group, "ranks")
+        and hasattr(group, "cp_size")
+        and hasattr(group, "cp_rank")
+    )
 
 
 def initialize_affine_weight_gpu(


### PR DESCRIPTION
## What

- Add an opt-in NCCL Device API transport for context-parallel P2P rings.
- Borrow one already-materialized parent NCCL communicator instead of creating a ProcessGroup for every dynamic CP size.
- Reuse one symmetric arena for forward KV, backward dKV, and auxiliary-loss communication.
- Accept lightweight logical CP descriptors while leaving the existing ProcessGroup path unchanged.
- Provide a non-allocating capability query so callers can agree on automatic selection before constructing groups or allocating a native arena.

## Scope

- The native path currently supports P2P context parallelism with FP16/BF16 and vanilla softmax.
- FP8, non-P2P CP algorithms, and max-logit output are rejected explicitly. CUDA Graph capture is not validated by this PR.
- The extension is built only when NCCL Device API headers and libraries are available.

## Capability-query regression (2026-09-17)

- Rebuilt the exact-source H100 extension; 27 transport tests passed.
- Eight-rank, two-parent startup checks verified global fallback when only one rank is unsupported and native selection when all ranks support it; queries created no native transport.
- MCore integration: 80 tests passed (4 skipped for insufficient ranks) and all four 10-step small GPT/MoE+MTP runs passed, comparing automatic native against legacy fallback for CP5+CP3 and CP4+CP4. LM loss max absolute difference <=9.537e-7, sequence aux <=1.193e-7, gradient norm identical; MTP/final parameters passed predeclared tolerances. Communication kernels are unchanged.
- DFW build 18816253, consensus/unit 18816442, E2E 18816724. This short integration regression does not replace the prior 100-step/model-scale studies below.

## Prior transport validation

- Exact-source H100 build and import checks passed with NCCL 2.29.7.
- FusedAttention forward/backward matched the no-CP reference for SBHD CP1-16 and THD CP1-14.
- Deterministic THD CP15/16 cases without inter-sequence padding passed for both NCCL P2P and native transport; CP16 also passed with random padding.
- A deterministic random-padding THD CP15 case exceeds the existing BF16 tolerance on both the original NCCL P2P path and the native path. This is not reported as a native-only pass; the raw comparison is retained as a known test-path limitation.
- Qwen3-30B-A3B on LongAlign-10k completed 100 fixed-CP16 and 100 native arbitrary-DCP training steps from identical sampled parameters and identical real batches. LM loss max/mean absolute differences were 0.000648/0.000131 (Pearson 0.999999589); sequence auxiliary loss differences were 0.005567/0.001644 (Pearson 0.999958020). Different CP layouts change BF16 reduction order, so bitwise equality is not claimed.
- Fresh-process 4x4 GB200 NVL72 accounting (32 P2P channels) shows that activating every bounded-ring CP1-16 path adds **0 MiB** after native transport creation. The measured native fixed cost was 42/46/54 MiB per rank for parent sizes 4/8/16 respectively; parent-16 used 54 MiB with the minimum 2 MiB window, or 182 MiB with a 128 MiB payload arena. The corresponding ProcessGroupNCCL paths retained 768 MiB on rank 0 (two peers) and 1536 MiB on the median/max rank (four peers); directly activating all 15 peers retained 5812 MiB on rank 0.
- An isolated H100 CP8 FusedAttention forward+backward A/B measured 10.178 ms for ProcessGroupNCCL and 10.327 ms for native transport (+1.47%). The transport is memory-oriented; end-to-end speedup comes from allowing the scheduler to use better non-power-of-two layouts, not from claiming a faster individual ring.
- The LongAlign run measured 7181.77 token/s for native arbitrary DCP versus 5811.30 token/s for fixed CP16 (+23.58%). A separate eight-GB200 CP5+CP3 case reduced median step time by 18.75% versus the same native transport constrained to CP8.

The dependent NVIDIA/Megatron-LM#6801 PR automatically selects this path for supported default GPT/TE full-attention DCP; no extra transport CLI flag is required.
