### PR TITLE
Compress CUDA binaries

### DIFF
--- a/transformer_engine/common/CMakeLists.txt
+++ b/transformer_engine/common/CMakeLists.txt
@@ -654,6 +654,14 @@ endforeach()
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3")
 
+# Compress every embedded cubin. CUDA 13 supports size-optimized compression
+# without imposing an additional driver requirement. Keep CUDA 12 on its
+# legacy/default compression mode to preserve compatibility with pre-12.4 drivers.
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xfatbin -compress-all")
+if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13.0)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compress-mode=size")
+endif()
+
 # Number of parallel build jobs
 if($ENV{MAX_JOBS})
   set(BUILD_JOBS_STR $ENV{MAX_JOBS})


### PR DESCRIPTION
# Description

Compresses build CUDA binaries to shrink the TE core library size.

I ran a build with and without this PR. The impact on CUDA 13 TE amd64 builds is significant:
* The core library size moves from 1058 MB to **361 MB**, cutting the size by two thirds
* The built wheel for `main` without this change is 556 MB, but implementing this cuts the size to 292 MB (which is much closer to the 2.18 release wheel size despite containing more GPU architectures and features)
* The built container image is currently 1221 MB, reduced to 719 MB with this changeset

The downsides are:
* Wheel build time is increased by about 7%
* The CUDA driver must decompress this data before first use

I'm not expecting decompression time to be meaningful, given that other projects (like pytorch itself) is using this same approach already. It's _possible_ in some systems startup time may actually be improved, if the added decompression time is less than the time savings from reduced disk I/O.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Compress build CUDA binaries to reduce TE core library size

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
