### PR TITLE
Add SM90 gate to distributed softcap score-mod test

### DIFF
--- a/tests/jax/test_distributed_fused_attn.py
+++ b/tests/jax/test_distributed_fused_attn.py
@@ -293,6 +293,10 @@ class TestDistributedScoreModSelfAttn:
     @pytest.mark.parametrize("device_count,mesh_shape,mesh_axes,mesh_resource", generate_configs())
     @pytest_parametrize_wrapper("data_shape", DISTRIBUTED_SCORE_MOD_DATA_SHAPES)
     @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.skipif(
+        get_device_compute_capability(0) < 90,
+        reason="Softcap score_mod tests require sm90+",
+    )
     def test_softcap_score_mod_with_aux_params_backward(
         self,
         device_count,


### PR DESCRIPTION
# Description

Put a distributed score_mod / softcap behind sm90+ gate. 

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Put a distributed score_mod / softcap behind sm90+ gate. 

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
