### PR TITLE
[Common] row-scaled nvfp4 path: add single-launch group fused amax 

### DIFF
--- a/tests/cpp/operator/CMakeLists.txt
+++ b/tests/cpp/operator/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(test_operator
                test_cast_mxfp8_grouped.cu
                test_cast_mxfp8_grouped_scaled_swiglu.cu
                test_cast_nvfp4_transpose.cu
+               test_row_scaled_nvfp4_grouped_amax.cu
                test_cast_float8blockwise.cu
                test_cast_float8blockwise_grouped.cu
                test_dequantize_mxfp8.cu

--- a/tests/cpp/operator/test_row_scaled_nvfp4_grouped_amax.cu
+++ b/tests/cpp/operator/test_row_scaled_nvfp4_grouped_amax.cu
@@ -1,0 +1,224 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <cuda_bf16.h>
+#include <cuda_fp4.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <transformer_engine/cast.h>
+#include "../test_common.h"
+#include "transformer_engine/transformer_engine.h"
+
+using namespace transformer_engine;
+using namespace test;
+
+namespace {
+
+// (per-expert row counts, shared column count); all values are multiples of 128.
+struct GroupedAmaxConfig {
+  std::vector<size_t> Ms;
+  size_t K;
+};
+
+std::vector<std::unique_ptr<Tensor>> make_row_scaled_outputs(const std::string& tag,
+                                                             const std::vector<size_t>& Ms,
+                                                             size_t K) {
+  std::vector<std::unique_ptr<Tensor>> outs;
+  for (size_t i = 0; i < Ms.size(); ++i) {
+    const std::vector<size_t> shape = {Ms[i], K};
+    auto t = std::make_unique<Tensor>(tag + std::to_string(i), shape, DType::kFloat4E2M1,
+                                      /*rowwise=*/true, /*columnwise=*/true, NVTE_NVFP4_1D_SCALING);
+    t->set_row_scaled_nvfp4(true);
+    outs.push_back(std::move(t));
+  }
+  return outs;
+}
+
+// Grouped fused amax over a packed (sum_M, K) input must equal the per-row /
+// per-col amax of the same BF16 bytes and be deterministic across launches.
+void performGroupedFusedAmaxTest(const GroupedAmaxConfig& cfg) {
+  const std::vector<size_t>& Ms = cfg.Ms;
+  const size_t K = cfg.K;
+  const size_t num_tensors = Ms.size();
+  size_t sum_M = 0;
+  for (size_t m : Ms) sum_M += m;
+
+  // Per-expert BF16 inputs; packed into one buffer with identical bytes so the
+  // grouped kernel and the per-expert oracle see the same values.
+  std::vector<std::unique_ptr<Tensor>> ins;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    const std::vector<size_t> shape = {Ms[i], K};
+    ins.push_back(std::make_unique<Tensor>("in_" + std::to_string(i), shape, DType::kBFloat16));
+    fillCase<fp32>(ins[i].get(), InputsFillCase::uniform);
+    ins[i]->to_cpu();
+  }
+
+  const std::vector<size_t> packed_shape = {sum_M, K};
+  Tensor packed("packed_input", packed_shape, DType::kBFloat16);
+  bf16* pdst = packed.rowwise_cpu_dptr<bf16>();
+  size_t row_off = 0;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    std::copy_n(ins[i]->rowwise_cpu_dptr<bf16>(), Ms[i] * K, pdst + row_off * K);
+    row_off += Ms[i];
+  }
+  packed.from_cpu();
+
+  const std::vector<size_t> splits(Ms);
+
+  auto outs = make_row_scaled_outputs("gout_", Ms, K);
+  std::vector<NVTETensor> out_handles;
+  for (auto& t : outs) out_handles.push_back(t->data());
+  nvte_group_nvfp4_compute_amax(packed.data(), out_handles.data(), splits.data(), num_tensors, 0);
+
+  auto outs2 = make_row_scaled_outputs("gout2_", Ms, K);
+  std::vector<NVTETensor> out_handles2;
+  for (auto& t : outs2) out_handles2.push_back(t->data());
+  nvte_group_nvfp4_compute_amax(packed.data(), out_handles2.data(), splits.data(), num_tensors, 0);
+
+  cudaDeviceSynchronize();
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << cudaGetErrorString(cudaGetLastError());
+
+  for (size_t i = 0; i < num_tensors; ++i) {
+    const bf16* src = ins[i]->rowwise_cpu_dptr<bf16>();
+    std::vector<float> row_ref(Ms[i], 0.0f);
+    std::vector<float> col_ref(K, 0.0f);
+    for (size_t r = 0; r < Ms[i]; ++r) {
+      for (size_t c = 0; c < K; ++c) {
+        const float v = fabsf(static_cast<float>(src[r * K + c]));
+        row_ref[r] = fmaxf(row_ref[r], v);
+        col_ref[c] = fmaxf(col_ref[c], v);
+      }
+    }
+
+    outs[i]->to_cpu();
+    outs2[i]->to_cpu();
+
+    const float* row_fused = outs[i]->cpu_rowwise_amax_ptr<float>();
+    const float* row_fused2 = outs2[i]->cpu_rowwise_amax_ptr<float>();
+    for (size_t r = 0; r < Ms[i]; ++r) {
+      ASSERT_EQ(row_fused[r], row_ref[r]) << "rowwise amax mismatch: expert " << i << " row " << r;
+      ASSERT_EQ(row_fused[r], row_fused2[r])
+          << "rowwise amax nondeterministic: expert " << i << " row " << r;
+    }
+
+    const float* col_fused = outs[i]->cpu_columnwise_amax_ptr<float>();
+    const float* col_fused2 = outs2[i]->cpu_columnwise_amax_ptr<float>();
+    for (size_t c = 0; c < K; ++c) {
+      ASSERT_EQ(col_fused[c], col_ref[c]) << "columnwise amax mismatch: expert " << i << " col " << c;
+      ASSERT_EQ(col_fused[c], col_fused2[c])
+          << "columnwise amax nondeterministic: expert " << i << " col " << c;
+    }
+  }
+}
+
+}  // namespace
+
+class NVFP4GroupedRowScaledAmaxTestSuite : public ::testing::TestWithParam<GroupedAmaxConfig> {};
+
+TEST_P(NVFP4GroupedRowScaledAmaxTestSuite, MatchesPerExpertOracle) {
+  if (getDeviceComputeCapability() < blackwellComputeCapability) {
+    GTEST_SKIP();
+  }
+  performGroupedFusedAmaxTest(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(NVFP4GroupedRowScaledAmax, NVFP4GroupedRowScaledAmaxTestSuite,
+                         ::testing::Values(GroupedAmaxConfig{{128}, 128},
+                                           GroupedAmaxConfig{{128, 128}, 128},
+                                           GroupedAmaxConfig{{128, 256, 128}, 256},
+                                           GroupedAmaxConfig{{256, 128}, 512},
+                                           GroupedAmaxConfig{{384, 128, 256}, 128},
+                                           GroupedAmaxConfig{{512}, 1024}));
+
+namespace {
+
+double median_ms(const std::function<void()>& fn, int iters) {
+  for (int i = 0; i < 10; ++i) fn();
+  NVTE_CHECK_CUDA(cudaDeviceSynchronize());
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+  std::vector<float> ts;
+  ts.reserve(iters);
+  for (int i = 0; i < iters; ++i) {
+    cudaEventRecord(start);
+    fn();
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    float ms = 0.0f;
+    cudaEventElapsedTime(&ms, start, stop);
+    ts.push_back(ms);
+  }
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+  std::sort(ts.begin(), ts.end());
+  return ts[ts.size() / 2];
+}
+
+void runLoopVsGroupedBench(size_t num_tensors, size_t M, size_t K, int iters) {
+  const std::vector<size_t> Ms(num_tensors, M);
+  size_t sum_M = M * num_tensors;
+
+  Tensor packed("packed", std::vector<size_t>{sum_M, K}, DType::kBFloat16);
+  fillCase<fp32>(&packed, InputsFillCase::uniform);
+
+  std::vector<std::unique_ptr<Tensor>> ins;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    ins.push_back(std::make_unique<Tensor>("in_" + std::to_string(i),
+                                           std::vector<size_t>{M, K}, DType::kBFloat16));
+    fillCase<fp32>(ins[i].get(), InputsFillCase::uniform);
+  }
+
+  auto outs_g = make_row_scaled_outputs("bg_", Ms, K);
+  std::vector<NVTETensor> h_g;
+  for (auto& t : outs_g) h_g.push_back(t->data());
+  std::vector<size_t> splits(Ms);
+
+  auto outs_l = make_row_scaled_outputs("bl_", Ms, K);
+
+  double grouped = median_ms(
+      [&]() {
+        nvte_group_nvfp4_compute_amax(packed.data(), h_g.data(), splits.data(), num_tensors, 0);
+      },
+      iters);
+
+  double loop = median_ms(
+      [&]() {
+        for (size_t i = 0; i < num_tensors; ++i) {
+          NVTETensor one = outs_l[i]->data();
+          size_t s1 = M;
+          nvte_group_nvfp4_compute_amax(ins[i]->data(), &one, &s1, 1, 0);
+        }
+      },
+      iters);
+
+  std::printf("%4zu experts  M=%5zu  K=%6zu   loop=%8.4f ms  grouped=%8.4f ms  speedup=%.2fx\n",
+              num_tensors, M, K, loop, grouped, loop / grouped);
+}
+
+}  // namespace
+
+TEST(NVFP4GroupedRowScaledAmaxBench, DISABLED_LoopVsGrouped) {
+  if (getDeviceComputeCapability() < blackwellComputeCapability) {
+    GTEST_SKIP();
+  }
+  const int iters = 100;
+  for (size_t M : {size_t(128), size_t(512)}) {
+    for (size_t n : {size_t(2), size_t(4), size_t(8), size_t(16), size_t(32), size_t(64)}) {
+      runLoopVsGroupedBench(n, M, 4096, iters);
+    }
+    std::printf("\n");
+  }
+}

--- a/tests/cpp/operator/test_row_scaled_nvfp4_grouped_amax.cu
+++ b/tests/cpp/operator/test_row_scaled_nvfp4_grouped_amax.cu
@@ -142,6 +142,81 @@ INSTANTIATE_TEST_SUITE_P(NVFP4GroupedRowScaledAmax, NVFP4GroupedRowScaledAmaxTes
                                            GroupedAmaxConfig{{384, 128, 256}, 128},
                                            GroupedAmaxConfig{{512}, 1024}));
 
