### PR TITLE
Drop the unsupported window_size argument from attention backend queries

### DIFF
--- a/benchmarks/attention/benchmark_attention.py
+++ b/benchmarks/attention/benchmark_attention.py
@@ -195,7 +195,6 @@ def main():
             config,
             qkv_dtype=dtype,
             qkv_layout=qkv_layout,
-            window_size=config.window_size,
             pad_between_seqs=pad_between_seqs,
         )
         flash_attn_supported, fused_attn_supported, unfused_attn_supported = available_backends

--- a/docs/examples/attention/example_attention.py
+++ b/docs/examples/attention/example_attention.py
@@ -90,7 +90,6 @@ def main():
             config,
             qkv_dtype=dtype,
             qkv_layout=qkv_layout,
-            window_size=config.window_size,
             pad_between_seqs=pad_between_seqs,
         )
         flash_attn_supported, fused_attn_supported, unfused_attn_supported = available_backends


### PR DESCRIPTION
## Description

`get_available_attention_backends()` (`tests/pytorch/utils.py:335`) does not accept a `window_size` argument and has no `**kwargs`:

```python
def get_available_attention_backends(
    config: ModelConfig,
    qkv_dtype: torch.dtype,
    qkv_layout: str,
    pad_between_seqs: bool = False,
    deterministic: bool = False,
    fp8: bool = False,
    fp8_meta: Optional[Dict[str, Any]] = None,
    is_training: bool = True,
    inference_params: Optional[InferenceParams] = None,
    score_mod: bool = False,
    score_mod_bprop: bool = False,
) -> Tuple[List, List]:
```

Two call sites still pass it, so both raise `TypeError` before a single backend is queried:

- `benchmarks/attention/benchmark_attention.py:198`
- `docs/examples/attention/example_attention.py:93`

```
TypeError: get_available_attention_backends() got an unexpected keyword argument 'window_size'
```

The second one is the script the attention documentation tells readers to run — `docs/examples/attention/attention.ipynb` executes `!NVTE_DEBUG=1 NVTE_DEBUG_LEVEL=1 python example_attention.py` — so the documented example currently cannot run.

The argument is redundant as well as invalid: `get_available_attention_backends` already reads the window size off the config itself when it assembles the `DotProductAttention` kwargs (`tests/pytorch/utils.py:392`, `window_size=config.window_size`). Every one of the ~20 other call sites (`tests/pytorch/attention/test_attention.py`, `test_attention_with_cp.py`, `test_flex_attention.py`, `test_kv_cache.py`, …) omits it.

## Fix

Drop the `window_size=config.window_size,` line from the two offending calls. No behaviour change — the helper derives the same value from `config`.

## Verification

No GPU is required to see the failure; it is argument binding, before any CUDA work. Reconstructed the real signature out of `tests/pytorch/utils.py` with `ast` and replayed both call shapes through `inspect.Signature.bind`:

```
SIGNATURE: (config, qkv_dtype, qkv_layout, pad_between_seqs=None, deterministic=None,
            fp8=None, fp8_meta=None, is_training=None, inference_params=None,
            score_mod=None, score_mod_bprop=None)

FAIL  benchmark_attention.py:198 & docs/example_attention.py:93
      -> TypeError: got an unexpected keyword argument 'window_size'
OK    tests/pytorch/attention/test_attention.py:215 (sibling call, no window_size)
```

After the patch both call sites bind cleanly. `black 24.4.2 --line-length=100 --preview --enable-unstable-feature=string_processing` reports both files unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
