### PR TITLE
test: skip cuBLASMp tests when unsupported

### DIFF
--- a/tests/cpp_distributed/test_comm_gemm.cu
+++ b/tests/cpp_distributed/test_comm_gemm.cu
@@ -10,6 +10,7 @@
 #include <mpi.h>
 #include <nccl.h>
 #include <transformer_engine/comm_gemm.h>
+#include <transformer_engine/comm_gemm_overlap.h>
 #include <transformer_engine/gemm.h>
 #include <transformer_engine/transformer_engine.h>
 
@@ -56,9 +57,20 @@ using transformer_engine::TypeInfo;
     }                                                           \
   } while (false)
 
+class CublasMpEnvironment final : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    if (!nvte_built_with_cublasmp()) {
+      GTEST_SKIP() << "test_comm_gemm requires TE/Common to be built with "
+                      "NVTE_WITH_CUBLASMP=1.";
+    }
+  }
+};
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   CHECK_MPI(MPI_Init(&argc, &argv));
+  ::testing::AddGlobalTestEnvironment(new CublasMpEnvironment);
   auto ret = RUN_ALL_TESTS();
   CHECK_MPI(MPI_Finalize());
   return ret;


### PR DESCRIPTION
# Description

Skip cuBLASMp tests if TE/Common is built without cuBLASMp support

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Skip cuBLASMp tests if TE/Common is built without cuBLASMp support

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
