### PR TITLE
[Common] Let MXFP8 quantization always reduce dbias in colwise

### DIFF
--- a/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
@@ -84,11 +84,13 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   // (no cross-thread reduction needed).
   constexpr bool DBIAS_REDUCTION_IN_COLWISE = IS_DBIAS && COLWISE_SCALING;
   // If columnwise is not quantized, and dbias is fused, we will do a columnwise reduction only pass
-  // (may also cache dact values) without quantization because doing dbias in rowwise requires a SMEM shuffle
-  // which is even slower
-  constexpr bool DBIAS_REDUCTION_COLWISE_ONLY = IS_DBIAS && (!COLWISE_SCALING);
-  // Never do dbias reduction in rowwise because it is slow. Leave this so in case it's enabled in the future
-  constexpr bool DBIAS_REDUCTION_IN_ROWWISE = false;
+  // (may also cache dact values) without quantization because doing dbias in rowwise is slower
+  // With fp32 input and DBIAS+DACT in which this approach is slower so we exclude that case specifically.
+  constexpr bool DBIAS_REDUCTION_COLWISE_ONLY =
+      IS_DBIAS && (!COLWISE_SCALING) && !(COMPUTE_ACTIVATIONS && std::is_same_v<IType, float>);
+  // Rowwise reduction is usually slower unless under the exception mentioned above.
+  constexpr bool DBIAS_REDUCTION_IN_ROWWISE =
+      IS_DBIAS && (!COLWISE_SCALING) && !DBIAS_REDUCTION_COLWISE_ONLY;
 
   // Fast path: keep the elements in BF16/FP16 and compute the AMAX with the half-precision
   // abs-max instead of upcasting every element to FP32. Only possible without activations.

--- a/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/quantize_mxfp8.cuh
@@ -80,7 +80,28 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
   constexpr size_t STAGES = CHUNK_DIM_Y / BUFF_DIM_Y;
   static_assert(STAGES >= 1);
 
-  constexpr bool IS_CACHED_ACT_OP = COMPUTE_ACTIVATIONS && ROWWISE_SCALING && COLWISE_SCALING;
+  // If columnwise is quantized and dbias is fused, do dbias reduction in colwise which is easier
+  // (no cross-thread reduction needed).
+  constexpr bool DBIAS_REDUCTION_IN_COLWISE = IS_DBIAS && COLWISE_SCALING;
+  // If columnwise is not quantized, and dbias is fused, we will do a columnwise reduction only pass
+  // (may also cache dact values) without quantization because doing dbias in rowwise requires a SMEM shuffle
+  // which is even slower
+  constexpr bool DBIAS_REDUCTION_COLWISE_ONLY = IS_DBIAS && (!COLWISE_SCALING);
+  // Never do dbias reduction in rowwise because it is slow. Leave this so in case it's enabled in the future
+  constexpr bool DBIAS_REDUCTION_IN_ROWWISE = false;
+
+  // Fast path: keep the elements in BF16/FP16 and compute the AMAX with the half-precision
+  // abs-max instead of upcasting every element to FP32. Only possible without activations.
+  // dbias does not disable it: the partial sums are accumulated in the scaling loop below, which
+  // upcasts the elements to FP32 anyway to feed the cvt.
+  constexpr bool USE_HALF_PRECISION = NO_ACTIVATIONS && (!std::is_same_v<IType, float>);
+
+  // Cache activations in-place in the SMEM input tile so the activation is computed only once, in
+  // the direction we favor (columnwise), and the rowwise pass reads the cached value back instead
+  // of recomputing it. The columnwise reduction-only pass computes the same values, so it can
+  // populate the cache too.
+  constexpr bool IS_CACHED_ACT_OP =
+      COMPUTE_ACTIVATIONS && ROWWISE_SCALING && (COLWISE_SCALING || DBIAS_REDUCTION_COLWISE_ONLY);
 
   const size_t block_offset_Y = blockIdx.y * CHUNK_DIM_Y;
   const size_t block_offset_X = blockIdx.x * CHUNK_DIM_X;
@@ -148,7 +169,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
   float partial_dbias_colwise = 0.0f;
   float thread_dbias_rowwise[SCALE_DIM_X];
