### PR TITLE
[PyTorch] Fix fake kernel metadata mismatch for empty-input MoE permute ops

### DIFF
--- a/tests/pytorch/test_permutation.py
+++ b/tests/pytorch/test_permutation.py
@@ -1706,6 +1706,25 @@ def test_permutation_index_map(
 
 
 @pytest.mark.parametrize("te_dtype", _te_dtypes)
+@pytest.mark.parametrize("use_torch_compile", [False, True])
+def test_permutation_index_map_empty_input(te_dtype, use_torch_compile):
+    with_probs = True
+    BENCHMARK = False
+
+    _test_permutation_index_map(
+        te_dtype=te_dtype,
+        num_tokens=0,
+        num_expert=8,
+        hidden_size=4096,
+        topK=2,
+        num_out_tokens=0,
+        with_probs=with_probs,
+        BENCHMARK=BENCHMARK,
+        use_torch_compile=use_torch_compile,
+    )
+
+
+@pytest.mark.parametrize("te_dtype", _te_dtypes)
 @pytest.mark.parametrize("num_tokens", [4096])
 @pytest.mark.parametrize("num_expert", [7, 16])
 @pytest.mark.parametrize("hidden_size", [4096])

--- a/transformer_engine/pytorch/permutation.py
+++ b/transformer_engine/pytorch/permutation.py
@@ -42,7 +42,7 @@ def moe_permute_index_map_forward(
     global _moe_permute_index_map_workspace, _moe_permute_index_map_max_expanded_token_num
 
     if not inp.numel():
-        return inp.clone(), torch.tensor([], device=inp.device)
+        return inp.clone(), torch.empty(0, dtype=torch.int32, device=inp.device)
 
     if not inp.is_cuda:
         raise ValueError(f"inp must be a CUDA tensor, but got tensor on {inp.device}.")
@@ -98,9 +98,10 @@ def _moe_permute_index_map_fake(  # pylint: disable=unused-argument
         assert (
             num_out_tokens >= 0
         ), f"moe_permute (index map) requires num_out_tokens >= 0, got {num_out_tokens}."
-
-    # Infer output shape
-    output_tokens = num_out_tokens if num_out_tokens > 0 else num_tokens * topK
+        output_tokens = num_out_tokens if num_out_tokens > 0 else num_tokens * topK
+    else:
+        # Match `moe_permute_index_map_forward` empty-input fast path (ignores num_out_tokens).
+        output_tokens = 0
 
     # row_id_map is 1D with size = num_tokens * topK
     fake_output = torch.empty((output_tokens, inp.shape[1]), dtype=inp.dtype, device=inp.device)
@@ -290,7 +291,13 @@ def moe_permute_mask_map_forward(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Forward pass for MoE permute with mask router map."""
     if not inp.numel():
-        return inp.clone(), torch.tensor([], device=inp.device), torch.tensor([], device=inp.device)
+        row_id_map = torch.empty(
+            (0, routing_map.size(1) * 2 + 1), dtype=torch.int32, device=inp.device
+        )
+        permuted_probs = torch.empty(
+            0, dtype=probs.dtype if probs is not None else torch.float32, device=inp.device
+        )
+        return inp.clone(), row_id_map, permuted_probs
 
     if not inp.is_cuda:
         raise ValueError(f"inp must be a CUDA tensor, but got tensor on {inp.device}.")
@@ -450,11 +457,7 @@ def _moe_permute_mask_map_forward_fake(  # pylint: disable=unused-argument
         (num_tokens, num_experts * 2 + 1), dtype=torch.int32, device=inp.device
     )
     if probs is not None:
-        fake_permuted_probs = (
-            torch.empty((out_rows,), dtype=probs.dtype, device=inp.device)
-            if out_rows > 0
-            else torch.empty(0, device=inp.device)
-        )
+        fake_permuted_probs = torch.empty((out_rows,), dtype=probs.dtype, device=inp.device)
     else:
         fake_permuted_probs = torch.empty(0, device=inp.device)
     return fake_output, fake_row_id_map, fake_permuted_probs


### PR DESCRIPTION
# Description

For empty input, `moe_permute` (both mask and index map) returns `row_id_map` created with `torch.tensor([])`, i.e. float32 with shape `(0,)`, while the registered fake (meta) kernels declare int32 with shape `(0, num_experts * 2 + 1)` (mask map) / `(num_tokens * topK,)` (index map).

PyTorch validates fallback output dtype metadata against the fake kernel at runtime since [pytorch#183731](https://github.com/pytorch/pytorch/pull/183731) (nightlies after 2026-07-22, torch 2.14), so `torch.compile`'d empty-input permute now fails with:

```
RuntimeError: expected dtype torch.int32 but got torch.float32
Error in op: torch.ops.te_moe.permute_mask_map_fwd.default
```

Reproduced by `test_permutation_mask_map_empty_input[True-*]` and `test_permutation_mask_map_alongside_probs_empty_input[True-*]` on torch 2.14 nightly. On torch <= 2.13 the mismatch passes silently (no metadata check), so these tests will start failing once CI containers move to a newer PyTorch.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `permute_mask_map_fwd` empty-input fast path returns `row_id_map` as int32 `(0, num_experts * 2 + 1)` (the degenerate case of the non-empty `make_row_id_map` shape) and `permuted_probs` with `probs.dtype`, matching the fake kernel.
- `permute_index_map` empty-input fast path returns `row_id_map` as int32 `(0,)` instead of float32.
- `_moe_permute_index_map_fake` output shape now matches the empty-input fast path (0 rows, `num_out_tokens` ignored), mirroring the existing mask-map fake handling.
- `_moe_permute_mask_map_forward_fake` uses `probs.dtype` for `permuted_probs` also when `out_rows == 0`, keeping eager and fake consistent.
- Added `test_permutation_index_map_empty_input` (eager + compile) — the index-map path had the same bug but no empty-input test coverage.

Verified on torch 2.14.0.dev20260807 nightly: all `empty_input` tests pass (24/24; 9 compile variants fail without the fix), full `tests/pytorch/test_permutation.py` green (248 passed, 154 skipped).

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)