### PR TITLE
[PyT] Fix PyTorch BF16 reduction numerics tests

### DIFF
--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -257,6 +257,11 @@ def reset_global_fp8_state():
 
 @contextmanager
 def _disable_bf16_reduced_precision_reduction():
+    """TE disables cuBLASLt heuristics that store partial GEMM results in BF16.
+    This is to ensure precision is kept. This affects older archs like L40.
+    PyTorch does not do this by default, so we need to adjust PyTorch's
+    settings here to match TE's increased precision here.
+    """
     original_value = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
     torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
     try:
@@ -265,7 +270,7 @@ def _disable_bf16_reduced_precision_reduction():
         torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = original_value
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def disable_bf16_reduced_precision_reduction():
     with _disable_bf16_reduced_precision_reduction():
         yield
@@ -1716,14 +1721,7 @@ def test_layernorm_accuracy(dtype, bs, model, eps, zero_centered_gamma):
 @pytest.mark.parametrize("return_bias", all_boolean)
 @pytest.mark.parametrize("bias", all_boolean)
 def test_layernorm_linear_accuracy(
-    dtype,
-    bs,
-    model,
-    normalization,
-    zero_centered_gamma,
-    return_bias,
-    bias,
-    disable_bf16_reduced_precision_reduction,
+    dtype, bs, model, normalization, zero_centered_gamma, return_bias, bias
 ):
     config = model_configs[model]
 
@@ -1807,14 +1805,7 @@ def test_layernorm_linear_accuracy(
 @pytest.mark.parametrize("bias", all_boolean)
 @pytest.mark.parametrize("fuse_wgrad_accumulation", all_boolean)
 def test_layernorm_linear_accuracy_delay_wgrad_compute(
-    dtype,
-    bs,
-    model,
-    normalization,
-    zero_centered_gamma,
-    bias,
-    fuse_wgrad_accumulation,
-    disable_bf16_reduced_precision_reduction,
+    dtype, bs, model, normalization, zero_centered_gamma, bias, fuse_wgrad_accumulation
 ):
     if NVTE_TEST_NVINSPECT_ENABLED:
         pytest.skip("Delayed wgrad compute is not supported in debug mode.")

--- a/tests/pytorch/test_numerics.py
+++ b/tests/pytorch/test_numerics.py
@@ -4,6 +4,7 @@
 
 import math
 import os
+from contextlib import contextmanager
 from typing import Dict, List, Tuple, Optional
 import pytest
 
@@ -252,6 +253,22 @@ def assert_allclose(
 def reset_global_fp8_state():
     yield
     FP8GlobalStateManager.reset()
+
+
+@contextmanager
+def _disable_bf16_reduced_precision_reduction():
+    original_value = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+    try:
+        yield
+    finally:
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = original_value
+
+
+@pytest.fixture
+def disable_bf16_reduced_precision_reduction():
+    with _disable_bf16_reduced_precision_reduction():
+        yield
 
 
 class TorchScaledMaskedSoftmax(nn.Module):
@@ -1699,7 +1716,14 @@ def test_layernorm_accuracy(dtype, bs, model, eps, zero_centered_gamma):
 @pytest.mark.parametrize("return_bias", all_boolean)
 @pytest.mark.parametrize("bias", all_boolean)
 def test_layernorm_linear_accuracy(
-    dtype, bs, model, normalization, zero_centered_gamma, return_bias, bias
+    dtype,
+    bs,
+    model,
+    normalization,
+    zero_centered_gamma,
+    return_bias,
+    bias,
+    disable_bf16_reduced_precision_reduction,
 ):
     config = model_configs[model]
 
@@ -1783,7 +1807,14 @@ def test_layernorm_linear_accuracy(
 @pytest.mark.parametrize("bias", all_boolean)
 @pytest.mark.parametrize("fuse_wgrad_accumulation", all_boolean)
 def test_layernorm_linear_accuracy_delay_wgrad_compute(
-    dtype, bs, model, normalization, zero_centered_gamma, bias, fuse_wgrad_accumulation
+    dtype,
+    bs,
+    model,
+    normalization,
+    zero_centered_gamma,
+    bias,
+    fuse_wgrad_accumulation,
+    disable_bf16_reduced_precision_reduction,
 ):
     if NVTE_TEST_NVINSPECT_ENABLED:
         pytest.skip("Delayed wgrad compute is not supported in debug mode.")


### PR DESCRIPTION
# Description

Fixes PyTorch tests to match tolerances on L40 that were changed in this PR #3440  . Now BF16 partial results reductions are disabled

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Guard tests with PyTorch flag to disable bf16 partial result reductions in reference 

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