-  if constexpr (IS_DBIAS) {
+  if constexpr (DBIAS_REDUCTION_IN_ROWWISE) {
 #pragma unroll
     for (int j = 0; j < SCALE_DIM_X; ++j) {
       thread_dbias_rowwise[j] = 0.0f;
@@ -214,7 +235,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       IType in_colwise_IType[BUFF_DIM_Y];
 
       // 1. Read/Compute elements. Find MXFP8-block AMAX
-      if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+      if constexpr (USE_HALF_PRECISION) {
         IType thread_amax_f16 = static_cast<IType>(0.0f);
 #pragma unroll
         for (int i = 0; i < BUFF_DIM_Y; ++i) {
@@ -236,7 +257,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
             float act_in_elt = static_cast<float>(act_in_sh[shmem_offset_colwise]);
             elt *= OP(act_in_elt, {});
           }
-          if constexpr (IS_DBIAS) {
+          if constexpr (DBIAS_REDUCTION_IN_COLWISE) {
+            // Accumulate before the truncation below so the partial sums stay full precision
             partial_dbias_colwise += elt;
           }
           // Numerical truncation: Downcast to IType (BF16/FP16), then upcast it back to FP32
@@ -287,15 +309,45 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 #pragma unroll
       for (int i = 0; i < SCALE_DIM_Y; ++i) {
         float in;
-        if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+        if constexpr (USE_HALF_PRECISION) {
           in = static_cast<float>(in_colwise_IType[i]);
         } else {
           in = in_compute_colwise[i];
+        }
+        // On the half-precision path the read loop kept the elements in IType, so dbias is
+        // accumulated here instead, reusing the FP32 value the cvt needs anyway.
+        if constexpr (DBIAS_REDUCTION_IN_COLWISE && USE_HALF_PRECISION) {
+          partial_dbias_colwise += in;
         }
         const float scaled_out = in * block_scale_inverse;
 
         const size_t shmem_offset_elt = shmem_offset_base_colwise + i * BUFF_DIM_X;
         out_colwise_data_sh[shmem_offset_elt] = static_cast<OType>(scaled_out);
+      }
+    }
+
+    // If the columnwise direction is not quantized but dbias is fused, run a columnwise
+    // reduction-only pass (no quantization). When activations are fused, this pass also caches the
+    // post-activation values so that the rowwise pass below does not recompute them.
+    if constexpr (DBIAS_REDUCTION_COLWISE_ONLY) {
+      const size_t shmem_offset_base_colwise = buff * BUFF_DIM + tid_X_colwise;
+#pragma unroll
+      for (int i = 0; i < BUFF_DIM_Y; ++i) {
+        const size_t shmem_offset_colwise = shmem_offset_base_colwise + i * BUFF_DIM_X;
+
+        float elt = static_cast<float>(in_sh[shmem_offset_colwise]);
+        if constexpr (IS_ACT) {
+          elt = OP(elt, {});
+        }
+        if constexpr (IS_DACT) {
+          const float act_in_elt = static_cast<float>(act_in_sh[shmem_offset_colwise]);
+          elt *= OP(act_in_elt, {});
+        }
+        partial_dbias_colwise += elt;
+        // Cache computed activations to avoid computing them again in the rowwise pass
+        if constexpr (IS_CACHED_ACT_OP) {
+          cached_act_sh[shmem_offset_colwise] = static_cast<IType>(elt);
+        }
       }
     }
 
@@ -310,7 +362,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       Vec<IType2, PACK_SIZE / 2> in_IType[WAVES];
 
       // 1. Read/Compute elements. Find MXFP8-block AMAX
-      if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+      if constexpr (USE_HALF_PRECISION) {
         IType2 thread_amax_2x = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
 #pragma unroll
         for (int w = 0; w < WAVES; ++w) {
@@ -392,7 +444,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
             }
 
             // If DBIAS was computed in the 1st pass (COLWISE) then no need to compute it again
-            if constexpr (IS_DBIAS && (!COLWISE_SCALING)) {
+            if constexpr (DBIAS_REDUCTION_IN_ROWWISE) {
               thread_dbias_rowwise[j] += elt;
             }
             // Numerical truncation: Downcast to IType (BF16/FP16), then upcast it back to FP32
@@ -419,9 +471,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
       // 2. Compute E8M0 scaling factor
       e8m0_t biased_exponent;
       if constexpr (kIs2DBlockScaling) {
-        using AMax2DType =
-            std::conditional_t<NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>),
-                               IType, float>;
+        using AMax2DType = std::conditional_t<USE_HALF_PRECISION, IType, float>;
         __shared__ e8m0_t block_scales_2d[THREADS_X];
         __shared__ AMax2DType block_amax_2d[THREADS_X * THREADS_Y];
         block_amax_2d[tid_X_rowwise * THREADS_Y + tid_Y_rowwise] =
@@ -469,7 +519,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
         for (int e = 0; e < PACK_SIZE / 2; ++e) {
           IType2 in;
           OType2 &out_pair = reinterpret_cast<OType2 &>(out.data.elt[e]);
-          if constexpr (NO_ACTIVATIONS && (!IS_DBIAS) && (!std::is_same_v<IType, float>)) {
+          if constexpr (USE_HALF_PRECISION) {
             in = in_IType[w].data.elt[e];
           } else if constexpr (IS_CACHED_ACT_OP) {
             in.x = in_cached[w].data.elt[2 * e];
@@ -523,7 +573,7 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK)
 
   if constexpr (IS_DBIAS) {
     float thread_partial_dbias = 0.0f;
-    if constexpr (COLWISE_SCALING) {
+    if constexpr (!DBIAS_REDUCTION_IN_ROWWISE) {
       thread_partial_dbias = partial_dbias_colwise;
     } else {
       ptx::cp_async_bulk_wait_group_read<0>();


### PR DESCRIPTION
Update: I really can't find out why in the CUDA kernel this optimization regresses on FP32+DBIAS+DACT, but for my CuTeDSL kernel it still improves on this case. I don't find anything that could explain this

# Description

This PR improve MXFP8 kernel's performance for DBIAS reduction by disabling row-wise DBIAS reduction and letting column-wise do it instead. By doing this we can eliminate the row-wise reduction register array and skip the thread data exchange where each thread owns a column instead of the row it had after the row-wise quantization, and reduce this column fragment and write the result in the workspace buffer.

The only exception is when we have FP32+DBIAS+DACT, where registers are no longer bottleneck, so this optimization's cost (extra SMEM traffic when we cache activations in the column-wise reduction only pass) is more than its gain (register save doesn't alleviate the bottleneck) so we disable it for this case only.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- DBIAS reduction always happens in the column-wise direction even we don't quantize column-wisely, in which case the column-wise pass only does DBIAS reduction and will not quantize
- If activation is involved, column-wise will also cache the activation result into the SMEM buffer for row-wise pass to use
- Column-wise pass now also use the half precision path with DBIAS (independent optimization)

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
