### PR TITLE
Fix GH action generated docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
           sudo apt-get install -y pandoc graphviz doxygen
           export GIT_SHA=$(git show-ref --hash HEAD)
       - name: 'Build docs'
+        env:
+          NVTE_DOCS_DISABLE_PUBLIC_FEATURES: '1'
         run: | # SPHINXOPTS="-W" errors out on warnings
           doxygen docs/Doxyfile
           cd docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,8 +96,10 @@ switcher_json_url = os.getenv(
 )
 switcher_version = os.getenv("NVTE_DOCS_SWITCHER_VERSION", "latest")
 
+public_docs_features = os.getenv("NVTE_DOCS_DISABLE_PUBLIC_FEATURES", "0") != "1"
+
 html_theme_options = {
-    "public_docs_features": True,
+    "public_docs_features": public_docs_features,
     "switcher": {
         "json_url": switcher_json_url,
         "version_match": switcher_version,


### PR DESCRIPTION
# Description

Issue introduced in #3399, where `public_docs_features` in the new theme makes the cookies not save on non `docs.nvidia.com` domains, resulting in continuous pop-up.

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Switch `public_docs_features` off via envvar, and set this envvar in GH actions for a clean preview.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
