### PR TITLE
Fix TE EP MOE tests aborting insted of skipping when < 4 GPUs are available

### DIFF
--- a/tests/jax/run_te_ep_moe.sh
+++ b/tests/jax/run_te_ep_moe.sh
@@ -19,8 +19,8 @@ PYTEST_INI="$TE_ROOT/tests/jax/pytest.ini"
 
 NUM_GPUS="${NUM_GPUS:-$(nvidia-smi -L | wc -l)}"
 if [ "$NUM_GPUS" -lt 4 ]; then
-    echo "[run_te_ep_moe.sh] need >=4 GPUs (got $NUM_GPUS); aborting" >&2
-    exit 1
+    echo "[run_te_ep_moe.sh] need >=4 GPUs (got $NUM_GPUS); SKIPPING."
+    exit 0
 fi
 
 export XLA_PYTHON_CLIENT_PREALLOCATE="${XLA_PYTHON_CLIENT_PREALLOCATE:-false}"


### PR DESCRIPTION
# Description

Tests executed by `run_te_ep_moe.sh` require >= 4 GPUs as a prerequisite or the script exits and fails. This makes the script exit cleanly instead, skipping the tests.

Fixes NV bug 6675583

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Skip `run_te_ep_moe.sh` tests when < 4 GPUs are available

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
