### PR TITLE
Replace RuntimeError with warnings in ScaledSReLU

### DIFF
--- a/transformer_engine/pytorch/ops/basic/activation.py
+++ b/transformer_engine/pytorch/ops/basic/activation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import abc
 from collections.abc import Iterable
 from typing import Any, Optional
+import warnings
 
 import torch
 
@@ -394,7 +395,7 @@ class ScaledSReLU(BasicOperation):
         basic_op_kwargs: list[dict[str, Any]],  # pylint: disable=unused-argument
     ) -> tuple[torch.Tensor, Iterable[Iterable[torch.Tensor]]]:
         if self.activation_recompute_in_mlp:
-            raise RuntimeError(
+            warnings.warn(
                 f"{self.__class__.__name__}(activation_recompute_in_mlp=True) requires the "
                 "fused grouped MLP path."
             )
@@ -437,7 +438,7 @@ class ScaledSReLU(BasicOperation):
         del basic_op_grad_extra_outputs
 
         if self.activation_recompute_in_mlp:
-            raise RuntimeError(
+            warnings.warn(
                 f"{self.__class__.__name__}(activation_recompute_in_mlp=True) requires the "
                 "fused grouped MLP path."
             )


### PR DESCRIPTION
# Description

Replace RuntimeError with warnings in ScaledSReLU for `activation_recompute_in_mlp` path

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

Import warnings module, replace RuntimeError with warnings.warn

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
