### PR TITLE
[JAX] Fix classification of sync-tagged collective start instructions

### DIFF
--- a/tests/jax/distributed_test_base.py
+++ b/tests/jax/distributed_test_base.py
@@ -168,13 +168,16 @@ def assert_equal_collectives(target_hlo, coll_count_ref):
             is_sync_collective = "collective_backend_config" in line and sync_symb in line
 
             if is_async_start or is_sync_collective:
-                if is_sync_collective:
-                    is_all_reduce = re.search(r"\ball-reduce\s*\(", line)
-                    is_all_gather = re.search(r"\ball-gather\s*\(", line)
-                else:
+                # Some direct *-start instructions are tagged with
+                # `"is_sync":true`. Classify the explicit async form first so
+                # it is not mistaken for an unsuffixed synchronous collective.
+                if is_async_start:
                     called_collective = get_called_collective_type(line)
                     is_all_reduce = COLL_AR_KEY in txt[0] or called_collective == COLL_AR_KEY
                     is_all_gather = COLL_AG_KEY in txt[0] or called_collective == COLL_AG_KEY
+                else:
+                    is_all_reduce = re.search(r"\ball-reduce\s*\(", line)
+                    is_all_gather = re.search(r"\ball-gather\s*\(", line)
 
                 if is_all_reduce:
                     result[COLL_AR_KEY] += count_bytes(txt)


### PR DESCRIPTION
# Description

Fix JAX collective-byte accounting when XLA emits an `all-reduce-start` instruction with `"is_sync":true`.
The parser previously treated this as an unsuffixed synchronous collective and classified the communication bytes as `other`. This change prioritizes the explicit `*-start` instruction form.

No LayerNorm/RMSNorm implementation or expected byte calculations are changed.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes


# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
