### PR TITLE
[Pytorch] Replace TorchScript fallbacks with eager execution

### DIFF
--- a/transformer_engine/pytorch/jit.py
+++ b/transformer_engine/pytorch/jit.py
@@ -42,12 +42,6 @@ if torch_version() >= (2, 0, 0) and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"
     jit_fuser = lazy_compile
 
 
-# See: https://github.com/NVIDIA/TransformerEngine/issues/597
-dropout_fuser = torch.jit.script
-if torch_version() >= (2, 2, 0) and bool(int(os.getenv("NVTE_TORCH_COMPILE", "1"))):
-    dropout_fuser = lazy_compile
-
-
 # Decorator to disable Torch Dynamo
 # See: https://github.com/NVIDIA/TransformerEngine/issues/308
 if torch.__version__ >= "2":
@@ -302,7 +296,7 @@ def get_bias_dropout_add(training: bool) -> Callable:
     return _bias_dropout_add
 
 
-@dropout_fuser
+@jit_fuser
 def bias_dropout_add_fused_train_(
     x: torch.Tensor, bias: torch.Tensor, residual: torch.Tensor, prob: float
 ) -> torch.Tensor:
@@ -319,7 +313,7 @@ def bias_dropout_add_fused_train(
             return bias_dropout_add_fused_train_(x, bias, residual, prob)
 
 
-@dropout_fuser
+@jit_fuser
 def bias_dropout_add_fused_inference_(
     x: torch.Tensor, bias: torch.Tensor, residual: torch.Tensor, prob: float
 ) -> torch.Tensor:

--- a/transformer_engine/pytorch/quantization.py
+++ b/transformer_engine/pytorch/quantization.py
@@ -1073,7 +1073,7 @@ def _update_amax_history(amax_history: torch.Tensor) -> torch.Tensor:
     return amax_history
 
 
-@torch.jit.script
+@jit_fuser
 def _default_get_amax_and_update_history(
     amax_history: torch.Tensor,
     amax_compute_algo: str,


### PR DESCRIPTION
TorchScript is deprecated, and selecting it when torch.compile is disabled keeps an unnecessary legacy path. Reuse the existing decorator policy so enabled configurations use lazy torch.compile while disabled or unsupported configurations execute eagerly.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Bias-dropout-add performance

Measured the FP32 forward expression from #597, `dropout(x + bias, p=0.1, training=True) + residual`, on H100. Results are CUDA-event medians after warm-up. The larger inputs are model-scale proxies by element count, not exact model tensor dimensions. Times are in microseconds.

| Shape `(S, B, D)` | Elements | Purpose |
| --- | ---: | --- |
| `(1024, 2, 1024)` | 2.1M | #597 small-input control |
| `(4096, 8, 1024)` | 33.6M | 16x model-scale proxy |
| `(8192, 16, 1024)` | 134.2M | 64x model-scale proxy |

| Shape | PyTorch 2.1 TorchScript + nvFuser | PyTorch 2.1 `torch.compile` | PyTorch 2.1 eager | PyTorch 2.14.0a0+b2c75dd062 `torch.compile` | PyTorch 2.14.0a0+b2c75dd062 eager | PyTorch 2.14.0a0+b2c75dd062 TorchScript reference |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Small control | 9.2 | 33.1 | 25.6 | 40.9 | 23.8 | 24.8 |
| 16x proxy | 136.6 | 135.8 | 368.6 | 138.0 | 367.4 | 367.5 |
| 64x proxy | 548.5 | 527.6 | 1433.5 | 532.9 | 1433.9 | 1433.7 |

The small PyTorch 2.1 input reproduces #597: `torch.compile` is 3.59x slower than TorchScript + nvFuser. At 16x, they are effectively tied; at 64x, `torch.compile` is 3.8% faster. For both model-scale proxies, `torch.compile` is about 2.7x faster than eager.

With PyTorch `2.14.0a0+b2c75dd062`, TorchScript no longer forms a CUDA fusion group and tracks eager performance. The PyTorch 2.1 measurements isolate the exact BDA expression; the current `torch.compile` and eager measurements call Transformer Engine's public BDA wrapper, with a standalone TorchScript reference.