### PR TITLE
[Common] Preserve shared-memory pointer provenance in TMA kernels

### DIFF
--- a/transformer_engine/common/cast/core/grouped_tma.cuh
+++ b/transformer_engine/common/cast/core/grouped_tma.cuh
@@ -53,12 +53,6 @@ inline bool dimensions_supported_by_TMA(const Tensor *const t) {
   return cols % alignment_requirement == 0;
 }
 
-__device__ __forceinline__ unsigned char *align_smem_ptr_per_TMA_requirements(unsigned char *p) {
-  size_t addr = reinterpret_cast<size_t>(p);
-  addr = (addr + TMA_SHMEM_ALIGNMENT - 1) & ~(TMA_SHMEM_ALIGNMENT - 1);
-  return reinterpret_cast<unsigned char *>(addr);
-}
-
 // Copies the base tensor map to shmem, modifies the copy, stores the modified tensor map at index
 __device__ __forceinline__ void modify_base_tensor_map(const CUtensorMap base_tensor_map,
                                                        CUtensorMap *global_tensor_map,

--- a/transformer_engine/common/cast/fp8_blockwise/group_quantize_fp8_blockwise.cuh
+++ b/transformer_engine/common/cast/fp8_blockwise/group_quantize_fp8_blockwise.cuh
@@ -315,8 +315,8 @@ __global__ void __launch_bounds__(kThreadsPerBlock, 4) group_block_scaled_2d_tma
   // Dynamic smem holds the IType input tile (TMA dest, must be 128 B aligned).
   // warp_amaxes and tma_mbar are static smem.
   extern __shared__ char smem_raw_2d_tma[];
-  IType(*smem_in)[kTileDim] = reinterpret_cast<IType(*)[kTileDim]>(
-      align_up(smem_raw_2d_tma, TMA_SHMEM_ALIGNMENT));
+  IType(*smem_in)[kTileDim] =
+      reinterpret_cast<IType(*)[kTileDim]>(align_up(smem_raw_2d_tma, TMA_SHMEM_ALIGNMENT));
 
   __shared__ CType warp_amaxes[kNumWarps];
   __shared__ size_t warp_offset_partials[kNumWarps];
@@ -604,7 +604,7 @@ __global__ void __launch_bounds__(kThreadsPerBlock) group_block_scaled_1d_tma_ke
   // Dynamic smem: IType[kTileDim][kTileDim], 128 B aligned for TMA. Static smem
   // (smem_T when CW, tma_mbar) lives outside the dynamic region.
   extern __shared__ char smem_raw_1d_tma[];
-  char *smem_base = align_up(smem_raw_1d_tma, TMA_SHMEM_ALIGNMENT);
+  char* smem_base = align_up(smem_raw_1d_tma, TMA_SHMEM_ALIGNMENT);
   IType(*smem)[kTileDim] = reinterpret_cast<IType(*)[kTileDim]>(smem_base);
 
   __shared__ uint64_t tma_mbar;

--- a/transformer_engine/common/cast/fp8_blockwise/group_quantize_fp8_blockwise.cuh
+++ b/transformer_engine/common/cast/fp8_blockwise/group_quantize_fp8_blockwise.cuh
@@ -314,9 +314,9 @@ __global__ void __launch_bounds__(kThreadsPerBlock, 4) group_block_scaled_2d_tma
 
   // Dynamic smem holds the IType input tile (TMA dest, must be 128 B aligned).
   // warp_amaxes and tma_mbar are static smem.
-  extern __shared__ unsigned char smem_raw_2d_tma[];
+  extern __shared__ char smem_raw_2d_tma[];
   IType(*smem_in)[kTileDim] = reinterpret_cast<IType(*)[kTileDim]>(
-      common::align_smem_ptr_per_TMA_requirements(smem_raw_2d_tma));
+      align_up(smem_raw_2d_tma, TMA_SHMEM_ALIGNMENT));
 
   __shared__ CType warp_amaxes[kNumWarps];
   __shared__ size_t warp_offset_partials[kNumWarps];
@@ -603,8 +603,8 @@ __global__ void __launch_bounds__(kThreadsPerBlock) group_block_scaled_1d_tma_ke
 
   // Dynamic smem: IType[kTileDim][kTileDim], 128 B aligned for TMA. Static smem
   // (smem_T when CW, tma_mbar) lives outside the dynamic region.
-  extern __shared__ unsigned char smem_raw_1d_tma[];
-  unsigned char* smem_base = common::align_smem_ptr_per_TMA_requirements(smem_raw_1d_tma);
+  extern __shared__ char smem_raw_1d_tma[];
+  char *smem_base = align_up(smem_raw_1d_tma, TMA_SHMEM_ALIGNMENT);
   IType(*smem)[kTileDim] = reinterpret_cast<IType(*)[kTileDim]>(smem_base);
 
   __shared__ uint64_t tma_mbar;

