### PR TITLE
[Common] Gate FP8 THD sink backward on cuDNN 9.26

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn.cpp
+++ b/transformer_engine/common/fused_attn/fused_attn.cpp
@@ -294,6 +294,9 @@ NVTE_Fused_Attn_Backend nvte_get_fused_attn_backend(
          qkv_format == NVTE_QKV_Format::NVTE_BHSD)) ||
        ((cudnn_runtime_version >= 92300 && (sm_arch_ >= 100 || (sm_arch_ >= 90 && !is_training))) &&
         qkv_format == NVTE_QKV_Format::NVTE_THD && supported_ragged_offset_size &&
+        // cuDNN before 9.26 misindexes ragged FP8 Stats during sink-token backward.
+        (!is_training || softmax_type == NVTE_Softmax_Type::NVTE_VANILLA_SOFTMAX ||
+         cudnn_runtime_version >= 92600) &&
         (attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_MASK ||
          attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_MASK ||
          attn_mask_type == NVTE_Mask_Type::NVTE_PADDING_CAUSAL_BOTTOM_RIGHT_MASK))) &&


### PR DESCRIPTION
## Description

cuDNN versions before 9.26 can misindex ragged FP8 Stats during sink-token backward. FP8 THD backend selection currently permits this training path with cuDNN 9.23 and newer.

Require cuDNN 9.26 only when selecting FP8 THD training with a non-vanilla softmax mode. This preserves FP8 THD inference and vanilla-softmax training on older supported cuDNN versions.

## Testing

- `pre-commit run clang-format --files transformer_engine/common/fused_attn/fused_attn.cpp`
- `git diff --check`

GPU runtime validation is left to CI.