### PR TITLE
[Pytorch][Attention] Fix FP8 THD backward workspace scaling

### DIFF
--- a/transformer_engine/common/fused_attn/fused_attn_fp8.cu
+++ b/transformer_engine/common/fused_attn/fused_attn_fp8.cu
@@ -701,9 +701,8 @@ void fused_attn_fp8_bwd_impl(
   if ((is_ragged_q || is_ragged_kv) && cudnn_runtime_version >= kFP8THDRaggedCudnnVersion) {
     NVTE_CHECK(is_padding, "Ragged QKV input requires padding or padding_causal mask!");
     if (sm_arch_ != 120) {
+      // Ragged offsets address packed storage; sequence axes stay per-sequence maxima.
       b = max_b;
-      s_q = is_ragged_q ? max_t_q : s_q;
-      s_kv = is_ragged_kv ? max_t_kv : s_kv;
     }
   }
 


### PR DESCRIPTION
The FP8 backward graph uses its sequence dimensions to size intermediates. Replacing them with total packed-token buckets adds an extra batch factor to workspace growth.

Keep the caller-provided per-sequence maxima while retaining the existing batch bucketing and ragged-offset handling.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
