### PR TITLE
Add opt-in rowwise-only quantized primary weights

### DIFF
--- a/tests/pytorch/test_backward_override.py
+++ b/tests/pytorch/test_backward_override.py
@@ -90,6 +90,19 @@ _quantized_numerics_recipe_list = [
     ),
 ]
 
+_primary_weight_recipe_list = [
+    pytest.param(
+        "mxfp8",
+        marks=pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8),
+        id="MXFP8BlockScaling",
+    ),
+    pytest.param(
+        "nvfp4",
+        marks=pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4),
+        id="NVFP4BlockScaling1D",
+    ),
+]
+
 
 @pytest.fixture(autouse=True)
 def _reset_global_fp8_state():
@@ -856,6 +869,46 @@ def test_backward_override_recipe_matches_requested_mode(
     quant_recipe = make_recipe(recipe_name)
     assert mode_recipe.backward_override == backward_override
     assert quant_recipe.backward_override is None
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+@pytest.mark.parametrize("backward_override", (None, *_BACKWARD_OVERRIDES))
+def test_primary_weight_layout_respects_backward_override(
+    recipe_name: str,
+    backward_override: Optional[str],
+) -> None:
+    """Primary weights only keep representations consumed by the configured backward."""
+    mode_recipe = make_recipe(recipe_name, backward_override=backward_override)
+    skip_unsupported_backward_override("linear", mode_recipe, backward_override)
+
+    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+        module = te.Linear(
+            64,
+            64,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    weight = module.weight
+    expect_columnwise = backward_override is None
+
+    def _check_weight_layout() -> None:
+        assert weight._rowwise_data is not None
+        assert weight._rowwise_scale_inv is not None
+        assert (weight._columnwise_data is not None) == expect_columnwise
+        assert (weight._columnwise_scale_inv is not None) == expect_columnwise
+        if hasattr(weight, "_amax_columnwise"):
+            assert (weight._amax_columnwise is not None) == expect_columnwise
+
+    _check_weight_layout()
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    with te.autocast(enabled=True, recipe=mode_recipe):
+        y = module(x)
+    y.sum().backward()
+
+    _check_weight_layout()
 
 
 @pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)

--- a/tests/pytorch/test_backward_override.py
+++ b/tests/pytorch/test_backward_override.py
@@ -872,16 +872,26 @@ def test_backward_override_recipe_matches_requested_mode(
 
 
 @pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
-@pytest.mark.parametrize("backward_override", (None, *_BACKWARD_OVERRIDES))
-def test_primary_weight_layout_respects_backward_override(
+@pytest.mark.parametrize("backward_override", _BACKWARD_OVERRIDES)
+@pytest.mark.parametrize(
+    "omit_columnwise_primary_weight_storage",
+    (False, True),
+    ids=("default_storage", "rowwise_only"),
+)
+def test_primary_weight_layout_with_backward_override(
     recipe_name: str,
-    backward_override: Optional[str],
+    backward_override: str,
+    omit_columnwise_primary_weight_storage: bool,
 ) -> None:
-    """Primary weights only keep representations consumed by the configured backward."""
+    """Columnwise primary-weight storage is omitted only when explicitly requested."""
     mode_recipe = make_recipe(recipe_name, backward_override=backward_override)
     skip_unsupported_backward_override("linear", mode_recipe, backward_override)
 
-    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+    with te.quantized_model_init(
+        enabled=True,
+        recipe=mode_recipe,
+        omit_columnwise_primary_weight_storage=omit_columnwise_primary_weight_storage,
+    ):
         module = te.Linear(
             64,
             64,
@@ -891,7 +901,7 @@ def test_primary_weight_layout_respects_backward_override(
         )
 
     weight = module.weight
-    expect_columnwise = backward_override is None
+    expect_columnwise = not omit_columnwise_primary_weight_storage
 
     def _check_weight_layout() -> None:
         assert weight._rowwise_data is not None
@@ -909,6 +919,66 @@ def test_primary_weight_layout_respects_backward_override(
     y.sum().backward()
 
     _check_weight_layout()
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+def test_default_primary_weight_storage_allows_quantized_backward_switch(
+    recipe_name: str,
+) -> None:
+    """Default storage preserves runtime switches from an override to quantized backward."""
+    mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
+    default_recipe = make_recipe(recipe_name)
+
+    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+        module = te.Linear(
+            64,
+            64,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    with te.autocast(enabled=True, recipe=default_recipe):
+        y = module(x)
+    y.sum().backward()
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+def test_rowwise_only_primary_weight_rejects_quantized_backward(recipe_name: str) -> None:
+    """A rowwise-only primary weight fails before quantized backward requests columnwise data."""
+    mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
+    default_recipe = make_recipe(recipe_name)
+
+    with te.quantized_model_init(
+        enabled=True,
+        recipe=mode_recipe,
+        omit_columnwise_primary_weight_storage=True,
+    ):
+        module = te.Linear(
+            64,
+            64,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    with pytest.raises(RuntimeError, match="without columnwise storage"):
+        with te.autocast(enabled=True, recipe=default_recipe):
+            module(x)
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+def test_rowwise_only_primary_weight_requires_backward_override(recipe_name: str) -> None:
+    """The rowwise-only opt-in rejects recipes that need quantized backward."""
+    with pytest.raises(ValueError, match="requires a recipe with backward_override"):
+        with te.quantized_model_init(
+            enabled=True,
+            recipe=make_recipe(recipe_name),
+            omit_columnwise_primary_weight_storage=True,
+        ):
+            pass
 
 
 @pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -910,6 +910,9 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         self.param_init_meta = {}
         self.primary_weights_in_fp8 = FP8GlobalStateManager.with_fp8_parameters()
         self.preserve_high_precision_init_val = FP8GlobalStateManager.with_high_precision_init_val()
+        self.omit_columnwise_primary_weight_storage = (
+            FP8GlobalStateManager.should_omit_columnwise_primary_weight_storage()
+        )
         self.fsdp_wrapped = False
         self.fsdp_group = None
         self._fp8_workspaces: Dict[str, QuantizedTensor] = {}
@@ -1845,13 +1848,10 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 quantizer = self.quantizers["scaling_fwd"][fp8_meta_index]
                 if quantizer is None:
                     raise RuntimeError("Weight quantizer has not been initialized")
-                # Backward overrides consume high-precision or dequantized weights,
-                # so they do not need a quantized columnwise representation.
                 quantizer.set_usage(
                     rowwise=True,
                     columnwise=(
-                        torch.is_grad_enabled()
-                        and self.fp8_meta["recipe"].backward_override is None
+                        torch.is_grad_enabled() and not self.omit_columnwise_primary_weight_storage
                     ),
                 )
                 quantizer.internal = False
@@ -2069,6 +2069,12 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             return
 
         recipe = self.fp8_meta["recipe"]
+        if self.omit_columnwise_primary_weight_storage and recipe.backward_override is None:
+            raise RuntimeError(
+                "Primary weights were initialized without columnwise storage, but the current "
+                "recipe uses quantized backward. Recreate the model with columnwise primary-weight "
+                "storage or keep backward_override set to 'high_precision' or 'dequantized'."
+            )
         weight_tensors = [getattr(self, name) for name in self.weight_names]
         for i, tensor in enumerate(weight_tensors):
             if isinstance(tensor, QuantizedTensorStorage):

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -1845,7 +1845,15 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 quantizer = self.quantizers["scaling_fwd"][fp8_meta_index]
                 if quantizer is None:
                     raise RuntimeError("Weight quantizer has not been initialized")
-                quantizer.set_usage(rowwise=True, columnwise=torch.is_grad_enabled())
+                # Backward overrides consume high-precision or dequantized weights,
+                # so they do not need a quantized columnwise representation.
+                quantizer.set_usage(
+                    rowwise=True,
+                    columnwise=(
+                        torch.is_grad_enabled()
+                        and self.fp8_meta["recipe"].backward_override is None
+                    ),
+                )
                 quantizer.internal = False
                 # HybridQuantizer is included so its current-scaling / NVFP4
                 # sub-quantizers get the same cross-shard amax reduction as the

--- a/transformer_engine/pytorch/quantization.py
+++ b/transformer_engine/pytorch/quantization.py
@@ -399,6 +399,7 @@ class FP8GlobalState:
     fp8_distributed_group: Optional[dist_group_type] = None
     fp8_parameters: bool = False
     high_precision_init_val: bool = False
+    omit_columnwise_primary_weight_storage: bool = False
     is_first_fp8_module: bool = False
     fp8_graph_capturing: bool = False
     autocast_depth: int = 0
@@ -583,6 +584,11 @@ class FP8GlobalStateManager:
     def with_high_precision_init_val(cls) -> bool:
         """Should the high precision initial values be stored with FP8 parameters"""
         return cls.quantization_state.high_precision_init_val
+
+    @classmethod
+    def should_omit_columnwise_primary_weight_storage(cls) -> bool:
+        """Should quantized primary weights omit columnwise storage"""
+        return cls.quantization_state.omit_columnwise_primary_weight_storage
 
     @classmethod
     def fp8_graph_capturing(cls) -> bool:
@@ -879,6 +885,7 @@ def quantized_model_init(
     enabled: bool = True,
     recipe: Optional[Recipe] = None,
     preserve_high_precision_init_val: bool = False,
+    omit_columnwise_primary_weight_storage: bool = False,
 ) -> None:
     """
     Context manager for initialization of quantized parameters.
@@ -921,21 +928,42 @@ def quantized_model_init(
              users should call `clear_high_precision_init_val()` to release this CPU memory.
 
              This functionality is *EXPERIMENTAL*.
+    omit_columnwise_primary_weight_storage : bool, default = False
+             when enabled, initialize quantized primary weights with rowwise storage only.
+             This requires a recipe with ``backward_override`` set to ``"high_precision"``
+             or ``"dequantized"`` and is intended for fixed-mode workloads such as frozen
+             LoRA base weights. A model initialized this way cannot later use quantized
+             backward without reconstructing its primary weights with columnwise storage.
+
+             This functionality is *EXPERIMENTAL*.
     """
 
     qstate = FP8GlobalStateManager.quantization_state
     _fp8_parameters = qstate.fp8_parameters
     _fp8_recipe = qstate.fp8_recipe
     _high_precision_init_val = qstate.high_precision_init_val
+    _omit_columnwise_primary_weight_storage = qstate.omit_columnwise_primary_weight_storage
+    resolved_recipe = get_default_fp8_recipe() if recipe is None else recipe
+    if (
+        enabled
+        and omit_columnwise_primary_weight_storage
+        and resolved_recipe.backward_override is None
+    ):
+        raise ValueError(
+            "omit_columnwise_primary_weight_storage requires a recipe with "
+            "backward_override='high_precision' or 'dequantized'"
+        )
     qstate.fp8_parameters = enabled
-    qstate.fp8_recipe = get_default_fp8_recipe() if recipe is None else recipe
+    qstate.fp8_recipe = resolved_recipe
     qstate.high_precision_init_val = preserve_high_precision_init_val
+    qstate.omit_columnwise_primary_weight_storage = omit_columnwise_primary_weight_storage
     try:
         yield
     finally:
         qstate.fp8_parameters = _fp8_parameters
         qstate.fp8_recipe = _fp8_recipe
         qstate.high_precision_init_val = _high_precision_init_val
+        qstate.omit_columnwise_primary_weight_storage = _omit_columnwise_primary_weight_storage
 
 
 def fp8_autocast(


### PR DESCRIPTION
# Description

`quantized_model_init` normally allocates both rowwise and columnwise storage for primary quantized weights when autograd is enabled. The columnwise representation is required by the default quantized dgrad, but it is not consumed when a fixed `backward_override="high_precision"` or `"dequantized"` mode computes dgrad from a high-precision or dequantized weight.

This matters for LoRA-style training with a large frozen quantized base: the base still participates in dgrad, while an unused columnwise copy remains attached to every primary weight.

This PR adds an explicit experimental opt-in:

```python
with te.quantized_model_init(
    enabled=True,
    recipe=recipe,
    omit_columnwise_primary_weight_storage=True,
):
    model = ...
```

When enabled, primary quantized weights allocate only the rowwise representation required by forward. The option requires an initialization recipe whose `backward_override` is `"high_precision"` or `"dequantized"`.

## Compatibility and safety

- The default is `False`, so existing callers retain bidirectional primary-weight storage, including callers that switch from a backward override to default quantized backward at runtime.
- Opt-in models fail early with a descriptive error if a later autocast recipe requests default quantized backward.
- The option is intended for fixed-mode workloads such as frozen LoRA base weights. Optimizer or distributed master-weight writeback paths that require columnwise primary storage must leave it disabled.

For block-scaled formats, omitting one persistent direction saves approximately 1.03 bytes/parameter for MXFP8 and 0.56 bytes/parameter for 1D NVFP4 before shape padding. The NVFP4 test explicitly uses one-dimensional scaling, which cannot synthesize columnwise storage from rowwise storage.

## Type of change

- [x] Documentation change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add `omit_columnwise_primary_weight_storage` to `quantized_model_init` and preserve it across nested context state.
- Apply the opt-in when allocating primary-weight storage.
- Validate the initialization recipe and reject an incompatible runtime switch before a quantized dgrad requests missing storage.
- Add MXFP8 and 1D NVFP4 coverage for default storage, rowwise-only storage, complete override forward/backward, preserved default runtime switching, and fail-fast behavior.

## Validation

- Repository-configured Black 24.4.2 passed for all three changed Python files.
- Python syntax compilation passed for all three changed Python files.
- Pylint passed for both changed Transformer Engine source files (10.00/10).
- `git diff --check` passed.
- CUDA tests were not run locally because this host has no CUDA/Blackwell runtime; the added tests use the existing MXFP8/NVFP4 availability gates.
- Full recursive Python lint is blocked on this host by the repository-pinned Astroid version parsing Python 3.14 `TemplateStr`; the changed source files pass the pinned Pylint independently.

# Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the public API documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works and preserves default compatibility
- [ ] New and existing GPU unit tests pass locally (CUDA/Blackwell runtime unavailable locally)
