### PR TITLE
Automatically omit unused columnwise primary weights for backward overrides

### DIFF
--- a/tests/pytorch/test_backward_override.py
+++ b/tests/pytorch/test_backward_override.py
@@ -90,6 +90,19 @@ _quantized_numerics_recipe_list = [
     ),
 ]
 
+_primary_weight_recipe_list = [
+    pytest.param(
+        "mxfp8",
+        marks=pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8),
+        id="MXFP8BlockScaling",
+    ),
+    pytest.param(
+        "nvfp4",
+        marks=pytest.mark.skipif(not nvfp4_available, reason=reason_for_no_nvfp4),
+        id="NVFP4BlockScaling1D",
+    ),
+]
+
 
 @pytest.fixture(autouse=True)
 def _reset_global_fp8_state():
@@ -856,6 +869,46 @@ def test_backward_override_recipe_matches_requested_mode(
     quant_recipe = make_recipe(recipe_name)
     assert mode_recipe.backward_override == backward_override
     assert quant_recipe.backward_override is None
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+@pytest.mark.parametrize("backward_override", (None, *_BACKWARD_OVERRIDES))
+def test_primary_weight_layout_respects_backward_override(
+    recipe_name: str,
+    backward_override: Optional[str],
+) -> None:
+    """Primary weights only keep representations consumed by the configured backward."""
+    mode_recipe = make_recipe(recipe_name, backward_override=backward_override)
+    skip_unsupported_backward_override("linear", mode_recipe, backward_override)
+
+    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+        module = te.Linear(
+            64,
+            64,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    weight = module.weight
+    expect_columnwise = backward_override is None
+
+    def _check_weight_layout() -> None:
+        assert weight._rowwise_data is not None
+        assert weight._rowwise_scale_inv is not None
+        assert (weight._columnwise_data is not None) == expect_columnwise
+        assert (weight._columnwise_scale_inv is not None) == expect_columnwise
+        if hasattr(weight, "_amax_columnwise"):
+            assert (weight._amax_columnwise is not None) == expect_columnwise
+
+    _check_weight_layout()
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    with te.autocast(enabled=True, recipe=mode_recipe):
+        y = module(x)
+    y.sum().backward()
+
+    _check_weight_layout()
 
 
 @pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)

--- a/tests/pytorch/test_backward_override.py
+++ b/tests/pytorch/test_backward_override.py
@@ -872,16 +872,26 @@ def test_backward_override_recipe_matches_requested_mode(
 
 
 @pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
-@pytest.mark.parametrize("backward_override", (None, *_BACKWARD_OVERRIDES))
-def test_primary_weight_layout_respects_backward_override(
+@pytest.mark.parametrize("backward_override", _BACKWARD_OVERRIDES)
+@pytest.mark.parametrize(
+    "omit_columnwise_primary_weight_storage",
+    (False, True),
+    ids=("default_storage", "rowwise_only"),
+)
+def test_primary_weight_layout_with_backward_override(
     recipe_name: str,
-    backward_override: Optional[str],
+    backward_override: str,
+    omit_columnwise_primary_weight_storage: bool,
 ) -> None:
-    """Primary weights only keep representations consumed by the configured backward."""
+    """Columnwise primary-weight storage is omitted only when explicitly requested."""
     mode_recipe = make_recipe(recipe_name, backward_override=backward_override)
     skip_unsupported_backward_override("linear", mode_recipe, backward_override)
 
-    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+    with te.quantized_model_init(
+        enabled=True,
+        recipe=mode_recipe,
+        omit_columnwise_primary_weight_storage=omit_columnwise_primary_weight_storage,
+    ):
         module = te.Linear(
             64,
             64,
@@ -891,7 +901,7 @@ def test_primary_weight_layout_respects_backward_override(
         )
 
     weight = module.weight
-    expect_columnwise = backward_override is None
+    expect_columnwise = not omit_columnwise_primary_weight_storage
 
     def _check_weight_layout() -> None:
         assert weight._rowwise_data is not None
@@ -909,6 +919,66 @@ def test_primary_weight_layout_respects_backward_override(
     y.sum().backward()
 
     _check_weight_layout()
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+def test_default_primary_weight_storage_allows_quantized_backward_switch(
+    recipe_name: str,
+) -> None:
+    """Default storage preserves runtime switches from an override to quantized backward."""
+    mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
+    default_recipe = make_recipe(recipe_name)
+
+    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+        module = te.Linear(
+            64,
+            64,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    with te.autocast(enabled=True, recipe=default_recipe):
+        y = module(x)
+    y.sum().backward()
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+def test_rowwise_only_primary_weight_rejects_quantized_backward(recipe_name: str) -> None:
+    """A rowwise-only primary weight fails before quantized backward requests columnwise data."""
+    mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
+    default_recipe = make_recipe(recipe_name)
+
+    with te.quantized_model_init(
+        enabled=True,
+        recipe=mode_recipe,
+        omit_columnwise_primary_weight_storage=True,
+    ):
+        module = te.Linear(
+            64,
+            64,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    with pytest.raises(RuntimeError, match="without columnwise storage"):
+        with te.autocast(enabled=True, recipe=default_recipe):
+            module(x)
+
+
+@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
+def test_rowwise_only_primary_weight_requires_backward_override(recipe_name: str) -> None:
+    """The rowwise-only opt-in rejects recipes that need quantized backward."""
+    with pytest.raises(ValueError, match="requires a recipe with backward_override"):
+        with te.quantized_model_init(
+            enabled=True,
+            recipe=make_recipe(recipe_name),
+            omit_columnwise_primary_weight_storage=True,
+        ):
+            pass
 
 
 @pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)

--- a/tests/pytorch/test_backward_override.py
+++ b/tests/pytorch/test_backward_override.py
@@ -872,36 +872,26 @@ def test_backward_override_recipe_matches_requested_mode(
 
 
 @pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
-@pytest.mark.parametrize("backward_override", _BACKWARD_OVERRIDES)
-@pytest.mark.parametrize(
-    "omit_columnwise_primary_weight_storage",
-    (False, True),
-    ids=("default_storage", "rowwise_only"),
-)
+@pytest.mark.parametrize("backward_override", (None, *_BACKWARD_OVERRIDES))
+@pytest.mark.parametrize("module_kind", ("linear", "basic_linear"))
 def test_primary_weight_layout_with_backward_override(
     recipe_name: str,
-    backward_override: str,
-    omit_columnwise_primary_weight_storage: bool,
+    backward_override: Optional[str],
+    module_kind: str,
 ) -> None:
-    """Columnwise primary-weight storage is omitted only when explicitly requested."""
+    """The recipe determines primary storage, which survives forward/backward."""
     mode_recipe = make_recipe(recipe_name, backward_override=backward_override)
-    skip_unsupported_backward_override("linear", mode_recipe, backward_override)
+    if backward_override is not None:
+        skip_unsupported_backward_override("linear", mode_recipe, backward_override)
 
-    with te.quantized_model_init(
-        enabled=True,
-        recipe=mode_recipe,
-        omit_columnwise_primary_weight_storage=omit_columnwise_primary_weight_storage,
-    ):
-        module = te.Linear(
-            64,
-            64,
-            bias=False,
-            params_dtype=torch.bfloat16,
-            device="cuda",
-        )
+    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+        if module_kind == "linear":
+            module = te.Linear(64, 64, bias=False, params_dtype=torch.bfloat16, device="cuda")
+        else:
+            module = te_ops.BasicLinear(64, 64, dtype=torch.bfloat16, device="cuda")
 
     weight = module.weight
-    expect_columnwise = not omit_columnwise_primary_weight_storage
+    expect_columnwise = backward_override is None
 
     def _check_weight_layout() -> None:
         assert weight._rowwise_data is not None
@@ -925,11 +915,11 @@ def test_primary_weight_layout_with_backward_override(
 def test_default_primary_weight_storage_allows_quantized_backward_switch(
     recipe_name: str,
 ) -> None:
-    """Default storage preserves runtime switches from an override to quantized backward."""
+    """Weights initialized for quantized backward can enter and leave override mode."""
     mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
     default_recipe = make_recipe(recipe_name)
 
-    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+    with te.quantized_model_init(enabled=True, recipe=default_recipe):
         module = te.Linear(
             64,
             64,
@@ -939,29 +929,26 @@ def test_default_primary_weight_storage_allows_quantized_backward_switch(
         )
 
     x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-    with te.autocast(enabled=True, recipe=default_recipe):
-        y = module(x)
-    y.sum().backward()
+    for runtime_recipe in (mode_recipe, default_recipe):
+        with te.autocast(enabled=True, recipe=runtime_recipe):
+            y = module(x)
+        y.sum().backward()
 
 
 @pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
-def test_rowwise_only_primary_weight_rejects_quantized_backward(recipe_name: str) -> None:
+@pytest.mark.parametrize("module_kind", ("linear", "basic_linear"))
+def test_rowwise_only_primary_weight_rejects_quantized_backward(
+    recipe_name: str, module_kind: str
+) -> None:
     """A rowwise-only primary weight fails before quantized backward requests columnwise data."""
     mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
     default_recipe = make_recipe(recipe_name)
 
-    with te.quantized_model_init(
-        enabled=True,
-        recipe=mode_recipe,
-        omit_columnwise_primary_weight_storage=True,
-    ):
-        module = te.Linear(
-            64,
-            64,
-            bias=False,
-            params_dtype=torch.bfloat16,
-            device="cuda",
-        )
+    with te.quantized_model_init(enabled=True, recipe=mode_recipe):
+        if module_kind == "linear":
+            module = te.Linear(64, 64, bias=False, params_dtype=torch.bfloat16, device="cuda")
+        else:
+            module = te_ops.BasicLinear(64, 64, dtype=torch.bfloat16, device="cuda")
 
     x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
     with pytest.raises(RuntimeError, match="without columnwise storage"):
@@ -969,16 +956,27 @@ def test_rowwise_only_primary_weight_rejects_quantized_backward(recipe_name: str
             module(x)
 
 
-@pytest.mark.parametrize("recipe_name", _primary_weight_recipe_list)
-def test_rowwise_only_primary_weight_requires_backward_override(recipe_name: str) -> None:
-    """The rowwise-only opt-in rejects recipes that need quantized backward."""
-    with pytest.raises(ValueError, match="requires a recipe with backward_override"):
-        with te.quantized_model_init(
-            enabled=True,
-            recipe=make_recipe(recipe_name),
-            omit_columnwise_primary_weight_storage=True,
-        ):
-            pass
+@pytest.mark.skipif(not mxfp8_available, reason=reason_for_no_mxfp8)
+@pytest.mark.parametrize("backward_override", (None, *_BACKWARD_OVERRIDES))
+def test_grouped_op_primary_weight_layout(backward_override: Optional[str]) -> None:
+    """Packed op weights use the same recipe-driven allocation policy as modules.
+
+    This checks allocation, not support for grouped-op override backward.
+    """
+    mode_recipe = make_recipe("mxfp8", backward_override=backward_override)
+    with te.quantized_model_init(recipe=mode_recipe):
+        module = te_ops.GroupedLinear(2, 64, 64, bias=False, dtype=torch.bfloat16, device="cuda")
+    for idx in range(2):
+        weight = getattr(module, f"weight{idx}")
+        assert weight._rowwise_data is not None
+        assert weight._rowwise_scale_inv is not None
+        assert (weight._columnwise_data is not None) == (backward_override is None)
+        assert (weight._columnwise_scale_inv is not None) == (backward_override is None)
+
+    if backward_override is not None:
+        with te.autocast(recipe=make_recipe("mxfp8")):
+            with pytest.raises(RuntimeError, match="without columnwise storage"):
+                module.pre_fuser_forward(requires_grad=True)
 
 
 @pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -910,6 +910,9 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         self.param_init_meta = {}
         self.primary_weights_in_fp8 = FP8GlobalStateManager.with_fp8_parameters()
         self.preserve_high_precision_init_val = FP8GlobalStateManager.with_high_precision_init_val()
+        self.omit_columnwise_primary_weight_storage = (
+            FP8GlobalStateManager.should_omit_columnwise_primary_weight_storage()
+        )
         self.fsdp_wrapped = False
         self.fsdp_group = None
         self._fp8_workspaces: Dict[str, QuantizedTensor] = {}
@@ -1845,13 +1848,10 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 quantizer = self.quantizers["scaling_fwd"][fp8_meta_index]
                 if quantizer is None:
                     raise RuntimeError("Weight quantizer has not been initialized")
-                # Backward overrides consume high-precision or dequantized weights,
-                # so they do not need a quantized columnwise representation.
                 quantizer.set_usage(
                     rowwise=True,
                     columnwise=(
-                        torch.is_grad_enabled()
-                        and self.fp8_meta["recipe"].backward_override is None
+                        torch.is_grad_enabled() and not self.omit_columnwise_primary_weight_storage
                     ),
                 )
                 quantizer.internal = False
@@ -2069,6 +2069,12 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             return
 
         recipe = self.fp8_meta["recipe"]
+        if self.omit_columnwise_primary_weight_storage and recipe.backward_override is None:
+            raise RuntimeError(
+                "Primary weights were initialized without columnwise storage, but the current "
+                "recipe uses quantized backward. Recreate the model with columnwise primary-weight "
+                "storage or keep backward_override set to 'high_precision' or 'dequantized'."
+            )
         weight_tensors = [getattr(self, name) for name in self.weight_names]
         for i, tensor in enumerate(weight_tensors):
             if isinstance(tensor, QuantizedTensorStorage):

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -1845,7 +1845,15 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 quantizer = self.quantizers["scaling_fwd"][fp8_meta_index]
                 if quantizer is None:
                     raise RuntimeError("Weight quantizer has not been initialized")
-                quantizer.set_usage(rowwise=True, columnwise=torch.is_grad_enabled())
+                # Backward overrides consume high-precision or dequantized weights,
+                # so they do not need a quantized columnwise representation.
+                quantizer.set_usage(
+                    rowwise=True,
+                    columnwise=(
+                        torch.is_grad_enabled()
+                        and self.fp8_meta["recipe"].backward_override is None
+                    ),
+                )
                 quantizer.internal = False
                 # HybridQuantizer is included so its current-scaling / NVFP4
                 # sub-quantizers get the same cross-shard amax reduction as the

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -910,9 +910,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
         self.param_init_meta = {}
         self.primary_weights_in_fp8 = FP8GlobalStateManager.with_fp8_parameters()
         self.preserve_high_precision_init_val = FP8GlobalStateManager.with_high_precision_init_val()
-        self.omit_columnwise_primary_weight_storage = (
-            FP8GlobalStateManager.should_omit_columnwise_primary_weight_storage()
-        )
+        self._primary_weights_rowwise_only = False
         self.fsdp_wrapped = False
         self.fsdp_group = None
         self._fp8_workspaces: Dict[str, QuantizedTensor] = {}
@@ -1848,11 +1846,13 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
                 quantizer = self.quantizers["scaling_fwd"][fp8_meta_index]
                 if quantizer is None:
                     raise RuntimeError("Weight quantizer has not been initialized")
+                self._primary_weights_rowwise_only = (
+                    FP8GlobalStateManager.get_fp8_recipe().backward_override
+                    in ("high_precision", "dequantized")
+                )
                 quantizer.set_usage(
                     rowwise=True,
-                    columnwise=(
-                        torch.is_grad_enabled() and not self.omit_columnwise_primary_weight_storage
-                    ),
+                    columnwise=torch.is_grad_enabled() and not self._primary_weights_rowwise_only,
                 )
                 quantizer.internal = False
                 # HybridQuantizer is included so its current-scaling / NVFP4
@@ -2069,7 +2069,7 @@ class TransformerEngineBaseModule(torch.nn.Module, ABC):
             return
 
         recipe = self.fp8_meta["recipe"]
-        if self.omit_columnwise_primary_weight_storage and recipe.backward_override is None:
+        if self._primary_weights_rowwise_only and recipe.backward_override is None:
             raise RuntimeError(
                 "Primary weights were initialized without columnwise storage, but the current "
                 "recipe uses quantized backward. Recreate the model with columnwise primary-weight "

--- a/transformer_engine/pytorch/ops/basic/basic_linear.py
+++ b/transformer_engine/pytorch/ops/basic/basic_linear.py
@@ -328,9 +328,13 @@ class BasicLinear(BasicOperation):
                     "within quantized_model_init, but the forward pass was not "
                     "performed within autocast."
                 )
+            self._primary_weight_rowwise_only = (
+                FP8GlobalStateManager.get_fp8_recipe().backward_override
+                in ("high_precision", "dequantized")
+            )
             quantizer.set_usage(
                 rowwise=True,
-                columnwise=torch.is_grad_enabled(),
+                columnwise=torch.is_grad_enabled() and not self._primary_weight_rowwise_only,
             )
             quantizer.internal = False
             with torch.no_grad():
@@ -347,6 +351,15 @@ class BasicLinear(BasicOperation):
             self.reset_parameters()
 
     def pre_fuser_forward(self, *, requires_grad: bool) -> None:
+        if (
+            FP8GlobalStateManager.is_fp8_enabled()
+            and getattr(self, "_primary_weight_rowwise_only", False)
+            and FP8GlobalStateManager.get_fp8_recipe().backward_override is None
+        ):
+            raise RuntimeError(
+                "Primary weights were initialized without columnwise storage; "
+                "keep backward_override set to 'high_precision' or 'dequantized'."
+            )
         super().pre_fuser_forward(requires_grad=requires_grad)
         if FP8GlobalStateManager.is_fp8_enabled():
             # Configure quantizer usages

--- a/transformer_engine/pytorch/ops/basic/grouped_linear.py
+++ b/transformer_engine/pytorch/ops/basic/grouped_linear.py
@@ -463,7 +463,13 @@ class GroupedLinear(BasicOperation):
                 self.get_quantizer("forward", 2 * idx + 1) for idx in range(self.num_groups)
             ]
             with_rowwise_usage = True
-            with_columnwise_usage = torch.is_grad_enabled()
+            self._primary_weights_rowwise_only = (
+                FP8GlobalStateManager.get_fp8_recipe().backward_override
+                in ("high_precision", "dequantized")
+            )
+            with_columnwise_usage = (
+                torch.is_grad_enabled() and not self._primary_weights_rowwise_only
+            )
             for quantizer in quantizers:
                 if quantizer is None:
                     raise RuntimeError(
@@ -756,6 +762,15 @@ class GroupedLinear(BasicOperation):
                         )
 
     def pre_fuser_forward(self, *, requires_grad: bool) -> None:
+        if (
+            FP8GlobalStateManager.is_fp8_enabled()
+            and getattr(self, "_primary_weights_rowwise_only", False)
+            and FP8GlobalStateManager.get_fp8_recipe().backward_override is None
+        ):
+            raise RuntimeError(
+                "Primary weights were initialized without columnwise storage; "
+                "keep backward_override set to 'high_precision' or 'dequantized'."
+            )
         super().pre_fuser_forward(requires_grad=requires_grad)
         if FP8GlobalStateManager.is_fp8_enabled():
             # Assume weights have consistent grad requirement

--- a/transformer_engine/pytorch/quantization.py
+++ b/transformer_engine/pytorch/quantization.py
@@ -399,6 +399,7 @@ class FP8GlobalState:
     fp8_distributed_group: Optional[dist_group_type] = None
     fp8_parameters: bool = False
     high_precision_init_val: bool = False
+    omit_columnwise_primary_weight_storage: bool = False
     is_first_fp8_module: bool = False
     fp8_graph_capturing: bool = False
     autocast_depth: int = 0
@@ -583,6 +584,11 @@ class FP8GlobalStateManager:
     def with_high_precision_init_val(cls) -> bool:
         """Should the high precision initial values be stored with FP8 parameters"""
         return cls.quantization_state.high_precision_init_val
+
+    @classmethod
+    def should_omit_columnwise_primary_weight_storage(cls) -> bool:
+        """Should quantized primary weights omit columnwise storage"""
+        return cls.quantization_state.omit_columnwise_primary_weight_storage
 
     @classmethod
     def fp8_graph_capturing(cls) -> bool:
@@ -879,6 +885,7 @@ def quantized_model_init(
     enabled: bool = True,
     recipe: Optional[Recipe] = None,
     preserve_high_precision_init_val: bool = False,
+    omit_columnwise_primary_weight_storage: bool = False,
 ) -> None:
     """
     Context manager for initialization of quantized parameters.
@@ -921,21 +928,42 @@ def quantized_model_init(
              users should call `clear_high_precision_init_val()` to release this CPU memory.
 
              This functionality is *EXPERIMENTAL*.
+    omit_columnwise_primary_weight_storage : bool, default = False
+             when enabled, initialize quantized primary weights with rowwise storage only.
+             This requires a recipe with ``backward_override`` set to ``"high_precision"``
+             or ``"dequantized"`` and is intended for fixed-mode workloads such as frozen
+             LoRA base weights. A model initialized this way cannot later use quantized
+             backward without reconstructing its primary weights with columnwise storage.
+
+             This functionality is *EXPERIMENTAL*.
     """
 
     qstate = FP8GlobalStateManager.quantization_state
     _fp8_parameters = qstate.fp8_parameters
     _fp8_recipe = qstate.fp8_recipe
     _high_precision_init_val = qstate.high_precision_init_val
+    _omit_columnwise_primary_weight_storage = qstate.omit_columnwise_primary_weight_storage
+    resolved_recipe = get_default_fp8_recipe() if recipe is None else recipe
+    if (
+        enabled
+        and omit_columnwise_primary_weight_storage
+        and resolved_recipe.backward_override is None
+    ):
+        raise ValueError(
+            "omit_columnwise_primary_weight_storage requires a recipe with "
+            "backward_override='high_precision' or 'dequantized'"
+        )
     qstate.fp8_parameters = enabled
-    qstate.fp8_recipe = get_default_fp8_recipe() if recipe is None else recipe
+    qstate.fp8_recipe = resolved_recipe
     qstate.high_precision_init_val = preserve_high_precision_init_val
+    qstate.omit_columnwise_primary_weight_storage = omit_columnwise_primary_weight_storage
     try:
         yield
     finally:
         qstate.fp8_parameters = _fp8_parameters
         qstate.fp8_recipe = _fp8_recipe
         qstate.high_precision_init_val = _high_precision_init_val
+        qstate.omit_columnwise_primary_weight_storage = _omit_columnwise_primary_weight_storage
 
 
 def fp8_autocast(

--- a/transformer_engine/pytorch/quantization.py
+++ b/transformer_engine/pytorch/quantization.py
@@ -399,7 +399,6 @@ class FP8GlobalState:
     fp8_distributed_group: Optional[dist_group_type] = None
     fp8_parameters: bool = False
     high_precision_init_val: bool = False
-    omit_columnwise_primary_weight_storage: bool = False
     is_first_fp8_module: bool = False
     fp8_graph_capturing: bool = False
     autocast_depth: int = 0
@@ -584,11 +583,6 @@ class FP8GlobalStateManager:
     def with_high_precision_init_val(cls) -> bool:
         """Should the high precision initial values be stored with FP8 parameters"""
         return cls.quantization_state.high_precision_init_val
-
-    @classmethod
-    def should_omit_columnwise_primary_weight_storage(cls) -> bool:
-        """Should quantized primary weights omit columnwise storage"""
-        return cls.quantization_state.omit_columnwise_primary_weight_storage
 
     @classmethod
     def fp8_graph_capturing(cls) -> bool:
@@ -885,7 +879,6 @@ def quantized_model_init(
     enabled: bool = True,
     recipe: Optional[Recipe] = None,
     preserve_high_precision_init_val: bool = False,
-    omit_columnwise_primary_weight_storage: bool = False,
 ) -> None:
     """
     Context manager for initialization of quantized parameters.
@@ -928,42 +921,27 @@ def quantized_model_init(
              users should call `clear_high_precision_init_val()` to release this CPU memory.
 
              This functionality is *EXPERIMENTAL*.
-    omit_columnwise_primary_weight_storage : bool, default = False
-             when enabled, initialize quantized primary weights with rowwise storage only.
-             This requires a recipe with ``backward_override`` set to ``"high_precision"``
-             or ``"dequantized"`` and is intended for fixed-mode workloads such as frozen
-             LoRA base weights. A model initialized this way cannot later use quantized
-             backward without reconstructing its primary weights with columnwise storage.
 
-             This functionality is *EXPERIMENTAL*.
+    Recipes with ``backward_override="high_precision"`` or ``"dequantized"``
+    automatically omit columnwise primary-weight storage. Such weights must be
+    reconstructed with columnwise storage before switching to quantized backward
+    or using an external optimizer that requires both storage directions.
     """
 
     qstate = FP8GlobalStateManager.quantization_state
     _fp8_parameters = qstate.fp8_parameters
     _fp8_recipe = qstate.fp8_recipe
     _high_precision_init_val = qstate.high_precision_init_val
-    _omit_columnwise_primary_weight_storage = qstate.omit_columnwise_primary_weight_storage
     resolved_recipe = get_default_fp8_recipe() if recipe is None else recipe
-    if (
-        enabled
-        and omit_columnwise_primary_weight_storage
-        and resolved_recipe.backward_override is None
-    ):
-        raise ValueError(
-            "omit_columnwise_primary_weight_storage requires a recipe with "
-            "backward_override='high_precision' or 'dequantized'"
-        )
     qstate.fp8_parameters = enabled
     qstate.fp8_recipe = resolved_recipe
     qstate.high_precision_init_val = preserve_high_precision_init_val
-    qstate.omit_columnwise_primary_weight_storage = omit_columnwise_primary_weight_storage
     try:
         yield
     finally:
         qstate.fp8_parameters = _fp8_parameters
         qstate.fp8_recipe = _fp8_recipe
         qstate.high_precision_init_val = _high_precision_init_val
-        qstate.omit_columnwise_primary_weight_storage = _omit_columnwise_primary_weight_storage
 
 
 def fp8_autocast(


### PR DESCRIPTION
## Description

Optimization for memory usage for: https://github.com/radixark/miles/issues/615

Quantized primary weights normally allocate rowwise and columnwise representations when autograd is enabled. With `backward_override="high_precision"` or `"dequantized"`, the backward computation does not consume the columnwise primary weight. Keeping that representation wastes persistent memory, especially for a large frozen LoRA base.

Primary-weight initialization now derives its storage usage from the recipe automatically:

```python
recipe = MXFP8BlockScaling(backward_override="dequantized")
with te.quantized_model_init(recipe=recipe):
    model = te.Linear(...)
```

No storage-policy argument is required. With an override recipe, primary weights are initialized rowwise-only. Without an override, autograd-enabled initialization retains both directions. The same allocation policy applies to the module API and the op fuser's `BasicLinear` and `GroupedLinear`.

The implementation records the inferred policy locally to reject an incompatible switch to default quantized backward before it requests missing columnwise storage. Weights initialized with both directions can still enter and leave override mode. There is no new global storage-policy state or public opt-in.

For block-scaled formats, omitting one persistent direction saves approximately 1.03 bytes/parameter for MXFP8 and 0.56 bytes/parameter for 1D NVFP4 before padding. The NVFP4 tests use one-dimensional scaling.

## Compatibility

This changes storage automatically for override recipes, including trainable primary weights. External optimizers or distributed writeback paths that require both directions must initialize with a non-override recipe or add row-only support. In particular, current Megatron distributed MXFP8 master-weight writeback still assumes columnwise data and scales exist; this PR does not change that integration. Frozen LoRA bases excluded from optimizer parameter groups do not enter that writeback path.

The op fuser GroupedLinear change covers allocation and incompatible-recipe checking; it does not add grouped-op backward-override compute support.

## Tests and validation

- MXFP8 and 1D NVFP4: recipe-derived layout and forward/backward coverage for Linear and BasicLinear, plus incompatible recipe switching.
- Bidirectional initialization followed by override and default quantized backward.
- GroupedLinear packed MXFP8 allocation with and without overrides, and incompatible recipe rejection.
- Repository-configured Black 24.4.2, Python syntax compilation, and `git diff --check` passed.
- Pylint passed for all four changed source files (10.00/10) using the local Python 3.14 lint environment.
- CUDA tests were not run locally; this host has no CUDA/Blackwell runtime.