+// Experts opt into the columnwise direction independently: the kernel must skip
+// experts whose columnwise buffer is null (including the first one) instead of
+// dereferencing it, while still computing the direction for those that request it.
+TEST(NVFP4GroupedRowScaledAmaxTestSuite, HeterogeneousColumnwise) {
+  if (getDeviceComputeCapability() < blackwellComputeCapability) {
+    GTEST_SKIP();
+  }
+
+  const std::vector<size_t> Ms = {128, 128, 128};
+  const size_t K = 256;
+  const size_t num_tensors = Ms.size();
+  const bool want_col[3] = {false, true, false};
+
+  size_t sum_M = 0;
+  for (size_t m : Ms) sum_M += m;
+
+  std::vector<std::unique_ptr<Tensor>> ins;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    ins.push_back(std::make_unique<Tensor>("hin_" + std::to_string(i),
+                                           std::vector<size_t>{Ms[i], K}, DType::kBFloat16));
+    fillCase<fp32>(ins[i].get(), InputsFillCase::uniform);
+    ins[i]->to_cpu();
+  }
+
+  Tensor packed("hpacked", std::vector<size_t>{sum_M, K}, DType::kBFloat16);
+  bf16* pdst = packed.rowwise_cpu_dptr<bf16>();
+  size_t row_off = 0;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    std::copy_n(ins[i]->rowwise_cpu_dptr<bf16>(), Ms[i] * K, pdst + row_off * K);
+    row_off += Ms[i];
+  }
+  packed.from_cpu();
+
+  std::vector<std::unique_ptr<Tensor>> outs;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    auto t = std::make_unique<Tensor>("hout_" + std::to_string(i),
+                                      std::vector<size_t>{Ms[i], K}, DType::kFloat4E2M1,
+                                      /*rowwise=*/true, /*columnwise=*/want_col[i],
+                                      NVTE_NVFP4_1D_SCALING);
+    t->set_row_scaled_nvfp4(true);
+    outs.push_back(std::move(t));
+  }
+  std::vector<NVTETensor> handles;
+  for (auto& t : outs) handles.push_back(t->data());
+  const std::vector<size_t> splits(Ms);
+  nvte_group_nvfp4_compute_amax(packed.data(), handles.data(), splits.data(), num_tensors, 0);
+  cudaDeviceSynchronize();
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << cudaGetErrorString(cudaGetLastError());
+
+  for (size_t i = 0; i < num_tensors; ++i) {
+    const bf16* src = ins[i]->rowwise_cpu_dptr<bf16>();
+    std::vector<float> row_ref(Ms[i], 0.0f);
+    std::vector<float> col_ref(K, 0.0f);
+    for (size_t r = 0; r < Ms[i]; ++r) {
+      for (size_t c = 0; c < K; ++c) {
+        const float v = fabsf(static_cast<float>(src[r * K + c]));
+        row_ref[r] = fmaxf(row_ref[r], v);
+        col_ref[c] = fmaxf(col_ref[c], v);
+      }
+    }
+
+    outs[i]->to_cpu();
+    const float* row = outs[i]->cpu_rowwise_amax_ptr<float>();
+    for (size_t r = 0; r < Ms[i]; ++r) {
+      ASSERT_EQ(row[r], row_ref[r]) << "rowwise amax mismatch: expert " << i << " row " << r;
+    }
+    if (want_col[i]) {
+      const float* col = outs[i]->cpu_columnwise_amax_ptr<float>();
+      for (size_t c = 0; c < K; ++c) {
+        ASSERT_EQ(col[c], col_ref[c]) << "columnwise amax mismatch: expert " << i << " col " << c;
+      }
+    }
+  }
+}
+
 namespace {
 
 double median_ms(const std::function<void()>& fn, int iters) {

--- a/transformer_engine/common/cast/cast_grouped.cu
+++ b/transformer_engine/common/cast/cast_grouped.cu
@@ -10,6 +10,8 @@
 #include <transformer_engine/cast.h>
 #include <transformer_engine/recipe.h>
 
+#include <vector>
+
 #include "../common.h"
 #include "dispatch/dequantize.cuh"
 #include "dispatch/quantize.cuh"
@@ -94,4 +96,21 @@ void nvte_group_nvfp4_quantize_with_amax(const NVTETensor input, NVTETensor *out
 
   dispatch::group_quantize_fwd_host_aware_helper<IS_ACT, Empty, nullptr>(
       input, outputs, split_sections, num_tensors, quant_config, stream);
+}
+
+void nvte_group_nvfp4_compute_amax(const NVTETensor input, NVTETensor *outputs,
+                                   const size_t *split_sections, const size_t num_tensors,
+                                   cudaStream_t stream) {
+  NVTE_API_CALL(nvte_group_nvfp4_compute_amax);
+  using namespace transformer_engine;
+
+  const Tensor *input_tensor = convertNVTETensorCheck(input);
+  std::vector<Tensor *> output_tensors;
+  output_tensors.reserve(num_tensors);
+  for (size_t i = 0; i < num_tensors; ++i) {
+    output_tensors.push_back(convertNVTETensorCheck(outputs[i]));
+  }
+
+  dispatch::nvfp4::group_compute_fused_amax(*input_tensor, /*noop=*/nullptr, output_tensors,
+                                            split_sections, num_tensors, stream);
 }

--- a/transformer_engine/common/cast/nvfp4/group_quantize_transpose_nvfp4.cuh
+++ b/transformer_engine/common/cast/nvfp4/group_quantize_transpose_nvfp4.cuh
@@ -16,6 +16,10 @@
 #include <cuda_runtime.h>
 #include <transformer_engine/transformer_engine.h>
 
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
 #include "../../common.h"
 #include "../../util/math.h"
 #include "../../util/ptx_arch_spec.cuh"
@@ -25,6 +29,346 @@
 namespace transformer_engine {
 namespace dispatch {
 namespace nvfp4 {
+
+// Single-launch fused row/col amax for grouped (MoE) row-scaled NVFP4. Grouped
+// counterpart of the single-tensor row_scaled_amax_kernel: the input is one
+// packed (sum_M, K) buffer, so a single input TMA map covers all experts; only
+// the tiny per-expert amax vectors are selected via GetTensorId.
+namespace group_row_scaled_amax_kernel {
+
+using namespace ptx;
+
+#if FP4_TYPE_SUPPORTED
+
+constexpr int kMaxAmaxTensorsPerKernel = 64;
+
+// Per-expert amax output pointers plus the prefix sum of per-expert row counts.
+struct GroupedFusedAmaxArgs {
+  void *row_amax_list[kMaxAmaxTensorsPerKernel];           // float* [M_i], null if !DO_ROW
+  void *col_amax_list[kMaxAmaxTensorsPerKernel];           // float* [K],   null if !DO_COL
+  int split_sections_range[kMaxAmaxTensorsPerKernel + 1];  // prefix sum of M_i (rows)
+  int num_tensors;
+};
+
+// A 128-row chunk lies fully inside one expert (each M_i is 128-aligned), so the
+// tensor id is constant per CTA.
+__device__ __forceinline__ int GetTensorId(const GroupedFusedAmaxArgs &args, int row_offset) {
+  int tensor_id = 0;
+  while (args.split_sections_range[tensor_id + 1] <= row_offset) {
+    ++tensor_id;
+  }
+  return tensor_id;
+}
+
+constexpr int FA_CHUNK_DIM_Y = 128;
+constexpr int FA_CHUNK_DIM_X = 128;
+constexpr int FA_TILE_DIM_Y = 64;
+constexpr int FA_TILE_DIM_X = 64;
+constexpr int FA_THREADS_NUM = 128;
+constexpr int FA_TILES_Y = FA_CHUNK_DIM_Y / FA_TILE_DIM_Y;
+constexpr int FA_TILES_X = FA_CHUNK_DIM_X / FA_TILE_DIM_X;
+constexpr int FA_STAGES = FA_TILES_Y * FA_TILES_X;
+constexpr int FA_PREFETCH_STAGES = 1;
+constexpr int FA_BUFFS_NUM = FA_PREFETCH_STAGES + 1;
+constexpr int FA_BUFF_IN_SIZE = FA_TILE_DIM_Y * FA_TILE_DIM_X;
+
+// Zero the per-expert amax vectors so the main kernel can atomicMax into them.
+// ``static`` gives internal linkage so this header can be included by multiple TUs.
+static __global__ void group_fused_amax_zero_kernel(GroupedFusedAmaxArgs args, const int cols,
+                                                    const float *noop) {
+  if (noop != nullptr && noop[0] == 1.0f) {
+    return;
+  }
+  const int tensor_id = blockIdx.x;
+  if (tensor_id >= args.num_tensors) {
+    return;
+  }
+  const int rows = args.split_sections_range[tensor_id + 1] - args.split_sections_range[tensor_id];
+  float *row_amax = reinterpret_cast<float *>(args.row_amax_list[tensor_id]);
+  float *col_amax = reinterpret_cast<float *>(args.col_amax_list[tensor_id]);
+  const int stride = blockDim.x * gridDim.y;
+  const int base = threadIdx.x + blockIdx.y * blockDim.x;
+  if (row_amax != nullptr) {
+    for (int i = base; i < rows; i += stride) {
+      row_amax[i] = 0.0f;
+    }
+  }
+  if (col_amax != nullptr) {
+    for (int i = base; i < cols; i += stride) {
+      col_amax[i] = 0.0f;
+    }
+  }
+}
+
+template <bool DO_ROW, bool DO_COL>
+__global__ void __launch_bounds__(FA_THREADS_NUM)
+    group_compute_fused_amax_kernel(const __grid_constant__ CUtensorMap tensor_map_input,
+                                    GroupedFusedAmaxArgs args, const float *noop, const size_t rows,
+                                    const size_t cols) {
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  if (noop != nullptr && noop[0] == 1.0f) {
+    return;
+  }
+
+  using IType = __nv_bfloat16;
+  using IType2 = ptx::FPx2<IType>;
+  using IType3D = IType[FA_BUFFS_NUM][FA_TILE_DIM_Y][FA_TILE_DIM_X];
+
+  const bool leading_thread = (threadIdx.x == 0);
+  const int tid = threadIdx.x;
+  const int block_offset_Y = blockIdx.y * FA_CHUNK_DIM_Y;
+  const int block_offset_X = blockIdx.x * FA_CHUNK_DIM_X;
+
+  // The 128-row chunk is inside a single expert. Select its per-expert outputs
+  // and remap the global row to a tensor-local row.
+  const int tensor_id = GetTensorId(args, block_offset_Y);
+  const int split_start = args.split_sections_range[tensor_id];
+  float *const row_amax_out =
+      DO_ROW ? reinterpret_cast<float *>(args.row_amax_list[tensor_id]) : nullptr;
+  float *const col_amax_out =
+      DO_COL ? reinterpret_cast<float *>(args.col_amax_list[tensor_id]) : nullptr;
+  const int local_row = block_offset_Y - split_start + tid;
+  const int global_col = block_offset_X + tid;
+
+  constexpr size_t buff_elems_total = FA_BUFFS_NUM * FA_BUFF_IN_SIZE;
+  constexpr size_t buff_size_aligned_in =
+      DIVUP_TO_MULTIPLE(buff_elems_total * sizeof(IType), TMA_SHMEM_ALIGNMENT);
+  constexpr size_t shmem_buff_size = buff_size_aligned_in / FA_BUFFS_NUM;
+
+  extern __shared__ char dynamic_shmem[];
+  char *dshmem = align_up(dynamic_shmem, TMA_SHMEM_ALIGNMENT);
+  auto &sIn = *reinterpret_cast<IType3D *>(dshmem);
+
+  __shared__ alignas(8) uint64_t in_readable_mbar[FA_BUFFS_NUM];
+
+  const int my_row_stage_Y = tid / FA_TILE_DIM_Y;
+  const int my_col_stage_X = tid / FA_TILE_DIM_X;
+  const int my_row_in_subtile = tid % FA_TILE_DIM_Y;
+  const int my_col_in_subtile = tid % FA_TILE_DIM_X;
+
+  float row_partial = 0.0f;
+  float col_partial = 0.0f;
+
+  if (leading_thread) {
+#pragma unroll
+    for (int buff = 0; buff < FA_BUFFS_NUM; ++buff) {
+      ptx::mbarrier_init(&in_readable_mbar[buff], 1);
+    }
+    ptx::fence_proxy_async_shared_cta();
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int stage = 0; stage < FA_PREFETCH_STAGES; ++stage) {
+    const int buff_in = stage;
+    const int stage_Y = stage / FA_TILES_X;
+    const int stage_X = stage % FA_TILES_X;
+    const int global_offset_Y = block_offset_Y + stage_Y * FA_TILE_DIM_Y;
+    const int global_offset_X = block_offset_X + stage_X * FA_TILE_DIM_X;
+    if (leading_thread) {
+      ptx::mbarrier_arrive_expect_tx(&in_readable_mbar[buff_in], shmem_buff_size);
+      ptx::cp_async_bulk_tensor_2d_global_to_shared(
+          reinterpret_cast<uint64_t *>(&sIn[buff_in]),
+          reinterpret_cast<const uint64_t *>(&tensor_map_input), global_offset_X, global_offset_Y,
+          &in_readable_mbar[buff_in]);
+    }
+  }
+
+  int buff_in = 0;
+  int readable_parity[FA_BUFFS_NUM] = {0, 0};
+
+#pragma unroll
+  for (int stage = 0; stage < FA_STAGES; ++stage) {
+    const int stage_Y = stage / FA_TILES_X;
+    const int stage_X = stage % FA_TILES_X;
+
+    if (stage < FA_STAGES - FA_PREFETCH_STAGES) {
+      const int next_prefetch_buff = (buff_in + FA_PREFETCH_STAGES) % FA_BUFFS_NUM;
+      const int next_prefetch_stage = (stage + FA_PREFETCH_STAGES) % FA_STAGES;
+      const int next_stage_Y = next_prefetch_stage / FA_TILES_X;
+      const int next_stage_X = next_prefetch_stage % FA_TILES_X;
+      const int next_global_offset_Y = block_offset_Y + next_stage_Y * FA_TILE_DIM_Y;
+      const int next_global_offset_X = block_offset_X + next_stage_X * FA_TILE_DIM_X;
+      if (leading_thread) {
+        ptx::mbarrier_arrive_expect_tx(&in_readable_mbar[next_prefetch_buff], shmem_buff_size);
+        ptx::cp_async_bulk_tensor_2d_global_to_shared(
+            reinterpret_cast<uint64_t *>(&sIn[next_prefetch_buff]),
+            reinterpret_cast<const uint64_t *>(&tensor_map_input), next_global_offset_X,
+            next_global_offset_Y, &in_readable_mbar[next_prefetch_buff]);
+      }
+      ptx::fence_proxy_async_shared_cta();
+    }
+
+    // Acquire wait orders the TMA store before the SMEM read; required for buffer reuse.
+    ptx::mbarrier_wait_parity_acquire_cta_shared_cta(&in_readable_mbar[buff_in],
+                                                     readable_parity[buff_in]);
+    readable_parity[buff_in] ^= 1;
+
+    if constexpr (DO_ROW) {
+      if (stage_Y == my_row_stage_Y) {
+        float local_max = row_partial;
+        const int row_bank_group = (my_row_in_subtile >> 2) & 0x7;
+#pragma unroll
+        for (int e_iter = 0; e_iter < FA_TILE_DIM_X / 8; ++e_iter) {
+          const int e = ((e_iter + row_bank_group) & 0x7) << 3;
+          __uint128_t elts_8x = ptx::ld_shared_b128(&sIn[buff_in][my_row_in_subtile][e]);
+          const IType2 *pairs = reinterpret_cast<const IType2 *>(&elts_8x);
+          IType2 amax_2x = {static_cast<IType>(0.0f), static_cast<IType>(0.0f)};
+#pragma unroll
+          for (int p = 0; p < 4; ++p) {
+            ptx::abs_max_2x(amax_2x, amax_2x, pairs[p]);
+          }
+          local_max = fmaxf(local_max,
+                            static_cast<float>(__hmax(__habs(amax_2x.x), __habs(amax_2x.y))));
+        }
+        row_partial = local_max;
+      }
+    }
+
+    if constexpr (DO_COL) {
+      if (stage_X == my_col_stage_X) {
+        float local_max = col_partial;
+#pragma unroll
+        for (int e = 0; e < FA_TILE_DIM_Y; ++e) {
+          const IType v = sIn[buff_in][e][my_col_in_subtile];
+          local_max = fmaxf(local_max, fabsf(static_cast<float>(v)));
+        }
+        col_partial = local_max;
+      }
+    }
+
+    __syncthreads();
+    buff_in = (buff_in + 1) % FA_BUFFS_NUM;
+  }
+
+  if constexpr (DO_ROW) {
+    atomicMaxFloat(&row_amax_out[local_row], row_partial);
+  }
+  if constexpr (DO_COL) {
+    atomicMaxFloat(&col_amax_out[global_col], col_partial);
+  }
+
+  if (leading_thread) {
+#pragma unroll
+    for (int buff = 0; buff < FA_BUFFS_NUM; ++buff) {
+      ptx::mbarrier_invalid(&in_readable_mbar[buff]);
+    }
+  }
+#else
+  NVTE_DEVICE_ERROR("Grouped fused amax kernel requires SM 10.0+ (Blackwell).");
+#endif  // __CUDA_ARCH__ >= 1000
+}
+
+#endif  // FP4_TYPE_SUPPORTED
+
+}  // namespace group_row_scaled_amax_kernel
+
+// Returns true if the packed grouped input and per-expert split sizes are eligible
+// for the single-launch fused amax path.
+inline bool group_fused_amax_supported(const Tensor &input, const size_t *split_sections,
+                                       size_t num_tensors) {
+#if FP4_TYPE_SUPPORTED
+  using namespace group_row_scaled_amax_kernel;
+  static const bool enabled = []() {
+    const char *e = std::getenv("NVTE_NVFP4_FUSED_AMAX");
+    return (e == nullptr) || (e[0] != '0');
+  }();
+  if (!enabled) return false;
+  if (num_tensors == 0 || num_tensors > static_cast<size_t>(kMaxAmaxTensorsPerKernel)) return false;
+  const auto [rows, cols] = input.flat_2d_dims();
+  if (input.dtype() != DType::kBFloat16) return false;
+  if (rows % FA_CHUNK_DIM_Y != 0 || cols % FA_CHUNK_DIM_X != 0) return false;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    if (split_sections[i] % FA_CHUNK_DIM_Y != 0) return false;
+  }
+  return true;
+#else
+  return false;
+#endif  // FP4_TYPE_SUPPORTED
+}
+
+// Single-launch fused row/col amax over a packed grouped (sum_M, K) BF16 input.
+// Writes per-expert rowwise amax [M_i] (output_list[i]->amax) and/or columnwise
+// amax [K] (output_list[i]->columnwise_amax).
+inline void group_compute_fused_amax(const Tensor &input, const Tensor *noop,
+                                     std::vector<Tensor *> &output_list,
+                                     const size_t *split_sections, size_t num_tensors,
+                                     cudaStream_t stream) {
+#if FP4_TYPE_SUPPORTED
+  using namespace group_row_scaled_amax_kernel;
+
+  const auto [rows, cols] = input.flat_2d_dims();
+  NVTE_CHECK(input.dtype() == DType::kBFloat16, "Grouped fused amax requires BF16 input.");
+  NVTE_CHECK(num_tensors <= static_cast<size_t>(kMaxAmaxTensorsPerKernel),
+             "Number of tensors should be <= ", kMaxAmaxTensorsPerKernel);
+
+  // Determine directions from the first non-empty output.
+  bool do_row = false;
+  bool do_col = false;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    if (split_sections[i] == 0) continue;
+    do_row = output_list[i]->amax.dptr != nullptr;
+    do_col = output_list[i]->columnwise_amax.dptr != nullptr;
+    break;
+  }
+  if (!do_row && !do_col) return;
+
+  GroupedFusedAmaxArgs args;
+  args.num_tensors = 0;
+  args.split_sections_range[0] = 0;
+  for (size_t i = 0; i < num_tensors; ++i) {
+    if (split_sections[i] == 0) continue;
+    args.row_amax_list[args.num_tensors] =
+        do_row ? reinterpret_cast<void *>(output_list[i]->amax.dptr) : nullptr;
+    args.col_amax_list[args.num_tensors] =
+        do_col ? reinterpret_cast<void *>(output_list[i]->columnwise_amax.dptr) : nullptr;
+    args.split_sections_range[args.num_tensors + 1] =
+        args.split_sections_range[args.num_tensors] + static_cast<int>(split_sections[i]);
+    args.num_tensors++;
+  }
+  NVTE_CHECK(args.split_sections_range[args.num_tensors] == static_cast<int>(rows),
+             "Sum of split sections must equal the number of input rows.");
+
+  checkCuDriverContext(stream);
+
+  const float *noop_ptr = (noop != nullptr && noop->data.dptr != nullptr)
+                              ? reinterpret_cast<const float *>(noop->data.dptr)
+                              : nullptr;
+
+  // Zero the per-expert amax vectors before atomicMax accumulation.
+  {
+    const dim3 zero_grid(static_cast<unsigned>(args.num_tensors),
+                         DIVUP(std::max(rows, cols), static_cast<size_t>(1024)));
+    group_fused_amax_zero_kernel<<<zero_grid, 256, 0, stream>>>(args, static_cast<int>(cols),
+                                                                noop_ptr);
+    NVTE_CHECK_CUDA(cudaGetLastError());
+  }
+
+  alignas(64) CUtensorMap tensor_map_input{};
+  create_2D_tensor_map(tensor_map_input, input.data, rows, cols, FA_TILE_DIM_Y, FA_TILE_DIM_X, cols,
+                       0, sizeof(__nv_bfloat16) * 8);
+
+  constexpr size_t buff_elems_total = FA_BUFFS_NUM * FA_BUFF_IN_SIZE;
+  constexpr size_t buff_size_aligned_in =
+      DIVUP_TO_MULTIPLE(buff_elems_total * sizeof(__nv_bfloat16), TMA_SHMEM_ALIGNMENT);
+  constexpr size_t dshmem_size = buff_size_aligned_in + TMA_SHMEM_ALIGNMENT;
+
+  const dim3 grid(static_cast<unsigned>(cols / FA_CHUNK_DIM_X),
+                  static_cast<unsigned>(rows / FA_CHUNK_DIM_Y), 1);
+  const dim3 block(FA_THREADS_NUM, 1, 1);
+
+  TRANSFORMER_ENGINE_SWITCH_CONDITION(
+      do_row, DO_ROW,
+      TRANSFORMER_ENGINE_SWITCH_CONDITION(do_col, DO_COL, {
+        auto kernel = group_compute_fused_amax_kernel<DO_ROW, DO_COL>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
+        kernel<<<grid, block, dshmem_size, stream>>>(tensor_map_input, args, noop_ptr, rows, cols);
+      }));
+  NVTE_CHECK_CUDA(cudaGetLastError());
+#else
+  NVTE_ERROR("FP4 support requires CUDA 12.8+, but compile-time CUDA version is ", CUDA_VERSION);
+#endif  // FP4_TYPE_SUPPORTED
+}
 
 namespace group_quantize_transpose_kernel {
 

--- a/transformer_engine/common/cast/nvfp4/group_quantize_transpose_nvfp4.cuh
+++ b/transformer_engine/common/cast/nvfp4/group_quantize_transpose_nvfp4.cuh
@@ -218,8 +218,8 @@ __global__ void __launch_bounds__(FA_THREADS_NUM)
           for (int p = 0; p < 4; ++p) {
             ptx::abs_max_2x(amax_2x, amax_2x, pairs[p]);
           }
-          local_max = fmaxf(local_max,
-                            static_cast<float>(__hmax(__habs(amax_2x.x), __habs(amax_2x.y))));
+          local_max =
+              fmaxf(local_max, static_cast<float>(__hmax(__habs(amax_2x.x), __habs(amax_2x.y))));
         }
         row_partial = local_max;
       }
@@ -358,8 +358,7 @@ inline void group_compute_fused_amax(const Tensor &input, const Tensor *noop,
   const dim3 block(FA_THREADS_NUM, 1, 1);
 
   TRANSFORMER_ENGINE_SWITCH_CONDITION(
-      do_row, DO_ROW,
-      TRANSFORMER_ENGINE_SWITCH_CONDITION(do_col, DO_COL, {
+      do_row, DO_ROW, TRANSFORMER_ENGINE_SWITCH_CONDITION(do_col, DO_COL, {
         auto kernel = group_compute_fused_amax_kernel<DO_ROW, DO_COL>;
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, dshmem_size);
         kernel<<<grid, block, dshmem_size, stream>>>(tensor_map_input, args, noop_ptr, rows, cols);

--- a/transformer_engine/common/cast/nvfp4/group_quantize_transpose_nvfp4.cuh
+++ b/transformer_engine/common/cast/nvfp4/group_quantize_transpose_nvfp4.cuh
@@ -242,10 +242,14 @@ __global__ void __launch_bounds__(FA_THREADS_NUM)
   }
 
   if constexpr (DO_ROW) {
-    atomicMaxFloat(&row_amax_out[local_row], row_partial);
+    if (row_amax_out != nullptr) {
+      atomicMaxFloat(&row_amax_out[local_row], row_partial);
+    }
   }
   if constexpr (DO_COL) {
-    atomicMaxFloat(&col_amax_out[global_col], col_partial);
+    if (col_amax_out != nullptr) {
+      atomicMaxFloat(&col_amax_out[global_col], col_partial);
+    }
   }
 
   if (leading_thread) {
@@ -301,15 +305,20 @@ inline void group_compute_fused_amax(const Tensor &input, const Tensor *noop,
   NVTE_CHECK(input.dtype() == DType::kBFloat16, "Grouped fused amax requires BF16 input.");
   NVTE_CHECK(num_tensors <= static_cast<size_t>(kMaxAmaxTensorsPerKernel),
              "Number of tensors should be <= ", kMaxAmaxTensorsPerKernel);
+  NVTE_CHECK(cols % FA_CHUNK_DIM_X == 0, "Grouped fused amax requires cols to be a multiple of ",
+             FA_CHUNK_DIM_X, " (got ", cols, ").");
 
-  // Determine directions from the first non-empty output.
+  // A direction runs if any non-empty expert allocates it; per-expert null buffers
+  // are then skipped by the kernel, so experts may opt in independently.
   bool do_row = false;
   bool do_col = false;
   for (size_t i = 0; i < num_tensors; ++i) {
     if (split_sections[i] == 0) continue;
-    do_row = output_list[i]->amax.dptr != nullptr;
-    do_col = output_list[i]->columnwise_amax.dptr != nullptr;
-    break;
+    NVTE_CHECK(split_sections[i] % FA_CHUNK_DIM_Y == 0,
+               "Grouped fused amax requires each split to be a multiple of ", FA_CHUNK_DIM_Y,
+               " (split ", i, " = ", split_sections[i], ").");
+    if (output_list[i]->amax.dptr != nullptr) do_row = true;
+    if (output_list[i]->columnwise_amax.dptr != nullptr) do_col = true;
   }
   if (!do_row && !do_col) return;
 
@@ -318,10 +327,9 @@ inline void group_compute_fused_amax(const Tensor &input, const Tensor *noop,
   args.split_sections_range[0] = 0;
   for (size_t i = 0; i < num_tensors; ++i) {
     if (split_sections[i] == 0) continue;
-    args.row_amax_list[args.num_tensors] =
-        do_row ? reinterpret_cast<void *>(output_list[i]->amax.dptr) : nullptr;
+    args.row_amax_list[args.num_tensors] = reinterpret_cast<void *>(output_list[i]->amax.dptr);
     args.col_amax_list[args.num_tensors] =
-        do_col ? reinterpret_cast<void *>(output_list[i]->columnwise_amax.dptr) : nullptr;
+        reinterpret_cast<void *>(output_list[i]->columnwise_amax.dptr);
     args.split_sections_range[args.num_tensors + 1] =
         args.split_sections_range[args.num_tensors] + static_cast<int>(split_sections[i]);
     args.num_tensors++;

--- a/transformer_engine/common/include/transformer_engine/cast.h
+++ b/transformer_engine/common/include/transformer_engine/cast.h
@@ -494,6 +494,24 @@ void nvte_group_nvfp4_quantize_with_amax(const NVTETensor input, NVTETensor *out
                                          const NVTEQuantizationConfig quant_config,
                                          cudaStream_t stream);
 
+/*! \brief Computes per-expert rowwise and/or columnwise amax for a grouped
+ *         row-scaled NVFP4 input in a single kernel launch.
+ *
+ *  The input is one packed (sum_M, K) BF16 buffer; `split_sections` gives the
+ *  per-expert row counts (each a multiple of 128). For expert i the rowwise amax
+ *  [M_i] is written to `outputs[i]->amax` and the columnwise amax [K] to
+ *  `outputs[i]->columnwise_amax`, whichever are allocated.
+ *
+ *  \param[in]      input           Packed grouped input tensor (BF16).
+ *  \param[in,out]  outputs         Per-expert output tensors receiving the amax vectors.
+ *  \param[in]      split_sections  Per-expert row counts.
+ *  \param[in]      num_tensors     Number of output tensors.
+ *  \param[in]      stream          CUDA stream used for the operation.
+ */
+void nvte_group_nvfp4_compute_amax(const NVTETensor input, NVTETensor *outputs,
+                                   const size_t *split_sections, size_t num_tensors,
+                                   cudaStream_t stream);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/transformer_engine/common/include/transformer_engine/cast.h
+++ b/transformer_engine/common/include/transformer_engine/cast.h
@@ -498,9 +498,11 @@ void nvte_group_nvfp4_quantize_with_amax(const NVTETensor input, NVTETensor *out
  *         row-scaled NVFP4 input in a single kernel launch.
  *
  *  The input is one packed (sum_M, K) BF16 buffer; `split_sections` gives the
- *  per-expert row counts (each a multiple of 128). For expert i the rowwise amax
- *  [M_i] is written to `outputs[i]->amax` and the columnwise amax [K] to
- *  `outputs[i]->columnwise_amax`, whichever are allocated.
+ *  per-expert row counts (each a multiple of 128) and K must also be a multiple
+ *  of 128. For expert i the rowwise amax [M_i] is written to `outputs[i]->amax`
+ *  and the columnwise amax [K] to `outputs[i]->columnwise_amax`, whichever are
+ *  allocated; experts may opt into either direction independently (a null buffer
+ *  is skipped).
  *
  *  \param[in]      input           Packed grouped input tensor (BF16).
  *  \param[in,out]  outputs         Per-expert output tensors receiving the amax vectors.


### PR DESCRIPTION
# Description

Adds a single-kernel row/col amax pass for grouped (MoE) row-scaled NVFP4. It replaces the per-expert loop of `compute_rowwise_amax` + `compute_columnwise_amax` with one launch over a packed `(sum_M, K)` input, exposed as `nvte_group_nvfp4_compute_amax`. The kernel is the grouped generalization of #3454 - the single-tensor `compute_fused_amax_kernel` (same tiling / SMEM pipeline / acquire-barrier reduction). A single input TMA map covers all experts; per-expert amax vectors are selected via a prefix sum of row counts, so a 128-row chunk always lands in one expert.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes
New gtest `tests/cpp/operator/test_row_scaled_nvfp4_grouped_amax.cu`:
- `NVFP4GroupedRowScaledAmaxTestSuite.MatchesPerExpertOracle` — grouped amax vs a CPU per-row/per-col `max(|x|)` reference over the same BF16 bytes, plus cross-launch determinism, across 6 expert/shape configs.
- `DISABLED_LoopVsGrouped` — microbench comparing the same kernel called per-expert (loop)
  vs once (grouped).
  
```bash
cmake -Btests/cpp/build tests/cpp && cmake --build tests/cpp/build -j
./tests/cpp/build/operator/test_operator --gtest_filter='*NVFP4GroupedRowScaledAmax*'
./tests/cpp/build/operator/test_operator --gtest_also_run_disabled_tests --gtest_filter='*GroupedRowScaledAmaxBench*'
```    
    
### Performance
Same kernel called per-expert (loop) vs a single grouped launch, GB200, K=4096. Speedup is loop / grouped.

| experts | M=128 loop→grouped (ms) | speedup | M=512 loop→grouped (ms) | speedup |
|---|---|---|---|---|
| 2  | 0.0179 → 0.0117 | 1.52x | 0.0180 → 0.0124 | 1.45x |
| 4  | 0.0288 → 0.0120 | 2.39x | 0.0271 → 0.0138 | 1.97x |
| 8  | 0.0513 → 0.0124 | 4.15x | 0.0514 → 0.0165 | 3.11x |
| 16 | 0.0950 → 0.0140 | 6.81x | 0.0960 → 0.0238 | 4.04x |
| 32 | 0.1852 → 0.0173 | 10.70x | 0.2009 → 0.0370 | 5.43x |
| 64 | 0.3631 → 0.0232 | 15.65x | 0.3960 → 0.0607 | 6.53x |  


# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
