### PR TITLE
[Core] Fix L40 cublas heuristics

### DIFF
--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -747,18 +747,15 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
   NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceCreate(&preference));
   NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceSetAttribute(
       preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspaceSize, sizeof(workspaceSize)));
-  // Avoid reduced-precision split-K reductions for BF16 GEMMs with FP32 compute. In particular,
+  // Avoid reduced-precision split-K reductions. In particular,
   // CUBLASLT_REDUCTION_SCHEME_OUTPUT_TYPE converts each split-K partial to BF16 before the final
   // reduction, which can introduce significant error for cancellation-heavy dot products.
   // Non-split algorithms remain eligible, as do split-K algorithms that reduce their partials in
   // the FP32 compute type.
-  if (A_type == CUDA_R_16BF && B_type == CUDA_R_16BF && D_type == CUDA_R_16BF &&
-      gemm_compute_type == CUBLAS_COMPUTE_32F) {
-    const uint32_t reduction_scheme_mask = CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE;
-    NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceSetAttribute(
-        preference, CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, &reduction_scheme_mask,
-        sizeof(reduction_scheme_mask)));
-  }
+  const uint32_t reduction_scheme_mask = CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE;
+  NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceSetAttribute(
+      preference, CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, &reduction_scheme_mask,
+      sizeof(reduction_scheme_mask)));
   const auto A_alignment = _getAlignment(reinterpret_cast<uintptr_t>(param.A));
   const auto B_alignment = _getAlignment(reinterpret_cast<uintptr_t>(param.B));
   const auto C_alignment = _getAlignment(reinterpret_cast<uintptr_t>(C));

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -753,9 +753,9 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
   // Non-split algorithms remain eligible, as do split-K algorithms that reduce their partials in
   // the FP32 compute type.
   const uint32_t reduction_scheme_mask = CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE;
-  NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceSetAttribute(
-      preference, CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, &reduction_scheme_mask,
-      sizeof(reduction_scheme_mask)));
+  NVTE_CHECK_CUBLAS(
+      cublasLtMatmulPreferenceSetAttribute(preference, CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK,
+                                           &reduction_scheme_mask, sizeof(reduction_scheme_mask)));
   const auto A_alignment = _getAlignment(reinterpret_cast<uintptr_t>(param.A));
   const auto B_alignment = _getAlignment(reinterpret_cast<uintptr_t>(param.B));
   const auto C_alignment = _getAlignment(reinterpret_cast<uintptr_t>(C));

--- a/transformer_engine/common/gemm/cublaslt_gemm.cu
+++ b/transformer_engine/common/gemm/cublaslt_gemm.cu
@@ -747,6 +747,18 @@ void cublas_gemm(const Tensor *inputA, const Tensor *inputB, Tensor *outputD,
   NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceCreate(&preference));
   NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceSetAttribute(
       preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspaceSize, sizeof(workspaceSize)));
+  // Avoid reduced-precision split-K reductions for BF16 GEMMs with FP32 compute. In particular,
+  // CUBLASLT_REDUCTION_SCHEME_OUTPUT_TYPE converts each split-K partial to BF16 before the final
+  // reduction, which can introduce significant error for cancellation-heavy dot products.
+  // Non-split algorithms remain eligible, as do split-K algorithms that reduce their partials in
+  // the FP32 compute type.
+  if (A_type == CUDA_R_16BF && B_type == CUDA_R_16BF && D_type == CUDA_R_16BF &&
+      gemm_compute_type == CUBLAS_COMPUTE_32F) {
+    const uint32_t reduction_scheme_mask = CUBLASLT_REDUCTION_SCHEME_COMPUTE_TYPE;
+    NVTE_CHECK_CUBLAS(cublasLtMatmulPreferenceSetAttribute(
+        preference, CUBLASLT_MATMUL_PREF_REDUCTION_SCHEME_MASK, &reduction_scheme_mask,
+        sizeof(reduction_scheme_mask)));
+  }
   const auto A_alignment = _getAlignment(reinterpret_cast<uintptr_t>(param.A));
   const auto B_alignment = _getAlignment(reinterpret_cast<uintptr_t>(param.B));
   const auto C_alignment = _getAlignment(reinterpret_cast<uintptr_t>(C));


### PR DESCRIPTION
# Description

In certain cases on L40 we would allow a cuBLASLt heuristic that performed split-K with partial results stored in BF16. This lead to some loss of precision in the results. This PR fixes this by disallowing such heuristics

H100 and above were not observed to be affected by this. 

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [x] Code refactoring

## Changes

- Disallow split-K BF16 cuBLASLt heuristics

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