--- a/transformer_engine/common/cast/mxfp8/group_quantize_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/group_quantize_mxfp8.cuh
@@ -704,8 +704,8 @@ __global__ void __launch_bounds__(CastTraits::THREADS_PER_CHUNK) group_quantize_
   constexpr size_t out_mem_rowwise = (ROWWISE_SCALING ? buff_size_aligned_out : 0);
 
   // The destination shared memory buffer of a bulk tensor operation should be 16-byte aligned
-  extern __shared__ unsigned char dynamic_shmem[];
-  unsigned char *dshmem = align_smem_ptr_per_TMA_requirements(dynamic_shmem);
+  extern __shared__ char dynamic_shmem[];
+  char *dshmem = align_up(dynamic_shmem, TMA_SHMEM_ALIGNMENT);
 
   // The destination shared memory buffer of a bulk tensor operation should be 16-byte aligned
   IType *sIn_ptr = reinterpret_cast<IType *>(dshmem);

--- a/transformer_engine/common/cast/mxfp8/group_scaled_swiglu_mxfp8.cuh
+++ b/transformer_engine/common/cast/mxfp8/group_scaled_swiglu_mxfp8.cuh
@@ -209,8 +209,8 @@ __global__ void __launch_bounds__(THREADS_PER_CHUNK) group_scaled_swiglu_mxfp8_k
         DIVUP_TO_MULTIPLE(CHUNK_DIM_Y * sizeof(float), TMA_SHMEM_ALIGNMENT);
 
     // shmem layout: [act input][gate input][colwise output][prob]
-    extern __shared__ unsigned char dynamic_shmem[];
-    unsigned char *dshmem = align_smem_ptr_per_TMA_requirements(dynamic_shmem);
+    extern __shared__ char dynamic_shmem[];
+    char *dshmem = align_up(dynamic_shmem, TMA_SHMEM_ALIGNMENT);
 
     IType *sInAct_ptr = reinterpret_cast<IType *>(dshmem);
     IType *sInGate_ptr = reinterpret_cast<IType *>(dshmem + buff_size_aligned_in);

--- a/transformer_engine/common/cast/nvfp4/specialized/quantize_transpose_nvfp4_tuned_1D.cuh
+++ b/transformer_engine/common/cast/nvfp4/specialized/quantize_transpose_nvfp4_tuned_1D.cuh
@@ -410,8 +410,8 @@ __global__ void __launch_bounds__(THREADS_NUM) quantize_transpose_nvfp4_tuned_1D
       TunableConfig::CHUNK_DIM_Y * SCALES_PER_CHUNK_X * sizeof(nvfp4_scale_t), TMA_SHMEM_ALIGNMENT);
 
   // The destination shared memory buffer of a bulk tensor operation should be 16-byte aligned
-  extern __shared__ unsigned char dynamic_shmem[];
-  unsigned char *dshmem = common::align_smem_ptr_per_TMA_requirements(dynamic_shmem);
+  extern __shared__ char dynamic_shmem[];
+  char *dshmem = align_up(dynamic_shmem, TMA_SHMEM_ALIGNMENT);
 
   IType *sIn_ptr = reinterpret_cast<IType *>(dshmem);
   fp4e2m1x2 *sOut_ptr = reinterpret_cast<fp4e2m1x2 *>(dshmem + in_mem);


### PR DESCRIPTION
# Description

This PR replaces the remaining custom dynamic shared-memory alignment helper with the common pointer-preserving `align_up` implementation introduced in #3291.

The removed helper aligned an `extern __shared__` pointer by converting it to an integer, rounding the integer address, and converting it back to a pointer. This can cause the compiler to lose the pointer's shared-memory address-space provenance and emit generic `LD.E`/`ST.E` instructions instead of `LDS`/`STS`, potentially resulting in illegal memory accesses.

All affected kernels now use the common `align_up` helper directly and consistently declare their dynamic shared-memory buffers as `char[]`.

Fixes #3474 

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove the duplicate `align_smem_ptr_per_TMA_requirements` helper.
- Use the common pointer-preserving `align_up` implementation in all remaining affected TMA kernels.
- Change the corresponding dynamic shared-memory declarations from `unsigned char[]`/`unsigned char*` to `char[]`/`char*`.
- Apply the fix to grouped MXFP8, grouped scaled SwiGLU, grouped FP8 blockwise, and the affected specialized NVFP4 kernel.

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes