### PR TITLE
[Pytorch][Attention][CP][CI] Make 3221 changes robust

### DIFF
--- a/qa/L1_pytorch_distributed_unittest/test.sh
+++ b/qa/L1_pytorch_distributed_unittest/test.sh
@@ -43,7 +43,9 @@ else
     NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_attention_deterministic_with_cp.xml $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py || test_fail "NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 test_attention_with_cp.py"
 fi
 
-# Force FA2 in a fresh process to cover deterministic no-load-balance GQA backward.
+# The full runs above exercise both modes with normal backend selection.
+# Determinism is captured when the test module is imported, so use a fresh process and
+# disable FA3 (FA4 is disabled above) to force FA2 for the deterministic GQA regression.
 NVTE_FLASH_ATTN_V3=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 python3 -m pytest -v -s \
     --junitxml=$XML_LOG_DIR/pytest_test_attention_with_cp_fa2_no_load_balance.xml \
     $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py::test_cp_with_flash_attention_no_load_balance \

--- a/qa/L1_pytorch_distributed_unittest/test.sh
+++ b/qa/L1_pytorch_distributed_unittest/test.sh
@@ -43,6 +43,12 @@ else
     NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_attention_deterministic_with_cp.xml $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py || test_fail "NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 test_attention_with_cp.py"
 fi
 
+# Force FA2 in a fresh process to cover deterministic no-load-balance GQA backward.
+NVTE_FLASH_ATTN_V3=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 python3 -m pytest -v -s \
+    --junitxml=$XML_LOG_DIR/pytest_test_attention_with_cp_fa2_no_load_balance.xml \
+    $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py::test_cp_with_flash_attention_no_load_balance \
+    || test_fail "FlashAttention 2 no-load-balance deterministic GQA"
+
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_sanity.xml $TE_PATH/tests/pytorch/distributed/test_sanity.py || test_fail "test_sanity.py"
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/distributed/test_numerics.py || test_fail "test_numerics.py"
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_numerics_exact.xml $TE_PATH/tests/pytorch/distributed/test_numerics_exact.py || test_fail "test_numerics_exact.py"

--- a/qa/L1_pytorch_distributed_unittest/test.sh
+++ b/qa/L1_pytorch_distributed_unittest/test.sh
@@ -43,14 +43,6 @@ else
     NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_attention_deterministic_with_cp.xml $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py || test_fail "NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 test_attention_with_cp.py"
 fi
 
-# The full runs above exercise both modes with normal backend selection.
-# Determinism is captured when the test module is imported, so use a fresh process and
-# disable FA3 (FA4 is disabled above) to force FA2 for the deterministic GQA regression.
-NVTE_FLASH_ATTN_V3=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 python3 -m pytest -v -s \
-    --junitxml=$XML_LOG_DIR/pytest_test_attention_with_cp_fa2_no_load_balance.xml \
-    $TE_PATH/tests/pytorch/attention/test_attention_with_cp.py::test_cp_with_flash_attention_no_load_balance \
-    || test_fail "FlashAttention 2 no-load-balance deterministic GQA"
-
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_sanity.xml $TE_PATH/tests/pytorch/distributed/test_sanity.py || test_fail "test_sanity.py"
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_numerics.xml $TE_PATH/tests/pytorch/distributed/test_numerics.py || test_fail "test_numerics.py"
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_numerics_exact.xml $TE_PATH/tests/pytorch/distributed/test_numerics_exact.py || test_fail "test_numerics_exact.py"

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -46,10 +46,9 @@ torch.cuda.manual_seed(seed)
 
 test_essential = bool(int(os.getenv("NVTE_TEST_ESSENTIAL", "1")))
 # An installed FA4 package must not select tests when the backend is explicitly disabled.
-flash_attn_enabled = bool(int(os.getenv("NVTE_FLASH_ATTN", "1")))
-fa2_enabled = flash_attn_enabled and bool(int(os.getenv("NVTE_FLASH_ATTN_V2", "1")))
-fa3_enabled = flash_attn_enabled and bool(int(os.getenv("NVTE_FLASH_ATTN_V3", "1")))
-fa4_enabled = flash_attn_enabled and bool(int(os.getenv("NVTE_FLASH_ATTN_V4", "1")))
+fa4_enabled = bool(int(os.getenv("NVTE_FLASH_ATTN", "1"))) and bool(
+    int(os.getenv("NVTE_FLASH_ATTN_V4", "1"))
+)
 
 model_configs_flash_attn = {
     # test: ModelConfig(b, sq, hq, dqk)
@@ -740,25 +739,22 @@ def test_cp_with_fused_attention_no_load_balance(cp_pool):
     )
 
 
-@pytest.mark.skipif(
-    not (
-        (
-            get_device_compute_capability() == (9, 0)
-            and (
-                (fa2_enabled and FlashAttentionUtils.v2_plus)
-                or (fa3_enabled and FlashAttentionUtils.v3_is_installed)
-            )
-        )
-        or (
-            get_device_compute_capability() >= (10, 0)
-            and fa4_enabled
-            and FlashAttentionUtils.v4_is_installed
-        )
-    ),
-    reason="FlashAttention 2 or 3 on sm90, or FlashAttention 4 on sm100+, is required.",
-)
 def test_cp_with_flash_attention_no_load_balance(cp_pool):
     """Check the supported unpadded FlashAttention path."""
+    config = copy.deepcopy(model_configs_flash_attn["cp_2_0"])
+    config.context_parallel = True
+    config.cp_comm_type = "all_gather"
+    config.attn_mask_type = "padding_causal"
+    available_backends, _, _ = get_available_attention_backends(
+        config,
+        qkv_dtype=torch.bfloat16,
+        qkv_layout="thd_thd_thd",
+        pad_between_seqs=False,
+        is_training=True,
+        deterministic=_deterministic,
+    )
+    if not available_backends[0]:
+        pytest.skip("FlashAttention is unavailable.")
     _submit(
         cp_pool(2),
         dtype="bf16",

--- a/tests/pytorch/attention/test_attention_with_cp.py
+++ b/tests/pytorch/attention/test_attention_with_cp.py
@@ -46,9 +46,10 @@ torch.cuda.manual_seed(seed)
 
 test_essential = bool(int(os.getenv("NVTE_TEST_ESSENTIAL", "1")))
 # An installed FA4 package must not select tests when the backend is explicitly disabled.
-fa4_enabled = bool(int(os.getenv("NVTE_FLASH_ATTN", "1"))) and bool(
-    int(os.getenv("NVTE_FLASH_ATTN_V4", "1"))
-)
+flash_attn_enabled = bool(int(os.getenv("NVTE_FLASH_ATTN", "1")))
+fa2_enabled = flash_attn_enabled and bool(int(os.getenv("NVTE_FLASH_ATTN_V2", "1")))
+fa3_enabled = flash_attn_enabled and bool(int(os.getenv("NVTE_FLASH_ATTN_V3", "1")))
+fa4_enabled = flash_attn_enabled and bool(int(os.getenv("NVTE_FLASH_ATTN_V4", "1")))
 
 model_configs_flash_attn = {
     # test: ModelConfig(b, sq, hq, dqk)
@@ -740,11 +741,24 @@ def test_cp_with_fused_attention_no_load_balance(cp_pool):
 
 
 @pytest.mark.skipif(
-    get_device_compute_capability() != (9, 0) or not FlashAttentionUtils.v3_is_installed,
-    reason="FlashAttention 3 requires sm90 and an installed FA3 package.",
+    not (
+        (
+            get_device_compute_capability() == (9, 0)
+            and (
+                (fa2_enabled and FlashAttentionUtils.v2_plus)
+                or (fa3_enabled and FlashAttentionUtils.v3_is_installed)
+            )
+        )
+        or (
+            get_device_compute_capability() >= (10, 0)
+            and fa4_enabled
+            and FlashAttentionUtils.v4_is_installed
+        )
+    ),
+    reason="FlashAttention 2 or 3 on sm90, or FlashAttention 4 on sm100+, is required.",
 )
-def test_cp_with_flash_attention_3_no_load_balance(cp_pool):
-    """Check the supported unpadded FlashAttention 3 path."""
+def test_cp_with_flash_attention_no_load_balance(cp_pool):
+    """Check the supported unpadded FlashAttention path."""
     _submit(
         cp_pool(2),
         dtype="bf16",

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -4188,6 +4188,8 @@ class AttnFuncWithCPAndKVAllGather(torch.autograd.Function):
                     ctx.qkv_format == "thd"
                     and ctx.load_balancing_strategy is CPLoadBalancingStrategy.NO_LOAD_BALANCE
                 ):
+                    # FA2 GQA backward accumulates into expanded K/V gradient buffers.
+                    # Initialize them before accumulation in this partitioning path.
                     fa_backward_kwargs["zero_tensors"] = True
 
         local_seq_chunk_ids = (
@@ -5458,7 +5460,7 @@ def attn_forward_func_with_cp(
     assigns one contiguous physical-buffer chunk to each rank and uses one attention
     step per rank. Logical sequences remain isolated by ``cu_seqlens``. This strategy
     requires THD, all-gather, causal self-attention without a sliding window, and
-    FusedAttention, or FlashAttention 3 with ``pad_between_seqs=False``. Input producers
+    FusedAttention, or FlashAttention with ``pad_between_seqs=False``. Input producers
     must use the same strategy when partitioning inputs with
     :func:`get_batch_on_this_cp_rank` or :func:`get_thd_partitioned_indices`.
 
@@ -5546,8 +5548,10 @@ def attn_forward_func_with_cp(
         assert (
             cp_comm_type == "all_gather"
         ), "No-load-balance THD partitioning requires cp_comm_type='all_gather'."
+        # Backend selection is handled by the caller. FlashAttention does not yet
+        # support inter-sequence padding with this partitioning strategy.
         assert (
-            use_fused_attention or not pad_between_seqs
+            not pad_between_seqs or use_fused_attention
         ), "No-load-balance THD partitioning only supports padding with FusedAttention."
         assert "causal" in attn_mask_type and window_size == (
             -1,

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -4184,6 +4184,11 @@ class AttnFuncWithCPAndKVAllGather(torch.autograd.Function):
                     fa_backward_kwargs["deterministic"] = ctx.deterministic
                 if fa_utils.v2_6_0_plus:
                     fa_backward_kwargs["softcap"] = 0.0
+                if (
+                    ctx.qkv_format == "thd"
+                    and ctx.load_balancing_strategy is CPLoadBalancingStrategy.NO_LOAD_BALANCE
+                ):
+                    fa_backward_kwargs["zero_tensors"] = True
 
         local_seq_chunk_ids = (
             [rank]
@@ -4538,6 +4543,7 @@ class AttnFuncWithCPAndKVAllGather(torch.autograd.Function):
             dq,
             dk,
             dv,
+            None,
             None,
             None,
             None,
@@ -5540,12 +5546,9 @@ def attn_forward_func_with_cp(
         assert (
             cp_comm_type == "all_gather"
         ), "No-load-balance THD partitioning requires cp_comm_type='all_gather'."
-        assert (
-            use_fused_attention or use_flash_attn_3
-        ), "No-load-balance THD partitioning requires FusedAttention or FlashAttention 3."
-        assert not (
-            use_flash_attn_3 and pad_between_seqs
-        ), "No-load-balance THD partitioning with FlashAttention 3 does not support padding yet."
+        assert use_fused_attention or not pad_between_seqs, (
+            "No-load-balance THD partitioning only supports padding with FusedAttention."
+        )
         assert "causal" in attn_mask_type and window_size == (
             -1,
             0,

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -5546,9 +5546,9 @@ def attn_forward_func_with_cp(
         assert (
             cp_comm_type == "all_gather"
         ), "No-load-balance THD partitioning requires cp_comm_type='all_gather'."
-        assert use_fused_attention or not pad_between_seqs, (
-            "No-load-balance THD partitioning only supports padding with FusedAttention."
-        )
+        assert (
+            use_fused_attention or not pad_between_seqs
+        ), "No-load-balance THD partitioning only supports padding with FusedAttention."
         assert "causal" in attn_mask_type and window_size == (
             -1,
             0,


### PR DESCRIPTION
## Description

Follow-up to #3221 that makes no-load-balance THD all-gather context parallelism robust for unpadded FlashAttention backends and fixes a bug in CP

- Request zeroed FlashAttention 2 backward outputs for deterministic grouped-query attention.
- Match the autograd backward return arity to the forward inputs.
- Allow unpadded FlashAttention backends while retaining the FusedAttention requirement when sequences have inter-sequence padding.

## Validation

- `git diff --check`
- Python 3.12 syntax compilation
- H100, FlashAttention 2, deterministic GQA, THD all-gather CP without load balancing: output, dQ, dK, and dV matched on both ranks
- `qa/L1_pytorch_distributed_unittest/test.sh`: all tests passed