### PR TITLE
[PyTorch] Deprecate unused is_cg_capturable in parallel_cross_entropy

### DIFF
--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -187,7 +187,6 @@ def parallel_cross_entropy(
         Target value for ignored rows.
     is_cg_capturable : bool, default = False
         Deprecated and unused. The operation is always CUDA graph capturable.
-        Will be removed in a future release.
     overwrite_input : bool, default = False
         Allow ``inp`` to be overwritten during backward. The input must be
         contiguous and cannot be reused afterward. This mode is incompatible with

--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -31,7 +31,6 @@ class CrossEntropyFunction(torch.autograd.Function):
         reduce_loss=False,
         dist_process_group=None,
         ignore_idx=-100,
-        is_cg_capturable=False,
         overwrite_input=False,
     ):
         """Compute the loss and save the input and softmax statistics for backward."""
@@ -62,7 +61,6 @@ class CrossEntropyFunction(torch.autograd.Function):
         ctx.rank = rank
         ctx.world_size = world_size
         ctx.ignore_idx = ignore_idx
-        ctx.is_cg_capturable = is_cg_capturable
         ctx.overwrite_input = overwrite_input
         ctx.did_backward = False
         return loss
@@ -90,11 +88,10 @@ class CrossEntropyFunction(torch.autograd.Function):
             ctx.rank,
             ctx.world_size,
             ctx.ignore_idx,
-            ctx.is_cg_capturable,
         )
         if ctx.overwrite_input:
             torch.autograd.graph.increment_version(saved_input)
-        return grad_input, None, None, None, None, None, None, None
+        return grad_input, None, None, None, None, None, None
 
 
 def _validate_inputs(
@@ -136,7 +133,6 @@ def _parallel_cross_entropy_overwrite_input(
     reduce_loss: bool,
     dist_process_group: Optional[torch.distributed.ProcessGroup],
     ignore_idx: int,
-    is_cg_capturable: bool,
 ) -> torch.Tensor:
     """Run destructive cross entropy outside Torch Dynamo's compiled graph."""
 
@@ -147,7 +143,6 @@ def _parallel_cross_entropy_overwrite_input(
         reduce_loss,
         dist_process_group,
         ignore_idx,
-        is_cg_capturable,
         True,
     )
 
@@ -191,7 +186,9 @@ def parallel_cross_entropy(
     ignore_idx : int, default = -100
         Target value for ignored rows.
     is_cg_capturable : bool, default = False
-        Whether the operation is CUDA graph capturable.
+        Deprecated and unused. The operation is always CUDA graph capturable
+        since the backward pass no longer contains a synchronization point.
+        Kept for backward compatibility; will be removed in a future release.
     overwrite_input : bool, default = False
         Allow ``inp`` to be overwritten during backward. The input must be
         contiguous and cannot be reused afterward. This mode is incompatible with
@@ -210,6 +207,13 @@ def parallel_cross_entropy(
         )
         inp = _input
 
+    if is_cg_capturable:
+        warnings.warn(
+            "The 'is_cg_capturable' parameter is deprecated and has no effect. "
+            "The operation is always CUDA graph capturable.",
+            FutureWarning,
+        )
+
     _validate_inputs(inp, target, label_smoothing, overwrite_input)
     if overwrite_input:
         return _parallel_cross_entropy_overwrite_input(
@@ -219,7 +223,6 @@ def parallel_cross_entropy(
             reduce_loss,
             dist_process_group,
             ignore_idx,
-            is_cg_capturable,
         )
     return CrossEntropyFunction.apply(
         inp,
@@ -228,6 +231,5 @@ def parallel_cross_entropy(
         reduce_loss,
         dist_process_group,
         ignore_idx,
-        is_cg_capturable,
         overwrite_input,
     )

--- a/transformer_engine/pytorch/cross_entropy.py
+++ b/transformer_engine/pytorch/cross_entropy.py
@@ -186,9 +186,8 @@ def parallel_cross_entropy(
     ignore_idx : int, default = -100
         Target value for ignored rows.
     is_cg_capturable : bool, default = False
-        Deprecated and unused. The operation is always CUDA graph capturable
-        since the backward pass no longer contains a synchronization point.
-        Kept for backward compatibility; will be removed in a future release.
+        Deprecated and unused. The operation is always CUDA graph capturable.
+        Will be removed in a future release.
     overwrite_input : bool, default = False
         Allow ``inp`` to be overwritten during backward. The input must be
         contiguous and cannot be reused afterward. This mode is incompatible with

--- a/transformer_engine/pytorch/triton/cross_entropy.py
+++ b/transformer_engine/pytorch/triton/cross_entropy.py
@@ -126,11 +126,9 @@ def cross_entropy_backward(
     rank: int,
     world_size: int,
     ignore_idx: int,
-    is_cg_capturable: bool = False,
 ):
     """Reconstruct the derivative in FP32 and overwrite the saved input buffer."""
 
-    del is_cg_capturable
     B, SQ, V = saved_input.shape
     n_rows = B * SQ
     BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))


### PR DESCRIPTION
# Description

Since #3273 the fused cross entropy backward reconstructs the derivative from saved statistics and no longer contains the `torch.equal`-based synchronization point. The `is_cg_capturable` flag therefore has no effect — the operation is always CUDA graph capturable.

This PR marks the flag as deprecated on the public `parallel_cross_entropy` API (docstring note + `FutureWarning` when set) and removes the dead internal plumbing. The parameter is kept in the signature for backward compatibility, since Megatron-LM passes it explicitly.

Should also be mentioned as deprecated in the v2.19 release notes.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Deprecate `is_cg_capturable` in `parallel_cross_entropy`: docstring now states it is unused, and passing `True` emits a `FutureWarning`.
- Remove the flag from `CrossEntropyFunction`, `_parallel_cross_entropy_overwrite_input` and the Triton `cross_entropy_backward` wrapper, where it was already a no-op.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
